### PR TITLE
feat(generator/rust)!: use integers for enums

### DIFF
--- a/generator/internal/rust/rust_used_by_test.go
+++ b/generator/internal/rust/rust_used_by_test.go
@@ -28,7 +28,7 @@ func TestUsedByServicesWithServices(t *testing.T) {
 		ID:   ".test.Service",
 	}
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
-	c, err := newCodec(map[string]string{
+	c, err := newCodec(true, map[string]string{
 		"package:tracing":  "used-if=services,package=tracing,version=0.1.41",
 		"package:location": "package=gcp-sdk-location,source=google.cloud.location,path=src/generated/cloud/location,version=0.1.0",
 	})
@@ -62,7 +62,7 @@ func TestUsedByServicesWithServices(t *testing.T) {
 
 func TestUsedByServicesNoServices(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
-	c, err := newCodec(map[string]string{
+	c, err := newCodec(true, map[string]string{
 		"package:tracing":  "used-if=services,package=tracing,version=0.1.41",
 		"package:location": "package=gcp-sdk-location,source=google.cloud.location,path=src/generated/cloud/location,version=0.1.0",
 	})
@@ -104,7 +104,7 @@ func TestUsedByLROsWithLRO(t *testing.T) {
 		Methods: []*api.Method{method},
 	}
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
-	c, err := newCodec(map[string]string{
+	c, err := newCodec(true, map[string]string{
 		"package:location": "package=gcp-sdk-location,source=google.cloud.location,path=src/generated/cloud/location,version=0.1.0",
 		"package:lro":      "used-if=lro,package=google-cloud-lro,path=src/lro,version=0.1.0",
 	})
@@ -147,7 +147,7 @@ func TestUsedByLROsWithoutLRO(t *testing.T) {
 		Methods: []*api.Method{method},
 	}
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
-	c, err := newCodec(map[string]string{
+	c, err := newCodec(true, map[string]string{
 		"package:location": "package=gcp-sdk-location,source=google.cloud.location,path=src/generated/cloud/location,version=0.1.0",
 		"package:lro":      "used-if=lro,package=google-cloud-lro,path=src/lro,version=0.1.0",
 	})
@@ -188,7 +188,7 @@ func TestRequiredPackages(t *testing.T) {
 		"package:gax":         "package=gcp-sdk-gax,path=src/gax,version=1.2.3,force-used=true",
 		"package:auth":        "ignore=true",
 	}
-	c, err := newCodec(options)
+	c, err := newCodec(true, options)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +209,7 @@ func TestRequiredPackagesLocal(t *testing.T) {
 	options := map[string]string{
 		"package:gtype": "package=types,path=src/generated/type,source=google.type,source=test-only,force-used=true",
 	}
-	c, err := newCodec(options)
+	c, err := newCodec(true, options)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,7 +257,7 @@ func TestFindUsedPackages(t *testing.T) {
 		Package: "google.cloud.common",
 	}
 
-	c, err := newCodec(map[string]string{
+	c, err := newCodec(true, map[string]string{
 		"package:common":      "package=google-cloud-common,source=google.cloud.common,path=src/generated/cloud/common,version=0.2",
 		"package:longrunning": "package=google-longrunning,source=google.longrunning,path=src/generated/longrunning,version=0.2",
 	})

--- a/generator/internal/rust/rusttemplate.go
+++ b/generator/internal/rust/rusttemplate.go
@@ -53,6 +53,8 @@ type modelAnnotations struct {
 	// If true, disable rustdoc warnings known to be triggered by our generated
 	// documentation.
 	DisabledRustdocWarnings []string
+	// Sets the default system parameters
+	DefaultSystemParameters []systemParameter
 }
 
 type serviceAnnotations struct {
@@ -106,6 +108,7 @@ type methodAnnotation struct {
 	ServiceNameToCamel  string
 	ServiceNameToSnake  string
 	OperationInfo       *operationInfo
+	SystemParameters    []systemParameter
 }
 
 type pathInfoAnnotation struct {
@@ -397,6 +400,7 @@ func (c *codec) annotateMethod(m *api.Method, s *api.Service, state *api.APIStat
 		ServiceNameToPascal: toPascal(s.Name),
 		ServiceNameToCamel:  toCamel(s.Name),
 		ServiceNameToSnake:  toSnake(s.Name),
+		SystemParameters:    c.systemParameters,
 	}
 	if m.OperationInfo != nil {
 		metadataType := methodInOutTypeName(m.OperationInfo.MetadataTypeID, state, c.modulePath, sourceSpecificationPackageName, c.packageMapping)

--- a/generator/internal/rust/rusttemplate_test.go
+++ b/generator/internal/rust/rusttemplate_test.go
@@ -28,7 +28,7 @@ func TestPackageNames(t *testing.T) {
 		[]*api.Service{{Name: "Workflows", Package: "google.cloud.workflows.v1"}})
 	// Override the default name for test APIs ("Test").
 	model.Name = "workflows-v1"
-	codec, err := newCodec(map[string]string{})
+	codec, err := newCodec(true, map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func Test_OneOfAnnotations(t *testing.T) {
 	}
 	model := api.NewTestAPI([]*api.Message{message, map_message}, []*api.Enum{}, []*api.Service{})
 	api.CrossReference(model)
-	codec, err := newCodec(map[string]string{})
+	codec, err := newCodec(true, map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,7 +196,7 @@ func Test_RustEnumAnnotations(t *testing.T) {
 
 	model := api.NewTestAPI(
 		[]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
-	codec, err := newCodec(map[string]string{})
+	codec, err := newCodec(true, map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -264,7 +264,7 @@ func Test_JsonNameAnnotations(t *testing.T) {
 	}
 	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
 	api.CrossReference(model)
-	codec, err := newCodec(map[string]string{})
+	codec, err := newCodec(true, map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/generator/internal/rust/templates/common/enum.mustache
+++ b/generator/internal/rust/templates/common/enum.mustache
@@ -18,46 +18,56 @@ limitations under the License.
 {{{.}}}
 {{/Codec.DocLines}}
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct {{Codec.Name}}(std::borrow::Cow<'static, str>);
+pub struct {{Codec.Name}}(i32);
 
 impl {{Codec.Name}} {
-    /// Creates a new {{Codec.Name}} instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [{{Codec.Name}}]({{Codec.Name}})
-pub mod {{Codec.ModuleName}} {
-    use super::{{Codec.Name}};
-    
     {{#Values}}
 
     {{#Codec.DocLines}}
     {{{.}}}
     {{/Codec.DocLines}}
-    pub const {{Codec.Name}}: {{Codec.EnumType}} = {{Codec.EnumType}}::new("{{Codec.Name}}");
+    pub const {{Codec.Name}}: {{Codec.EnumType}} = {{Codec.EnumType}}::new({{Number}});
     {{/Values}}
+
+    /// Creates a new {{Codec.Name}} instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+    
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            {{#UniqueNumberValues}}
+            {{Number}} => std::borrow::Cow::Borrowed("{{Name}}"),
+            {{/UniqueNumberValues}}
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            {{#Values}}
+            "{{Name}}" => std::option::Option::Some(Self::{{Codec.Name}}),
+            {{/Values}}
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for {{Codec.Name}} {
-  fn from(value: std::string::String) -> Self {
-    Self(std::borrow::Cow::Owned(value))
-  }
+impl std::convert::From<i32> for {{Codec.Name}} {
+    fn from(value: i32) -> Self {
+        Self::new(value)
+    }
 }
 
 impl std::default::Default for {{Codec.Name}} {
     fn default() -> Self {
-        {{#Codec.DefaultValueName}}
-        {{Codec.ModuleName}}::{{Codec.DefaultValueName}}
-        {{/Codec.DefaultValueName}}
-        {{^Codec.DefaultValueName}}
-        Self::new("")
-        {{/Codec.DefaultValueName}}
+        Self::new(0)
     }
 }

--- a/generator/internal/rust/templates/crate/src/transport.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/transport.rs.mustache
@@ -71,7 +71,9 @@ impl crate::stubs::{{Codec.Name}} for {{Codec.Name}} {
                 )
                 {{/PathInfo.Codec.HasPathArgs}}
             )
-            .query(&[("alt", "json")])
+            {{#Codec.SystemParameters}}
+            .query(&[("{{Name}}", "{{Value}}")])
+            {{/Codec.SystemParameters}}
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         {{#Codec.QueryParams}}
         {{{Codec.AddQueryParameter}}}

--- a/generator/testdata/rust/openapi/golden/src/transport.rs
+++ b/generator/testdata/rust/openapi/golden/src/transport.rs
@@ -54,7 +54,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.project
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.filter.iter().fold(builder, |builder, p| builder.query(&[("filter", p)]));
         let builder = req.page_size.iter().fold(builder, |builder, p| builder.query(&[("pageSize", p)]));
@@ -82,7 +82,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.location
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -106,7 +106,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.project
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.page_size.iter().fold(builder, |builder, p| builder.query(&[("pageSize", p)]));
         let builder = req.page_token.iter().fold(builder, |builder, p| builder.query(&[("pageToken", p)]));
@@ -133,7 +133,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.project
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("secretId", &req.secret_id)]);
         self.inner.execute(
@@ -159,7 +159,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.location
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.page_size.iter().fold(builder, |builder, p| builder.query(&[("pageSize", p)]));
         let builder = req.page_token.iter().fold(builder, |builder, p| builder.query(&[("pageToken", p)]));
@@ -187,7 +187,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.location
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("secretId", &req.secret_id)]);
         self.inner.execute(
@@ -213,7 +213,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.secret
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -239,7 +239,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.secret
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -264,7 +264,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.secret
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -289,7 +289,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.secret
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.etag.iter().fold(builder, |builder, p| builder.query(&[("etag", p)]));
         self.inner.execute(
@@ -315,7 +315,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.secret
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = { use gax::query_parameter::QueryParameter; serde_json::to_value(&req.update_mask).map_err(Error::serde)?.add(builder, "updateMask") };
         self.inner.execute(
@@ -342,7 +342,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.secret
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -368,7 +368,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.secret
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.etag.iter().fold(builder, |builder, p| builder.query(&[("etag", p)]));
         self.inner.execute(
@@ -395,7 +395,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.secret
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = { use gax::query_parameter::QueryParameter; serde_json::to_value(&req.update_mask).map_err(Error::serde)?.add(builder, "updateMask") };
         self.inner.execute(
@@ -421,7 +421,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.secret
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.page_size.iter().fold(builder, |builder, p| builder.query(&[("pageSize", p)]));
         let builder = req.page_token.iter().fold(builder, |builder, p| builder.query(&[("pageToken", p)]));
@@ -450,7 +450,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.secret
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.page_size.iter().fold(builder, |builder, p| builder.query(&[("pageSize", p)]));
         let builder = req.page_token.iter().fold(builder, |builder, p| builder.query(&[("pageToken", p)]));
@@ -479,7 +479,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.version
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -506,7 +506,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.version
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -532,7 +532,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.version
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -559,7 +559,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.version
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -585,7 +585,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.version
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -612,7 +612,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.version
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -638,7 +638,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.version
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -665,7 +665,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.version
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -691,7 +691,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.version
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -718,7 +718,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.version
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -743,7 +743,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.secret
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -769,7 +769,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.secret
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -794,7 +794,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.secret
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.options_requested_policy_version.iter().fold(builder, |builder, p| builder.query(&[("options.requestedPolicyVersion", p)]));
         self.inner.execute(
@@ -821,7 +821,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.secret
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.options_requested_policy_version.iter().fold(builder, |builder, p| builder.query(&[("options.requestedPolicyVersion", p)]));
         self.inner.execute(
@@ -847,7 +847,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.secret
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -873,7 +873,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.secret
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,

--- a/generator/testdata/rust/protobuf/golden/iam/v1/src/model.rs
+++ b/generator/testdata/rust/protobuf/golden/iam/v1/src/model.rs
@@ -721,47 +721,64 @@ pub mod audit_log_config {
     /// The list of valid permission types for which logging can be configured.
     /// Admin writes are always logged, and are not configurable.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LogType(std::borrow::Cow<'static, str>);
+    pub struct LogType(i32);
 
     impl LogType {
+
+        /// Default case. Should never be this.
+        pub const LOG_TYPE_UNSPECIFIED: LogType = LogType::new(0);
+
+        /// Admin reads. Example: CloudIAM getIamPolicy
+        pub const ADMIN_READ: LogType = LogType::new(1);
+
+        /// Data writes. Example: CloudSQL Users create
+        pub const DATA_WRITE: LogType = LogType::new(2);
+
+        /// Data reads. Example: CloudSQL Users list
+        pub const DATA_READ: LogType = LogType::new(3);
+
         /// Creates a new LogType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LOG_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ADMIN_READ"),
+                2 => std::borrow::Cow::Borrowed("DATA_WRITE"),
+                3 => std::borrow::Cow::Borrowed("DATA_READ"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LOG_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::LOG_TYPE_UNSPECIFIED),
+                "ADMIN_READ" => std::option::Option::Some(Self::ADMIN_READ),
+                "DATA_WRITE" => std::option::Option::Some(Self::DATA_WRITE),
+                "DATA_READ" => std::option::Option::Some(Self::DATA_READ),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [LogType](LogType)
-    pub mod log_type {
-        use super::LogType;
-        
-
-        /// Default case. Should never be this.
-        pub const LOG_TYPE_UNSPECIFIED: LogType = LogType::new("LOG_TYPE_UNSPECIFIED");
-
-        /// Admin reads. Example: CloudIAM getIamPolicy
-        pub const ADMIN_READ: LogType = LogType::new("ADMIN_READ");
-
-        /// Data writes. Example: CloudSQL Users create
-        pub const DATA_WRITE: LogType = LogType::new("DATA_WRITE");
-
-        /// Data reads. Example: CloudSQL Users list
-        pub const DATA_READ: LogType = LogType::new("DATA_READ");
-    }
-
-    impl std::convert::From<std::string::String> for LogType {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for LogType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for LogType {
         fn default() -> Self {
-            log_type::LOG_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -889,44 +906,59 @@ pub mod binding_delta {
 
     /// The type of action performed on a Binding in a policy.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(std::borrow::Cow<'static, str>);
+    pub struct Action(i32);
 
     impl Action {
+
+        /// Unspecified.
+        pub const ACTION_UNSPECIFIED: Action = Action::new(0);
+
+        /// Addition of a Binding.
+        pub const ADD: Action = Action::new(1);
+
+        /// Removal of a Binding.
+        pub const REMOVE: Action = Action::new(2);
+
         /// Creates a new Action instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ACTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ADD"),
+                2 => std::borrow::Cow::Borrowed("REMOVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ACTION_UNSPECIFIED" => std::option::Option::Some(Self::ACTION_UNSPECIFIED),
+                "ADD" => std::option::Option::Some(Self::ADD),
+                "REMOVE" => std::option::Option::Some(Self::REMOVE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Action](Action)
-    pub mod action {
-        use super::Action;
-        
-
-        /// Unspecified.
-        pub const ACTION_UNSPECIFIED: Action = Action::new("ACTION_UNSPECIFIED");
-
-        /// Addition of a Binding.
-        pub const ADD: Action = Action::new("ADD");
-
-        /// Removal of a Binding.
-        pub const REMOVE: Action = Action::new("REMOVE");
-    }
-
-    impl std::convert::From<std::string::String> for Action {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            action::ACTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1007,44 +1039,59 @@ pub mod audit_config_delta {
 
     /// The type of action performed on an audit configuration in a policy.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(std::borrow::Cow<'static, str>);
+    pub struct Action(i32);
 
     impl Action {
+
+        /// Unspecified.
+        pub const ACTION_UNSPECIFIED: Action = Action::new(0);
+
+        /// Addition of an audit configuration.
+        pub const ADD: Action = Action::new(1);
+
+        /// Removal of an audit configuration.
+        pub const REMOVE: Action = Action::new(2);
+
         /// Creates a new Action instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ACTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ADD"),
+                2 => std::borrow::Cow::Borrowed("REMOVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ACTION_UNSPECIFIED" => std::option::Option::Some(Self::ACTION_UNSPECIFIED),
+                "ADD" => std::option::Option::Some(Self::ADD),
+                "REMOVE" => std::option::Option::Some(Self::REMOVE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Action](Action)
-    pub mod action {
-        use super::Action;
-        
-
-        /// Unspecified.
-        pub const ACTION_UNSPECIFIED: Action = Action::new("ACTION_UNSPECIFIED");
-
-        /// Addition of an audit configuration.
-        pub const ADD: Action = Action::new("ADD");
-
-        /// Removal of an audit configuration.
-        pub const REMOVE: Action = Action::new("REMOVE");
-    }
-
-    impl std::convert::From<std::string::String> for Action {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            action::ACTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/generator/testdata/rust/protobuf/golden/iam/v1/src/transport.rs
+++ b/generator/testdata/rust/protobuf/golden/iam/v1/src/transport.rs
@@ -54,7 +54,7 @@ impl crate::stubs::IAMPolicy for IAMPolicy {
                         , req.resource
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -78,7 +78,7 @@ impl crate::stubs::IAMPolicy for IAMPolicy {
                         , req.resource
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -102,7 +102,7 @@ impl crate::stubs::IAMPolicy for IAMPolicy {
                         , req.resource
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,

--- a/generator/testdata/rust/protobuf/golden/location/src/transport.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/transport.rs
@@ -54,7 +54,7 @@ impl crate::stubs::Locations for Locations {
                         , req.name
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("filter", &req.filter)]);
         let builder = builder.query(&[("pageSize", &req.page_size)]);
@@ -81,7 +81,7 @@ impl crate::stubs::Locations for Locations {
                         , req.name
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,

--- a/generator/testdata/rust/protobuf/golden/module/rpc/mod.rs
+++ b/generator/testdata/rust/protobuf/golden/module/rpc/mod.rs
@@ -848,34 +848,19 @@ impl wkt::message::Message for Status {
 /// `OUT_OF_RANGE` over `FAILED_PRECONDITION` if both codes apply.
 /// Similarly prefer `NOT_FOUND` or `ALREADY_EXISTS` over `FAILED_PRECONDITION`.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Code(std::borrow::Cow<'static, str>);
+pub struct Code(i32);
 
 impl Code {
-    /// Creates a new Code instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [Code](Code)
-pub mod code {
-    use super::Code;
-    
 
     /// Not an error; returned on success.
     ///
     /// HTTP Mapping: 200 OK
-    pub const OK: Code = Code::new("OK");
+    pub const OK: Code = Code::new(0);
 
     /// The operation was cancelled, typically by the caller.
     ///
     /// HTTP Mapping: 499 Client Closed Request
-    pub const CANCELLED: Code = Code::new("CANCELLED");
+    pub const CANCELLED: Code = Code::new(1);
 
     /// Unknown error.  For example, this error may be returned when
     /// a `Status` value received from another address space belongs to
@@ -884,7 +869,7 @@ pub mod code {
     /// may be converted to this error.
     ///
     /// HTTP Mapping: 500 Internal Server Error
-    pub const UNKNOWN: Code = Code::new("UNKNOWN");
+    pub const UNKNOWN: Code = Code::new(2);
 
     /// The client specified an invalid argument.  Note that this differs
     /// from `FAILED_PRECONDITION`.  `INVALID_ARGUMENT` indicates arguments
@@ -892,7 +877,7 @@ pub mod code {
     /// (e.g., a malformed file name).
     ///
     /// HTTP Mapping: 400 Bad Request
-    pub const INVALID_ARGUMENT: Code = Code::new("INVALID_ARGUMENT");
+    pub const INVALID_ARGUMENT: Code = Code::new(3);
 
     /// The deadline expired before the operation could complete. For operations
     /// that change the state of the system, this error may be returned
@@ -901,7 +886,7 @@ pub mod code {
     /// enough for the deadline to expire.
     ///
     /// HTTP Mapping: 504 Gateway Timeout
-    pub const DEADLINE_EXCEEDED: Code = Code::new("DEADLINE_EXCEEDED");
+    pub const DEADLINE_EXCEEDED: Code = Code::new(4);
 
     /// Some requested entity (e.g., file or directory) was not found.
     ///
@@ -912,13 +897,13 @@ pub mod code {
     /// must be used.
     ///
     /// HTTP Mapping: 404 Not Found
-    pub const NOT_FOUND: Code = Code::new("NOT_FOUND");
+    pub const NOT_FOUND: Code = Code::new(5);
 
     /// The entity that a client attempted to create (e.g., file or directory)
     /// already exists.
     ///
     /// HTTP Mapping: 409 Conflict
-    pub const ALREADY_EXISTS: Code = Code::new("ALREADY_EXISTS");
+    pub const ALREADY_EXISTS: Code = Code::new(6);
 
     /// The caller does not have permission to execute the specified
     /// operation. `PERMISSION_DENIED` must not be used for rejections
@@ -930,19 +915,19 @@ pub mod code {
     /// other pre-conditions.
     ///
     /// HTTP Mapping: 403 Forbidden
-    pub const PERMISSION_DENIED: Code = Code::new("PERMISSION_DENIED");
+    pub const PERMISSION_DENIED: Code = Code::new(7);
 
     /// The request does not have valid authentication credentials for the
     /// operation.
     ///
     /// HTTP Mapping: 401 Unauthorized
-    pub const UNAUTHENTICATED: Code = Code::new("UNAUTHENTICATED");
+    pub const UNAUTHENTICATED: Code = Code::new(16);
 
     /// Some resource has been exhausted, perhaps a per-user quota, or
     /// perhaps the entire file system is out of space.
     ///
     /// HTTP Mapping: 429 Too Many Requests
-    pub const RESOURCE_EXHAUSTED: Code = Code::new("RESOURCE_EXHAUSTED");
+    pub const RESOURCE_EXHAUSTED: Code = Code::new(8);
 
     /// The operation was rejected because the system is not in a state
     /// required for the operation's execution.  For example, the directory
@@ -962,7 +947,7 @@ pub mod code {
     /// the files are deleted from the directory.
     ///
     /// HTTP Mapping: 400 Bad Request
-    pub const FAILED_PRECONDITION: Code = Code::new("FAILED_PRECONDITION");
+    pub const FAILED_PRECONDITION: Code = Code::new(9);
 
     /// The operation was aborted, typically due to a concurrency issue such as
     /// a sequencer check failure or transaction abort.
@@ -971,7 +956,7 @@ pub mod code {
     /// `ABORTED`, and `UNAVAILABLE`.
     ///
     /// HTTP Mapping: 409 Conflict
-    pub const ABORTED: Code = Code::new("ABORTED");
+    pub const ABORTED: Code = Code::new(10);
 
     /// The operation was attempted past the valid range.  E.g., seeking or
     /// reading past end-of-file.
@@ -990,20 +975,20 @@ pub mod code {
     /// they are done.
     ///
     /// HTTP Mapping: 400 Bad Request
-    pub const OUT_OF_RANGE: Code = Code::new("OUT_OF_RANGE");
+    pub const OUT_OF_RANGE: Code = Code::new(11);
 
     /// The operation is not implemented or is not supported/enabled in this
     /// service.
     ///
     /// HTTP Mapping: 501 Not Implemented
-    pub const UNIMPLEMENTED: Code = Code::new("UNIMPLEMENTED");
+    pub const UNIMPLEMENTED: Code = Code::new(12);
 
     /// Internal errors.  This means that some invariants expected by the
     /// underlying system have been broken.  This error code is reserved
     /// for serious errors.
     ///
     /// HTTP Mapping: 500 Internal Server Error
-    pub const INTERNAL: Code = Code::new("INTERNAL");
+    pub const INTERNAL: Code = Code::new(13);
 
     /// The service is currently unavailable.  This is most likely a
     /// transient condition, which can be corrected by retrying with
@@ -1014,22 +999,80 @@ pub mod code {
     /// `ABORTED`, and `UNAVAILABLE`.
     ///
     /// HTTP Mapping: 503 Service Unavailable
-    pub const UNAVAILABLE: Code = Code::new("UNAVAILABLE");
+    pub const UNAVAILABLE: Code = Code::new(14);
 
     /// Unrecoverable data loss or corruption.
     ///
     /// HTTP Mapping: 500 Internal Server Error
-    pub const DATA_LOSS: Code = Code::new("DATA_LOSS");
+    pub const DATA_LOSS: Code = Code::new(15);
+
+    /// Creates a new Code instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+    
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("OK"),
+            1 => std::borrow::Cow::Borrowed("CANCELLED"),
+            2 => std::borrow::Cow::Borrowed("UNKNOWN"),
+            3 => std::borrow::Cow::Borrowed("INVALID_ARGUMENT"),
+            4 => std::borrow::Cow::Borrowed("DEADLINE_EXCEEDED"),
+            5 => std::borrow::Cow::Borrowed("NOT_FOUND"),
+            6 => std::borrow::Cow::Borrowed("ALREADY_EXISTS"),
+            7 => std::borrow::Cow::Borrowed("PERMISSION_DENIED"),
+            8 => std::borrow::Cow::Borrowed("RESOURCE_EXHAUSTED"),
+            9 => std::borrow::Cow::Borrowed("FAILED_PRECONDITION"),
+            10 => std::borrow::Cow::Borrowed("ABORTED"),
+            11 => std::borrow::Cow::Borrowed("OUT_OF_RANGE"),
+            12 => std::borrow::Cow::Borrowed("UNIMPLEMENTED"),
+            13 => std::borrow::Cow::Borrowed("INTERNAL"),
+            14 => std::borrow::Cow::Borrowed("UNAVAILABLE"),
+            15 => std::borrow::Cow::Borrowed("DATA_LOSS"),
+            16 => std::borrow::Cow::Borrowed("UNAUTHENTICATED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "OK" => std::option::Option::Some(Self::OK),
+            "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+            "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+            "INVALID_ARGUMENT" => std::option::Option::Some(Self::INVALID_ARGUMENT),
+            "DEADLINE_EXCEEDED" => std::option::Option::Some(Self::DEADLINE_EXCEEDED),
+            "NOT_FOUND" => std::option::Option::Some(Self::NOT_FOUND),
+            "ALREADY_EXISTS" => std::option::Option::Some(Self::ALREADY_EXISTS),
+            "PERMISSION_DENIED" => std::option::Option::Some(Self::PERMISSION_DENIED),
+            "UNAUTHENTICATED" => std::option::Option::Some(Self::UNAUTHENTICATED),
+            "RESOURCE_EXHAUSTED" => std::option::Option::Some(Self::RESOURCE_EXHAUSTED),
+            "FAILED_PRECONDITION" => std::option::Option::Some(Self::FAILED_PRECONDITION),
+            "ABORTED" => std::option::Option::Some(Self::ABORTED),
+            "OUT_OF_RANGE" => std::option::Option::Some(Self::OUT_OF_RANGE),
+            "UNIMPLEMENTED" => std::option::Option::Some(Self::UNIMPLEMENTED),
+            "INTERNAL" => std::option::Option::Some(Self::INTERNAL),
+            "UNAVAILABLE" => std::option::Option::Some(Self::UNAVAILABLE),
+            "DATA_LOSS" => std::option::Option::Some(Self::DATA_LOSS),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for Code {
-  fn from(value: std::string::String) -> Self {
-    Self(std::borrow::Cow::Owned(value))
-  }
+impl std::convert::From<i32> for Code {
+    fn from(value: i32) -> Self {
+        Self::new(value)
+    }
 }
 
 impl std::default::Default for Code {
     fn default() -> Self {
-        code::OK
+        Self::new(0)
     }
 }

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/model.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/model.rs
@@ -531,33 +531,18 @@ pub mod secret_version {
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-        
 
         /// Not specified. This value is unused and invalid.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] may be
         /// accessed.
         ///
         /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-        pub const ENABLED: State = State::new("ENABLED");
+        pub const ENABLED: State = State::new(1);
 
         /// The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] may not
         /// be accessed, but the secret data is still available and can be placed
@@ -567,25 +552,57 @@ pub mod secret_version {
         ///
         /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
         /// [google.cloud.secretmanager.v1.SecretVersion.State.ENABLED]: crate::model::secret_version::state::ENABLED
-        pub const DISABLED: State = State::new("DISABLED");
+        pub const DISABLED: State = State::new(2);
 
         /// The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] is
         /// destroyed and the secret data is no longer stored. A version may not
         /// leave this state once entered.
         ///
         /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-        pub const DESTROYED: State = State::new("DESTROYED");
+        pub const DESTROYED: State = State::new(3);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENABLED"),
+                2 => std::borrow::Cow::Borrowed("DISABLED"),
+                3 => std::borrow::Cow::Borrowed("DESTROYED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "DESTROYED" => std::option::Option::Some(Self::DESTROYED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/transport.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/transport.rs
@@ -54,7 +54,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.parent
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
@@ -81,7 +81,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.parent
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("secretId", &req.secret_id)]);
         self.inner.execute(
@@ -106,7 +106,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.parent
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -130,7 +130,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.name
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -154,7 +154,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.secret.as_ref().ok_or_else(|| gax::path_parameter::missing("secret"))?.name
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.update_mask.as_ref().map(|p| serde_json::to_value(p).map_err(Error::serde) ).transpose()?.into_iter().fold(builder, |builder, v| { use gax::query_parameter::QueryParameter; v.add(builder, "updateMask") });
         self.inner.execute(
@@ -179,7 +179,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.name
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("etag", &req.etag)]);
         self.inner.execute(
@@ -204,7 +204,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.parent
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
@@ -231,7 +231,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.name
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -255,7 +255,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.name
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -279,7 +279,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.name
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -303,7 +303,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.name
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -327,7 +327,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.name
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -351,7 +351,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.resource
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -375,7 +375,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.resource
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.options.as_ref().map(|p| serde_json::to_value(p).map_err(Error::serde) ).transpose()?.into_iter().fold(builder, |builder, v| { use gax::query_parameter::QueryParameter; v.add(builder, "options") });
         self.inner.execute(
@@ -400,7 +400,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.resource
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -424,7 +424,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.name
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("filter", &req.filter)]);
         let builder = builder.query(&[("pageSize", &req.page_size)]);
@@ -451,7 +451,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         , req.name
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,

--- a/guide/samples/src/lro.rs
+++ b/guide/samples/src/lro.rs
@@ -41,7 +41,7 @@ pub async fn start(project_id: &str) -> crate::Result<()> {
         // ANCHOR_END: transcript-output
         // ANCHOR: configuration
         .set_processing_strategy(
-            speech::model::batch_recognize_request::processing_strategy::DYNAMIC_BATCHING,
+            speech::model::batch_recognize_request::ProcessingStrategy::DYNAMIC_BATCHING,
         )
         .set_config(
             speech::model::RecognitionConfig::new()
@@ -84,7 +84,7 @@ pub async fn automatic(project_id: &str) -> crate::Result<()> {
                 .set_inline_response_config(speech::model::InlineOutputConfig::new()),
         )
         .set_processing_strategy(
-            speech::model::batch_recognize_request::processing_strategy::DYNAMIC_BATCHING,
+            speech::model::batch_recognize_request::ProcessingStrategy::DYNAMIC_BATCHING,
         )
         .set_config(
             speech::model::RecognitionConfig::new()
@@ -126,7 +126,7 @@ pub async fn polling(project_id: &str) -> crate::Result<()> {
                 .set_inline_response_config(speech::model::InlineOutputConfig::new()),
         )
         .set_processing_strategy(
-            speech::model::batch_recognize_request::processing_strategy::DYNAMIC_BATCHING,
+            speech::model::batch_recognize_request::ProcessingStrategy::DYNAMIC_BATCHING,
         )
         .set_config(
             speech::model::RecognitionConfig::new()

--- a/guide/samples/src/polling_policies.rs
+++ b/guide/samples/src/polling_policies.rs
@@ -53,7 +53,7 @@ pub async fn client_backoff(project_id: &str) -> crate::Result<()> {
                 .set_inline_response_config(speech::model::InlineOutputConfig::new()),
         )
         .set_processing_strategy(
-            speech::model::batch_recognize_request::processing_strategy::DYNAMIC_BATCHING,
+            speech::model::batch_recognize_request::ProcessingStrategy::DYNAMIC_BATCHING,
         )
         .set_config(
             speech::model::RecognitionConfig::new()
@@ -111,7 +111,7 @@ pub async fn rpc_backoff(project_id: &str) -> crate::Result<()> {
                 .set_inline_response_config(speech::model::InlineOutputConfig::new()),
         )
         .set_processing_strategy(
-            speech::model::batch_recognize_request::processing_strategy::DYNAMIC_BATCHING,
+            speech::model::batch_recognize_request::ProcessingStrategy::DYNAMIC_BATCHING,
         )
         .set_config(
             speech::model::RecognitionConfig::new()
@@ -167,7 +167,7 @@ pub async fn client_errors(project_id: &str) -> crate::Result<()> {
                 .set_inline_response_config(speech::model::InlineOutputConfig::new()),
         )
         .set_processing_strategy(
-            speech::model::batch_recognize_request::processing_strategy::DYNAMIC_BATCHING,
+            speech::model::batch_recognize_request::ProcessingStrategy::DYNAMIC_BATCHING,
         )
         .set_config(
             speech::model::RecognitionConfig::new()
@@ -225,7 +225,7 @@ pub async fn rpc_errors(project_id: &str) -> crate::Result<()> {
                 .set_inline_response_config(speech::model::InlineOutputConfig::new()),
         )
         .set_processing_strategy(
-            speech::model::batch_recognize_request::processing_strategy::DYNAMIC_BATCHING,
+            speech::model::batch_recognize_request::ProcessingStrategy::DYNAMIC_BATCHING,
         )
         .set_config(
             speech::model::RecognitionConfig::new()

--- a/src/auth/integration-tests/tests/driver.rs
+++ b/src/auth/integration-tests/tests/driver.rs
@@ -115,7 +115,7 @@ mod driver {
         // Make a request using the API key.
         let d = Document::new()
             .set_content("Hello, world!")
-            .set_type("PLAIN_TEXT".to_string());
+            .set_type(language::model::document::Type::PLAIN_TEXT);
         client.analyze_sentiment().set_document(d).send().await?;
 
         Ok(())

--- a/src/firestore/src/model/mod.rs
+++ b/src/firestore/src/model/mod.rs
@@ -4367,32 +4367,17 @@ pub mod target_change {
 
     /// The type of change.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TargetChangeType(std::borrow::Cow<'static, str>);
+    pub struct TargetChangeType(i32);
 
     impl TargetChangeType {
-        /// Creates a new TargetChangeType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [TargetChangeType](TargetChangeType)
-    pub mod target_change_type {
-        use super::TargetChangeType;
-
         /// No change has occurred. Used only to send an updated `resume_token`.
-        pub const NO_CHANGE: TargetChangeType = TargetChangeType::new("NO_CHANGE");
+        pub const NO_CHANGE: TargetChangeType = TargetChangeType::new(0);
 
         /// The targets have been added.
-        pub const ADD: TargetChangeType = TargetChangeType::new("ADD");
+        pub const ADD: TargetChangeType = TargetChangeType::new(1);
 
         /// The targets have been removed.
-        pub const REMOVE: TargetChangeType = TargetChangeType::new("REMOVE");
+        pub const REMOVE: TargetChangeType = TargetChangeType::new(2);
 
         /// The targets reflect all changes committed before the targets were added
         /// to the stream.
@@ -4402,25 +4387,59 @@ pub mod target_change {
         ///
         /// Listeners can wait for this change if read-after-write semantics
         /// are desired.
-        pub const CURRENT: TargetChangeType = TargetChangeType::new("CURRENT");
+        pub const CURRENT: TargetChangeType = TargetChangeType::new(3);
 
         /// The targets have been reset, and a new initial state for the targets
         /// will be returned in subsequent changes.
         ///
         /// After the initial state is complete, `CURRENT` will be returned even
         /// if the target was previously indicated to be `CURRENT`.
-        pub const RESET: TargetChangeType = TargetChangeType::new("RESET");
+        pub const RESET: TargetChangeType = TargetChangeType::new(4);
+
+        /// Creates a new TargetChangeType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("NO_CHANGE"),
+                1 => std::borrow::Cow::Borrowed("ADD"),
+                2 => std::borrow::Cow::Borrowed("REMOVE"),
+                3 => std::borrow::Cow::Borrowed("CURRENT"),
+                4 => std::borrow::Cow::Borrowed("RESET"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "NO_CHANGE" => std::option::Option::Some(Self::NO_CHANGE),
+                "ADD" => std::option::Option::Some(Self::ADD),
+                "REMOVE" => std::option::Option::Some(Self::REMOVE),
+                "CURRENT" => std::option::Option::Some(Self::CURRENT),
+                "RESET" => std::option::Option::Some(Self::RESET),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for TargetChangeType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TargetChangeType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TargetChangeType {
         fn default() -> Self {
-            target_change_type::NO_CHANGE
+            Self::new(0)
         }
     }
 }
@@ -5217,43 +5236,58 @@ pub mod structured_query {
 
         /// A composite filter operator.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Operator(std::borrow::Cow<'static, str>);
+        pub struct Operator(i32);
 
         impl Operator {
+            /// Unspecified. This value must not be used.
+            pub const OPERATOR_UNSPECIFIED: Operator = Operator::new(0);
+
+            /// Documents are required to satisfy all of the combined filters.
+            pub const AND: Operator = Operator::new(1);
+
+            /// Documents are required to satisfy at least one of the combined filters.
+            pub const OR: Operator = Operator::new(2);
+
             /// Creates a new Operator instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("OPERATOR_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("AND"),
+                    2 => std::borrow::Cow::Borrowed("OR"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "OPERATOR_UNSPECIFIED" => std::option::Option::Some(Self::OPERATOR_UNSPECIFIED),
+                    "AND" => std::option::Option::Some(Self::AND),
+                    "OR" => std::option::Option::Some(Self::OR),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Operator](Operator)
-        pub mod operator {
-            use super::Operator;
-
-            /// Unspecified. This value must not be used.
-            pub const OPERATOR_UNSPECIFIED: Operator = Operator::new("OPERATOR_UNSPECIFIED");
-
-            /// Documents are required to satisfy all of the combined filters.
-            pub const AND: Operator = Operator::new("AND");
-
-            /// Documents are required to satisfy at least one of the combined filters.
-            pub const OR: Operator = Operator::new("OR");
-        }
-
-        impl std::convert::From<std::string::String> for Operator {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Operator {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Operator {
             fn default() -> Self {
-                operator::OPERATOR_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -5326,57 +5360,42 @@ pub mod structured_query {
 
         /// A field filter operator.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Operator(std::borrow::Cow<'static, str>);
+        pub struct Operator(i32);
 
         impl Operator {
-            /// Creates a new Operator instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [Operator](Operator)
-        pub mod operator {
-            use super::Operator;
-
             /// Unspecified. This value must not be used.
-            pub const OPERATOR_UNSPECIFIED: Operator = Operator::new("OPERATOR_UNSPECIFIED");
+            pub const OPERATOR_UNSPECIFIED: Operator = Operator::new(0);
 
             /// The given `field` is less than the given `value`.
             ///
             /// Requires:
             ///
             /// * That `field` come first in `order_by`.
-            pub const LESS_THAN: Operator = Operator::new("LESS_THAN");
+            pub const LESS_THAN: Operator = Operator::new(1);
 
             /// The given `field` is less than or equal to the given `value`.
             ///
             /// Requires:
             ///
             /// * That `field` come first in `order_by`.
-            pub const LESS_THAN_OR_EQUAL: Operator = Operator::new("LESS_THAN_OR_EQUAL");
+            pub const LESS_THAN_OR_EQUAL: Operator = Operator::new(2);
 
             /// The given `field` is greater than the given `value`.
             ///
             /// Requires:
             ///
             /// * That `field` come first in `order_by`.
-            pub const GREATER_THAN: Operator = Operator::new("GREATER_THAN");
+            pub const GREATER_THAN: Operator = Operator::new(3);
 
             /// The given `field` is greater than or equal to the given `value`.
             ///
             /// Requires:
             ///
             /// * That `field` come first in `order_by`.
-            pub const GREATER_THAN_OR_EQUAL: Operator = Operator::new("GREATER_THAN_OR_EQUAL");
+            pub const GREATER_THAN_OR_EQUAL: Operator = Operator::new(4);
 
             /// The given `field` is equal to the given `value`.
-            pub const EQUAL: Operator = Operator::new("EQUAL");
+            pub const EQUAL: Operator = Operator::new(5);
 
             /// The given `field` is not equal to the given `value`.
             ///
@@ -5384,10 +5403,10 @@ pub mod structured_query {
             ///
             /// * No other `NOT_EQUAL`, `NOT_IN`, `IS_NOT_NULL`, or `IS_NOT_NAN`.
             /// * That `field` comes first in the `order_by`.
-            pub const NOT_EQUAL: Operator = Operator::new("NOT_EQUAL");
+            pub const NOT_EQUAL: Operator = Operator::new(6);
 
             /// The given `field` is an array that contains the given `value`.
-            pub const ARRAY_CONTAINS: Operator = Operator::new("ARRAY_CONTAINS");
+            pub const ARRAY_CONTAINS: Operator = Operator::new(7);
 
             /// The given `field` is equal to at least one value in the given array.
             ///
@@ -5396,7 +5415,7 @@ pub mod structured_query {
             /// * That `value` is a non-empty `ArrayValue`, subject to disjunction
             ///   limits.
             /// * No `NOT_IN` filters in the same query.
-            pub const IN: Operator = Operator::new("IN");
+            pub const IN: Operator = Operator::new(8);
 
             /// The given `field` is an array that contains any of the values in the
             /// given array.
@@ -5407,7 +5426,7 @@ pub mod structured_query {
             ///   limits.
             /// * No other `ARRAY_CONTAINS_ANY` filters within the same disjunction.
             /// * No `NOT_IN` filters in the same query.
-            pub const ARRAY_CONTAINS_ANY: Operator = Operator::new("ARRAY_CONTAINS_ANY");
+            pub const ARRAY_CONTAINS_ANY: Operator = Operator::new(9);
 
             /// The value of the `field` is not in the given array.
             ///
@@ -5417,18 +5436,66 @@ pub mod structured_query {
             /// * No other `OR`, `IN`, `ARRAY_CONTAINS_ANY`, `NOT_IN`, `NOT_EQUAL`,
             ///   `IS_NOT_NULL`, or `IS_NOT_NAN`.
             /// * That `field` comes first in the `order_by`.
-            pub const NOT_IN: Operator = Operator::new("NOT_IN");
+            pub const NOT_IN: Operator = Operator::new(10);
+
+            /// Creates a new Operator instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("OPERATOR_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("LESS_THAN"),
+                    2 => std::borrow::Cow::Borrowed("LESS_THAN_OR_EQUAL"),
+                    3 => std::borrow::Cow::Borrowed("GREATER_THAN"),
+                    4 => std::borrow::Cow::Borrowed("GREATER_THAN_OR_EQUAL"),
+                    5 => std::borrow::Cow::Borrowed("EQUAL"),
+                    6 => std::borrow::Cow::Borrowed("NOT_EQUAL"),
+                    7 => std::borrow::Cow::Borrowed("ARRAY_CONTAINS"),
+                    8 => std::borrow::Cow::Borrowed("IN"),
+                    9 => std::borrow::Cow::Borrowed("ARRAY_CONTAINS_ANY"),
+                    10 => std::borrow::Cow::Borrowed("NOT_IN"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "OPERATOR_UNSPECIFIED" => std::option::Option::Some(Self::OPERATOR_UNSPECIFIED),
+                    "LESS_THAN" => std::option::Option::Some(Self::LESS_THAN),
+                    "LESS_THAN_OR_EQUAL" => std::option::Option::Some(Self::LESS_THAN_OR_EQUAL),
+                    "GREATER_THAN" => std::option::Option::Some(Self::GREATER_THAN),
+                    "GREATER_THAN_OR_EQUAL" => {
+                        std::option::Option::Some(Self::GREATER_THAN_OR_EQUAL)
+                    }
+                    "EQUAL" => std::option::Option::Some(Self::EQUAL),
+                    "NOT_EQUAL" => std::option::Option::Some(Self::NOT_EQUAL),
+                    "ARRAY_CONTAINS" => std::option::Option::Some(Self::ARRAY_CONTAINS),
+                    "IN" => std::option::Option::Some(Self::IN),
+                    "ARRAY_CONTAINS_ANY" => std::option::Option::Some(Self::ARRAY_CONTAINS_ANY),
+                    "NOT_IN" => std::option::Option::Some(Self::NOT_IN),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for Operator {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Operator {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Operator {
             fn default() -> Self {
-                operator::OPERATOR_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -5524,32 +5591,17 @@ pub mod structured_query {
 
         /// A unary operator.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Operator(std::borrow::Cow<'static, str>);
+        pub struct Operator(i32);
 
         impl Operator {
-            /// Creates a new Operator instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [Operator](Operator)
-        pub mod operator {
-            use super::Operator;
-
             /// Unspecified. This value must not be used.
-            pub const OPERATOR_UNSPECIFIED: Operator = Operator::new("OPERATOR_UNSPECIFIED");
+            pub const OPERATOR_UNSPECIFIED: Operator = Operator::new(0);
 
             /// The given `field` is equal to `NaN`.
-            pub const IS_NAN: Operator = Operator::new("IS_NAN");
+            pub const IS_NAN: Operator = Operator::new(2);
 
             /// The given `field` is equal to `NULL`.
-            pub const IS_NULL: Operator = Operator::new("IS_NULL");
+            pub const IS_NULL: Operator = Operator::new(3);
 
             /// The given `field` is not equal to `NaN`.
             ///
@@ -5557,7 +5609,7 @@ pub mod structured_query {
             ///
             /// * No other `NOT_EQUAL`, `NOT_IN`, `IS_NOT_NULL`, or `IS_NOT_NAN`.
             /// * That `field` comes first in the `order_by`.
-            pub const IS_NOT_NAN: Operator = Operator::new("IS_NOT_NAN");
+            pub const IS_NOT_NAN: Operator = Operator::new(4);
 
             /// The given `field` is not equal to `NULL`.
             ///
@@ -5565,18 +5617,52 @@ pub mod structured_query {
             ///
             /// * A single `NOT_EQUAL`, `NOT_IN`, `IS_NOT_NULL`, or `IS_NOT_NAN`.
             /// * That `field` comes first in the `order_by`.
-            pub const IS_NOT_NULL: Operator = Operator::new("IS_NOT_NULL");
+            pub const IS_NOT_NULL: Operator = Operator::new(5);
+
+            /// Creates a new Operator instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("OPERATOR_UNSPECIFIED"),
+                    2 => std::borrow::Cow::Borrowed("IS_NAN"),
+                    3 => std::borrow::Cow::Borrowed("IS_NULL"),
+                    4 => std::borrow::Cow::Borrowed("IS_NOT_NAN"),
+                    5 => std::borrow::Cow::Borrowed("IS_NOT_NULL"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "OPERATOR_UNSPECIFIED" => std::option::Option::Some(Self::OPERATOR_UNSPECIFIED),
+                    "IS_NAN" => std::option::Option::Some(Self::IS_NAN),
+                    "IS_NULL" => std::option::Option::Some(Self::IS_NULL),
+                    "IS_NOT_NAN" => std::option::Option::Some(Self::IS_NOT_NAN),
+                    "IS_NOT_NULL" => std::option::Option::Some(Self::IS_NOT_NULL),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for Operator {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Operator {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Operator {
             fn default() -> Self {
-                operator::OPERATOR_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -5837,33 +5923,17 @@ pub mod structured_query {
 
         /// The distance measure to use when comparing vectors.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct DistanceMeasure(std::borrow::Cow<'static, str>);
+        pub struct DistanceMeasure(i32);
 
         impl DistanceMeasure {
-            /// Creates a new DistanceMeasure instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [DistanceMeasure](DistanceMeasure)
-        pub mod distance_measure {
-            use super::DistanceMeasure;
-
             /// Should not be set.
-            pub const DISTANCE_MEASURE_UNSPECIFIED: DistanceMeasure =
-                DistanceMeasure::new("DISTANCE_MEASURE_UNSPECIFIED");
+            pub const DISTANCE_MEASURE_UNSPECIFIED: DistanceMeasure = DistanceMeasure::new(0);
 
             /// Measures the EUCLIDEAN distance between the vectors. See
             /// [Euclidean](https://en.wikipedia.org/wiki/Euclidean_distance) to learn
             /// more. The resulting distance decreases the more similar two vectors
             /// are.
-            pub const EUCLIDEAN: DistanceMeasure = DistanceMeasure::new("EUCLIDEAN");
+            pub const EUCLIDEAN: DistanceMeasure = DistanceMeasure::new(1);
 
             /// COSINE distance compares vectors based on the angle between them, which
             /// allows you to measure similarity that isn't based on the vectors
@@ -5873,66 +5943,115 @@ pub mod structured_query {
             /// Similarity](https://en.wikipedia.org/wiki/Cosine_similarity) to learn
             /// more about COSINE similarity and COSINE distance. The resulting
             /// COSINE distance decreases the more similar two vectors are.
-            pub const COSINE: DistanceMeasure = DistanceMeasure::new("COSINE");
+            pub const COSINE: DistanceMeasure = DistanceMeasure::new(2);
 
             /// Similar to cosine but is affected by the magnitude of the vectors. See
             /// [Dot Product](https://en.wikipedia.org/wiki/Dot_product) to learn more.
             /// The resulting distance increases the more similar two vectors are.
-            pub const DOT_PRODUCT: DistanceMeasure = DistanceMeasure::new("DOT_PRODUCT");
+            pub const DOT_PRODUCT: DistanceMeasure = DistanceMeasure::new(3);
+
+            /// Creates a new DistanceMeasure instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("DISTANCE_MEASURE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("EUCLIDEAN"),
+                    2 => std::borrow::Cow::Borrowed("COSINE"),
+                    3 => std::borrow::Cow::Borrowed("DOT_PRODUCT"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "DISTANCE_MEASURE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::DISTANCE_MEASURE_UNSPECIFIED)
+                    }
+                    "EUCLIDEAN" => std::option::Option::Some(Self::EUCLIDEAN),
+                    "COSINE" => std::option::Option::Some(Self::COSINE),
+                    "DOT_PRODUCT" => std::option::Option::Some(Self::DOT_PRODUCT),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for DistanceMeasure {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for DistanceMeasure {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for DistanceMeasure {
             fn default() -> Self {
-                distance_measure::DISTANCE_MEASURE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// A sort direction.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Direction(std::borrow::Cow<'static, str>);
+    pub struct Direction(i32);
 
     impl Direction {
+        /// Unspecified.
+        pub const DIRECTION_UNSPECIFIED: Direction = Direction::new(0);
+
+        /// Ascending.
+        pub const ASCENDING: Direction = Direction::new(1);
+
+        /// Descending.
+        pub const DESCENDING: Direction = Direction::new(2);
+
         /// Creates a new Direction instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DIRECTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ASCENDING"),
+                2 => std::borrow::Cow::Borrowed("DESCENDING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DIRECTION_UNSPECIFIED" => std::option::Option::Some(Self::DIRECTION_UNSPECIFIED),
+                "ASCENDING" => std::option::Option::Some(Self::ASCENDING),
+                "DESCENDING" => std::option::Option::Some(Self::DESCENDING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Direction](Direction)
-    pub mod direction {
-        use super::Direction;
-
-        /// Unspecified.
-        pub const DIRECTION_UNSPECIFIED: Direction = Direction::new("DIRECTION_UNSPECIFIED");
-
-        /// Ascending.
-        pub const ASCENDING: Direction = Direction::new("ASCENDING");
-
-        /// Descending.
-        pub const DESCENDING: Direction = Direction::new("DESCENDING");
-    }
-
-    impl std::convert::From<std::string::String> for Direction {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Direction {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Direction {
         fn default() -> Self {
-            direction::DIRECTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7144,43 +7263,57 @@ pub mod document_transform {
 
         /// A value that is calculated by the server.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ServerValue(std::borrow::Cow<'static, str>);
+        pub struct ServerValue(i32);
 
         impl ServerValue {
-            /// Creates a new ServerValue instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [ServerValue](ServerValue)
-        pub mod server_value {
-            use super::ServerValue;
-
             /// Unspecified. This value must not be used.
-            pub const SERVER_VALUE_UNSPECIFIED: ServerValue =
-                ServerValue::new("SERVER_VALUE_UNSPECIFIED");
+            pub const SERVER_VALUE_UNSPECIFIED: ServerValue = ServerValue::new(0);
 
             /// The time at which the server processed the request, with millisecond
             /// precision. If used on multiple fields (same or different documents) in
             /// a transaction, all the fields will get the same server timestamp.
-            pub const REQUEST_TIME: ServerValue = ServerValue::new("REQUEST_TIME");
+            pub const REQUEST_TIME: ServerValue = ServerValue::new(1);
+
+            /// Creates a new ServerValue instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("SERVER_VALUE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("REQUEST_TIME"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "SERVER_VALUE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::SERVER_VALUE_UNSPECIFIED)
+                    }
+                    "REQUEST_TIME" => std::option::Option::Some(Self::REQUEST_TIME),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for ServerValue {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for ServerValue {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for ServerValue {
             fn default() -> Self {
-                server_value::SERVER_VALUE_UNSPECIFIED
+                Self::new(0)
             }
         }
 

--- a/src/generated/api/apikeys/v2/src/transport.rs
+++ b/src/generated/api/apikeys/v2/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::ApiKeys for ApiKeys {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}/keys", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -67,7 +67,7 @@ impl crate::stubs::ApiKeys for ApiKeys {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/keys", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -89,7 +89,7 @@ impl crate::stubs::ApiKeys for ApiKeys {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -108,7 +108,7 @@ impl crate::stubs::ApiKeys for ApiKeys {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/keyString", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -136,7 +136,7 @@ impl crate::stubs::ApiKeys for ApiKeys {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -163,7 +163,7 @@ impl crate::stubs::ApiKeys for ApiKeys {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -183,7 +183,7 @@ impl crate::stubs::ApiKeys for ApiKeys {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:undelete", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -200,7 +200,7 @@ impl crate::stubs::ApiKeys for ApiKeys {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v2/keys:lookupKey".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -220,7 +220,7 @@ impl crate::stubs::ApiKeys for ApiKeys {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/api/servicecontrol/v1/src/model.rs
+++ b/src/generated/api/servicecontrol/v1/src/model.rs
@@ -113,105 +113,163 @@ pub mod check_error {
 
     /// Error codes for Check responses.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Code(std::borrow::Cow<'static, str>);
+    pub struct Code(i32);
 
     impl Code {
-        /// Creates a new Code instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Code](Code)
-    pub mod code {
-        use super::Code;
-
         /// This is never used in `CheckResponse`.
-        pub const ERROR_CODE_UNSPECIFIED: Code = Code::new("ERROR_CODE_UNSPECIFIED");
+        pub const ERROR_CODE_UNSPECIFIED: Code = Code::new(0);
 
         /// The consumer's project id, network container, or resource container was
         /// not found. Same as [google.rpc.Code.NOT_FOUND][google.rpc.Code.NOT_FOUND].
-        pub const NOT_FOUND: Code = Code::new("NOT_FOUND");
+        pub const NOT_FOUND: Code = Code::new(5);
 
         /// The consumer doesn't have access to the specified resource.
         /// Same as [google.rpc.Code.PERMISSION_DENIED][google.rpc.Code.PERMISSION_DENIED].
-        pub const PERMISSION_DENIED: Code = Code::new("PERMISSION_DENIED");
+        pub const PERMISSION_DENIED: Code = Code::new(7);
 
         /// Quota check failed. Same as [google.rpc.Code.RESOURCE_EXHAUSTED][google.rpc.Code.RESOURCE_EXHAUSTED].
-        pub const RESOURCE_EXHAUSTED: Code = Code::new("RESOURCE_EXHAUSTED");
+        pub const RESOURCE_EXHAUSTED: Code = Code::new(8);
 
         /// The consumer hasn't activated the service.
-        pub const SERVICE_NOT_ACTIVATED: Code = Code::new("SERVICE_NOT_ACTIVATED");
+        pub const SERVICE_NOT_ACTIVATED: Code = Code::new(104);
 
         /// The consumer cannot access the service because billing is disabled.
-        pub const BILLING_DISABLED: Code = Code::new("BILLING_DISABLED");
+        pub const BILLING_DISABLED: Code = Code::new(107);
 
         /// The consumer's project has been marked as deleted (soft deletion).
-        pub const PROJECT_DELETED: Code = Code::new("PROJECT_DELETED");
+        pub const PROJECT_DELETED: Code = Code::new(108);
 
         /// The consumer's project number or id does not represent a valid project.
-        pub const PROJECT_INVALID: Code = Code::new("PROJECT_INVALID");
+        pub const PROJECT_INVALID: Code = Code::new(114);
 
         /// The input consumer info does not represent a valid consumer folder or
         /// organization.
-        pub const CONSUMER_INVALID: Code = Code::new("CONSUMER_INVALID");
+        pub const CONSUMER_INVALID: Code = Code::new(125);
 
         /// The IP address of the consumer is invalid for the specific consumer
         /// project.
-        pub const IP_ADDRESS_BLOCKED: Code = Code::new("IP_ADDRESS_BLOCKED");
+        pub const IP_ADDRESS_BLOCKED: Code = Code::new(109);
 
         /// The referer address of the consumer request is invalid for the specific
         /// consumer project.
-        pub const REFERER_BLOCKED: Code = Code::new("REFERER_BLOCKED");
+        pub const REFERER_BLOCKED: Code = Code::new(110);
 
         /// The client application of the consumer request is invalid for the
         /// specific consumer project.
-        pub const CLIENT_APP_BLOCKED: Code = Code::new("CLIENT_APP_BLOCKED");
+        pub const CLIENT_APP_BLOCKED: Code = Code::new(111);
 
         /// The API targeted by this request is invalid for the specified consumer
         /// project.
-        pub const API_TARGET_BLOCKED: Code = Code::new("API_TARGET_BLOCKED");
+        pub const API_TARGET_BLOCKED: Code = Code::new(122);
 
         /// The consumer's API key is invalid.
-        pub const API_KEY_INVALID: Code = Code::new("API_KEY_INVALID");
+        pub const API_KEY_INVALID: Code = Code::new(105);
 
         /// The consumer's API Key has expired.
-        pub const API_KEY_EXPIRED: Code = Code::new("API_KEY_EXPIRED");
+        pub const API_KEY_EXPIRED: Code = Code::new(112);
 
         /// The consumer's API Key was not found in config record.
-        pub const API_KEY_NOT_FOUND: Code = Code::new("API_KEY_NOT_FOUND");
+        pub const API_KEY_NOT_FOUND: Code = Code::new(113);
 
         /// The credential in the request can not be verified.
-        pub const INVALID_CREDENTIAL: Code = Code::new("INVALID_CREDENTIAL");
+        pub const INVALID_CREDENTIAL: Code = Code::new(123);
 
         /// The backend server for looking up project id/number is unavailable.
-        pub const NAMESPACE_LOOKUP_UNAVAILABLE: Code = Code::new("NAMESPACE_LOOKUP_UNAVAILABLE");
+        pub const NAMESPACE_LOOKUP_UNAVAILABLE: Code = Code::new(300);
 
         /// The backend server for checking service status is unavailable.
-        pub const SERVICE_STATUS_UNAVAILABLE: Code = Code::new("SERVICE_STATUS_UNAVAILABLE");
+        pub const SERVICE_STATUS_UNAVAILABLE: Code = Code::new(301);
 
         /// The backend server for checking billing status is unavailable.
-        pub const BILLING_STATUS_UNAVAILABLE: Code = Code::new("BILLING_STATUS_UNAVAILABLE");
+        pub const BILLING_STATUS_UNAVAILABLE: Code = Code::new(302);
 
         /// Cloud Resource Manager backend server is unavailable.
-        pub const CLOUD_RESOURCE_MANAGER_BACKEND_UNAVAILABLE: Code =
-            Code::new("CLOUD_RESOURCE_MANAGER_BACKEND_UNAVAILABLE");
+        pub const CLOUD_RESOURCE_MANAGER_BACKEND_UNAVAILABLE: Code = Code::new(305);
+
+        /// Creates a new Code instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ERROR_CODE_UNSPECIFIED"),
+                5 => std::borrow::Cow::Borrowed("NOT_FOUND"),
+                7 => std::borrow::Cow::Borrowed("PERMISSION_DENIED"),
+                8 => std::borrow::Cow::Borrowed("RESOURCE_EXHAUSTED"),
+                104 => std::borrow::Cow::Borrowed("SERVICE_NOT_ACTIVATED"),
+                105 => std::borrow::Cow::Borrowed("API_KEY_INVALID"),
+                107 => std::borrow::Cow::Borrowed("BILLING_DISABLED"),
+                108 => std::borrow::Cow::Borrowed("PROJECT_DELETED"),
+                109 => std::borrow::Cow::Borrowed("IP_ADDRESS_BLOCKED"),
+                110 => std::borrow::Cow::Borrowed("REFERER_BLOCKED"),
+                111 => std::borrow::Cow::Borrowed("CLIENT_APP_BLOCKED"),
+                112 => std::borrow::Cow::Borrowed("API_KEY_EXPIRED"),
+                113 => std::borrow::Cow::Borrowed("API_KEY_NOT_FOUND"),
+                114 => std::borrow::Cow::Borrowed("PROJECT_INVALID"),
+                122 => std::borrow::Cow::Borrowed("API_TARGET_BLOCKED"),
+                123 => std::borrow::Cow::Borrowed("INVALID_CREDENTIAL"),
+                125 => std::borrow::Cow::Borrowed("CONSUMER_INVALID"),
+                300 => std::borrow::Cow::Borrowed("NAMESPACE_LOOKUP_UNAVAILABLE"),
+                301 => std::borrow::Cow::Borrowed("SERVICE_STATUS_UNAVAILABLE"),
+                302 => std::borrow::Cow::Borrowed("BILLING_STATUS_UNAVAILABLE"),
+                305 => std::borrow::Cow::Borrowed("CLOUD_RESOURCE_MANAGER_BACKEND_UNAVAILABLE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ERROR_CODE_UNSPECIFIED" => std::option::Option::Some(Self::ERROR_CODE_UNSPECIFIED),
+                "NOT_FOUND" => std::option::Option::Some(Self::NOT_FOUND),
+                "PERMISSION_DENIED" => std::option::Option::Some(Self::PERMISSION_DENIED),
+                "RESOURCE_EXHAUSTED" => std::option::Option::Some(Self::RESOURCE_EXHAUSTED),
+                "SERVICE_NOT_ACTIVATED" => std::option::Option::Some(Self::SERVICE_NOT_ACTIVATED),
+                "BILLING_DISABLED" => std::option::Option::Some(Self::BILLING_DISABLED),
+                "PROJECT_DELETED" => std::option::Option::Some(Self::PROJECT_DELETED),
+                "PROJECT_INVALID" => std::option::Option::Some(Self::PROJECT_INVALID),
+                "CONSUMER_INVALID" => std::option::Option::Some(Self::CONSUMER_INVALID),
+                "IP_ADDRESS_BLOCKED" => std::option::Option::Some(Self::IP_ADDRESS_BLOCKED),
+                "REFERER_BLOCKED" => std::option::Option::Some(Self::REFERER_BLOCKED),
+                "CLIENT_APP_BLOCKED" => std::option::Option::Some(Self::CLIENT_APP_BLOCKED),
+                "API_TARGET_BLOCKED" => std::option::Option::Some(Self::API_TARGET_BLOCKED),
+                "API_KEY_INVALID" => std::option::Option::Some(Self::API_KEY_INVALID),
+                "API_KEY_EXPIRED" => std::option::Option::Some(Self::API_KEY_EXPIRED),
+                "API_KEY_NOT_FOUND" => std::option::Option::Some(Self::API_KEY_NOT_FOUND),
+                "INVALID_CREDENTIAL" => std::option::Option::Some(Self::INVALID_CREDENTIAL),
+                "NAMESPACE_LOOKUP_UNAVAILABLE" => {
+                    std::option::Option::Some(Self::NAMESPACE_LOOKUP_UNAVAILABLE)
+                }
+                "SERVICE_STATUS_UNAVAILABLE" => {
+                    std::option::Option::Some(Self::SERVICE_STATUS_UNAVAILABLE)
+                }
+                "BILLING_STATUS_UNAVAILABLE" => {
+                    std::option::Option::Some(Self::BILLING_STATUS_UNAVAILABLE)
+                }
+                "CLOUD_RESOURCE_MANAGER_BACKEND_UNAVAILABLE" => {
+                    std::option::Option::Some(Self::CLOUD_RESOURCE_MANAGER_BACKEND_UNAVAILABLE)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Code {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Code {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Code {
         fn default() -> Self {
-            code::ERROR_CODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1711,43 +1769,56 @@ pub mod operation {
 
     /// Defines the importance of the data contained in the operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Importance(std::borrow::Cow<'static, str>);
+    pub struct Importance(i32);
 
     impl Importance {
-        /// Creates a new Importance instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Importance](Importance)
-    pub mod importance {
-        use super::Importance;
-
         /// Allows data caching, batching, and aggregation. It provides
         /// higher performance with higher data loss risk.
-        pub const LOW: Importance = Importance::new("LOW");
+        pub const LOW: Importance = Importance::new(0);
 
         /// Disables data aggregation to minimize data loss. It is for operations
         /// that contains significant monetary value or audit trail. This feature
         /// only applies to the client libraries.
-        pub const HIGH: Importance = Importance::new("HIGH");
+        pub const HIGH: Importance = Importance::new(1);
+
+        /// Creates a new Importance instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LOW"),
+                1 => std::borrow::Cow::Borrowed("HIGH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LOW" => std::option::Option::Some(Self::LOW),
+                "HIGH" => std::option::Option::Some(Self::HIGH),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Importance {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Importance {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Importance {
         fn default() -> Self {
-            importance::LOW
+            Self::new(0)
         }
     }
 }
@@ -1946,26 +2017,11 @@ pub mod quota_operation {
 
     /// Supported quota modes.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct QuotaMode(std::borrow::Cow<'static, str>);
+    pub struct QuotaMode(i32);
 
     impl QuotaMode {
-        /// Creates a new QuotaMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [QuotaMode](QuotaMode)
-    pub mod quota_mode {
-        use super::QuotaMode;
-
         /// Guard against implicit default. Must not be used.
-        pub const UNSPECIFIED: QuotaMode = QuotaMode::new("UNSPECIFIED");
+        pub const UNSPECIFIED: QuotaMode = QuotaMode::new(0);
 
         /// For AllocateQuota request, allocates quota for the amount specified in
         /// the service configuration or specified using the quota metrics. If the
@@ -1973,7 +2029,7 @@ pub mod quota_operation {
         /// returned and no quota will be allocated.
         /// If multiple quotas are part of the request, and one fails, none of the
         /// quotas are allocated or released.
-        pub const NORMAL: QuotaMode = QuotaMode::new("NORMAL");
+        pub const NORMAL: QuotaMode = QuotaMode::new(1);
 
         /// The operation allocates quota for the amount specified in the service
         /// configuration or specified using the quota metrics. If the amount is
@@ -1983,37 +2039,73 @@ pub mod quota_operation {
         /// even if one does not have enough quota. For allocation, it will find the
         /// minimum available amount across all groups and deduct that amount from
         /// all the affected groups.
-        pub const BEST_EFFORT: QuotaMode = QuotaMode::new("BEST_EFFORT");
+        pub const BEST_EFFORT: QuotaMode = QuotaMode::new(2);
 
         /// For AllocateQuota request, only checks if there is enough quota
         /// available and does not change the available quota. No lock is placed on
         /// the available quota either.
-        pub const CHECK_ONLY: QuotaMode = QuotaMode::new("CHECK_ONLY");
+        pub const CHECK_ONLY: QuotaMode = QuotaMode::new(3);
 
         /// Unimplemented. When used in AllocateQuotaRequest, this returns the
         /// effective quota limit(s) in the response, and no quota check will be
         /// performed. Not supported for other requests, and even for
         /// AllocateQuotaRequest, this is currently supported only for allowlisted
         /// services.
-        pub const QUERY_ONLY: QuotaMode = QuotaMode::new("QUERY_ONLY");
+        pub const QUERY_ONLY: QuotaMode = QuotaMode::new(4);
 
         /// The operation allocates quota for the amount specified in the service
         /// configuration or specified using the quota metrics. If the requested
         /// amount is higher than the available quota, request does not fail and
         /// remaining quota would become negative (going over the limit).
         /// Not supported for Rate Quota.
-        pub const ADJUST_ONLY: QuotaMode = QuotaMode::new("ADJUST_ONLY");
+        pub const ADJUST_ONLY: QuotaMode = QuotaMode::new(5);
+
+        /// Creates a new QuotaMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NORMAL"),
+                2 => std::borrow::Cow::Borrowed("BEST_EFFORT"),
+                3 => std::borrow::Cow::Borrowed("CHECK_ONLY"),
+                4 => std::borrow::Cow::Borrowed("QUERY_ONLY"),
+                5 => std::borrow::Cow::Borrowed("ADJUST_ONLY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
+                "NORMAL" => std::option::Option::Some(Self::NORMAL),
+                "BEST_EFFORT" => std::option::Option::Some(Self::BEST_EFFORT),
+                "CHECK_ONLY" => std::option::Option::Some(Self::CHECK_ONLY),
+                "QUERY_ONLY" => std::option::Option::Some(Self::QUERY_ONLY),
+                "ADJUST_ONLY" => std::option::Option::Some(Self::ADJUST_ONLY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for QuotaMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for QuotaMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for QuotaMode {
         fn default() -> Self {
-            quota_mode::UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2181,54 +2273,75 @@ pub mod quota_error {
     /// these validations before calling the quota controller methods. These
     /// methods check only for project deletion to be wipe out compliant.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Code(std::borrow::Cow<'static, str>);
+    pub struct Code(i32);
 
     impl Code {
-        /// Creates a new Code instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Code](Code)
-    pub mod code {
-        use super::Code;
-
         /// This is never used.
-        pub const UNSPECIFIED: Code = Code::new("UNSPECIFIED");
+        pub const UNSPECIFIED: Code = Code::new(0);
 
         /// Quota allocation failed.
         /// Same as [google.rpc.Code.RESOURCE_EXHAUSTED][google.rpc.Code.RESOURCE_EXHAUSTED].
-        pub const RESOURCE_EXHAUSTED: Code = Code::new("RESOURCE_EXHAUSTED");
+        pub const RESOURCE_EXHAUSTED: Code = Code::new(8);
 
         /// Consumer cannot access the service because the service requires active
         /// billing.
-        pub const BILLING_NOT_ACTIVE: Code = Code::new("BILLING_NOT_ACTIVE");
+        pub const BILLING_NOT_ACTIVE: Code = Code::new(107);
 
         /// Consumer's project has been marked as deleted (soft deletion).
-        pub const PROJECT_DELETED: Code = Code::new("PROJECT_DELETED");
+        pub const PROJECT_DELETED: Code = Code::new(108);
 
         /// Specified API key is invalid.
-        pub const API_KEY_INVALID: Code = Code::new("API_KEY_INVALID");
+        pub const API_KEY_INVALID: Code = Code::new(105);
 
         /// Specified API Key has expired.
-        pub const API_KEY_EXPIRED: Code = Code::new("API_KEY_EXPIRED");
+        pub const API_KEY_EXPIRED: Code = Code::new(112);
+
+        /// Creates a new Code instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
+                8 => std::borrow::Cow::Borrowed("RESOURCE_EXHAUSTED"),
+                105 => std::borrow::Cow::Borrowed("API_KEY_INVALID"),
+                107 => std::borrow::Cow::Borrowed("BILLING_NOT_ACTIVE"),
+                108 => std::borrow::Cow::Borrowed("PROJECT_DELETED"),
+                112 => std::borrow::Cow::Borrowed("API_KEY_EXPIRED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
+                "RESOURCE_EXHAUSTED" => std::option::Option::Some(Self::RESOURCE_EXHAUSTED),
+                "BILLING_NOT_ACTIVE" => std::option::Option::Some(Self::BILLING_NOT_ACTIVE),
+                "PROJECT_DELETED" => std::option::Option::Some(Self::PROJECT_DELETED),
+                "API_KEY_INVALID" => std::option::Option::Some(Self::API_KEY_INVALID),
+                "API_KEY_EXPIRED" => std::option::Option::Some(Self::API_KEY_EXPIRED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Code {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Code {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Code {
         fn default() -> Self {
-            code::UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2527,52 +2640,72 @@ pub mod check_response {
         /// The type of the consumer as defined in
         /// [Google Resource Manager](https://cloud.google.com/resource-manager/).
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ConsumerType(std::borrow::Cow<'static, str>);
+        pub struct ConsumerType(i32);
 
         impl ConsumerType {
-            /// Creates a new ConsumerType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [ConsumerType](ConsumerType)
-        pub mod consumer_type {
-            use super::ConsumerType;
-
             /// This is never used.
-            pub const CONSUMER_TYPE_UNSPECIFIED: ConsumerType =
-                ConsumerType::new("CONSUMER_TYPE_UNSPECIFIED");
+            pub const CONSUMER_TYPE_UNSPECIFIED: ConsumerType = ConsumerType::new(0);
 
             /// The consumer is a Google Cloud Project.
-            pub const PROJECT: ConsumerType = ConsumerType::new("PROJECT");
+            pub const PROJECT: ConsumerType = ConsumerType::new(1);
 
             /// The consumer is a Google Cloud Folder.
-            pub const FOLDER: ConsumerType = ConsumerType::new("FOLDER");
+            pub const FOLDER: ConsumerType = ConsumerType::new(2);
 
             /// The consumer is a Google Cloud Organization.
-            pub const ORGANIZATION: ConsumerType = ConsumerType::new("ORGANIZATION");
+            pub const ORGANIZATION: ConsumerType = ConsumerType::new(3);
 
             /// Service-specific resource container which is defined by the service
             /// producer to offer their users the ability to manage service control
             /// functionalities at a finer level of granularity than the PROJECT.
-            pub const SERVICE_SPECIFIC: ConsumerType = ConsumerType::new("SERVICE_SPECIFIC");
+            pub const SERVICE_SPECIFIC: ConsumerType = ConsumerType::new(4);
+
+            /// Creates a new ConsumerType instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("CONSUMER_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("PROJECT"),
+                    2 => std::borrow::Cow::Borrowed("FOLDER"),
+                    3 => std::borrow::Cow::Borrowed("ORGANIZATION"),
+                    4 => std::borrow::Cow::Borrowed("SERVICE_SPECIFIC"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "CONSUMER_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::CONSUMER_TYPE_UNSPECIFIED)
+                    }
+                    "PROJECT" => std::option::Option::Some(Self::PROJECT),
+                    "FOLDER" => std::option::Option::Some(Self::FOLDER),
+                    "ORGANIZATION" => std::option::Option::Some(Self::ORGANIZATION),
+                    "SERVICE_SPECIFIC" => std::option::Option::Some(Self::SERVICE_SPECIFIC),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for ConsumerType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for ConsumerType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for ConsumerType {
             fn default() -> Self {
-                consumer_type::CONSUMER_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }

--- a/src/generated/api/servicecontrol/v1/src/transport.rs
+++ b/src/generated/api/servicecontrol/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::QuotaController for QuotaController {
                 reqwest::Method::POST,
                 format!("/v1/services/{}:allocateQuota", req.service_name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -95,7 +95,7 @@ impl crate::stubs::ServiceController for ServiceController {
                 reqwest::Method::POST,
                 format!("/v1/services/{}:check", req.service_name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -115,7 +115,7 @@ impl crate::stubs::ServiceController for ServiceController {
                 reqwest::Method::POST,
                 format!("/v1/services/{}:report", req.service_name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/api/servicecontrol/v2/src/transport.rs
+++ b/src/generated/api/servicecontrol/v2/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::ServiceController for ServiceController {
                 reqwest::Method::POST,
                 format!("/v2/services/{}:check", req.service_name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::ServiceController for ServiceController {
                 reqwest::Method::POST,
                 format!("/v2/services/{}:report", req.service_name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/api/servicemanagement/v1/src/model.rs
+++ b/src/generated/api/servicemanagement/v1/src/model.rs
@@ -198,53 +198,74 @@ pub mod operation_metadata {
 
     /// Code describes the status of the operation (or one of its steps).
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(std::borrow::Cow<'static, str>);
+    pub struct Status(i32);
 
     impl Status {
-        /// Creates a new Status instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Status](Status)
-    pub mod status {
-        use super::Status;
-
         /// Unspecifed code.
-        pub const STATUS_UNSPECIFIED: Status = Status::new("STATUS_UNSPECIFIED");
+        pub const STATUS_UNSPECIFIED: Status = Status::new(0);
 
         /// The operation or step has completed without errors.
-        pub const DONE: Status = Status::new("DONE");
+        pub const DONE: Status = Status::new(1);
 
         /// The operation or step has not started yet.
-        pub const NOT_STARTED: Status = Status::new("NOT_STARTED");
+        pub const NOT_STARTED: Status = Status::new(2);
 
         /// The operation or step is in progress.
-        pub const IN_PROGRESS: Status = Status::new("IN_PROGRESS");
+        pub const IN_PROGRESS: Status = Status::new(3);
 
         /// The operation or step has completed with errors. If the operation is
         /// rollbackable, the rollback completed with errors too.
-        pub const FAILED: Status = Status::new("FAILED");
+        pub const FAILED: Status = Status::new(4);
 
         /// The operation or step has completed with cancellation.
-        pub const CANCELLED: Status = Status::new("CANCELLED");
+        pub const CANCELLED: Status = Status::new(5);
+
+        /// Creates a new Status instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATUS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DONE"),
+                2 => std::borrow::Cow::Borrowed("NOT_STARTED"),
+                3 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                5 => std::borrow::Cow::Borrowed("CANCELLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATUS_UNSPECIFIED" => std::option::Option::Some(Self::STATUS_UNSPECIFIED),
+                "DONE" => std::option::Option::Some(Self::DONE),
+                "NOT_STARTED" => std::option::Option::Some(Self::NOT_STARTED),
+                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Status {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            status::STATUS_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -304,40 +325,53 @@ pub mod diagnostic {
 
     /// The kind of diagnostic information possible.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Kind(std::borrow::Cow<'static, str>);
+    pub struct Kind(i32);
 
     impl Kind {
+        /// Warnings and errors
+        pub const WARNING: Kind = Kind::new(0);
+
+        /// Only errors
+        pub const ERROR: Kind = Kind::new(1);
+
         /// Creates a new Kind instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("WARNING"),
+                1 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "WARNING" => std::option::Option::Some(Self::WARNING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Kind](Kind)
-    pub mod kind {
-        use super::Kind;
-
-        /// Warnings and errors
-        pub const WARNING: Kind = Kind::new("WARNING");
-
-        /// Only errors
-        pub const ERROR: Kind = Kind::new("ERROR");
-    }
-
-    impl std::convert::From<std::string::String> for Kind {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Kind {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Kind {
         fn default() -> Self {
-            kind::WARNING
+            Self::new(0)
         }
     }
 }
@@ -448,35 +482,20 @@ pub mod config_file {
     use super::*;
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FileType(std::borrow::Cow<'static, str>);
+    pub struct FileType(i32);
 
     impl FileType {
-        /// Creates a new FileType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [FileType](FileType)
-    pub mod file_type {
-        use super::FileType;
-
         /// Unknown file type.
-        pub const FILE_TYPE_UNSPECIFIED: FileType = FileType::new("FILE_TYPE_UNSPECIFIED");
+        pub const FILE_TYPE_UNSPECIFIED: FileType = FileType::new(0);
 
         /// YAML-specification of service.
-        pub const SERVICE_CONFIG_YAML: FileType = FileType::new("SERVICE_CONFIG_YAML");
+        pub const SERVICE_CONFIG_YAML: FileType = FileType::new(1);
 
         /// OpenAPI specification, serialized in JSON.
-        pub const OPEN_API_JSON: FileType = FileType::new("OPEN_API_JSON");
+        pub const OPEN_API_JSON: FileType = FileType::new(2);
 
         /// OpenAPI specification, serialized in YAML.
-        pub const OPEN_API_YAML: FileType = FileType::new("OPEN_API_YAML");
+        pub const OPEN_API_YAML: FileType = FileType::new(3);
 
         /// FileDescriptorSet, generated by protoc.
         ///
@@ -485,25 +504,63 @@ pub mod config_file {
         /// in a new file named out.pb.
         ///
         /// $protoc --include_imports --include_source_info test.proto -o out.pb
-        pub const FILE_DESCRIPTOR_SET_PROTO: FileType = FileType::new("FILE_DESCRIPTOR_SET_PROTO");
+        pub const FILE_DESCRIPTOR_SET_PROTO: FileType = FileType::new(4);
 
         /// Uncompiled Proto file. Used for storage and display purposes only,
         /// currently server-side compilation is not supported. Should match the
         /// inputs to 'protoc' command used to generated FILE_DESCRIPTOR_SET_PROTO. A
         /// file of this type can only be included if at least one file of type
         /// FILE_DESCRIPTOR_SET_PROTO is included.
-        pub const PROTO_FILE: FileType = FileType::new("PROTO_FILE");
+        pub const PROTO_FILE: FileType = FileType::new(6);
+
+        /// Creates a new FileType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FILE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SERVICE_CONFIG_YAML"),
+                2 => std::borrow::Cow::Borrowed("OPEN_API_JSON"),
+                3 => std::borrow::Cow::Borrowed("OPEN_API_YAML"),
+                4 => std::borrow::Cow::Borrowed("FILE_DESCRIPTOR_SET_PROTO"),
+                6 => std::borrow::Cow::Borrowed("PROTO_FILE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FILE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::FILE_TYPE_UNSPECIFIED),
+                "SERVICE_CONFIG_YAML" => std::option::Option::Some(Self::SERVICE_CONFIG_YAML),
+                "OPEN_API_JSON" => std::option::Option::Some(Self::OPEN_API_JSON),
+                "OPEN_API_YAML" => std::option::Option::Some(Self::OPEN_API_YAML),
+                "FILE_DESCRIPTOR_SET_PROTO" => {
+                    std::option::Option::Some(Self::FILE_DESCRIPTOR_SET_PROTO)
+                }
+                "PROTO_FILE" => std::option::Option::Some(Self::PROTO_FILE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for FileType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for FileType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for FileType {
         fn default() -> Self {
-            file_type::FILE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -843,58 +900,82 @@ pub mod rollout {
 
     /// Status of a Rollout.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RolloutStatus(std::borrow::Cow<'static, str>);
+    pub struct RolloutStatus(i32);
 
     impl RolloutStatus {
-        /// Creates a new RolloutStatus instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RolloutStatus](RolloutStatus)
-    pub mod rollout_status {
-        use super::RolloutStatus;
-
         /// No status specified.
-        pub const ROLLOUT_STATUS_UNSPECIFIED: RolloutStatus =
-            RolloutStatus::new("ROLLOUT_STATUS_UNSPECIFIED");
+        pub const ROLLOUT_STATUS_UNSPECIFIED: RolloutStatus = RolloutStatus::new(0);
 
         /// The Rollout is in progress.
-        pub const IN_PROGRESS: RolloutStatus = RolloutStatus::new("IN_PROGRESS");
+        pub const IN_PROGRESS: RolloutStatus = RolloutStatus::new(1);
 
         /// The Rollout has completed successfully.
-        pub const SUCCESS: RolloutStatus = RolloutStatus::new("SUCCESS");
+        pub const SUCCESS: RolloutStatus = RolloutStatus::new(2);
 
         /// The Rollout has been cancelled. This can happen if you have overlapping
         /// Rollout pushes, and the previous ones will be cancelled.
-        pub const CANCELLED: RolloutStatus = RolloutStatus::new("CANCELLED");
+        pub const CANCELLED: RolloutStatus = RolloutStatus::new(3);
 
         /// The Rollout has failed and the rollback attempt has failed too.
-        pub const FAILED: RolloutStatus = RolloutStatus::new("FAILED");
+        pub const FAILED: RolloutStatus = RolloutStatus::new(4);
 
         /// The Rollout has not started yet and is pending for execution.
-        pub const PENDING: RolloutStatus = RolloutStatus::new("PENDING");
+        pub const PENDING: RolloutStatus = RolloutStatus::new(5);
 
         /// The Rollout has failed and rolled back to the previous successful
         /// Rollout.
-        pub const FAILED_ROLLED_BACK: RolloutStatus = RolloutStatus::new("FAILED_ROLLED_BACK");
+        pub const FAILED_ROLLED_BACK: RolloutStatus = RolloutStatus::new(6);
+
+        /// Creates a new RolloutStatus instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ROLLOUT_STATUS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                2 => std::borrow::Cow::Borrowed("SUCCESS"),
+                3 => std::borrow::Cow::Borrowed("CANCELLED"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                5 => std::borrow::Cow::Borrowed("PENDING"),
+                6 => std::borrow::Cow::Borrowed("FAILED_ROLLED_BACK"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ROLLOUT_STATUS_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ROLLOUT_STATUS_UNSPECIFIED)
+                }
+                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                "SUCCESS" => std::option::Option::Some(Self::SUCCESS),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "FAILED_ROLLED_BACK" => std::option::Option::Some(Self::FAILED_ROLLED_BACK),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RolloutStatus {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RolloutStatus {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RolloutStatus {
         fn default() -> Self {
-            rollout_status::ROLLOUT_STATUS_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1258,43 +1339,56 @@ pub mod get_service_config_request {
     use super::*;
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConfigView(std::borrow::Cow<'static, str>);
+    pub struct ConfigView(i32);
 
     impl ConfigView {
-        /// Creates a new ConfigView instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ConfigView](ConfigView)
-    pub mod config_view {
-        use super::ConfigView;
-
         /// Server response includes all fields except SourceInfo.
-        pub const BASIC: ConfigView = ConfigView::new("BASIC");
+        pub const BASIC: ConfigView = ConfigView::new(0);
 
         /// Server response includes all fields including SourceInfo.
         /// SourceFiles are of type 'google.api.servicemanagement.v1.ConfigFile'
         /// and are only available for configs created using the
         /// SubmitConfigSource method.
-        pub const FULL: ConfigView = ConfigView::new("FULL");
+        pub const FULL: ConfigView = ConfigView::new(1);
+
+        /// Creates a new ConfigView instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("BASIC"),
+                1 => std::borrow::Cow::Borrowed("FULL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "BASIC" => std::option::Option::Some(Self::BASIC),
+                "FULL" => std::option::Option::Some(Self::FULL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ConfigView {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ConfigView {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ConfigView {
         fn default() -> Self {
-            config_view::BASIC
+            Self::new(0)
         }
     }
 }

--- a/src/generated/api/servicemanagement/v1/src/transport.rs
+++ b/src/generated/api/servicemanagement/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::ServiceManager for ServiceManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v1/services".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::ServiceManager for ServiceManager {
                 reqwest::Method::GET,
                 format!("/v1/services/{}", req.service_name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -94,7 +94,7 @@ impl crate::stubs::ServiceManager for ServiceManager {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, "/v1/services".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -116,7 +116,7 @@ impl crate::stubs::ServiceManager for ServiceManager {
                 reqwest::Method::DELETE,
                 format!("/v1/services/{}", req.service_name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -138,7 +138,7 @@ impl crate::stubs::ServiceManager for ServiceManager {
                 reqwest::Method::POST,
                 format!("/v1/services/{}:undelete", req.service_name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -160,7 +160,7 @@ impl crate::stubs::ServiceManager for ServiceManager {
                 reqwest::Method::GET,
                 format!("/v1/services/{}/configs", req.service_name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -187,7 +187,7 @@ impl crate::stubs::ServiceManager for ServiceManager {
                     req.service_name, req.config_id
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -210,7 +210,7 @@ impl crate::stubs::ServiceManager for ServiceManager {
                 reqwest::Method::POST,
                 format!("/v1/services/{}/configs", req.service_name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -232,7 +232,7 @@ impl crate::stubs::ServiceManager for ServiceManager {
                 reqwest::Method::POST,
                 format!("/v1/services/{}/configs:submit", req.service_name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -252,7 +252,7 @@ impl crate::stubs::ServiceManager for ServiceManager {
                 reqwest::Method::GET,
                 format!("/v1/services/{}/rollouts", req.service_name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -280,7 +280,7 @@ impl crate::stubs::ServiceManager for ServiceManager {
                     req.service_name, req.rollout_id
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -302,7 +302,7 @@ impl crate::stubs::ServiceManager for ServiceManager {
                 reqwest::Method::POST,
                 format!("/v1/services/{}/rollouts", req.service_name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -324,7 +324,7 @@ impl crate::stubs::ServiceManager for ServiceManager {
                 reqwest::Method::POST,
                 "/v1/services:generateConfigReport".to_string(),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -344,7 +344,7 @@ impl crate::stubs::ServiceManager for ServiceManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -364,7 +364,7 @@ impl crate::stubs::ServiceManager for ServiceManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -384,7 +384,7 @@ impl crate::stubs::ServiceManager for ServiceManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -401,7 +401,7 @@ impl crate::stubs::ServiceManager for ServiceManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v1/operations".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -424,7 +424,7 @@ impl crate::stubs::ServiceManager for ServiceManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/api/serviceusage/v1/src/model.rs
+++ b/src/generated/api/serviceusage/v1/src/model.rs
@@ -444,46 +444,63 @@ pub mod disable_service_request {
     /// Enum to determine if service usage should be checked when disabling a
     /// service.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CheckIfServiceHasUsage(std::borrow::Cow<'static, str>);
+    pub struct CheckIfServiceHasUsage(i32);
 
     impl CheckIfServiceHasUsage {
-        /// Creates a new CheckIfServiceHasUsage instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CheckIfServiceHasUsage](CheckIfServiceHasUsage)
-    pub mod check_if_service_has_usage {
-        use super::CheckIfServiceHasUsage;
-
         /// When unset, the default behavior is used, which is SKIP.
         pub const CHECK_IF_SERVICE_HAS_USAGE_UNSPECIFIED: CheckIfServiceHasUsage =
-            CheckIfServiceHasUsage::new("CHECK_IF_SERVICE_HAS_USAGE_UNSPECIFIED");
+            CheckIfServiceHasUsage::new(0);
 
         /// If set, skip checking service usage when disabling a service.
-        pub const SKIP: CheckIfServiceHasUsage = CheckIfServiceHasUsage::new("SKIP");
+        pub const SKIP: CheckIfServiceHasUsage = CheckIfServiceHasUsage::new(1);
 
         /// If set, service usage is checked when disabling the service. If a
         /// service, or its dependents, has usage in the last 30 days, the request
         /// returns a FAILED_PRECONDITION error.
-        pub const CHECK: CheckIfServiceHasUsage = CheckIfServiceHasUsage::new("CHECK");
+        pub const CHECK: CheckIfServiceHasUsage = CheckIfServiceHasUsage::new(2);
+
+        /// Creates a new CheckIfServiceHasUsage instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CHECK_IF_SERVICE_HAS_USAGE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SKIP"),
+                2 => std::borrow::Cow::Borrowed("CHECK"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CHECK_IF_SERVICE_HAS_USAGE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CHECK_IF_SERVICE_HAS_USAGE_UNSPECIFIED)
+                }
+                "SKIP" => std::option::Option::Some(Self::SKIP),
+                "CHECK" => std::option::Option::Some(Self::CHECK),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CheckIfServiceHasUsage {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CheckIfServiceHasUsage {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CheckIfServiceHasUsage {
         fn default() -> Self {
-            check_if_service_has_usage::CHECK_IF_SERVICE_HAS_USAGE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -926,45 +943,60 @@ impl wkt::message::Message for BatchGetServicesResponse {
 
 /// Whether or not a service has been enabled for use by a consumer.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct State(std::borrow::Cow<'static, str>);
+pub struct State(i32);
 
 impl State {
-    /// Creates a new State instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [State](State)
-pub mod state {
-    use super::State;
-
     /// The default value, which indicates that the enabled state of the service
     /// is unspecified or not meaningful. Currently, all consumers other than
     /// projects (such as folders and organizations) are always in this state.
-    pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+    pub const STATE_UNSPECIFIED: State = State::new(0);
 
     /// The service cannot be used by this consumer. It has either been explicitly
     /// disabled, or has never been enabled.
-    pub const DISABLED: State = State::new("DISABLED");
+    pub const DISABLED: State = State::new(1);
 
     /// The service has been explicitly enabled for use by this consumer.
-    pub const ENABLED: State = State::new("ENABLED");
+    pub const ENABLED: State = State::new(2);
+
+    /// Creates a new State instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("DISABLED"),
+            2 => std::borrow::Cow::Borrowed("ENABLED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+            "DISABLED" => std::option::Option::Some(Self::DISABLED),
+            "ENABLED" => std::option::Option::Some(Self::ENABLED),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for State {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for State {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for State {
     fn default() -> Self {
-        state::STATE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/api/serviceusage/v1/src/transport.rs
+++ b/src/generated/api/serviceusage/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::ServiceUsage for ServiceUsage {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:enable", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -66,7 +66,7 @@ impl crate::stubs::ServiceUsage for ServiceUsage {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:disable", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -83,7 +83,7 @@ impl crate::stubs::ServiceUsage for ServiceUsage {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -102,7 +102,7 @@ impl crate::stubs::ServiceUsage for ServiceUsage {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/services", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -127,7 +127,7 @@ impl crate::stubs::ServiceUsage for ServiceUsage {
                 reqwest::Method::POST,
                 format!("/v1/{}/services:batchEnable", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -147,7 +147,7 @@ impl crate::stubs::ServiceUsage for ServiceUsage {
                 reqwest::Method::GET,
                 format!("/v1/{}/services:batchGet", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -170,7 +170,7 @@ impl crate::stubs::ServiceUsage for ServiceUsage {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v1/operations".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -193,7 +193,7 @@ impl crate::stubs::ServiceUsage for ServiceUsage {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/api/types/src/model.rs
+++ b/src/generated/api/types/src/model.rs
@@ -864,26 +864,10 @@ pub mod backend_rule {
     /// do not accept requests over HTTP/HTTPS should leave `path_translation`
     /// unspecified.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PathTranslation(std::borrow::Cow<'static, str>);
+    pub struct PathTranslation(i32);
 
     impl PathTranslation {
-        /// Creates a new PathTranslation instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PathTranslation](PathTranslation)
-    pub mod path_translation {
-        use super::PathTranslation;
-
-        pub const PATH_TRANSLATION_UNSPECIFIED: PathTranslation =
-            PathTranslation::new("PATH_TRANSLATION_UNSPECIFIED");
+        pub const PATH_TRANSLATION_UNSPECIFIED: PathTranslation = PathTranslation::new(0);
 
         /// Use the backend address as-is, with no modification to the path. If the
         /// URL pattern contains variables, the variable names and values will be
@@ -912,7 +896,7 @@ pub mod backend_rule {
         /// Translated:
         /// https://example.cloudfunctions.net/getUser?timezone=EST&cid=widgetworks&uid=johndoe
         /// ```
-        pub const CONSTANT_ADDRESS: PathTranslation = PathTranslation::new("CONSTANT_ADDRESS");
+        pub const CONSTANT_ADDRESS: PathTranslation = PathTranslation::new(1);
 
         /// The request path will be appended to the backend address.
         ///
@@ -937,19 +921,50 @@ pub mod backend_rule {
         /// Translated:
         /// https://example.appspot.com/api/company/widgetworks/user/johndoe?timezone=EST
         /// ```
-        pub const APPEND_PATH_TO_ADDRESS: PathTranslation =
-            PathTranslation::new("APPEND_PATH_TO_ADDRESS");
+        pub const APPEND_PATH_TO_ADDRESS: PathTranslation = PathTranslation::new(2);
+
+        /// Creates a new PathTranslation instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PATH_TRANSLATION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CONSTANT_ADDRESS"),
+                2 => std::borrow::Cow::Borrowed("APPEND_PATH_TO_ADDRESS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PATH_TRANSLATION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PATH_TRANSLATION_UNSPECIFIED)
+                }
+                "CONSTANT_ADDRESS" => std::option::Option::Some(Self::CONSTANT_ADDRESS),
+                "APPEND_PATH_TO_ADDRESS" => std::option::Option::Some(Self::APPEND_PATH_TO_ADDRESS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PathTranslation {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PathTranslation {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PathTranslation {
         fn default() -> Self {
-            path_translation::PATH_TRANSLATION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -2502,49 +2517,68 @@ pub mod property {
 
     /// Supported data type of the property values
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PropertyType(std::borrow::Cow<'static, str>);
+    pub struct PropertyType(i32);
 
     impl PropertyType {
+        /// The type is unspecified, and will result in an error.
+        pub const UNSPECIFIED: PropertyType = PropertyType::new(0);
+
+        /// The type is `int64`.
+        pub const INT64: PropertyType = PropertyType::new(1);
+
+        /// The type is `bool`.
+        pub const BOOL: PropertyType = PropertyType::new(2);
+
+        /// The type is `string`.
+        pub const STRING: PropertyType = PropertyType::new(3);
+
+        /// The type is 'double'.
+        pub const DOUBLE: PropertyType = PropertyType::new(4);
+
         /// Creates a new PropertyType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INT64"),
+                2 => std::borrow::Cow::Borrowed("BOOL"),
+                3 => std::borrow::Cow::Borrowed("STRING"),
+                4 => std::borrow::Cow::Borrowed("DOUBLE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
+                "INT64" => std::option::Option::Some(Self::INT64),
+                "BOOL" => std::option::Option::Some(Self::BOOL),
+                "STRING" => std::option::Option::Some(Self::STRING),
+                "DOUBLE" => std::option::Option::Some(Self::DOUBLE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [PropertyType](PropertyType)
-    pub mod property_type {
-        use super::PropertyType;
-
-        /// The type is unspecified, and will result in an error.
-        pub const UNSPECIFIED: PropertyType = PropertyType::new("UNSPECIFIED");
-
-        /// The type is `int64`.
-        pub const INT64: PropertyType = PropertyType::new("INT64");
-
-        /// The type is `bool`.
-        pub const BOOL: PropertyType = PropertyType::new("BOOL");
-
-        /// The type is `string`.
-        pub const STRING: PropertyType = PropertyType::new("STRING");
-
-        /// The type is 'double'.
-        pub const DOUBLE: PropertyType = PropertyType::new("DOUBLE");
-    }
-
-    impl std::convert::From<std::string::String> for PropertyType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PropertyType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PropertyType {
         fn default() -> Self {
-            property_type::UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3792,62 +3826,81 @@ pub mod field_info {
     /// The standard format of a field value. The supported formats are all backed
     /// by either an RFC defined by the IETF or a Google-defined AIP.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Format(std::borrow::Cow<'static, str>);
+    pub struct Format(i32);
 
     impl Format {
-        /// Creates a new Format instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Format](Format)
-    pub mod format {
-        use super::Format;
-
         /// Default, unspecified value.
-        pub const FORMAT_UNSPECIFIED: Format = Format::new("FORMAT_UNSPECIFIED");
+        pub const FORMAT_UNSPECIFIED: Format = Format::new(0);
 
         /// Universally Unique Identifier, version 4, value as defined by
         /// <https://datatracker.ietf.org/doc/html/rfc4122>. The value may be
         /// normalized to entirely lowercase letters. For example, the value
         /// `F47AC10B-58CC-0372-8567-0E02B2C3D479` would be normalized to
         /// `f47ac10b-58cc-0372-8567-0e02b2c3d479`.
-        pub const UUID4: Format = Format::new("UUID4");
+        pub const UUID4: Format = Format::new(1);
 
         /// Internet Protocol v4 value as defined by [RFC
         /// 791](https://datatracker.ietf.org/doc/html/rfc791). The value may be
         /// condensed, with leading zeros in each octet stripped. For example,
         /// `001.022.233.040` would be condensed to `1.22.233.40`.
-        pub const IPV4: Format = Format::new("IPV4");
+        pub const IPV4: Format = Format::new(2);
 
         /// Internet Protocol v6 value as defined by [RFC
         /// 2460](https://datatracker.ietf.org/doc/html/rfc2460). The value may be
         /// normalized to entirely lowercase letters with zeros compressed, following
         /// [RFC 5952](https://datatracker.ietf.org/doc/html/rfc5952). For example,
         /// the value `2001:0DB8:0::0` would be normalized to `2001:db8::`.
-        pub const IPV6: Format = Format::new("IPV6");
+        pub const IPV6: Format = Format::new(3);
 
         /// An IP address in either v4 or v6 format as described by the individual
         /// values defined herein. See the comments on the IPV4 and IPV6 types for
         /// allowed normalizations of each.
-        pub const IPV4_OR_IPV6: Format = Format::new("IPV4_OR_IPV6");
+        pub const IPV4_OR_IPV6: Format = Format::new(4);
+
+        /// Creates a new Format instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FORMAT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("UUID4"),
+                2 => std::borrow::Cow::Borrowed("IPV4"),
+                3 => std::borrow::Cow::Borrowed("IPV6"),
+                4 => std::borrow::Cow::Borrowed("IPV4_OR_IPV6"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FORMAT_UNSPECIFIED" => std::option::Option::Some(Self::FORMAT_UNSPECIFIED),
+                "UUID4" => std::option::Option::Some(Self::UUID4),
+                "IPV4" => std::option::Option::Some(Self::IPV4),
+                "IPV6" => std::option::Option::Some(Self::IPV6),
+                "IPV4_OR_IPV6" => std::option::Option::Some(Self::IPV4_OR_IPV6),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Format {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Format {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Format {
         fn default() -> Self {
-            format::FORMAT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4689,43 +4742,58 @@ pub mod label_descriptor {
 
     /// Value types that can be used as label values.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ValueType(std::borrow::Cow<'static, str>);
+    pub struct ValueType(i32);
 
     impl ValueType {
+        /// A variable-length string. This is the default.
+        pub const STRING: ValueType = ValueType::new(0);
+
+        /// Boolean; true or false.
+        pub const BOOL: ValueType = ValueType::new(1);
+
+        /// A 64-bit signed integer.
+        pub const INT64: ValueType = ValueType::new(2);
+
         /// Creates a new ValueType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STRING"),
+                1 => std::borrow::Cow::Borrowed("BOOL"),
+                2 => std::borrow::Cow::Borrowed("INT64"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STRING" => std::option::Option::Some(Self::STRING),
+                "BOOL" => std::option::Option::Some(Self::BOOL),
+                "INT64" => std::option::Option::Some(Self::INT64),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ValueType](ValueType)
-    pub mod value_type {
-        use super::ValueType;
-
-        /// A variable-length string. This is the default.
-        pub const STRING: ValueType = ValueType::new("STRING");
-
-        /// Boolean; true or false.
-        pub const BOOL: ValueType = ValueType::new("BOOL");
-
-        /// A 64-bit signed integer.
-        pub const INT64: ValueType = ValueType::new("INT64");
-    }
-
-    impl std::convert::From<std::string::String> for ValueType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ValueType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ValueType {
         fn default() -> Self {
-            value_type::STRING
+            Self::new(0)
         }
     }
 }
@@ -5355,52 +5423,73 @@ pub mod metric_descriptor {
 
         /// The resource hierarchy level of the timeseries data of a metric.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct TimeSeriesResourceHierarchyLevel(std::borrow::Cow<'static, str>);
+        pub struct TimeSeriesResourceHierarchyLevel(i32);
 
         impl TimeSeriesResourceHierarchyLevel {
-            /// Creates a new TimeSeriesResourceHierarchyLevel instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [TimeSeriesResourceHierarchyLevel](TimeSeriesResourceHierarchyLevel)
-        pub mod time_series_resource_hierarchy_level {
-            use super::TimeSeriesResourceHierarchyLevel;
-
             /// Do not use this default value.
             pub const TIME_SERIES_RESOURCE_HIERARCHY_LEVEL_UNSPECIFIED:
-                TimeSeriesResourceHierarchyLevel = TimeSeriesResourceHierarchyLevel::new(
-                "TIME_SERIES_RESOURCE_HIERARCHY_LEVEL_UNSPECIFIED",
-            );
+                TimeSeriesResourceHierarchyLevel = TimeSeriesResourceHierarchyLevel::new(0);
 
             /// Scopes a metric to a project.
             pub const PROJECT: TimeSeriesResourceHierarchyLevel =
-                TimeSeriesResourceHierarchyLevel::new("PROJECT");
+                TimeSeriesResourceHierarchyLevel::new(1);
 
             /// Scopes a metric to an organization.
             pub const ORGANIZATION: TimeSeriesResourceHierarchyLevel =
-                TimeSeriesResourceHierarchyLevel::new("ORGANIZATION");
+                TimeSeriesResourceHierarchyLevel::new(2);
 
             /// Scopes a metric to a folder.
             pub const FOLDER: TimeSeriesResourceHierarchyLevel =
-                TimeSeriesResourceHierarchyLevel::new("FOLDER");
+                TimeSeriesResourceHierarchyLevel::new(3);
+
+            /// Creates a new TimeSeriesResourceHierarchyLevel instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed(
+                        "TIME_SERIES_RESOURCE_HIERARCHY_LEVEL_UNSPECIFIED",
+                    ),
+                    1 => std::borrow::Cow::Borrowed("PROJECT"),
+                    2 => std::borrow::Cow::Borrowed("ORGANIZATION"),
+                    3 => std::borrow::Cow::Borrowed("FOLDER"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "TIME_SERIES_RESOURCE_HIERARCHY_LEVEL_UNSPECIFIED" => {
+                        std::option::Option::Some(
+                            Self::TIME_SERIES_RESOURCE_HIERARCHY_LEVEL_UNSPECIFIED,
+                        )
+                    }
+                    "PROJECT" => std::option::Option::Some(Self::PROJECT),
+                    "ORGANIZATION" => std::option::Option::Some(Self::ORGANIZATION),
+                    "FOLDER" => std::option::Option::Some(Self::FOLDER),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for TimeSeriesResourceHierarchyLevel {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for TimeSeriesResourceHierarchyLevel {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for TimeSeriesResourceHierarchyLevel {
             fn default() -> Self {
-                time_series_resource_hierarchy_level::TIME_SERIES_RESOURCE_HIERARCHY_LEVEL_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -5409,108 +5498,150 @@ pub mod metric_descriptor {
     /// For information on setting the start time and end time based on
     /// the MetricKind, see [TimeInterval][google.monitoring.v3.TimeInterval].
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MetricKind(std::borrow::Cow<'static, str>);
+    pub struct MetricKind(i32);
 
     impl MetricKind {
-        /// Creates a new MetricKind instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [MetricKind](MetricKind)
-    pub mod metric_kind {
-        use super::MetricKind;
-
         /// Do not use this default value.
-        pub const METRIC_KIND_UNSPECIFIED: MetricKind = MetricKind::new("METRIC_KIND_UNSPECIFIED");
+        pub const METRIC_KIND_UNSPECIFIED: MetricKind = MetricKind::new(0);
 
         /// An instantaneous measurement of a value.
-        pub const GAUGE: MetricKind = MetricKind::new("GAUGE");
+        pub const GAUGE: MetricKind = MetricKind::new(1);
 
         /// The change in a value during a time interval.
-        pub const DELTA: MetricKind = MetricKind::new("DELTA");
+        pub const DELTA: MetricKind = MetricKind::new(2);
 
         /// A value accumulated over a time interval.  Cumulative
         /// measurements in a time series should have the same start time
         /// and increasing end times, until an event resets the cumulative
         /// value to zero and sets a new start time for the following
         /// points.
-        pub const CUMULATIVE: MetricKind = MetricKind::new("CUMULATIVE");
+        pub const CUMULATIVE: MetricKind = MetricKind::new(3);
+
+        /// Creates a new MetricKind instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("METRIC_KIND_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GAUGE"),
+                2 => std::borrow::Cow::Borrowed("DELTA"),
+                3 => std::borrow::Cow::Borrowed("CUMULATIVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "METRIC_KIND_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::METRIC_KIND_UNSPECIFIED)
+                }
+                "GAUGE" => std::option::Option::Some(Self::GAUGE),
+                "DELTA" => std::option::Option::Some(Self::DELTA),
+                "CUMULATIVE" => std::option::Option::Some(Self::CUMULATIVE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for MetricKind {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MetricKind {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MetricKind {
         fn default() -> Self {
-            metric_kind::METRIC_KIND_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The value type of a metric.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ValueType(std::borrow::Cow<'static, str>);
+    pub struct ValueType(i32);
 
     impl ValueType {
-        /// Creates a new ValueType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ValueType](ValueType)
-    pub mod value_type {
-        use super::ValueType;
-
         /// Do not use this default value.
-        pub const VALUE_TYPE_UNSPECIFIED: ValueType = ValueType::new("VALUE_TYPE_UNSPECIFIED");
+        pub const VALUE_TYPE_UNSPECIFIED: ValueType = ValueType::new(0);
 
         /// The value is a boolean.
         /// This value type can be used only if the metric kind is `GAUGE`.
-        pub const BOOL: ValueType = ValueType::new("BOOL");
+        pub const BOOL: ValueType = ValueType::new(1);
 
         /// The value is a signed 64-bit integer.
-        pub const INT64: ValueType = ValueType::new("INT64");
+        pub const INT64: ValueType = ValueType::new(2);
 
         /// The value is a double precision floating point number.
-        pub const DOUBLE: ValueType = ValueType::new("DOUBLE");
+        pub const DOUBLE: ValueType = ValueType::new(3);
 
         /// The value is a text string.
         /// This value type can be used only if the metric kind is `GAUGE`.
-        pub const STRING: ValueType = ValueType::new("STRING");
+        pub const STRING: ValueType = ValueType::new(4);
 
         /// The value is a [`Distribution`][google.api.Distribution].
         ///
         /// [google.api.Distribution]: crate::model::Distribution
-        pub const DISTRIBUTION: ValueType = ValueType::new("DISTRIBUTION");
+        pub const DISTRIBUTION: ValueType = ValueType::new(5);
 
         /// The value is money.
-        pub const MONEY: ValueType = ValueType::new("MONEY");
+        pub const MONEY: ValueType = ValueType::new(6);
+
+        /// Creates a new ValueType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VALUE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BOOL"),
+                2 => std::borrow::Cow::Borrowed("INT64"),
+                3 => std::borrow::Cow::Borrowed("DOUBLE"),
+                4 => std::borrow::Cow::Borrowed("STRING"),
+                5 => std::borrow::Cow::Borrowed("DISTRIBUTION"),
+                6 => std::borrow::Cow::Borrowed("MONEY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VALUE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::VALUE_TYPE_UNSPECIFIED),
+                "BOOL" => std::option::Option::Some(Self::BOOL),
+                "INT64" => std::option::Option::Some(Self::INT64),
+                "DOUBLE" => std::option::Option::Some(Self::DOUBLE),
+                "STRING" => std::option::Option::Some(Self::STRING),
+                "DISTRIBUTION" => std::option::Option::Some(Self::DISTRIBUTION),
+                "MONEY" => std::option::Option::Some(Self::MONEY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ValueType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ValueType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ValueType {
         fn default() -> Self {
-            value_type::VALUE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6689,71 +6820,73 @@ pub mod resource_descriptor {
     /// A description of the historical or future-looking state of the
     /// resource pattern.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct History(std::borrow::Cow<'static, str>);
+    pub struct History(i32);
 
     impl History {
-        /// Creates a new History instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [History](History)
-    pub mod history {
-        use super::History;
-
         /// The "unset" value.
-        pub const HISTORY_UNSPECIFIED: History = History::new("HISTORY_UNSPECIFIED");
+        pub const HISTORY_UNSPECIFIED: History = History::new(0);
 
         /// The resource originally had one pattern and launched as such, and
         /// additional patterns were added later.
-        pub const ORIGINALLY_SINGLE_PATTERN: History = History::new("ORIGINALLY_SINGLE_PATTERN");
+        pub const ORIGINALLY_SINGLE_PATTERN: History = History::new(1);
 
         /// The resource has one pattern, but the API owner expects to add more
         /// later. (This is the inverse of ORIGINALLY_SINGLE_PATTERN, and prevents
         /// that from being necessary once there are multiple patterns.)
-        pub const FUTURE_MULTI_PATTERN: History = History::new("FUTURE_MULTI_PATTERN");
+        pub const FUTURE_MULTI_PATTERN: History = History::new(2);
+
+        /// Creates a new History instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("HISTORY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ORIGINALLY_SINGLE_PATTERN"),
+                2 => std::borrow::Cow::Borrowed("FUTURE_MULTI_PATTERN"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "HISTORY_UNSPECIFIED" => std::option::Option::Some(Self::HISTORY_UNSPECIFIED),
+                "ORIGINALLY_SINGLE_PATTERN" => {
+                    std::option::Option::Some(Self::ORIGINALLY_SINGLE_PATTERN)
+                }
+                "FUTURE_MULTI_PATTERN" => std::option::Option::Some(Self::FUTURE_MULTI_PATTERN),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for History {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for History {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for History {
         fn default() -> Self {
-            history::HISTORY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// A flag representing a specific style that a resource claims to conform to.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Style(std::borrow::Cow<'static, str>);
+    pub struct Style(i32);
 
     impl Style {
-        /// Creates a new Style instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Style](Style)
-    pub mod style {
-        use super::Style;
-
         /// The unspecified value. Do not use.
-        pub const STYLE_UNSPECIFIED: Style = Style::new("STYLE_UNSPECIFIED");
+        pub const STYLE_UNSPECIFIED: Style = Style::new(0);
 
         /// This resource is intended to be "declarative-friendly".
         ///
@@ -6763,18 +6896,46 @@ pub mod resource_descriptor {
         ///
         /// Note: This is used by the API linter (linter.aip.dev) to enable
         /// additional checks.
-        pub const DECLARATIVE_FRIENDLY: Style = Style::new("DECLARATIVE_FRIENDLY");
+        pub const DECLARATIVE_FRIENDLY: Style = Style::new(1);
+
+        /// Creates a new Style instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STYLE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DECLARATIVE_FRIENDLY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STYLE_UNSPECIFIED" => std::option::Option::Some(Self::STYLE_UNSPECIFIED),
+                "DECLARATIVE_FRIENDLY" => std::option::Option::Some(Self::DECLARATIVE_FRIENDLY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Style {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Style {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Style {
         fn default() -> Self {
-            style::STYLE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8350,156 +8511,214 @@ impl wkt::message::Message for VisibilityRule {
 /// The organization for which the client libraries are being published.
 /// Affects the url where generated docs are published, etc.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ClientLibraryOrganization(std::borrow::Cow<'static, str>);
+pub struct ClientLibraryOrganization(i32);
 
 impl ClientLibraryOrganization {
+    /// Not useful.
+    pub const CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED: ClientLibraryOrganization =
+        ClientLibraryOrganization::new(0);
+
+    /// Google Cloud Platform Org.
+    pub const CLOUD: ClientLibraryOrganization = ClientLibraryOrganization::new(1);
+
+    /// Ads (Advertising) Org.
+    pub const ADS: ClientLibraryOrganization = ClientLibraryOrganization::new(2);
+
+    /// Photos Org.
+    pub const PHOTOS: ClientLibraryOrganization = ClientLibraryOrganization::new(3);
+
+    /// Street View Org.
+    pub const STREET_VIEW: ClientLibraryOrganization = ClientLibraryOrganization::new(4);
+
+    /// Shopping Org.
+    pub const SHOPPING: ClientLibraryOrganization = ClientLibraryOrganization::new(5);
+
+    /// Geo Org.
+    pub const GEO: ClientLibraryOrganization = ClientLibraryOrganization::new(6);
+
+    /// Generative AI - <https://developers.generativeai.google>
+    pub const GENERATIVE_AI: ClientLibraryOrganization = ClientLibraryOrganization::new(7);
+
     /// Creates a new ClientLibraryOrganization instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("CLOUD"),
+            2 => std::borrow::Cow::Borrowed("ADS"),
+            3 => std::borrow::Cow::Borrowed("PHOTOS"),
+            4 => std::borrow::Cow::Borrowed("STREET_VIEW"),
+            5 => std::borrow::Cow::Borrowed("SHOPPING"),
+            6 => std::borrow::Cow::Borrowed("GEO"),
+            7 => std::borrow::Cow::Borrowed("GENERATIVE_AI"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED" => {
+                std::option::Option::Some(Self::CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED)
+            }
+            "CLOUD" => std::option::Option::Some(Self::CLOUD),
+            "ADS" => std::option::Option::Some(Self::ADS),
+            "PHOTOS" => std::option::Option::Some(Self::PHOTOS),
+            "STREET_VIEW" => std::option::Option::Some(Self::STREET_VIEW),
+            "SHOPPING" => std::option::Option::Some(Self::SHOPPING),
+            "GEO" => std::option::Option::Some(Self::GEO),
+            "GENERATIVE_AI" => std::option::Option::Some(Self::GENERATIVE_AI),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [ClientLibraryOrganization](ClientLibraryOrganization)
-pub mod client_library_organization {
-    use super::ClientLibraryOrganization;
-
-    /// Not useful.
-    pub const CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED: ClientLibraryOrganization =
-        ClientLibraryOrganization::new("CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED");
-
-    /// Google Cloud Platform Org.
-    pub const CLOUD: ClientLibraryOrganization = ClientLibraryOrganization::new("CLOUD");
-
-    /// Ads (Advertising) Org.
-    pub const ADS: ClientLibraryOrganization = ClientLibraryOrganization::new("ADS");
-
-    /// Photos Org.
-    pub const PHOTOS: ClientLibraryOrganization = ClientLibraryOrganization::new("PHOTOS");
-
-    /// Street View Org.
-    pub const STREET_VIEW: ClientLibraryOrganization =
-        ClientLibraryOrganization::new("STREET_VIEW");
-
-    /// Shopping Org.
-    pub const SHOPPING: ClientLibraryOrganization = ClientLibraryOrganization::new("SHOPPING");
-
-    /// Geo Org.
-    pub const GEO: ClientLibraryOrganization = ClientLibraryOrganization::new("GEO");
-
-    /// Generative AI - <https://developers.generativeai.google>
-    pub const GENERATIVE_AI: ClientLibraryOrganization =
-        ClientLibraryOrganization::new("GENERATIVE_AI");
-}
-
-impl std::convert::From<std::string::String> for ClientLibraryOrganization {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ClientLibraryOrganization {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ClientLibraryOrganization {
     fn default() -> Self {
-        client_library_organization::CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// To where should client libraries be published?
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ClientLibraryDestination(std::borrow::Cow<'static, str>);
+pub struct ClientLibraryDestination(i32);
 
 impl ClientLibraryDestination {
-    /// Creates a new ClientLibraryDestination instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ClientLibraryDestination](ClientLibraryDestination)
-pub mod client_library_destination {
-    use super::ClientLibraryDestination;
-
     /// Client libraries will neither be generated nor published to package
     /// managers.
     pub const CLIENT_LIBRARY_DESTINATION_UNSPECIFIED: ClientLibraryDestination =
-        ClientLibraryDestination::new("CLIENT_LIBRARY_DESTINATION_UNSPECIFIED");
+        ClientLibraryDestination::new(0);
 
     /// Generate the client library in a repo under github.com/googleapis,
     /// but don't publish it to package managers.
-    pub const GITHUB: ClientLibraryDestination = ClientLibraryDestination::new("GITHUB");
+    pub const GITHUB: ClientLibraryDestination = ClientLibraryDestination::new(10);
 
     /// Publish the library to package managers like nuget.org and npmjs.com.
-    pub const PACKAGE_MANAGER: ClientLibraryDestination =
-        ClientLibraryDestination::new("PACKAGE_MANAGER");
+    pub const PACKAGE_MANAGER: ClientLibraryDestination = ClientLibraryDestination::new(20);
+
+    /// Creates a new ClientLibraryDestination instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("CLIENT_LIBRARY_DESTINATION_UNSPECIFIED"),
+            10 => std::borrow::Cow::Borrowed("GITHUB"),
+            20 => std::borrow::Cow::Borrowed("PACKAGE_MANAGER"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "CLIENT_LIBRARY_DESTINATION_UNSPECIFIED" => {
+                std::option::Option::Some(Self::CLIENT_LIBRARY_DESTINATION_UNSPECIFIED)
+            }
+            "GITHUB" => std::option::Option::Some(Self::GITHUB),
+            "PACKAGE_MANAGER" => std::option::Option::Some(Self::PACKAGE_MANAGER),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ClientLibraryDestination {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ClientLibraryDestination {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ClientLibraryDestination {
     fn default() -> Self {
-        client_library_destination::CLIENT_LIBRARY_DESTINATION_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Classifies set of possible modifications to an object in the service
 /// configuration.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ChangeType(std::borrow::Cow<'static, str>);
+pub struct ChangeType(i32);
 
 impl ChangeType {
-    /// Creates a new ChangeType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ChangeType](ChangeType)
-pub mod change_type {
-    use super::ChangeType;
-
     /// No value was provided.
-    pub const CHANGE_TYPE_UNSPECIFIED: ChangeType = ChangeType::new("CHANGE_TYPE_UNSPECIFIED");
+    pub const CHANGE_TYPE_UNSPECIFIED: ChangeType = ChangeType::new(0);
 
     /// The changed object exists in the 'new' service configuration, but not
     /// in the 'old' service configuration.
-    pub const ADDED: ChangeType = ChangeType::new("ADDED");
+    pub const ADDED: ChangeType = ChangeType::new(1);
 
     /// The changed object exists in the 'old' service configuration, but not
     /// in the 'new' service configuration.
-    pub const REMOVED: ChangeType = ChangeType::new("REMOVED");
+    pub const REMOVED: ChangeType = ChangeType::new(2);
 
     /// The changed object exists in both service configurations, but its value
     /// is different.
-    pub const MODIFIED: ChangeType = ChangeType::new("MODIFIED");
+    pub const MODIFIED: ChangeType = ChangeType::new(3);
+
+    /// Creates a new ChangeType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("CHANGE_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ADDED"),
+            2 => std::borrow::Cow::Borrowed("REMOVED"),
+            3 => std::borrow::Cow::Borrowed("MODIFIED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "CHANGE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::CHANGE_TYPE_UNSPECIFIED),
+            "ADDED" => std::option::Option::Some(Self::ADDED),
+            "REMOVED" => std::option::Option::Some(Self::REMOVED),
+            "MODIFIED" => std::option::Option::Some(Self::MODIFIED),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ChangeType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ChangeType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ChangeType {
     fn default() -> Self {
-        change_type::CHANGE_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -8514,26 +8733,11 @@ impl std::default::Default for ChangeType {
 /// reason. For more information, see the definition of the specific error
 /// reason.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ErrorReason(std::borrow::Cow<'static, str>);
+pub struct ErrorReason(i32);
 
 impl ErrorReason {
-    /// Creates a new ErrorReason instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ErrorReason](ErrorReason)
-pub mod error_reason {
-    use super::ErrorReason;
-
     /// Do not use this default value.
-    pub const ERROR_REASON_UNSPECIFIED: ErrorReason = ErrorReason::new("ERROR_REASON_UNSPECIFIED");
+    pub const ERROR_REASON_UNSPECIFIED: ErrorReason = ErrorReason::new(0);
 
     /// The request is calling a disabled service for a consumer.
     ///
@@ -8552,7 +8756,7 @@ pub mod error_reason {
     ///
     /// This response indicates the "pubsub.googleapis.com" has been disabled in
     /// "projects/123".
-    pub const SERVICE_DISABLED: ErrorReason = ErrorReason::new("SERVICE_DISABLED");
+    pub const SERVICE_DISABLED: ErrorReason = ErrorReason::new(1);
 
     /// The request whose associated billing account is disabled.
     ///
@@ -8571,7 +8775,7 @@ pub mod error_reason {
     /// ```
     ///
     /// This response indicates the billing account associated has been disabled.
-    pub const BILLING_DISABLED: ErrorReason = ErrorReason::new("BILLING_DISABLED");
+    pub const BILLING_DISABLED: ErrorReason = ErrorReason::new(2);
 
     /// The request is denied because the provided [API
     /// key](https://cloud.google.com/docs/authentication/api-keys) is invalid. It
@@ -8588,7 +8792,7 @@ pub mod error_reason {
     ///   }
     /// }
     /// ```
-    pub const API_KEY_INVALID: ErrorReason = ErrorReason::new("API_KEY_INVALID");
+    pub const API_KEY_INVALID: ErrorReason = ErrorReason::new(3);
 
     /// The request is denied because it violates [API key API
     /// restrictions](https://cloud.google.com/docs/authentication/api-keys#adding_api_restrictions).
@@ -8606,7 +8810,7 @@ pub mod error_reason {
     ///   }
     /// }
     /// ```
-    pub const API_KEY_SERVICE_BLOCKED: ErrorReason = ErrorReason::new("API_KEY_SERVICE_BLOCKED");
+    pub const API_KEY_SERVICE_BLOCKED: ErrorReason = ErrorReason::new(4);
 
     /// The request is denied because it violates [API key HTTP
     /// restrictions](https://cloud.google.com/docs/authentication/api-keys#adding_http_restrictions).
@@ -8624,8 +8828,7 @@ pub mod error_reason {
     ///   }
     /// }
     /// ```
-    pub const API_KEY_HTTP_REFERRER_BLOCKED: ErrorReason =
-        ErrorReason::new("API_KEY_HTTP_REFERRER_BLOCKED");
+    pub const API_KEY_HTTP_REFERRER_BLOCKED: ErrorReason = ErrorReason::new(7);
 
     /// The request is denied because it violates [API key IP address
     /// restrictions](https://cloud.google.com/docs/authentication/api-keys#adding_application_restrictions).
@@ -8643,8 +8846,7 @@ pub mod error_reason {
     ///   }
     /// }
     /// ```
-    pub const API_KEY_IP_ADDRESS_BLOCKED: ErrorReason =
-        ErrorReason::new("API_KEY_IP_ADDRESS_BLOCKED");
+    pub const API_KEY_IP_ADDRESS_BLOCKED: ErrorReason = ErrorReason::new(8);
 
     /// The request is denied because it violates [API key Android application
     /// restrictions](https://cloud.google.com/docs/authentication/api-keys#adding_application_restrictions).
@@ -8662,8 +8864,7 @@ pub mod error_reason {
     ///   }
     /// }
     /// ```
-    pub const API_KEY_ANDROID_APP_BLOCKED: ErrorReason =
-        ErrorReason::new("API_KEY_ANDROID_APP_BLOCKED");
+    pub const API_KEY_ANDROID_APP_BLOCKED: ErrorReason = ErrorReason::new(9);
 
     /// The request is denied because it violates [API key iOS application
     /// restrictions](https://cloud.google.com/docs/authentication/api-keys#adding_application_restrictions).
@@ -8681,7 +8882,7 @@ pub mod error_reason {
     ///   }
     /// }
     /// ```
-    pub const API_KEY_IOS_APP_BLOCKED: ErrorReason = ErrorReason::new("API_KEY_IOS_APP_BLOCKED");
+    pub const API_KEY_IOS_APP_BLOCKED: ErrorReason = ErrorReason::new(13);
 
     /// The request is denied because there is not enough rate quota for the
     /// consumer.
@@ -8720,7 +8921,7 @@ pub mod error_reason {
     ///   }
     /// }
     /// ```
-    pub const RATE_LIMIT_EXCEEDED: ErrorReason = ErrorReason::new("RATE_LIMIT_EXCEEDED");
+    pub const RATE_LIMIT_EXCEEDED: ErrorReason = ErrorReason::new(5);
 
     /// The request is denied because there is not enough resource quota for the
     /// consumer.
@@ -8758,7 +8959,7 @@ pub mod error_reason {
     ///   }
     /// }
     /// ```
-    pub const RESOURCE_QUOTA_EXCEEDED: ErrorReason = ErrorReason::new("RESOURCE_QUOTA_EXCEEDED");
+    pub const RESOURCE_QUOTA_EXCEEDED: ErrorReason = ErrorReason::new(6);
 
     /// The request whose associated billing account address is in a tax restricted
     /// location, violates the local tax restrictions when creating resources in
@@ -8781,8 +8982,7 @@ pub mod error_reason {
     ///
     /// This response indicates creating the Cloud Storage Bucket in
     /// "locations/asia-northeast3" violates the location tax restriction.
-    pub const LOCATION_TAX_POLICY_VIOLATED: ErrorReason =
-        ErrorReason::new("LOCATION_TAX_POLICY_VIOLATED");
+    pub const LOCATION_TAX_POLICY_VIOLATED: ErrorReason = ErrorReason::new(10);
 
     /// The request is denied because the caller does not have required permission
     /// on the user project "projects/123" or the user project is invalid. For more
@@ -8801,7 +9001,7 @@ pub mod error_reason {
     ///   }
     /// }
     /// ```
-    pub const USER_PROJECT_DENIED: ErrorReason = ErrorReason::new("USER_PROJECT_DENIED");
+    pub const USER_PROJECT_DENIED: ErrorReason = ErrorReason::new(11);
 
     /// The request is denied because the consumer "projects/123" is suspended due
     /// to Terms of Service(Tos) violations. Check [Project suspension
@@ -8820,7 +9020,7 @@ pub mod error_reason {
     ///   }
     /// }
     /// ```
-    pub const CONSUMER_SUSPENDED: ErrorReason = ErrorReason::new("CONSUMER_SUSPENDED");
+    pub const CONSUMER_SUSPENDED: ErrorReason = ErrorReason::new(12);
 
     /// The request is denied because the associated consumer is invalid. It may be
     /// in a bad format, cannot be found, or have been deleted.
@@ -8837,7 +9037,7 @@ pub mod error_reason {
     ///   }
     /// }
     /// ```
-    pub const CONSUMER_INVALID: ErrorReason = ErrorReason::new("CONSUMER_INVALID");
+    pub const CONSUMER_INVALID: ErrorReason = ErrorReason::new(14);
 
     /// The request is denied because it violates [VPC Service
     /// Controls](https://cloud.google.com/vpc-service-controls/docs/overview).
@@ -8860,7 +9060,7 @@ pub mod error_reason {
     ///   }
     /// }
     /// ```
-    pub const SECURITY_POLICY_VIOLATED: ErrorReason = ErrorReason::new("SECURITY_POLICY_VIOLATED");
+    pub const SECURITY_POLICY_VIOLATED: ErrorReason = ErrorReason::new(15);
 
     /// The request is denied because the provided access token has expired.
     ///
@@ -8876,7 +9076,7 @@ pub mod error_reason {
     ///   }
     /// }
     /// ```
-    pub const ACCESS_TOKEN_EXPIRED: ErrorReason = ErrorReason::new("ACCESS_TOKEN_EXPIRED");
+    pub const ACCESS_TOKEN_EXPIRED: ErrorReason = ErrorReason::new(16);
 
     /// The request is denied because the provided access token doesn't have at
     /// least one of the acceptable scopes required for the API. Please check
@@ -8897,8 +9097,7 @@ pub mod error_reason {
     ///   }
     /// }
     /// ```
-    pub const ACCESS_TOKEN_SCOPE_INSUFFICIENT: ErrorReason =
-        ErrorReason::new("ACCESS_TOKEN_SCOPE_INSUFFICIENT");
+    pub const ACCESS_TOKEN_SCOPE_INSUFFICIENT: ErrorReason = ErrorReason::new(17);
 
     /// The request is denied because the account associated with the provided
     /// access token is in an invalid state, such as disabled or deleted.
@@ -8922,7 +9121,7 @@ pub mod error_reason {
     ///   }
     /// }
     /// ```
-    pub const ACCOUNT_STATE_INVALID: ErrorReason = ErrorReason::new("ACCOUNT_STATE_INVALID");
+    pub const ACCOUNT_STATE_INVALID: ErrorReason = ErrorReason::new(18);
 
     /// The request is denied because the type of the provided access token is not
     /// supported by the API being called.
@@ -8939,8 +9138,7 @@ pub mod error_reason {
     ///   }
     /// }
     /// ```
-    pub const ACCESS_TOKEN_TYPE_UNSUPPORTED: ErrorReason =
-        ErrorReason::new("ACCESS_TOKEN_TYPE_UNSUPPORTED");
+    pub const ACCESS_TOKEN_TYPE_UNSUPPORTED: ErrorReason = ErrorReason::new(19);
 
     /// The request is denied because the request doesn't have any authentication
     /// credentials. For more information regarding the supported authentication
@@ -8959,7 +9157,7 @@ pub mod error_reason {
     ///   }
     /// }
     /// ```
-    pub const CREDENTIALS_MISSING: ErrorReason = ErrorReason::new("CREDENTIALS_MISSING");
+    pub const CREDENTIALS_MISSING: ErrorReason = ErrorReason::new(20);
 
     /// The request is denied because the provided project owning the resource
     /// which acts as the [API
@@ -8980,7 +9178,7 @@ pub mod error_reason {
     ///   }
     /// }
     /// ```
-    pub const RESOURCE_PROJECT_INVALID: ErrorReason = ErrorReason::new("RESOURCE_PROJECT_INVALID");
+    pub const RESOURCE_PROJECT_INVALID: ErrorReason = ErrorReason::new(21);
 
     /// The request is denied because the provided session cookie is missing,
     /// invalid or failed to decode.
@@ -8998,7 +9196,7 @@ pub mod error_reason {
     ///   }
     /// }
     /// ```
-    pub const SESSION_COOKIE_INVALID: ErrorReason = ErrorReason::new("SESSION_COOKIE_INVALID");
+    pub const SESSION_COOKIE_INVALID: ErrorReason = ErrorReason::new(23);
 
     /// The request is denied because the user is from a Google Workspace customer
     /// that blocks their users from accessing a particular service.
@@ -9017,7 +9215,7 @@ pub mod error_reason {
     ///   }
     /// }
     /// ```
-    pub const USER_BLOCKED_BY_ADMIN: ErrorReason = ErrorReason::new("USER_BLOCKED_BY_ADMIN");
+    pub const USER_BLOCKED_BY_ADMIN: ErrorReason = ErrorReason::new(24);
 
     /// The request is denied because the resource service usage is restricted
     /// by administrators according to the organization policy constraint.
@@ -9036,8 +9234,7 @@ pub mod error_reason {
     ///   }
     /// }
     /// ```
-    pub const RESOURCE_USAGE_RESTRICTION_VIOLATED: ErrorReason =
-        ErrorReason::new("RESOURCE_USAGE_RESTRICTION_VIOLATED");
+    pub const RESOURCE_USAGE_RESTRICTION_VIOLATED: ErrorReason = ErrorReason::new(25);
 
     /// Unimplemented. Do not use.
     ///
@@ -9057,8 +9254,7 @@ pub mod error_reason {
     ///   }
     /// }
     /// ```
-    pub const SYSTEM_PARAMETER_UNSUPPORTED: ErrorReason =
-        ErrorReason::new("SYSTEM_PARAMETER_UNSUPPORTED");
+    pub const SYSTEM_PARAMETER_UNSUPPORTED: ErrorReason = ErrorReason::new(26);
 
     /// The request is denied because it violates Org Restriction: the requested
     /// resource does not belong to allowed organizations specified in
@@ -9075,8 +9271,7 @@ pub mod error_reason {
     /// "service": "pubsub.googleapis.com"
     /// }
     /// }
-    pub const ORG_RESTRICTION_VIOLATION: ErrorReason =
-        ErrorReason::new("ORG_RESTRICTION_VIOLATION");
+    pub const ORG_RESTRICTION_VIOLATION: ErrorReason = ErrorReason::new(27);
 
     /// The request is denied because "X-Goog-Allowed-Resources" header is in a bad
     /// format.
@@ -9093,8 +9288,7 @@ pub mod error_reason {
     /// "service": "pubsub.googleapis.com"
     /// }
     /// }
-    pub const ORG_RESTRICTION_HEADER_INVALID: ErrorReason =
-        ErrorReason::new("ORG_RESTRICTION_HEADER_INVALID");
+    pub const ORG_RESTRICTION_HEADER_INVALID: ErrorReason = ErrorReason::new(28);
 
     /// Unimplemented. Do not use.
     ///
@@ -9115,7 +9309,7 @@ pub mod error_reason {
     ///
     /// This response indicates the "pubsub.googleapis.com" is not visible to
     /// "projects/123" (or it may not exist).
-    pub const SERVICE_NOT_VISIBLE: ErrorReason = ErrorReason::new("SERVICE_NOT_VISIBLE");
+    pub const SERVICE_NOT_VISIBLE: ErrorReason = ErrorReason::new(29);
 
     /// The request is related to a project for which GCP access is suspended.
     ///
@@ -9133,7 +9327,7 @@ pub mod error_reason {
     /// ```
     ///
     /// This response indicates the associated GCP account has been suspended.
-    pub const GCP_SUSPENDED: ErrorReason = ErrorReason::new("GCP_SUSPENDED");
+    pub const GCP_SUSPENDED: ErrorReason = ErrorReason::new(30);
 
     /// The request violates the location policies when creating resources in
     /// the restricted region.
@@ -9154,7 +9348,7 @@ pub mod error_reason {
     /// This response indicates creating the Cloud Storage Bucket in
     /// "locations/asia-northeast3" violates at least one location policy.
     /// The troubleshooting guidance is provided in the Help links.
-    pub const LOCATION_POLICY_VIOLATED: ErrorReason = ErrorReason::new("LOCATION_POLICY_VIOLATED");
+    pub const LOCATION_POLICY_VIOLATED: ErrorReason = ErrorReason::new(31);
 
     /// The request is denied because origin request header is missing.
     ///
@@ -9170,7 +9364,7 @@ pub mod error_reason {
     /// "service": "pubsub.googleapis.com"
     /// }
     /// }
-    pub const MISSING_ORIGIN: ErrorReason = ErrorReason::new("MISSING_ORIGIN");
+    pub const MISSING_ORIGIN: ErrorReason = ErrorReason::new(33);
 
     /// The request is denied because the request contains more than one credential
     /// type that are individually acceptable, but not together. The customer
@@ -9187,18 +9381,128 @@ pub mod error_reason {
     /// "service": "pubsub.googleapis.com"
     /// }
     /// }
-    pub const OVERLOADED_CREDENTIALS: ErrorReason = ErrorReason::new("OVERLOADED_CREDENTIALS");
+    pub const OVERLOADED_CREDENTIALS: ErrorReason = ErrorReason::new(34);
+
+    /// Creates a new ErrorReason instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ERROR_REASON_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SERVICE_DISABLED"),
+            2 => std::borrow::Cow::Borrowed("BILLING_DISABLED"),
+            3 => std::borrow::Cow::Borrowed("API_KEY_INVALID"),
+            4 => std::borrow::Cow::Borrowed("API_KEY_SERVICE_BLOCKED"),
+            5 => std::borrow::Cow::Borrowed("RATE_LIMIT_EXCEEDED"),
+            6 => std::borrow::Cow::Borrowed("RESOURCE_QUOTA_EXCEEDED"),
+            7 => std::borrow::Cow::Borrowed("API_KEY_HTTP_REFERRER_BLOCKED"),
+            8 => std::borrow::Cow::Borrowed("API_KEY_IP_ADDRESS_BLOCKED"),
+            9 => std::borrow::Cow::Borrowed("API_KEY_ANDROID_APP_BLOCKED"),
+            10 => std::borrow::Cow::Borrowed("LOCATION_TAX_POLICY_VIOLATED"),
+            11 => std::borrow::Cow::Borrowed("USER_PROJECT_DENIED"),
+            12 => std::borrow::Cow::Borrowed("CONSUMER_SUSPENDED"),
+            13 => std::borrow::Cow::Borrowed("API_KEY_IOS_APP_BLOCKED"),
+            14 => std::borrow::Cow::Borrowed("CONSUMER_INVALID"),
+            15 => std::borrow::Cow::Borrowed("SECURITY_POLICY_VIOLATED"),
+            16 => std::borrow::Cow::Borrowed("ACCESS_TOKEN_EXPIRED"),
+            17 => std::borrow::Cow::Borrowed("ACCESS_TOKEN_SCOPE_INSUFFICIENT"),
+            18 => std::borrow::Cow::Borrowed("ACCOUNT_STATE_INVALID"),
+            19 => std::borrow::Cow::Borrowed("ACCESS_TOKEN_TYPE_UNSUPPORTED"),
+            20 => std::borrow::Cow::Borrowed("CREDENTIALS_MISSING"),
+            21 => std::borrow::Cow::Borrowed("RESOURCE_PROJECT_INVALID"),
+            23 => std::borrow::Cow::Borrowed("SESSION_COOKIE_INVALID"),
+            24 => std::borrow::Cow::Borrowed("USER_BLOCKED_BY_ADMIN"),
+            25 => std::borrow::Cow::Borrowed("RESOURCE_USAGE_RESTRICTION_VIOLATED"),
+            26 => std::borrow::Cow::Borrowed("SYSTEM_PARAMETER_UNSUPPORTED"),
+            27 => std::borrow::Cow::Borrowed("ORG_RESTRICTION_VIOLATION"),
+            28 => std::borrow::Cow::Borrowed("ORG_RESTRICTION_HEADER_INVALID"),
+            29 => std::borrow::Cow::Borrowed("SERVICE_NOT_VISIBLE"),
+            30 => std::borrow::Cow::Borrowed("GCP_SUSPENDED"),
+            31 => std::borrow::Cow::Borrowed("LOCATION_POLICY_VIOLATED"),
+            33 => std::borrow::Cow::Borrowed("MISSING_ORIGIN"),
+            34 => std::borrow::Cow::Borrowed("OVERLOADED_CREDENTIALS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ERROR_REASON_UNSPECIFIED" => std::option::Option::Some(Self::ERROR_REASON_UNSPECIFIED),
+            "SERVICE_DISABLED" => std::option::Option::Some(Self::SERVICE_DISABLED),
+            "BILLING_DISABLED" => std::option::Option::Some(Self::BILLING_DISABLED),
+            "API_KEY_INVALID" => std::option::Option::Some(Self::API_KEY_INVALID),
+            "API_KEY_SERVICE_BLOCKED" => std::option::Option::Some(Self::API_KEY_SERVICE_BLOCKED),
+            "API_KEY_HTTP_REFERRER_BLOCKED" => {
+                std::option::Option::Some(Self::API_KEY_HTTP_REFERRER_BLOCKED)
+            }
+            "API_KEY_IP_ADDRESS_BLOCKED" => {
+                std::option::Option::Some(Self::API_KEY_IP_ADDRESS_BLOCKED)
+            }
+            "API_KEY_ANDROID_APP_BLOCKED" => {
+                std::option::Option::Some(Self::API_KEY_ANDROID_APP_BLOCKED)
+            }
+            "API_KEY_IOS_APP_BLOCKED" => std::option::Option::Some(Self::API_KEY_IOS_APP_BLOCKED),
+            "RATE_LIMIT_EXCEEDED" => std::option::Option::Some(Self::RATE_LIMIT_EXCEEDED),
+            "RESOURCE_QUOTA_EXCEEDED" => std::option::Option::Some(Self::RESOURCE_QUOTA_EXCEEDED),
+            "LOCATION_TAX_POLICY_VIOLATED" => {
+                std::option::Option::Some(Self::LOCATION_TAX_POLICY_VIOLATED)
+            }
+            "USER_PROJECT_DENIED" => std::option::Option::Some(Self::USER_PROJECT_DENIED),
+            "CONSUMER_SUSPENDED" => std::option::Option::Some(Self::CONSUMER_SUSPENDED),
+            "CONSUMER_INVALID" => std::option::Option::Some(Self::CONSUMER_INVALID),
+            "SECURITY_POLICY_VIOLATED" => std::option::Option::Some(Self::SECURITY_POLICY_VIOLATED),
+            "ACCESS_TOKEN_EXPIRED" => std::option::Option::Some(Self::ACCESS_TOKEN_EXPIRED),
+            "ACCESS_TOKEN_SCOPE_INSUFFICIENT" => {
+                std::option::Option::Some(Self::ACCESS_TOKEN_SCOPE_INSUFFICIENT)
+            }
+            "ACCOUNT_STATE_INVALID" => std::option::Option::Some(Self::ACCOUNT_STATE_INVALID),
+            "ACCESS_TOKEN_TYPE_UNSUPPORTED" => {
+                std::option::Option::Some(Self::ACCESS_TOKEN_TYPE_UNSUPPORTED)
+            }
+            "CREDENTIALS_MISSING" => std::option::Option::Some(Self::CREDENTIALS_MISSING),
+            "RESOURCE_PROJECT_INVALID" => std::option::Option::Some(Self::RESOURCE_PROJECT_INVALID),
+            "SESSION_COOKIE_INVALID" => std::option::Option::Some(Self::SESSION_COOKIE_INVALID),
+            "USER_BLOCKED_BY_ADMIN" => std::option::Option::Some(Self::USER_BLOCKED_BY_ADMIN),
+            "RESOURCE_USAGE_RESTRICTION_VIOLATED" => {
+                std::option::Option::Some(Self::RESOURCE_USAGE_RESTRICTION_VIOLATED)
+            }
+            "SYSTEM_PARAMETER_UNSUPPORTED" => {
+                std::option::Option::Some(Self::SYSTEM_PARAMETER_UNSUPPORTED)
+            }
+            "ORG_RESTRICTION_VIOLATION" => {
+                std::option::Option::Some(Self::ORG_RESTRICTION_VIOLATION)
+            }
+            "ORG_RESTRICTION_HEADER_INVALID" => {
+                std::option::Option::Some(Self::ORG_RESTRICTION_HEADER_INVALID)
+            }
+            "SERVICE_NOT_VISIBLE" => std::option::Option::Some(Self::SERVICE_NOT_VISIBLE),
+            "GCP_SUSPENDED" => std::option::Option::Some(Self::GCP_SUSPENDED),
+            "LOCATION_POLICY_VIOLATED" => std::option::Option::Some(Self::LOCATION_POLICY_VIOLATED),
+            "MISSING_ORIGIN" => std::option::Option::Some(Self::MISSING_ORIGIN),
+            "OVERLOADED_CREDENTIALS" => std::option::Option::Some(Self::OVERLOADED_CREDENTIALS),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ErrorReason {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ErrorReason {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ErrorReason {
     fn default() -> Self {
-        error_reason::ERROR_REASON_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -9209,65 +9513,49 @@ impl std::default::Default for ErrorReason {
 ///
 /// Note: This enum **may** receive new values in the future.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct FieldBehavior(std::borrow::Cow<'static, str>);
+pub struct FieldBehavior(i32);
 
 impl FieldBehavior {
-    /// Creates a new FieldBehavior instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [FieldBehavior](FieldBehavior)
-pub mod field_behavior {
-    use super::FieldBehavior;
-
     /// Conventional default for enums. Do not use this.
-    pub const FIELD_BEHAVIOR_UNSPECIFIED: FieldBehavior =
-        FieldBehavior::new("FIELD_BEHAVIOR_UNSPECIFIED");
+    pub const FIELD_BEHAVIOR_UNSPECIFIED: FieldBehavior = FieldBehavior::new(0);
 
     /// Specifically denotes a field as optional.
     /// While all fields in protocol buffers are optional, this may be specified
     /// for emphasis if appropriate.
-    pub const OPTIONAL: FieldBehavior = FieldBehavior::new("OPTIONAL");
+    pub const OPTIONAL: FieldBehavior = FieldBehavior::new(1);
 
     /// Denotes a field as required.
     /// This indicates that the field **must** be provided as part of the request,
     /// and failure to do so will cause an error (usually `INVALID_ARGUMENT`).
-    pub const REQUIRED: FieldBehavior = FieldBehavior::new("REQUIRED");
+    pub const REQUIRED: FieldBehavior = FieldBehavior::new(2);
 
     /// Denotes a field as output only.
     /// This indicates that the field is provided in responses, but including the
     /// field in a request does nothing (the server *must* ignore it and
     /// *must not* throw an error as a result of the field's presence).
-    pub const OUTPUT_ONLY: FieldBehavior = FieldBehavior::new("OUTPUT_ONLY");
+    pub const OUTPUT_ONLY: FieldBehavior = FieldBehavior::new(3);
 
     /// Denotes a field as input only.
     /// This indicates that the field is provided in requests, and the
     /// corresponding field is not included in output.
-    pub const INPUT_ONLY: FieldBehavior = FieldBehavior::new("INPUT_ONLY");
+    pub const INPUT_ONLY: FieldBehavior = FieldBehavior::new(4);
 
     /// Denotes a field as immutable.
     /// This indicates that the field may be set once in a request to create a
     /// resource, but may not be changed thereafter.
-    pub const IMMUTABLE: FieldBehavior = FieldBehavior::new("IMMUTABLE");
+    pub const IMMUTABLE: FieldBehavior = FieldBehavior::new(5);
 
     /// Denotes that a (repeated) field is an unordered list.
     /// This indicates that the service may provide the elements of the list
     /// in any arbitrary  order, rather than the order the user originally
     /// provided. Additionally, the list's order may or may not be stable.
-    pub const UNORDERED_LIST: FieldBehavior = FieldBehavior::new("UNORDERED_LIST");
+    pub const UNORDERED_LIST: FieldBehavior = FieldBehavior::new(6);
 
     /// Denotes that this field returns a non-empty default value if not set.
     /// This indicates that if the user provides the empty value in a request,
     /// a non-empty value will be returned. The user will not be aware of what
     /// non-empty value to expect.
-    pub const NON_EMPTY_DEFAULT: FieldBehavior = FieldBehavior::new("NON_EMPTY_DEFAULT");
+    pub const NON_EMPTY_DEFAULT: FieldBehavior = FieldBehavior::new(7);
 
     /// Denotes that the field in a resource (a message annotated with
     /// google.api.resource) is used in the resource name to uniquely identify the
@@ -9281,57 +9569,86 @@ pub mod field_behavior {
     /// depending on the request it is embedded in (e.g. for Create methods name
     /// is optional and unused, while for Update methods it is required). Instead
     /// of method-specific annotations, only `IDENTIFIER` is required.
-    pub const IDENTIFIER: FieldBehavior = FieldBehavior::new("IDENTIFIER");
+    pub const IDENTIFIER: FieldBehavior = FieldBehavior::new(8);
+
+    /// Creates a new FieldBehavior instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("FIELD_BEHAVIOR_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("OPTIONAL"),
+            2 => std::borrow::Cow::Borrowed("REQUIRED"),
+            3 => std::borrow::Cow::Borrowed("OUTPUT_ONLY"),
+            4 => std::borrow::Cow::Borrowed("INPUT_ONLY"),
+            5 => std::borrow::Cow::Borrowed("IMMUTABLE"),
+            6 => std::borrow::Cow::Borrowed("UNORDERED_LIST"),
+            7 => std::borrow::Cow::Borrowed("NON_EMPTY_DEFAULT"),
+            8 => std::borrow::Cow::Borrowed("IDENTIFIER"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "FIELD_BEHAVIOR_UNSPECIFIED" => {
+                std::option::Option::Some(Self::FIELD_BEHAVIOR_UNSPECIFIED)
+            }
+            "OPTIONAL" => std::option::Option::Some(Self::OPTIONAL),
+            "REQUIRED" => std::option::Option::Some(Self::REQUIRED),
+            "OUTPUT_ONLY" => std::option::Option::Some(Self::OUTPUT_ONLY),
+            "INPUT_ONLY" => std::option::Option::Some(Self::INPUT_ONLY),
+            "IMMUTABLE" => std::option::Option::Some(Self::IMMUTABLE),
+            "UNORDERED_LIST" => std::option::Option::Some(Self::UNORDERED_LIST),
+            "NON_EMPTY_DEFAULT" => std::option::Option::Some(Self::NON_EMPTY_DEFAULT),
+            "IDENTIFIER" => std::option::Option::Some(Self::IDENTIFIER),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for FieldBehavior {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for FieldBehavior {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for FieldBehavior {
     fn default() -> Self {
-        field_behavior::FIELD_BEHAVIOR_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The launch stage as defined by [Google Cloud Platform
 /// Launch Stages](https://cloud.google.com/terms/launch-stages).
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LaunchStage(std::borrow::Cow<'static, str>);
+pub struct LaunchStage(i32);
 
 impl LaunchStage {
-    /// Creates a new LaunchStage instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [LaunchStage](LaunchStage)
-pub mod launch_stage {
-    use super::LaunchStage;
-
     /// Do not use this default value.
-    pub const LAUNCH_STAGE_UNSPECIFIED: LaunchStage = LaunchStage::new("LAUNCH_STAGE_UNSPECIFIED");
+    pub const LAUNCH_STAGE_UNSPECIFIED: LaunchStage = LaunchStage::new(0);
 
     /// The feature is not yet implemented. Users can not use it.
-    pub const UNIMPLEMENTED: LaunchStage = LaunchStage::new("UNIMPLEMENTED");
+    pub const UNIMPLEMENTED: LaunchStage = LaunchStage::new(6);
 
     /// Prelaunch features are hidden from users and are only visible internally.
-    pub const PRELAUNCH: LaunchStage = LaunchStage::new("PRELAUNCH");
+    pub const PRELAUNCH: LaunchStage = LaunchStage::new(7);
 
     /// Early Access features are limited to a closed group of testers. To use
     /// these features, you must sign up in advance and sign a Trusted Tester
     /// agreement (which includes confidentiality provisions). These features may
     /// be unstable, changed in backward-incompatible ways, and are not
     /// guaranteed to be released.
-    pub const EARLY_ACCESS: LaunchStage = LaunchStage::new("EARLY_ACCESS");
+    pub const EARLY_ACCESS: LaunchStage = LaunchStage::new(1);
 
     /// Alpha is a limited availability test for releases before they are cleared
     /// for widespread use. By Alpha, all significant design issues are resolved
@@ -9342,35 +9659,75 @@ pub mod launch_stage {
     /// they will be far enough along that customers can actually use them in
     /// test environments or for limited-use tests -- just like they would in
     /// normal production cases.
-    pub const ALPHA: LaunchStage = LaunchStage::new("ALPHA");
+    pub const ALPHA: LaunchStage = LaunchStage::new(2);
 
     /// Beta is the point at which we are ready to open a release for any
     /// customer to use. There are no SLA or technical support obligations in a
     /// Beta release. Products will be complete from a feature perspective, but
     /// may have some open outstanding issues. Beta releases are suitable for
     /// limited production use cases.
-    pub const BETA: LaunchStage = LaunchStage::new("BETA");
+    pub const BETA: LaunchStage = LaunchStage::new(3);
 
     /// GA features are open to all developers and are considered stable and
     /// fully qualified for production use.
-    pub const GA: LaunchStage = LaunchStage::new("GA");
+    pub const GA: LaunchStage = LaunchStage::new(4);
 
     /// Deprecated features are scheduled to be shut down and removed. For more
     /// information, see the "Deprecation Policy" section of our [Terms of
     /// Service](https://cloud.google.com/terms/)
     /// and the [Google Cloud Platform Subject to the Deprecation
     /// Policy](https://cloud.google.com/terms/deprecation) documentation.
-    pub const DEPRECATED: LaunchStage = LaunchStage::new("DEPRECATED");
+    pub const DEPRECATED: LaunchStage = LaunchStage::new(5);
+
+    /// Creates a new LaunchStage instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("LAUNCH_STAGE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("EARLY_ACCESS"),
+            2 => std::borrow::Cow::Borrowed("ALPHA"),
+            3 => std::borrow::Cow::Borrowed("BETA"),
+            4 => std::borrow::Cow::Borrowed("GA"),
+            5 => std::borrow::Cow::Borrowed("DEPRECATED"),
+            6 => std::borrow::Cow::Borrowed("UNIMPLEMENTED"),
+            7 => std::borrow::Cow::Borrowed("PRELAUNCH"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "LAUNCH_STAGE_UNSPECIFIED" => std::option::Option::Some(Self::LAUNCH_STAGE_UNSPECIFIED),
+            "UNIMPLEMENTED" => std::option::Option::Some(Self::UNIMPLEMENTED),
+            "PRELAUNCH" => std::option::Option::Some(Self::PRELAUNCH),
+            "EARLY_ACCESS" => std::option::Option::Some(Self::EARLY_ACCESS),
+            "ALPHA" => std::option::Option::Some(Self::ALPHA),
+            "BETA" => std::option::Option::Some(Self::BETA),
+            "GA" => std::option::Option::Some(Self::GA),
+            "DEPRECATED" => std::option::Option::Some(Self::DEPRECATED),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for LaunchStage {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for LaunchStage {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for LaunchStage {
     fn default() -> Self {
-        launch_stage::LAUNCH_STAGE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/appengine/v1/src/model.rs
+++ b/src/generated/appengine/v1/src/model.rs
@@ -167,51 +167,70 @@ pub mod error_handler {
 
     /// Error codes.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ErrorCode(std::borrow::Cow<'static, str>);
+    pub struct ErrorCode(i32);
 
     impl ErrorCode {
-        /// Creates a new ErrorCode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ErrorCode](ErrorCode)
-    pub mod error_code {
-        use super::ErrorCode;
-
         /// Not specified. ERROR_CODE_DEFAULT is assumed.
-        pub const ERROR_CODE_UNSPECIFIED: ErrorCode = ErrorCode::new("ERROR_CODE_UNSPECIFIED");
+        pub const ERROR_CODE_UNSPECIFIED: ErrorCode = ErrorCode::new(0);
 
         /// All other error types.
-        pub const ERROR_CODE_DEFAULT: ErrorCode = ErrorCode::new("ERROR_CODE_DEFAULT");
+        pub const ERROR_CODE_DEFAULT: ErrorCode = ErrorCode::new(0);
 
         /// Application has exceeded a resource quota.
-        pub const ERROR_CODE_OVER_QUOTA: ErrorCode = ErrorCode::new("ERROR_CODE_OVER_QUOTA");
+        pub const ERROR_CODE_OVER_QUOTA: ErrorCode = ErrorCode::new(1);
 
         /// Client blocked by the application's Denial of Service protection
         /// configuration.
-        pub const ERROR_CODE_DOS_API_DENIAL: ErrorCode =
-            ErrorCode::new("ERROR_CODE_DOS_API_DENIAL");
+        pub const ERROR_CODE_DOS_API_DENIAL: ErrorCode = ErrorCode::new(2);
 
         /// Deadline reached before the application responds.
-        pub const ERROR_CODE_TIMEOUT: ErrorCode = ErrorCode::new("ERROR_CODE_TIMEOUT");
+        pub const ERROR_CODE_TIMEOUT: ErrorCode = ErrorCode::new(3);
+
+        /// Creates a new ErrorCode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ERROR_CODE_DEFAULT"),
+                1 => std::borrow::Cow::Borrowed("ERROR_CODE_OVER_QUOTA"),
+                2 => std::borrow::Cow::Borrowed("ERROR_CODE_DOS_API_DENIAL"),
+                3 => std::borrow::Cow::Borrowed("ERROR_CODE_TIMEOUT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ERROR_CODE_UNSPECIFIED" => std::option::Option::Some(Self::ERROR_CODE_UNSPECIFIED),
+                "ERROR_CODE_DEFAULT" => std::option::Option::Some(Self::ERROR_CODE_DEFAULT),
+                "ERROR_CODE_OVER_QUOTA" => std::option::Option::Some(Self::ERROR_CODE_OVER_QUOTA),
+                "ERROR_CODE_DOS_API_DENIAL" => {
+                    std::option::Option::Some(Self::ERROR_CODE_DOS_API_DENIAL)
+                }
+                "ERROR_CODE_TIMEOUT" => std::option::Option::Some(Self::ERROR_CODE_TIMEOUT),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ErrorCode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ErrorCode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ErrorCode {
         fn default() -> Self {
-            error_code::ERROR_CODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -408,54 +427,83 @@ pub mod url_map {
 
     /// Redirect codes.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RedirectHttpResponseCode(std::borrow::Cow<'static, str>);
+    pub struct RedirectHttpResponseCode(i32);
 
     impl RedirectHttpResponseCode {
-        /// Creates a new RedirectHttpResponseCode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RedirectHttpResponseCode](RedirectHttpResponseCode)
-    pub mod redirect_http_response_code {
-        use super::RedirectHttpResponseCode;
-
         /// Not specified. `302` is assumed.
         pub const REDIRECT_HTTP_RESPONSE_CODE_UNSPECIFIED: RedirectHttpResponseCode =
-            RedirectHttpResponseCode::new("REDIRECT_HTTP_RESPONSE_CODE_UNSPECIFIED");
+            RedirectHttpResponseCode::new(0);
 
         /// `301 Moved Permanently` code.
         pub const REDIRECT_HTTP_RESPONSE_CODE_301: RedirectHttpResponseCode =
-            RedirectHttpResponseCode::new("REDIRECT_HTTP_RESPONSE_CODE_301");
+            RedirectHttpResponseCode::new(1);
 
         /// `302 Moved Temporarily` code.
         pub const REDIRECT_HTTP_RESPONSE_CODE_302: RedirectHttpResponseCode =
-            RedirectHttpResponseCode::new("REDIRECT_HTTP_RESPONSE_CODE_302");
+            RedirectHttpResponseCode::new(2);
 
         /// `303 See Other` code.
         pub const REDIRECT_HTTP_RESPONSE_CODE_303: RedirectHttpResponseCode =
-            RedirectHttpResponseCode::new("REDIRECT_HTTP_RESPONSE_CODE_303");
+            RedirectHttpResponseCode::new(3);
 
         /// `307 Temporary Redirect` code.
         pub const REDIRECT_HTTP_RESPONSE_CODE_307: RedirectHttpResponseCode =
-            RedirectHttpResponseCode::new("REDIRECT_HTTP_RESPONSE_CODE_307");
+            RedirectHttpResponseCode::new(4);
+
+        /// Creates a new RedirectHttpResponseCode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("REDIRECT_HTTP_RESPONSE_CODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REDIRECT_HTTP_RESPONSE_CODE_301"),
+                2 => std::borrow::Cow::Borrowed("REDIRECT_HTTP_RESPONSE_CODE_302"),
+                3 => std::borrow::Cow::Borrowed("REDIRECT_HTTP_RESPONSE_CODE_303"),
+                4 => std::borrow::Cow::Borrowed("REDIRECT_HTTP_RESPONSE_CODE_307"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "REDIRECT_HTTP_RESPONSE_CODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::REDIRECT_HTTP_RESPONSE_CODE_UNSPECIFIED)
+                }
+                "REDIRECT_HTTP_RESPONSE_CODE_301" => {
+                    std::option::Option::Some(Self::REDIRECT_HTTP_RESPONSE_CODE_301)
+                }
+                "REDIRECT_HTTP_RESPONSE_CODE_302" => {
+                    std::option::Option::Some(Self::REDIRECT_HTTP_RESPONSE_CODE_302)
+                }
+                "REDIRECT_HTTP_RESPONSE_CODE_303" => {
+                    std::option::Option::Some(Self::REDIRECT_HTTP_RESPONSE_CODE_303)
+                }
+                "REDIRECT_HTTP_RESPONSE_CODE_307" => {
+                    std::option::Option::Some(Self::REDIRECT_HTTP_RESPONSE_CODE_307)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RedirectHttpResponseCode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RedirectHttpResponseCode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RedirectHttpResponseCode {
         fn default() -> Self {
-            redirect_http_response_code::REDIRECT_HTTP_RESPONSE_CODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -3272,92 +3320,128 @@ pub mod application {
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ServingStatus(std::borrow::Cow<'static, str>);
+    pub struct ServingStatus(i32);
 
     impl ServingStatus {
+        /// Serving status is unspecified.
+        pub const UNSPECIFIED: ServingStatus = ServingStatus::new(0);
+
+        /// Application is serving.
+        pub const SERVING: ServingStatus = ServingStatus::new(1);
+
+        /// Application has been disabled by the user.
+        pub const USER_DISABLED: ServingStatus = ServingStatus::new(2);
+
+        /// Application has been disabled by the system.
+        pub const SYSTEM_DISABLED: ServingStatus = ServingStatus::new(3);
+
         /// Creates a new ServingStatus instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SERVING"),
+                2 => std::borrow::Cow::Borrowed("USER_DISABLED"),
+                3 => std::borrow::Cow::Borrowed("SYSTEM_DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
+                "SERVING" => std::option::Option::Some(Self::SERVING),
+                "USER_DISABLED" => std::option::Option::Some(Self::USER_DISABLED),
+                "SYSTEM_DISABLED" => std::option::Option::Some(Self::SYSTEM_DISABLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ServingStatus](ServingStatus)
-    pub mod serving_status {
-        use super::ServingStatus;
-
-        /// Serving status is unspecified.
-        pub const UNSPECIFIED: ServingStatus = ServingStatus::new("UNSPECIFIED");
-
-        /// Application is serving.
-        pub const SERVING: ServingStatus = ServingStatus::new("SERVING");
-
-        /// Application has been disabled by the user.
-        pub const USER_DISABLED: ServingStatus = ServingStatus::new("USER_DISABLED");
-
-        /// Application has been disabled by the system.
-        pub const SYSTEM_DISABLED: ServingStatus = ServingStatus::new("SYSTEM_DISABLED");
-    }
-
-    impl std::convert::From<std::string::String> for ServingStatus {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ServingStatus {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ServingStatus {
         fn default() -> Self {
-            serving_status::UNSPECIFIED
+            Self::new(0)
         }
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DatabaseType(std::borrow::Cow<'static, str>);
+    pub struct DatabaseType(i32);
 
     impl DatabaseType {
+        /// Database type is unspecified.
+        pub const DATABASE_TYPE_UNSPECIFIED: DatabaseType = DatabaseType::new(0);
+
+        /// Cloud Datastore
+        pub const CLOUD_DATASTORE: DatabaseType = DatabaseType::new(1);
+
+        /// Cloud Firestore Native
+        pub const CLOUD_FIRESTORE: DatabaseType = DatabaseType::new(2);
+
+        /// Cloud Firestore in Datastore Mode
+        pub const CLOUD_DATASTORE_COMPATIBILITY: DatabaseType = DatabaseType::new(3);
+
         /// Creates a new DatabaseType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATABASE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CLOUD_DATASTORE"),
+                2 => std::borrow::Cow::Borrowed("CLOUD_FIRESTORE"),
+                3 => std::borrow::Cow::Borrowed("CLOUD_DATASTORE_COMPATIBILITY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATABASE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DATABASE_TYPE_UNSPECIFIED)
+                }
+                "CLOUD_DATASTORE" => std::option::Option::Some(Self::CLOUD_DATASTORE),
+                "CLOUD_FIRESTORE" => std::option::Option::Some(Self::CLOUD_FIRESTORE),
+                "CLOUD_DATASTORE_COMPATIBILITY" => {
+                    std::option::Option::Some(Self::CLOUD_DATASTORE_COMPATIBILITY)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DatabaseType](DatabaseType)
-    pub mod database_type {
-        use super::DatabaseType;
-
-        /// Database type is unspecified.
-        pub const DATABASE_TYPE_UNSPECIFIED: DatabaseType =
-            DatabaseType::new("DATABASE_TYPE_UNSPECIFIED");
-
-        /// Cloud Datastore
-        pub const CLOUD_DATASTORE: DatabaseType = DatabaseType::new("CLOUD_DATASTORE");
-
-        /// Cloud Firestore Native
-        pub const CLOUD_FIRESTORE: DatabaseType = DatabaseType::new("CLOUD_FIRESTORE");
-
-        /// Cloud Firestore in Datastore Mode
-        pub const CLOUD_DATASTORE_COMPATIBILITY: DatabaseType =
-            DatabaseType::new("CLOUD_DATASTORE_COMPATIBILITY");
-    }
-
-    impl std::convert::From<std::string::String> for DatabaseType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DatabaseType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DatabaseType {
         fn default() -> Self {
-            database_type::DATABASE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4340,47 +4424,63 @@ pub mod ssl_settings {
 
     /// The SSL management type for this domain.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SslManagementType(std::borrow::Cow<'static, str>);
+    pub struct SslManagementType(i32);
 
     impl SslManagementType {
-        /// Creates a new SslManagementType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [SslManagementType](SslManagementType)
-    pub mod ssl_management_type {
-        use super::SslManagementType;
-
         /// Defaults to `AUTOMATIC`.
-        pub const SSL_MANAGEMENT_TYPE_UNSPECIFIED: SslManagementType =
-            SslManagementType::new("SSL_MANAGEMENT_TYPE_UNSPECIFIED");
+        pub const SSL_MANAGEMENT_TYPE_UNSPECIFIED: SslManagementType = SslManagementType::new(0);
 
         /// SSL support for this domain is configured automatically. The mapped SSL
         /// certificate will be automatically renewed.
-        pub const AUTOMATIC: SslManagementType = SslManagementType::new("AUTOMATIC");
+        pub const AUTOMATIC: SslManagementType = SslManagementType::new(1);
 
         /// SSL support for this domain is configured manually by the user. Either
         /// the domain has no SSL support or a user-obtained SSL certificate has been
         /// explictly mapped to this domain.
-        pub const MANUAL: SslManagementType = SslManagementType::new("MANUAL");
+        pub const MANUAL: SslManagementType = SslManagementType::new(2);
+
+        /// Creates a new SslManagementType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SSL_MANAGEMENT_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AUTOMATIC"),
+                2 => std::borrow::Cow::Borrowed("MANUAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SSL_MANAGEMENT_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SSL_MANAGEMENT_TYPE_UNSPECIFIED)
+                }
+                "AUTOMATIC" => std::option::Option::Some(Self::AUTOMATIC),
+                "MANUAL" => std::option::Option::Some(Self::MANUAL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for SslManagementType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SslManagementType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SslManagementType {
         fn default() -> Self {
-            ssl_management_type::SSL_MANAGEMENT_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4446,46 +4546,65 @@ pub mod resource_record {
 
     /// A resource record type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RecordType(std::borrow::Cow<'static, str>);
+    pub struct RecordType(i32);
 
     impl RecordType {
+        /// An unknown resource record.
+        pub const RECORD_TYPE_UNSPECIFIED: RecordType = RecordType::new(0);
+
+        /// An A resource record. Data is an IPv4 address.
+        pub const A: RecordType = RecordType::new(1);
+
+        /// An AAAA resource record. Data is an IPv6 address.
+        pub const AAAA: RecordType = RecordType::new(2);
+
+        /// A CNAME resource record. Data is a domain name to be aliased.
+        pub const CNAME: RecordType = RecordType::new(3);
+
         /// Creates a new RecordType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RECORD_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("A"),
+                2 => std::borrow::Cow::Borrowed("AAAA"),
+                3 => std::borrow::Cow::Borrowed("CNAME"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RECORD_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RECORD_TYPE_UNSPECIFIED)
+                }
+                "A" => std::option::Option::Some(Self::A),
+                "AAAA" => std::option::Option::Some(Self::AAAA),
+                "CNAME" => std::option::Option::Some(Self::CNAME),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RecordType](RecordType)
-    pub mod record_type {
-        use super::RecordType;
-
-        /// An unknown resource record.
-        pub const RECORD_TYPE_UNSPECIFIED: RecordType = RecordType::new("RECORD_TYPE_UNSPECIFIED");
-
-        /// An A resource record. Data is an IPv4 address.
-        pub const A: RecordType = RecordType::new("A");
-
-        /// An AAAA resource record. Data is an IPv6 address.
-        pub const AAAA: RecordType = RecordType::new("AAAA");
-
-        /// A CNAME resource record. Data is a domain name to be aliased.
-        pub const CNAME: RecordType = RecordType::new("CNAME");
-    }
-
-    impl std::convert::From<std::string::String> for RecordType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RecordType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RecordType {
         fn default() -> Self {
-            record_type::RECORD_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4568,42 +4687,57 @@ pub mod firewall_rule {
 
     /// Available actions to take on matching requests.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(std::borrow::Cow<'static, str>);
+    pub struct Action(i32);
 
     impl Action {
+        pub const UNSPECIFIED_ACTION: Action = Action::new(0);
+
+        /// Matching requests are allowed.
+        pub const ALLOW: Action = Action::new(1);
+
+        /// Matching requests are denied.
+        pub const DENY: Action = Action::new(2);
+
         /// Creates a new Action instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNSPECIFIED_ACTION"),
+                1 => std::borrow::Cow::Borrowed("ALLOW"),
+                2 => std::borrow::Cow::Borrowed("DENY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNSPECIFIED_ACTION" => std::option::Option::Some(Self::UNSPECIFIED_ACTION),
+                "ALLOW" => std::option::Option::Some(Self::ALLOW),
+                "DENY" => std::option::Option::Some(Self::DENY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Action](Action)
-    pub mod action {
-        use super::Action;
-
-        pub const UNSPECIFIED_ACTION: Action = Action::new("UNSPECIFIED_ACTION");
-
-        /// Matching requests are allowed.
-        pub const ALLOW: Action = Action::new("ALLOW");
-
-        /// Matching requests are denied.
-        pub const DENY: Action = Action::new("DENY");
-    }
-
-    impl std::convert::From<std::string::String> for Action {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            action::UNSPECIFIED_ACTION
+            Self::new(0)
         }
     }
 }
@@ -4847,101 +4981,138 @@ pub mod instance {
 
         /// Liveness health check status for Flex instances.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct LivenessState(std::borrow::Cow<'static, str>);
+        pub struct LivenessState(i32);
 
         impl LivenessState {
-            /// Creates a new LivenessState instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [LivenessState](LivenessState)
-        pub mod liveness_state {
-            use super::LivenessState;
-
             /// There is no liveness health check for the instance. Only applicable for
             /// instances in App Engine standard environment.
-            pub const LIVENESS_STATE_UNSPECIFIED: LivenessState =
-                LivenessState::new("LIVENESS_STATE_UNSPECIFIED");
+            pub const LIVENESS_STATE_UNSPECIFIED: LivenessState = LivenessState::new(0);
 
             /// The health checking system is aware of the instance but its health is
             /// not known at the moment.
-            pub const UNKNOWN: LivenessState = LivenessState::new("UNKNOWN");
+            pub const UNKNOWN: LivenessState = LivenessState::new(1);
 
             /// The instance is reachable i.e. a connection to the application health
             /// checking endpoint can be established, and conforms to the requirements
             /// defined by the health check.
-            pub const HEALTHY: LivenessState = LivenessState::new("HEALTHY");
+            pub const HEALTHY: LivenessState = LivenessState::new(2);
 
             /// The instance is reachable, but does not conform to the requirements
             /// defined by the health check.
-            pub const UNHEALTHY: LivenessState = LivenessState::new("UNHEALTHY");
+            pub const UNHEALTHY: LivenessState = LivenessState::new(3);
 
             /// The instance is being drained. The existing connections to the instance
             /// have time to complete, but the new ones are being refused.
-            pub const DRAINING: LivenessState = LivenessState::new("DRAINING");
+            pub const DRAINING: LivenessState = LivenessState::new(4);
 
             /// The instance is unreachable i.e. a connection to the application health
             /// checking endpoint cannot be established, or the server does not respond
             /// within the specified timeout.
-            pub const TIMEOUT: LivenessState = LivenessState::new("TIMEOUT");
+            pub const TIMEOUT: LivenessState = LivenessState::new(5);
+
+            /// Creates a new LivenessState instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("LIVENESS_STATE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                    2 => std::borrow::Cow::Borrowed("HEALTHY"),
+                    3 => std::borrow::Cow::Borrowed("UNHEALTHY"),
+                    4 => std::borrow::Cow::Borrowed("DRAINING"),
+                    5 => std::borrow::Cow::Borrowed("TIMEOUT"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "LIVENESS_STATE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::LIVENESS_STATE_UNSPECIFIED)
+                    }
+                    "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                    "HEALTHY" => std::option::Option::Some(Self::HEALTHY),
+                    "UNHEALTHY" => std::option::Option::Some(Self::UNHEALTHY),
+                    "DRAINING" => std::option::Option::Some(Self::DRAINING),
+                    "TIMEOUT" => std::option::Option::Some(Self::TIMEOUT),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for LivenessState {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for LivenessState {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for LivenessState {
             fn default() -> Self {
-                liveness_state::LIVENESS_STATE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// Availability of the instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Availability(std::borrow::Cow<'static, str>);
+    pub struct Availability(i32);
 
     impl Availability {
+        pub const UNSPECIFIED: Availability = Availability::new(0);
+
+        pub const RESIDENT: Availability = Availability::new(1);
+
+        pub const DYNAMIC: Availability = Availability::new(2);
+
         /// Creates a new Availability instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RESIDENT"),
+                2 => std::borrow::Cow::Borrowed("DYNAMIC"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
+                "RESIDENT" => std::option::Option::Some(Self::RESIDENT),
+                "DYNAMIC" => std::option::Option::Some(Self::DYNAMIC),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Availability](Availability)
-    pub mod availability {
-        use super::Availability;
-
-        pub const UNSPECIFIED: Availability = Availability::new("UNSPECIFIED");
-
-        pub const RESIDENT: Availability = Availability::new("RESIDENT");
-
-        pub const DYNAMIC: Availability = Availability::new("DYNAMIC");
-    }
-
-    impl std::convert::From<std::string::String> for Availability {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Availability {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Availability {
         fn default() -> Self {
-            availability::UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5038,50 +5209,75 @@ pub mod network_settings {
 
     /// If unspecified, INGRESS_TRAFFIC_ALLOWED_ALL will be used.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IngressTrafficAllowed(std::borrow::Cow<'static, str>);
+    pub struct IngressTrafficAllowed(i32);
 
     impl IngressTrafficAllowed {
-        /// Creates a new IngressTrafficAllowed instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [IngressTrafficAllowed](IngressTrafficAllowed)
-    pub mod ingress_traffic_allowed {
-        use super::IngressTrafficAllowed;
-
         /// Unspecified
         pub const INGRESS_TRAFFIC_ALLOWED_UNSPECIFIED: IngressTrafficAllowed =
-            IngressTrafficAllowed::new("INGRESS_TRAFFIC_ALLOWED_UNSPECIFIED");
+            IngressTrafficAllowed::new(0);
 
         /// Allow HTTP traffic from public and private sources.
         pub const INGRESS_TRAFFIC_ALLOWED_ALL: IngressTrafficAllowed =
-            IngressTrafficAllowed::new("INGRESS_TRAFFIC_ALLOWED_ALL");
+            IngressTrafficAllowed::new(1);
 
         /// Allow HTTP traffic from only private VPC sources.
         pub const INGRESS_TRAFFIC_ALLOWED_INTERNAL_ONLY: IngressTrafficAllowed =
-            IngressTrafficAllowed::new("INGRESS_TRAFFIC_ALLOWED_INTERNAL_ONLY");
+            IngressTrafficAllowed::new(2);
 
         /// Allow HTTP traffic from private VPC sources and through load balancers.
         pub const INGRESS_TRAFFIC_ALLOWED_INTERNAL_AND_LB: IngressTrafficAllowed =
-            IngressTrafficAllowed::new("INGRESS_TRAFFIC_ALLOWED_INTERNAL_AND_LB");
+            IngressTrafficAllowed::new(3);
+
+        /// Creates a new IngressTrafficAllowed instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("INGRESS_TRAFFIC_ALLOWED_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INGRESS_TRAFFIC_ALLOWED_ALL"),
+                2 => std::borrow::Cow::Borrowed("INGRESS_TRAFFIC_ALLOWED_INTERNAL_ONLY"),
+                3 => std::borrow::Cow::Borrowed("INGRESS_TRAFFIC_ALLOWED_INTERNAL_AND_LB"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "INGRESS_TRAFFIC_ALLOWED_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::INGRESS_TRAFFIC_ALLOWED_UNSPECIFIED)
+                }
+                "INGRESS_TRAFFIC_ALLOWED_ALL" => {
+                    std::option::Option::Some(Self::INGRESS_TRAFFIC_ALLOWED_ALL)
+                }
+                "INGRESS_TRAFFIC_ALLOWED_INTERNAL_ONLY" => {
+                    std::option::Option::Some(Self::INGRESS_TRAFFIC_ALLOWED_INTERNAL_ONLY)
+                }
+                "INGRESS_TRAFFIC_ALLOWED_INTERNAL_AND_LB" => {
+                    std::option::Option::Some(Self::INGRESS_TRAFFIC_ALLOWED_INTERNAL_AND_LB)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for IngressTrafficAllowed {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for IngressTrafficAllowed {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for IngressTrafficAllowed {
         fn default() -> Self {
-            ingress_traffic_allowed::INGRESS_TRAFFIC_ALLOWED_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5469,50 +5665,67 @@ pub mod traffic_split {
 
     /// Available sharding mechanisms.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ShardBy(std::borrow::Cow<'static, str>);
+    pub struct ShardBy(i32);
 
     impl ShardBy {
-        /// Creates a new ShardBy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ShardBy](ShardBy)
-    pub mod shard_by {
-        use super::ShardBy;
-
         /// Diversion method unspecified.
-        pub const UNSPECIFIED: ShardBy = ShardBy::new("UNSPECIFIED");
+        pub const UNSPECIFIED: ShardBy = ShardBy::new(0);
 
         /// Diversion based on a specially named cookie, "GOOGAPPUID." The cookie
         /// must be set by the application itself or no diversion will occur.
-        pub const COOKIE: ShardBy = ShardBy::new("COOKIE");
+        pub const COOKIE: ShardBy = ShardBy::new(1);
 
         /// Diversion based on applying the modulus operation to a fingerprint
         /// of the IP address.
-        pub const IP: ShardBy = ShardBy::new("IP");
+        pub const IP: ShardBy = ShardBy::new(2);
 
         /// Diversion based on weighted random assignment. An incoming request is
         /// randomly routed to a version in the traffic split, with probability
         /// proportional to the version's traffic share.
-        pub const RANDOM: ShardBy = ShardBy::new("RANDOM");
+        pub const RANDOM: ShardBy = ShardBy::new(3);
+
+        /// Creates a new ShardBy instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("COOKIE"),
+                2 => std::borrow::Cow::Borrowed("IP"),
+                3 => std::borrow::Cow::Borrowed("RANDOM"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
+                "COOKIE" => std::option::Option::Some(Self::COOKIE),
+                "IP" => std::option::Option::Some(Self::IP),
+                "RANDOM" => std::option::Option::Some(Self::RANDOM),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ShardBy {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ShardBy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ShardBy {
         fn default() -> Self {
-            shard_by::UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6301,45 +6514,61 @@ pub mod endpoints_api_service {
 
     /// Available rollout strategies.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RolloutStrategy(std::borrow::Cow<'static, str>);
+    pub struct RolloutStrategy(i32);
 
     impl RolloutStrategy {
-        /// Creates a new RolloutStrategy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RolloutStrategy](RolloutStrategy)
-    pub mod rollout_strategy {
-        use super::RolloutStrategy;
-
         /// Not specified. Defaults to `FIXED`.
-        pub const UNSPECIFIED_ROLLOUT_STRATEGY: RolloutStrategy =
-            RolloutStrategy::new("UNSPECIFIED_ROLLOUT_STRATEGY");
+        pub const UNSPECIFIED_ROLLOUT_STRATEGY: RolloutStrategy = RolloutStrategy::new(0);
 
         /// Endpoints service configuration ID will be fixed to the configuration ID
         /// specified by `config_id`.
-        pub const FIXED: RolloutStrategy = RolloutStrategy::new("FIXED");
+        pub const FIXED: RolloutStrategy = RolloutStrategy::new(1);
 
         /// Endpoints service configuration ID will be updated with each rollout.
-        pub const MANAGED: RolloutStrategy = RolloutStrategy::new("MANAGED");
+        pub const MANAGED: RolloutStrategy = RolloutStrategy::new(2);
+
+        /// Creates a new RolloutStrategy instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNSPECIFIED_ROLLOUT_STRATEGY"),
+                1 => std::borrow::Cow::Borrowed("FIXED"),
+                2 => std::borrow::Cow::Borrowed("MANAGED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNSPECIFIED_ROLLOUT_STRATEGY" => {
+                    std::option::Option::Some(Self::UNSPECIFIED_ROLLOUT_STRATEGY)
+                }
+                "FIXED" => std::option::Option::Some(Self::FIXED),
+                "MANAGED" => std::option::Option::Some(Self::MANAGED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RolloutStrategy {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RolloutStrategy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RolloutStrategy {
         fn default() -> Self {
-            rollout_strategy::UNSPECIFIED_ROLLOUT_STRATEGY
+            Self::new(0)
         }
     }
 }
@@ -7148,43 +7377,59 @@ pub mod vpc_access_connector {
     /// This controls what traffic is diverted through the VPC Access Connector
     /// resource. By default PRIVATE_IP_RANGES will be used.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EgressSetting(std::borrow::Cow<'static, str>);
+    pub struct EgressSetting(i32);
 
     impl EgressSetting {
+        pub const EGRESS_SETTING_UNSPECIFIED: EgressSetting = EgressSetting::new(0);
+
+        /// Force the use of VPC Access for all egress traffic from the function.
+        pub const ALL_TRAFFIC: EgressSetting = EgressSetting::new(1);
+
+        /// Use the VPC Access Connector for private IP space from RFC1918.
+        pub const PRIVATE_IP_RANGES: EgressSetting = EgressSetting::new(2);
+
         /// Creates a new EgressSetting instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EGRESS_SETTING_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALL_TRAFFIC"),
+                2 => std::borrow::Cow::Borrowed("PRIVATE_IP_RANGES"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EGRESS_SETTING_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::EGRESS_SETTING_UNSPECIFIED)
+                }
+                "ALL_TRAFFIC" => std::option::Option::Some(Self::ALL_TRAFFIC),
+                "PRIVATE_IP_RANGES" => std::option::Option::Some(Self::PRIVATE_IP_RANGES),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [EgressSetting](EgressSetting)
-    pub mod egress_setting {
-        use super::EgressSetting;
-
-        pub const EGRESS_SETTING_UNSPECIFIED: EgressSetting =
-            EgressSetting::new("EGRESS_SETTING_UNSPECIFIED");
-
-        /// Force the use of VPC Access for all egress traffic from the function.
-        pub const ALL_TRAFFIC: EgressSetting = EgressSetting::new("ALL_TRAFFIC");
-
-        /// Use the VPC Access Connector for private IP space from RFC1918.
-        pub const PRIVATE_IP_RANGES: EgressSetting = EgressSetting::new("PRIVATE_IP_RANGES");
-    }
-
-    impl std::convert::From<std::string::String> for EgressSetting {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EgressSetting {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EgressSetting {
         fn default() -> Self {
-            egress_setting::EGRESS_SETTING_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7262,153 +7507,206 @@ pub mod entrypoint {
 
 /// Actions to take when the user is not logged in.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AuthFailAction(std::borrow::Cow<'static, str>);
+pub struct AuthFailAction(i32);
 
 impl AuthFailAction {
-    /// Creates a new AuthFailAction instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [AuthFailAction](AuthFailAction)
-pub mod auth_fail_action {
-    use super::AuthFailAction;
-
     /// Not specified. `AUTH_FAIL_ACTION_REDIRECT` is assumed.
-    pub const AUTH_FAIL_ACTION_UNSPECIFIED: AuthFailAction =
-        AuthFailAction::new("AUTH_FAIL_ACTION_UNSPECIFIED");
+    pub const AUTH_FAIL_ACTION_UNSPECIFIED: AuthFailAction = AuthFailAction::new(0);
 
     /// Redirects user to "accounts.google.com". The user is redirected back to the
     /// application URL after signing in or creating an account.
-    pub const AUTH_FAIL_ACTION_REDIRECT: AuthFailAction =
-        AuthFailAction::new("AUTH_FAIL_ACTION_REDIRECT");
+    pub const AUTH_FAIL_ACTION_REDIRECT: AuthFailAction = AuthFailAction::new(1);
 
     /// Rejects request with a `401` HTTP status code and an error
     /// message.
-    pub const AUTH_FAIL_ACTION_UNAUTHORIZED: AuthFailAction =
-        AuthFailAction::new("AUTH_FAIL_ACTION_UNAUTHORIZED");
+    pub const AUTH_FAIL_ACTION_UNAUTHORIZED: AuthFailAction = AuthFailAction::new(2);
+
+    /// Creates a new AuthFailAction instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("AUTH_FAIL_ACTION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("AUTH_FAIL_ACTION_REDIRECT"),
+            2 => std::borrow::Cow::Borrowed("AUTH_FAIL_ACTION_UNAUTHORIZED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "AUTH_FAIL_ACTION_UNSPECIFIED" => {
+                std::option::Option::Some(Self::AUTH_FAIL_ACTION_UNSPECIFIED)
+            }
+            "AUTH_FAIL_ACTION_REDIRECT" => {
+                std::option::Option::Some(Self::AUTH_FAIL_ACTION_REDIRECT)
+            }
+            "AUTH_FAIL_ACTION_UNAUTHORIZED" => {
+                std::option::Option::Some(Self::AUTH_FAIL_ACTION_UNAUTHORIZED)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for AuthFailAction {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for AuthFailAction {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for AuthFailAction {
     fn default() -> Self {
-        auth_fail_action::AUTH_FAIL_ACTION_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Methods to restrict access to a URL based on login status.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LoginRequirement(std::borrow::Cow<'static, str>);
+pub struct LoginRequirement(i32);
 
 impl LoginRequirement {
-    /// Creates a new LoginRequirement instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [LoginRequirement](LoginRequirement)
-pub mod login_requirement {
-    use super::LoginRequirement;
-
     /// Not specified. `LOGIN_OPTIONAL` is assumed.
-    pub const LOGIN_UNSPECIFIED: LoginRequirement = LoginRequirement::new("LOGIN_UNSPECIFIED");
+    pub const LOGIN_UNSPECIFIED: LoginRequirement = LoginRequirement::new(0);
 
     /// Does not require that the user is signed in.
-    pub const LOGIN_OPTIONAL: LoginRequirement = LoginRequirement::new("LOGIN_OPTIONAL");
+    pub const LOGIN_OPTIONAL: LoginRequirement = LoginRequirement::new(1);
 
     /// If the user is not signed in, the `auth_fail_action` is taken.
     /// In addition, if the user is not an administrator for the
     /// application, they are given an error message regardless of
     /// `auth_fail_action`. If the user is an administrator, the handler
     /// proceeds.
-    pub const LOGIN_ADMIN: LoginRequirement = LoginRequirement::new("LOGIN_ADMIN");
+    pub const LOGIN_ADMIN: LoginRequirement = LoginRequirement::new(2);
 
     /// If the user has signed in, the handler proceeds normally. Otherwise, the
     /// auth_fail_action is taken.
-    pub const LOGIN_REQUIRED: LoginRequirement = LoginRequirement::new("LOGIN_REQUIRED");
+    pub const LOGIN_REQUIRED: LoginRequirement = LoginRequirement::new(3);
+
+    /// Creates a new LoginRequirement instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("LOGIN_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("LOGIN_OPTIONAL"),
+            2 => std::borrow::Cow::Borrowed("LOGIN_ADMIN"),
+            3 => std::borrow::Cow::Borrowed("LOGIN_REQUIRED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "LOGIN_UNSPECIFIED" => std::option::Option::Some(Self::LOGIN_UNSPECIFIED),
+            "LOGIN_OPTIONAL" => std::option::Option::Some(Self::LOGIN_OPTIONAL),
+            "LOGIN_ADMIN" => std::option::Option::Some(Self::LOGIN_ADMIN),
+            "LOGIN_REQUIRED" => std::option::Option::Some(Self::LOGIN_REQUIRED),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for LoginRequirement {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for LoginRequirement {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for LoginRequirement {
     fn default() -> Self {
-        login_requirement::LOGIN_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Methods to enforce security (HTTPS) on a URL.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SecurityLevel(std::borrow::Cow<'static, str>);
+pub struct SecurityLevel(i32);
 
 impl SecurityLevel {
-    /// Creates a new SecurityLevel instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [SecurityLevel](SecurityLevel)
-pub mod security_level {
-    use super::SecurityLevel;
-
     /// Not specified.
-    pub const SECURE_UNSPECIFIED: SecurityLevel = SecurityLevel::new("SECURE_UNSPECIFIED");
+    pub const SECURE_UNSPECIFIED: SecurityLevel = SecurityLevel::new(0);
 
     /// Both HTTP and HTTPS requests with URLs that match the handler succeed
     /// without redirects. The application can examine the request to determine
     /// which protocol was used, and respond accordingly.
-    pub const SECURE_DEFAULT: SecurityLevel = SecurityLevel::new("SECURE_DEFAULT");
+    pub const SECURE_DEFAULT: SecurityLevel = SecurityLevel::new(0);
 
     /// Requests for a URL that match this handler that use HTTPS are automatically
     /// redirected to the HTTP equivalent URL.
-    pub const SECURE_NEVER: SecurityLevel = SecurityLevel::new("SECURE_NEVER");
+    pub const SECURE_NEVER: SecurityLevel = SecurityLevel::new(1);
 
     /// Both HTTP and HTTPS requests with URLs that match the handler succeed
     /// without redirects. The application can examine the request to determine
     /// which protocol was used and respond accordingly.
-    pub const SECURE_OPTIONAL: SecurityLevel = SecurityLevel::new("SECURE_OPTIONAL");
+    pub const SECURE_OPTIONAL: SecurityLevel = SecurityLevel::new(2);
 
     /// Requests for a URL that match this handler that do not use HTTPS are
     /// automatically redirected to the HTTPS URL with the same path. Query
     /// parameters are reserved for the redirect.
-    pub const SECURE_ALWAYS: SecurityLevel = SecurityLevel::new("SECURE_ALWAYS");
+    pub const SECURE_ALWAYS: SecurityLevel = SecurityLevel::new(3);
+
+    /// Creates a new SecurityLevel instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SECURE_DEFAULT"),
+            1 => std::borrow::Cow::Borrowed("SECURE_NEVER"),
+            2 => std::borrow::Cow::Borrowed("SECURE_OPTIONAL"),
+            3 => std::borrow::Cow::Borrowed("SECURE_ALWAYS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SECURE_UNSPECIFIED" => std::option::Option::Some(Self::SECURE_UNSPECIFIED),
+            "SECURE_DEFAULT" => std::option::Option::Some(Self::SECURE_DEFAULT),
+            "SECURE_NEVER" => std::option::Option::Some(Self::SECURE_NEVER),
+            "SECURE_OPTIONAL" => std::option::Option::Some(Self::SECURE_OPTIONAL),
+            "SECURE_ALWAYS" => std::option::Option::Some(Self::SECURE_ALWAYS),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for SecurityLevel {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SecurityLevel {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SecurityLevel {
     fn default() -> Self {
-        security_level::SECURE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -7417,186 +7715,209 @@ impl std::default::Default for SecurityLevel {
 ///
 /// [google.appengine.v1.Version]: crate::model::Version
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct VersionView(std::borrow::Cow<'static, str>);
+pub struct VersionView(i32);
 
 impl VersionView {
-    /// Creates a new VersionView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [VersionView](VersionView)
-pub mod version_view {
-    use super::VersionView;
-
     /// Basic version information including scaling and inbound services,
     /// but not detailed deployment information.
-    pub const BASIC: VersionView = VersionView::new("BASIC");
+    pub const BASIC: VersionView = VersionView::new(0);
 
     /// The information from `BASIC`, plus detailed information about the
     /// deployment. This format is required when creating resources, but
     /// is not returned in `Get` or `List` by default.
-    pub const FULL: VersionView = VersionView::new("FULL");
+    pub const FULL: VersionView = VersionView::new(1);
+
+    /// Creates a new VersionView instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("BASIC"),
+            1 => std::borrow::Cow::Borrowed("FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "BASIC" => std::option::Option::Some(Self::BASIC),
+            "FULL" => std::option::Option::Some(Self::FULL),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for VersionView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for VersionView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for VersionView {
     fn default() -> Self {
-        version_view::BASIC
+        Self::new(0)
     }
 }
 
 /// Fields that should be returned when an AuthorizedCertificate resource is
 /// retrieved.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AuthorizedCertificateView(std::borrow::Cow<'static, str>);
+pub struct AuthorizedCertificateView(i32);
 
 impl AuthorizedCertificateView {
-    /// Creates a new AuthorizedCertificateView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [AuthorizedCertificateView](AuthorizedCertificateView)
-pub mod authorized_certificate_view {
-    use super::AuthorizedCertificateView;
-
     /// Basic certificate information, including applicable domains and expiration
     /// date.
-    pub const BASIC_CERTIFICATE: AuthorizedCertificateView =
-        AuthorizedCertificateView::new("BASIC_CERTIFICATE");
+    pub const BASIC_CERTIFICATE: AuthorizedCertificateView = AuthorizedCertificateView::new(0);
 
     /// The information from `BASIC_CERTIFICATE`, plus detailed information on the
     /// domain mappings that have this certificate mapped.
-    pub const FULL_CERTIFICATE: AuthorizedCertificateView =
-        AuthorizedCertificateView::new("FULL_CERTIFICATE");
+    pub const FULL_CERTIFICATE: AuthorizedCertificateView = AuthorizedCertificateView::new(1);
+
+    /// Creates a new AuthorizedCertificateView instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("BASIC_CERTIFICATE"),
+            1 => std::borrow::Cow::Borrowed("FULL_CERTIFICATE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "BASIC_CERTIFICATE" => std::option::Option::Some(Self::BASIC_CERTIFICATE),
+            "FULL_CERTIFICATE" => std::option::Option::Some(Self::FULL_CERTIFICATE),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for AuthorizedCertificateView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for AuthorizedCertificateView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for AuthorizedCertificateView {
     fn default() -> Self {
-        authorized_certificate_view::BASIC_CERTIFICATE
+        Self::new(0)
     }
 }
 
 /// Override strategy for mutating an existing mapping.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DomainOverrideStrategy(std::borrow::Cow<'static, str>);
+pub struct DomainOverrideStrategy(i32);
 
 impl DomainOverrideStrategy {
-    /// Creates a new DomainOverrideStrategy instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [DomainOverrideStrategy](DomainOverrideStrategy)
-pub mod domain_override_strategy {
-    use super::DomainOverrideStrategy;
-
     /// Strategy unspecified. Defaults to `STRICT`.
     pub const UNSPECIFIED_DOMAIN_OVERRIDE_STRATEGY: DomainOverrideStrategy =
-        DomainOverrideStrategy::new("UNSPECIFIED_DOMAIN_OVERRIDE_STRATEGY");
+        DomainOverrideStrategy::new(0);
 
     /// Overrides not allowed. If a mapping already exists for the
     /// specified domain, the request will return an ALREADY_EXISTS (409).
-    pub const STRICT: DomainOverrideStrategy = DomainOverrideStrategy::new("STRICT");
+    pub const STRICT: DomainOverrideStrategy = DomainOverrideStrategy::new(1);
 
     /// Overrides allowed. If a mapping already exists for the specified domain,
     /// the request will overwrite it. Note that this might stop another
     /// Google product from serving. For example, if the domain is
     /// mapped to another App Engine application, that app will no
     /// longer serve from that domain.
-    pub const OVERRIDE: DomainOverrideStrategy = DomainOverrideStrategy::new("OVERRIDE");
+    pub const OVERRIDE: DomainOverrideStrategy = DomainOverrideStrategy::new(2);
+
+    /// Creates a new DomainOverrideStrategy instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("UNSPECIFIED_DOMAIN_OVERRIDE_STRATEGY"),
+            1 => std::borrow::Cow::Borrowed("STRICT"),
+            2 => std::borrow::Cow::Borrowed("OVERRIDE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "UNSPECIFIED_DOMAIN_OVERRIDE_STRATEGY" => {
+                std::option::Option::Some(Self::UNSPECIFIED_DOMAIN_OVERRIDE_STRATEGY)
+            }
+            "STRICT" => std::option::Option::Some(Self::STRICT),
+            "OVERRIDE" => std::option::Option::Some(Self::OVERRIDE),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for DomainOverrideStrategy {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DomainOverrideStrategy {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DomainOverrideStrategy {
     fn default() -> Self {
-        domain_override_strategy::UNSPECIFIED_DOMAIN_OVERRIDE_STRATEGY
+        Self::new(0)
     }
 }
 
 /// State of certificate management. Refers to the most recent certificate
 /// acquisition or renewal attempt.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ManagementStatus(std::borrow::Cow<'static, str>);
+pub struct ManagementStatus(i32);
 
 impl ManagementStatus {
-    /// Creates a new ManagementStatus instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ManagementStatus](ManagementStatus)
-pub mod management_status {
-    use super::ManagementStatus;
-
-    pub const MANAGEMENT_STATUS_UNSPECIFIED: ManagementStatus =
-        ManagementStatus::new("MANAGEMENT_STATUS_UNSPECIFIED");
+    pub const MANAGEMENT_STATUS_UNSPECIFIED: ManagementStatus = ManagementStatus::new(0);
 
     /// Certificate was successfully obtained and inserted into the serving
     /// system.
-    pub const OK: ManagementStatus = ManagementStatus::new("OK");
+    pub const OK: ManagementStatus = ManagementStatus::new(1);
 
     /// Certificate is under active attempts to acquire or renew.
-    pub const PENDING: ManagementStatus = ManagementStatus::new("PENDING");
+    pub const PENDING: ManagementStatus = ManagementStatus::new(2);
 
     /// Most recent renewal failed due to an invalid DNS setup and will be
     /// retried. Renewal attempts will continue to fail until the certificate
     /// domain's DNS configuration is fixed. The last successfully provisioned
     /// certificate may still be serving.
-    pub const FAILED_RETRYING_NOT_VISIBLE: ManagementStatus =
-        ManagementStatus::new("FAILED_RETRYING_NOT_VISIBLE");
+    pub const FAILED_RETRYING_NOT_VISIBLE: ManagementStatus = ManagementStatus::new(4);
 
     /// All renewal attempts have been exhausted, likely due to an invalid DNS
     /// setup.
-    pub const FAILED_PERMANENT: ManagementStatus = ManagementStatus::new("FAILED_PERMANENT");
+    pub const FAILED_PERMANENT: ManagementStatus = ManagementStatus::new(6);
 
     /// Most recent renewal failed due to an explicit CAA record that does not
     /// include one of the in-use CAs (Google CA and Let's Encrypt). Renewals will
     /// continue to fail until the CAA is reconfigured. The last successfully
     /// provisioned certificate may still be serving.
-    pub const FAILED_RETRYING_CAA_FORBIDDEN: ManagementStatus =
-        ManagementStatus::new("FAILED_RETRYING_CAA_FORBIDDEN");
+    pub const FAILED_RETRYING_CAA_FORBIDDEN: ManagementStatus = ManagementStatus::new(7);
 
     /// Most recent renewal failed due to a CAA retrieval failure. This means that
     /// the domain's DNS provider does not properly handle CAA records, failing
@@ -7604,134 +7925,227 @@ pub mod management_status {
     /// continue to fail until the DNS provider is changed or a CAA record is
     /// added for the given domain. The last successfully provisioned certificate
     /// may still be serving.
-    pub const FAILED_RETRYING_CAA_CHECKING: ManagementStatus =
-        ManagementStatus::new("FAILED_RETRYING_CAA_CHECKING");
+    pub const FAILED_RETRYING_CAA_CHECKING: ManagementStatus = ManagementStatus::new(8);
+
+    /// Creates a new ManagementStatus instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("MANAGEMENT_STATUS_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("OK"),
+            2 => std::borrow::Cow::Borrowed("PENDING"),
+            4 => std::borrow::Cow::Borrowed("FAILED_RETRYING_NOT_VISIBLE"),
+            6 => std::borrow::Cow::Borrowed("FAILED_PERMANENT"),
+            7 => std::borrow::Cow::Borrowed("FAILED_RETRYING_CAA_FORBIDDEN"),
+            8 => std::borrow::Cow::Borrowed("FAILED_RETRYING_CAA_CHECKING"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "MANAGEMENT_STATUS_UNSPECIFIED" => {
+                std::option::Option::Some(Self::MANAGEMENT_STATUS_UNSPECIFIED)
+            }
+            "OK" => std::option::Option::Some(Self::OK),
+            "PENDING" => std::option::Option::Some(Self::PENDING),
+            "FAILED_RETRYING_NOT_VISIBLE" => {
+                std::option::Option::Some(Self::FAILED_RETRYING_NOT_VISIBLE)
+            }
+            "FAILED_PERMANENT" => std::option::Option::Some(Self::FAILED_PERMANENT),
+            "FAILED_RETRYING_CAA_FORBIDDEN" => {
+                std::option::Option::Some(Self::FAILED_RETRYING_CAA_FORBIDDEN)
+            }
+            "FAILED_RETRYING_CAA_CHECKING" => {
+                std::option::Option::Some(Self::FAILED_RETRYING_CAA_CHECKING)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ManagementStatus {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ManagementStatus {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ManagementStatus {
     fn default() -> Self {
-        management_status::MANAGEMENT_STATUS_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Available inbound services.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct InboundServiceType(std::borrow::Cow<'static, str>);
+pub struct InboundServiceType(i32);
 
 impl InboundServiceType {
-    /// Creates a new InboundServiceType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [InboundServiceType](InboundServiceType)
-pub mod inbound_service_type {
-    use super::InboundServiceType;
-
     /// Not specified.
-    pub const INBOUND_SERVICE_UNSPECIFIED: InboundServiceType =
-        InboundServiceType::new("INBOUND_SERVICE_UNSPECIFIED");
+    pub const INBOUND_SERVICE_UNSPECIFIED: InboundServiceType = InboundServiceType::new(0);
 
     /// Allows an application to receive mail.
-    pub const INBOUND_SERVICE_MAIL: InboundServiceType =
-        InboundServiceType::new("INBOUND_SERVICE_MAIL");
+    pub const INBOUND_SERVICE_MAIL: InboundServiceType = InboundServiceType::new(1);
 
     /// Allows an application to receive email-bound notifications.
-    pub const INBOUND_SERVICE_MAIL_BOUNCE: InboundServiceType =
-        InboundServiceType::new("INBOUND_SERVICE_MAIL_BOUNCE");
+    pub const INBOUND_SERVICE_MAIL_BOUNCE: InboundServiceType = InboundServiceType::new(2);
 
     /// Allows an application to receive error stanzas.
-    pub const INBOUND_SERVICE_XMPP_ERROR: InboundServiceType =
-        InboundServiceType::new("INBOUND_SERVICE_XMPP_ERROR");
+    pub const INBOUND_SERVICE_XMPP_ERROR: InboundServiceType = InboundServiceType::new(3);
 
     /// Allows an application to receive instant messages.
-    pub const INBOUND_SERVICE_XMPP_MESSAGE: InboundServiceType =
-        InboundServiceType::new("INBOUND_SERVICE_XMPP_MESSAGE");
+    pub const INBOUND_SERVICE_XMPP_MESSAGE: InboundServiceType = InboundServiceType::new(4);
 
     /// Allows an application to receive user subscription POSTs.
-    pub const INBOUND_SERVICE_XMPP_SUBSCRIBE: InboundServiceType =
-        InboundServiceType::new("INBOUND_SERVICE_XMPP_SUBSCRIBE");
+    pub const INBOUND_SERVICE_XMPP_SUBSCRIBE: InboundServiceType = InboundServiceType::new(5);
 
     /// Allows an application to receive a user's chat presence.
-    pub const INBOUND_SERVICE_XMPP_PRESENCE: InboundServiceType =
-        InboundServiceType::new("INBOUND_SERVICE_XMPP_PRESENCE");
+    pub const INBOUND_SERVICE_XMPP_PRESENCE: InboundServiceType = InboundServiceType::new(6);
 
     /// Registers an application for notifications when a client connects or
     /// disconnects from a channel.
-    pub const INBOUND_SERVICE_CHANNEL_PRESENCE: InboundServiceType =
-        InboundServiceType::new("INBOUND_SERVICE_CHANNEL_PRESENCE");
+    pub const INBOUND_SERVICE_CHANNEL_PRESENCE: InboundServiceType = InboundServiceType::new(7);
 
     /// Enables warmup requests.
-    pub const INBOUND_SERVICE_WARMUP: InboundServiceType =
-        InboundServiceType::new("INBOUND_SERVICE_WARMUP");
+    pub const INBOUND_SERVICE_WARMUP: InboundServiceType = InboundServiceType::new(9);
+
+    /// Creates a new InboundServiceType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("INBOUND_SERVICE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("INBOUND_SERVICE_MAIL"),
+            2 => std::borrow::Cow::Borrowed("INBOUND_SERVICE_MAIL_BOUNCE"),
+            3 => std::borrow::Cow::Borrowed("INBOUND_SERVICE_XMPP_ERROR"),
+            4 => std::borrow::Cow::Borrowed("INBOUND_SERVICE_XMPP_MESSAGE"),
+            5 => std::borrow::Cow::Borrowed("INBOUND_SERVICE_XMPP_SUBSCRIBE"),
+            6 => std::borrow::Cow::Borrowed("INBOUND_SERVICE_XMPP_PRESENCE"),
+            7 => std::borrow::Cow::Borrowed("INBOUND_SERVICE_CHANNEL_PRESENCE"),
+            9 => std::borrow::Cow::Borrowed("INBOUND_SERVICE_WARMUP"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "INBOUND_SERVICE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::INBOUND_SERVICE_UNSPECIFIED)
+            }
+            "INBOUND_SERVICE_MAIL" => std::option::Option::Some(Self::INBOUND_SERVICE_MAIL),
+            "INBOUND_SERVICE_MAIL_BOUNCE" => {
+                std::option::Option::Some(Self::INBOUND_SERVICE_MAIL_BOUNCE)
+            }
+            "INBOUND_SERVICE_XMPP_ERROR" => {
+                std::option::Option::Some(Self::INBOUND_SERVICE_XMPP_ERROR)
+            }
+            "INBOUND_SERVICE_XMPP_MESSAGE" => {
+                std::option::Option::Some(Self::INBOUND_SERVICE_XMPP_MESSAGE)
+            }
+            "INBOUND_SERVICE_XMPP_SUBSCRIBE" => {
+                std::option::Option::Some(Self::INBOUND_SERVICE_XMPP_SUBSCRIBE)
+            }
+            "INBOUND_SERVICE_XMPP_PRESENCE" => {
+                std::option::Option::Some(Self::INBOUND_SERVICE_XMPP_PRESENCE)
+            }
+            "INBOUND_SERVICE_CHANNEL_PRESENCE" => {
+                std::option::Option::Some(Self::INBOUND_SERVICE_CHANNEL_PRESENCE)
+            }
+            "INBOUND_SERVICE_WARMUP" => std::option::Option::Some(Self::INBOUND_SERVICE_WARMUP),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for InboundServiceType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for InboundServiceType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for InboundServiceType {
     fn default() -> Self {
-        inbound_service_type::INBOUND_SERVICE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Run states of a version.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ServingStatus(std::borrow::Cow<'static, str>);
+pub struct ServingStatus(i32);
 
 impl ServingStatus {
-    /// Creates a new ServingStatus instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ServingStatus](ServingStatus)
-pub mod serving_status {
-    use super::ServingStatus;
-
     /// Not specified.
-    pub const SERVING_STATUS_UNSPECIFIED: ServingStatus =
-        ServingStatus::new("SERVING_STATUS_UNSPECIFIED");
+    pub const SERVING_STATUS_UNSPECIFIED: ServingStatus = ServingStatus::new(0);
 
     /// Currently serving. Instances are created according to the
     /// scaling settings of the version.
-    pub const SERVING: ServingStatus = ServingStatus::new("SERVING");
+    pub const SERVING: ServingStatus = ServingStatus::new(1);
 
     /// Disabled. No instances will be created and the scaling
     /// settings are ignored until the state of the version changes
     /// to `SERVING`.
-    pub const STOPPED: ServingStatus = ServingStatus::new("STOPPED");
+    pub const STOPPED: ServingStatus = ServingStatus::new(2);
+
+    /// Creates a new ServingStatus instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SERVING_STATUS_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SERVING"),
+            2 => std::borrow::Cow::Borrowed("STOPPED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SERVING_STATUS_UNSPECIFIED" => {
+                std::option::Option::Some(Self::SERVING_STATUS_UNSPECIFIED)
+            }
+            "SERVING" => std::option::Option::Some(Self::SERVING),
+            "STOPPED" => std::option::Option::Some(Self::STOPPED),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ServingStatus {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ServingStatus {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ServingStatus {
     fn default() -> Self {
-        serving_status::SERVING_STATUS_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/appengine/v1/src/transport.rs
+++ b/src/generated/appengine/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::Applications for Applications {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -68,7 +68,7 @@ impl crate::stubs::Applications for Applications {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, "/v1/apps".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -87,7 +87,7 @@ impl crate::stubs::Applications for Applications {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -116,7 +116,7 @@ impl crate::stubs::Applications for Applications {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:repair", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -133,7 +133,7 @@ impl crate::stubs::Applications for Applications {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -155,7 +155,7 @@ impl crate::stubs::Applications for Applications {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -211,7 +211,7 @@ impl crate::stubs::Services for Services {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/services", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -232,7 +232,7 @@ impl crate::stubs::Services for Services {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -251,7 +251,7 @@ impl crate::stubs::Services for Services {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -281,7 +281,7 @@ impl crate::stubs::Services for Services {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -300,7 +300,7 @@ impl crate::stubs::Services for Services {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -322,7 +322,7 @@ impl crate::stubs::Services for Services {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -378,7 +378,7 @@ impl crate::stubs::Versions for Versions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/versions", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -400,7 +400,7 @@ impl crate::stubs::Versions for Versions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -423,7 +423,7 @@ impl crate::stubs::Versions for Versions {
                 reqwest::Method::POST,
                 format!("/v1/{}/versions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -442,7 +442,7 @@ impl crate::stubs::Versions for Versions {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -471,7 +471,7 @@ impl crate::stubs::Versions for Versions {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -490,7 +490,7 @@ impl crate::stubs::Versions for Versions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -512,7 +512,7 @@ impl crate::stubs::Versions for Versions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -571,7 +571,7 @@ impl crate::stubs::Instances for Instances {
                 reqwest::Method::GET,
                 format!("/v1/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -592,7 +592,7 @@ impl crate::stubs::Instances for Instances {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -611,7 +611,7 @@ impl crate::stubs::Instances for Instances {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -630,7 +630,7 @@ impl crate::stubs::Instances for Instances {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:debug", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -647,7 +647,7 @@ impl crate::stubs::Instances for Instances {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -669,7 +669,7 @@ impl crate::stubs::Instances for Instances {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -728,7 +728,7 @@ impl crate::stubs::Firewall for Firewall {
                 reqwest::Method::GET,
                 format!("/v1/{}/firewall/ingressRules", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -753,7 +753,7 @@ impl crate::stubs::Firewall for Firewall {
                 reqwest::Method::POST,
                 format!("/v1/{}:batchUpdate", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -773,7 +773,7 @@ impl crate::stubs::Firewall for Firewall {
                 reqwest::Method::POST,
                 format!("/v1/{}/firewall/ingressRules", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -790,7 +790,7 @@ impl crate::stubs::Firewall for Firewall {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -809,7 +809,7 @@ impl crate::stubs::Firewall for Firewall {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -836,7 +836,7 @@ impl crate::stubs::Firewall for Firewall {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -855,7 +855,7 @@ impl crate::stubs::Firewall for Firewall {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -877,7 +877,7 @@ impl crate::stubs::Firewall for Firewall {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -922,7 +922,7 @@ impl crate::stubs::AuthorizedDomains for AuthorizedDomains {
                 reqwest::Method::GET,
                 format!("/v1/{}/authorizedDomains", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -943,7 +943,7 @@ impl crate::stubs::AuthorizedDomains for AuthorizedDomains {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -965,7 +965,7 @@ impl crate::stubs::AuthorizedDomains for AuthorizedDomains {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1010,7 +1010,7 @@ impl crate::stubs::AuthorizedCertificates for AuthorizedCertificates {
                 reqwest::Method::GET,
                 format!("/v1/{}/authorizedCertificates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1032,7 +1032,7 @@ impl crate::stubs::AuthorizedCertificates for AuthorizedCertificates {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1055,7 +1055,7 @@ impl crate::stubs::AuthorizedCertificates for AuthorizedCertificates {
                 reqwest::Method::POST,
                 format!("/v1/{}/authorizedCertificates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1074,7 +1074,7 @@ impl crate::stubs::AuthorizedCertificates for AuthorizedCertificates {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1103,7 +1103,7 @@ impl crate::stubs::AuthorizedCertificates for AuthorizedCertificates {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1122,7 +1122,7 @@ impl crate::stubs::AuthorizedCertificates for AuthorizedCertificates {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1144,7 +1144,7 @@ impl crate::stubs::AuthorizedCertificates for AuthorizedCertificates {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1189,7 +1189,7 @@ impl crate::stubs::DomainMappings for DomainMappings {
                 reqwest::Method::GET,
                 format!("/v1/{}/domainMappings", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1210,7 +1210,7 @@ impl crate::stubs::DomainMappings for DomainMappings {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1232,7 +1232,7 @@ impl crate::stubs::DomainMappings for DomainMappings {
                 reqwest::Method::POST,
                 format!("/v1/{}/domainMappings", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1252,7 +1252,7 @@ impl crate::stubs::DomainMappings for DomainMappings {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1281,7 +1281,7 @@ impl crate::stubs::DomainMappings for DomainMappings {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1300,7 +1300,7 @@ impl crate::stubs::DomainMappings for DomainMappings {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1322,7 +1322,7 @@ impl crate::stubs::DomainMappings for DomainMappings {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/apps/script/calendar/src/model.rs
+++ b/src/generated/apps/script/calendar/src/model.rs
@@ -143,55 +143,74 @@ pub mod calendar_add_on_manifest {
 
     /// An enum defining the level of data access event triggers require.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EventAccess(std::borrow::Cow<'static, str>);
+    pub struct EventAccess(i32);
 
     impl EventAccess {
-        /// Creates a new EventAccess instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [EventAccess](EventAccess)
-    pub mod event_access {
-        use super::EventAccess;
-
         /// Default value when nothing is set for EventAccess.
-        pub const UNSPECIFIED: EventAccess = EventAccess::new("UNSPECIFIED");
+        pub const UNSPECIFIED: EventAccess = EventAccess::new(0);
 
         /// METADATA gives event triggers the permission to access the metadata of
         /// events such as event id and calendar id.
-        pub const METADATA: EventAccess = EventAccess::new("METADATA");
+        pub const METADATA: EventAccess = EventAccess::new(1);
 
         /// READ gives event triggers access to all provided event fields including
         /// the metadata, attendees, and conference data.
-        pub const READ: EventAccess = EventAccess::new("READ");
+        pub const READ: EventAccess = EventAccess::new(3);
 
         /// WRITE gives event triggers access to the metadata of events and the
         /// ability to perform all actions, including adding attendees and setting
         /// conference data.
-        pub const WRITE: EventAccess = EventAccess::new("WRITE");
+        pub const WRITE: EventAccess = EventAccess::new(4);
 
         /// READ_WRITE gives event triggers access to all provided event fields
         /// including the metadata, attendees, and conference data and the ability to
         /// perform all actions.
-        pub const READ_WRITE: EventAccess = EventAccess::new("READ_WRITE");
+        pub const READ_WRITE: EventAccess = EventAccess::new(5);
+
+        /// Creates a new EventAccess instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("METADATA"),
+                3 => std::borrow::Cow::Borrowed("READ"),
+                4 => std::borrow::Cow::Borrowed("WRITE"),
+                5 => std::borrow::Cow::Borrowed("READ_WRITE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
+                "METADATA" => std::option::Option::Some(Self::METADATA),
+                "READ" => std::option::Option::Some(Self::READ),
+                "WRITE" => std::option::Option::Some(Self::WRITE),
+                "READ_WRITE" => std::option::Option::Some(Self::READ_WRITE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for EventAccess {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EventAccess {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EventAccess {
         fn default() -> Self {
-            event_access::UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/apps/script/gmail/src/model.rs
+++ b/src/generated/apps/script/gmail/src/model.rs
@@ -302,46 +302,61 @@ pub mod compose_trigger {
 
     /// An enum defining the level of data access this compose trigger requires.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DraftAccess(std::borrow::Cow<'static, str>);
+    pub struct DraftAccess(i32);
 
     impl DraftAccess {
-        /// Creates a new DraftAccess instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DraftAccess](DraftAccess)
-    pub mod draft_access {
-        use super::DraftAccess;
-
         /// Default value when nothing is set for DraftAccess.
-        pub const UNSPECIFIED: DraftAccess = DraftAccess::new("UNSPECIFIED");
+        pub const UNSPECIFIED: DraftAccess = DraftAccess::new(0);
 
         /// NONE means compose trigger won't be able to access any data of the draft
         /// when a compose addon is triggered.
-        pub const NONE: DraftAccess = DraftAccess::new("NONE");
+        pub const NONE: DraftAccess = DraftAccess::new(1);
 
         /// METADATA gives compose trigger the permission to access the metadata of
         /// the draft when a compose addon is triggered. This includes the audience
         /// list (To/cc list) of a draft message.
-        pub const METADATA: DraftAccess = DraftAccess::new("METADATA");
+        pub const METADATA: DraftAccess = DraftAccess::new(2);
+
+        /// Creates a new DraftAccess instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NONE"),
+                2 => std::borrow::Cow::Borrowed("METADATA"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
+                "NONE" => std::option::Option::Some(Self::NONE),
+                "METADATA" => std::option::Option::Some(Self::METADATA),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DraftAccess {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DraftAccess {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DraftAccess {
         fn default() -> Self {
-            draft_access::UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/apps/script/gtype/src/model.rs
+++ b/src/generated/apps/script/gtype/src/model.rs
@@ -64,59 +64,89 @@ pub mod add_on_widget_set {
 
     /// The Widget type. DEFAULT is the basic widget set.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct WidgetType(std::borrow::Cow<'static, str>);
+    pub struct WidgetType(i32);
 
     impl WidgetType {
+        /// The default widget set.
+        pub const WIDGET_TYPE_UNSPECIFIED: WidgetType = WidgetType::new(0);
+
+        /// The date picker.
+        pub const DATE_PICKER: WidgetType = WidgetType::new(1);
+
+        /// Styled buttons include filled buttons and disabled buttons.
+        pub const STYLED_BUTTONS: WidgetType = WidgetType::new(2);
+
+        /// Persistent forms allow persisting form values during actions.
+        pub const PERSISTENT_FORMS: WidgetType = WidgetType::new(3);
+
+        /// Fixed footer in card.
+        pub const FIXED_FOOTER: WidgetType = WidgetType::new(4);
+
+        /// Update the subject and recipients of a draft.
+        pub const UPDATE_SUBJECT_AND_RECIPIENTS: WidgetType = WidgetType::new(5);
+
+        /// The grid widget.
+        pub const GRID_WIDGET: WidgetType = WidgetType::new(6);
+
+        /// A Gmail add-on action that applies to the addon compose UI.
+        pub const ADDON_COMPOSE_UI_ACTION: WidgetType = WidgetType::new(7);
+
         /// Creates a new WidgetType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("WIDGET_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DATE_PICKER"),
+                2 => std::borrow::Cow::Borrowed("STYLED_BUTTONS"),
+                3 => std::borrow::Cow::Borrowed("PERSISTENT_FORMS"),
+                4 => std::borrow::Cow::Borrowed("FIXED_FOOTER"),
+                5 => std::borrow::Cow::Borrowed("UPDATE_SUBJECT_AND_RECIPIENTS"),
+                6 => std::borrow::Cow::Borrowed("GRID_WIDGET"),
+                7 => std::borrow::Cow::Borrowed("ADDON_COMPOSE_UI_ACTION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "WIDGET_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::WIDGET_TYPE_UNSPECIFIED)
+                }
+                "DATE_PICKER" => std::option::Option::Some(Self::DATE_PICKER),
+                "STYLED_BUTTONS" => std::option::Option::Some(Self::STYLED_BUTTONS),
+                "PERSISTENT_FORMS" => std::option::Option::Some(Self::PERSISTENT_FORMS),
+                "FIXED_FOOTER" => std::option::Option::Some(Self::FIXED_FOOTER),
+                "UPDATE_SUBJECT_AND_RECIPIENTS" => {
+                    std::option::Option::Some(Self::UPDATE_SUBJECT_AND_RECIPIENTS)
+                }
+                "GRID_WIDGET" => std::option::Option::Some(Self::GRID_WIDGET),
+                "ADDON_COMPOSE_UI_ACTION" => {
+                    std::option::Option::Some(Self::ADDON_COMPOSE_UI_ACTION)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [WidgetType](WidgetType)
-    pub mod widget_type {
-        use super::WidgetType;
-
-        /// The default widget set.
-        pub const WIDGET_TYPE_UNSPECIFIED: WidgetType = WidgetType::new("WIDGET_TYPE_UNSPECIFIED");
-
-        /// The date picker.
-        pub const DATE_PICKER: WidgetType = WidgetType::new("DATE_PICKER");
-
-        /// Styled buttons include filled buttons and disabled buttons.
-        pub const STYLED_BUTTONS: WidgetType = WidgetType::new("STYLED_BUTTONS");
-
-        /// Persistent forms allow persisting form values during actions.
-        pub const PERSISTENT_FORMS: WidgetType = WidgetType::new("PERSISTENT_FORMS");
-
-        /// Fixed footer in card.
-        pub const FIXED_FOOTER: WidgetType = WidgetType::new("FIXED_FOOTER");
-
-        /// Update the subject and recipients of a draft.
-        pub const UPDATE_SUBJECT_AND_RECIPIENTS: WidgetType =
-            WidgetType::new("UPDATE_SUBJECT_AND_RECIPIENTS");
-
-        /// The grid widget.
-        pub const GRID_WIDGET: WidgetType = WidgetType::new("GRID_WIDGET");
-
-        /// A Gmail add-on action that applies to the addon compose UI.
-        pub const ADDON_COMPOSE_UI_ACTION: WidgetType = WidgetType::new("ADDON_COMPOSE_UI_ACTION");
-    }
-
-    impl std::convert::From<std::string::String> for WidgetType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for WidgetType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for WidgetType {
         fn default() -> Self {
-            widget_type::WIDGET_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -556,49 +586,66 @@ impl wkt::message::Message for HttpOptions {
 
 /// Authorization header sent in add-on HTTP requests
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct HttpAuthorizationHeader(std::borrow::Cow<'static, str>);
+pub struct HttpAuthorizationHeader(i32);
 
 impl HttpAuthorizationHeader {
-    /// Creates a new HttpAuthorizationHeader instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [HttpAuthorizationHeader](HttpAuthorizationHeader)
-pub mod http_authorization_header {
-    use super::HttpAuthorizationHeader;
-
     /// Default value, equivalent to `SYSTEM_ID_TOKEN`
     pub const HTTP_AUTHORIZATION_HEADER_UNSPECIFIED: HttpAuthorizationHeader =
-        HttpAuthorizationHeader::new("HTTP_AUTHORIZATION_HEADER_UNSPECIFIED");
+        HttpAuthorizationHeader::new(0);
 
     /// Send an ID token for the project-specific Google Workspace add-ons system
     /// service account (default)
-    pub const SYSTEM_ID_TOKEN: HttpAuthorizationHeader =
-        HttpAuthorizationHeader::new("SYSTEM_ID_TOKEN");
+    pub const SYSTEM_ID_TOKEN: HttpAuthorizationHeader = HttpAuthorizationHeader::new(1);
 
     /// Send an ID token for the end user
-    pub const USER_ID_TOKEN: HttpAuthorizationHeader =
-        HttpAuthorizationHeader::new("USER_ID_TOKEN");
+    pub const USER_ID_TOKEN: HttpAuthorizationHeader = HttpAuthorizationHeader::new(2);
 
     /// Do not send an Authentication header
-    pub const NONE: HttpAuthorizationHeader = HttpAuthorizationHeader::new("NONE");
+    pub const NONE: HttpAuthorizationHeader = HttpAuthorizationHeader::new(3);
+
+    /// Creates a new HttpAuthorizationHeader instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("HTTP_AUTHORIZATION_HEADER_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SYSTEM_ID_TOKEN"),
+            2 => std::borrow::Cow::Borrowed("USER_ID_TOKEN"),
+            3 => std::borrow::Cow::Borrowed("NONE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "HTTP_AUTHORIZATION_HEADER_UNSPECIFIED" => {
+                std::option::Option::Some(Self::HTTP_AUTHORIZATION_HEADER_UNSPECIFIED)
+            }
+            "SYSTEM_ID_TOKEN" => std::option::Option::Some(Self::SYSTEM_ID_TOKEN),
+            "USER_ID_TOKEN" => std::option::Option::Some(Self::USER_ID_TOKEN),
+            "NONE" => std::option::Option::Some(Self::NONE),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for HttpAuthorizationHeader {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for HttpAuthorizationHeader {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for HttpAuthorizationHeader {
     fn default() -> Self {
-        http_authorization_header::HTTP_AUTHORIZATION_HEADER_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/bigtable/admin/v2/src/model.rs
+++ b/src/generated/bigtable/admin/v2/src/model.rs
@@ -811,50 +811,69 @@ pub mod create_cluster_metadata {
         use super::*;
 
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(std::borrow::Cow<'static, str>);
+        pub struct State(i32);
 
         impl State {
-            /// Creates a new State instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [State](State)
-        pub mod state {
-            use super::State;
-
-            pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+            pub const STATE_UNSPECIFIED: State = State::new(0);
 
             /// The table has not yet begun copying to the new cluster.
-            pub const PENDING: State = State::new("PENDING");
+            pub const PENDING: State = State::new(1);
 
             /// The table is actively being copied to the new cluster.
-            pub const COPYING: State = State::new("COPYING");
+            pub const COPYING: State = State::new(2);
 
             /// The table has been fully copied to the new cluster.
-            pub const COMPLETED: State = State::new("COMPLETED");
+            pub const COMPLETED: State = State::new(3);
 
             /// The table was deleted before it finished copying to the new cluster.
             /// Note that tables deleted after completion will stay marked as
             /// COMPLETED, not CANCELLED.
-            pub const CANCELLED: State = State::new("CANCELLED");
+            pub const CANCELLED: State = State::new(4);
+
+            /// Creates a new State instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("PENDING"),
+                    2 => std::borrow::Cow::Borrowed("COPYING"),
+                    3 => std::borrow::Cow::Borrowed("COMPLETED"),
+                    4 => std::borrow::Cow::Borrowed("CANCELLED"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                    "PENDING" => std::option::Option::Some(Self::PENDING),
+                    "COPYING" => std::option::Option::Some(Self::COPYING),
+                    "COMPLETED" => std::option::Option::Some(Self::COMPLETED),
+                    "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for State {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                state::STATE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -5152,91 +5171,121 @@ pub mod instance {
 
     /// Possible states of an instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The state of the instance could not be determined.
-        pub const STATE_NOT_KNOWN: State = State::new("STATE_NOT_KNOWN");
+        pub const STATE_NOT_KNOWN: State = State::new(0);
 
         /// The instance has been successfully created and can serve requests
         /// to its tables.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(1);
 
         /// The instance is currently being created, and may be destroyed
         /// if the creation process encounters an error.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_NOT_KNOWN"),
+                1 => std::borrow::Cow::Borrowed("READY"),
+                2 => std::borrow::Cow::Borrowed("CREATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_NOT_KNOWN" => std::option::Option::Some(Self::STATE_NOT_KNOWN),
+                "READY" => std::option::Option::Some(Self::READY),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_NOT_KNOWN
+            Self::new(0)
         }
     }
 
     /// The type of the instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// The type of the instance is unspecified. If set when creating an
         /// instance, a `PRODUCTION` instance will be created. If set when updating
         /// an instance, the type will be left unchanged.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// An instance meant for production use. `serve_nodes` must be set
         /// on the cluster.
-        pub const PRODUCTION: Type = Type::new("PRODUCTION");
+        pub const PRODUCTION: Type = Type::new(1);
 
         /// DEPRECATED: Prefer PRODUCTION for all use cases, as it no longer enforces
         /// a higher minimum node count than DEVELOPMENT.
-        pub const DEVELOPMENT: Type = Type::new("DEVELOPMENT");
+        pub const DEVELOPMENT: Type = Type::new(2);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PRODUCTION"),
+                2 => std::borrow::Cow::Borrowed("DEVELOPMENT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "PRODUCTION" => std::option::Option::Some(Self::PRODUCTION),
+                "DEVELOPMENT" => std::option::Option::Some(Self::DEVELOPMENT),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5612,104 +5661,137 @@ pub mod cluster {
 
     /// Possible states of a cluster.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The state of the cluster could not be determined.
-        pub const STATE_NOT_KNOWN: State = State::new("STATE_NOT_KNOWN");
+        pub const STATE_NOT_KNOWN: State = State::new(0);
 
         /// The cluster has been successfully created and is ready to serve requests.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(1);
 
         /// The cluster is currently being created, and may be destroyed
         /// if the creation process encounters an error.
         /// A cluster may not be able to serve requests while being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(2);
 
         /// The cluster is currently being resized, and may revert to its previous
         /// node count if the process encounters an error.
         /// A cluster is still capable of serving requests while being resized,
         /// but may exhibit performance as if its number of allocated nodes is
         /// between the starting and requested states.
-        pub const RESIZING: State = State::new("RESIZING");
+        pub const RESIZING: State = State::new(3);
 
         /// The cluster has no backing nodes. The data (tables) still
         /// exist, but no operations can be performed on the cluster.
-        pub const DISABLED: State = State::new("DISABLED");
+        pub const DISABLED: State = State::new(4);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_NOT_KNOWN"),
+                1 => std::borrow::Cow::Borrowed("READY"),
+                2 => std::borrow::Cow::Borrowed("CREATING"),
+                3 => std::borrow::Cow::Borrowed("RESIZING"),
+                4 => std::borrow::Cow::Borrowed("DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_NOT_KNOWN" => std::option::Option::Some(Self::STATE_NOT_KNOWN),
+                "READY" => std::option::Option::Some(Self::READY),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "RESIZING" => std::option::Option::Some(Self::RESIZING),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_NOT_KNOWN
+            Self::new(0)
         }
     }
 
     /// Possible node scaling factors of the clusters. Node scaling delivers better
     /// latency and more throughput by removing node boundaries.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NodeScalingFactor(std::borrow::Cow<'static, str>);
+    pub struct NodeScalingFactor(i32);
 
     impl NodeScalingFactor {
-        /// Creates a new NodeScalingFactor instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [NodeScalingFactor](NodeScalingFactor)
-    pub mod node_scaling_factor {
-        use super::NodeScalingFactor;
-
         /// No node scaling specified. Defaults to NODE_SCALING_FACTOR_1X.
-        pub const NODE_SCALING_FACTOR_UNSPECIFIED: NodeScalingFactor =
-            NodeScalingFactor::new("NODE_SCALING_FACTOR_UNSPECIFIED");
+        pub const NODE_SCALING_FACTOR_UNSPECIFIED: NodeScalingFactor = NodeScalingFactor::new(0);
 
         /// The cluster is running with a scaling factor of 1.
-        pub const NODE_SCALING_FACTOR_1X: NodeScalingFactor =
-            NodeScalingFactor::new("NODE_SCALING_FACTOR_1X");
+        pub const NODE_SCALING_FACTOR_1X: NodeScalingFactor = NodeScalingFactor::new(1);
 
         /// The cluster is running with a scaling factor of 2.
         /// All node count values must be in increments of 2 with this scaling factor
         /// enabled, otherwise an INVALID_ARGUMENT error will be returned.
-        pub const NODE_SCALING_FACTOR_2X: NodeScalingFactor =
-            NodeScalingFactor::new("NODE_SCALING_FACTOR_2X");
+        pub const NODE_SCALING_FACTOR_2X: NodeScalingFactor = NodeScalingFactor::new(2);
+
+        /// Creates a new NodeScalingFactor instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("NODE_SCALING_FACTOR_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NODE_SCALING_FACTOR_1X"),
+                2 => std::borrow::Cow::Borrowed("NODE_SCALING_FACTOR_2X"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "NODE_SCALING_FACTOR_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::NODE_SCALING_FACTOR_UNSPECIFIED)
+                }
+                "NODE_SCALING_FACTOR_1X" => std::option::Option::Some(Self::NODE_SCALING_FACTOR_1X),
+                "NODE_SCALING_FACTOR_2X" => std::option::Option::Some(Self::NODE_SCALING_FACTOR_2X),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for NodeScalingFactor {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for NodeScalingFactor {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for NodeScalingFactor {
         fn default() -> Self {
-            node_scaling_factor::NODE_SCALING_FACTOR_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -6259,42 +6341,57 @@ pub mod app_profile {
         /// Data Boost. Compute Billing Owner also configures which Cloud Project is
         /// charged for relevant quota.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ComputeBillingOwner(std::borrow::Cow<'static, str>);
+        pub struct ComputeBillingOwner(i32);
 
         impl ComputeBillingOwner {
-            /// Creates a new ComputeBillingOwner instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [ComputeBillingOwner](ComputeBillingOwner)
-        pub mod compute_billing_owner {
-            use super::ComputeBillingOwner;
-
             /// Unspecified value.
             pub const COMPUTE_BILLING_OWNER_UNSPECIFIED: ComputeBillingOwner =
-                ComputeBillingOwner::new("COMPUTE_BILLING_OWNER_UNSPECIFIED");
+                ComputeBillingOwner::new(0);
 
             /// The host Cloud Project containing the targeted Bigtable Instance /
             /// Table pays for compute.
-            pub const HOST_PAYS: ComputeBillingOwner = ComputeBillingOwner::new("HOST_PAYS");
+            pub const HOST_PAYS: ComputeBillingOwner = ComputeBillingOwner::new(1);
+
+            /// Creates a new ComputeBillingOwner instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("COMPUTE_BILLING_OWNER_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("HOST_PAYS"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "COMPUTE_BILLING_OWNER_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::COMPUTE_BILLING_OWNER_UNSPECIFIED)
+                    }
+                    "HOST_PAYS" => std::option::Option::Some(Self::HOST_PAYS),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for ComputeBillingOwner {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for ComputeBillingOwner {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for ComputeBillingOwner {
             fn default() -> Self {
-                compute_billing_owner::COMPUTE_BILLING_OWNER_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -6303,43 +6400,60 @@ pub mod app_profile {
     /// can sometimes queue behind lower priority writes to the same tablet, as
     /// writes must be strictly sequenced in the durability log.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Priority(std::borrow::Cow<'static, str>);
+    pub struct Priority(i32);
 
     impl Priority {
+        /// Default value. Mapped to PRIORITY_HIGH (the legacy behavior) on creation.
+        pub const PRIORITY_UNSPECIFIED: Priority = Priority::new(0);
+
+        pub const PRIORITY_LOW: Priority = Priority::new(1);
+
+        pub const PRIORITY_MEDIUM: Priority = Priority::new(2);
+
+        pub const PRIORITY_HIGH: Priority = Priority::new(3);
+
         /// Creates a new Priority instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PRIORITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PRIORITY_LOW"),
+                2 => std::borrow::Cow::Borrowed("PRIORITY_MEDIUM"),
+                3 => std::borrow::Cow::Borrowed("PRIORITY_HIGH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PRIORITY_UNSPECIFIED" => std::option::Option::Some(Self::PRIORITY_UNSPECIFIED),
+                "PRIORITY_LOW" => std::option::Option::Some(Self::PRIORITY_LOW),
+                "PRIORITY_MEDIUM" => std::option::Option::Some(Self::PRIORITY_MEDIUM),
+                "PRIORITY_HIGH" => std::option::Option::Some(Self::PRIORITY_HIGH),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Priority](Priority)
-    pub mod priority {
-        use super::Priority;
-
-        /// Default value. Mapped to PRIORITY_HIGH (the legacy behavior) on creation.
-        pub const PRIORITY_UNSPECIFIED: Priority = Priority::new("PRIORITY_UNSPECIFIED");
-
-        pub const PRIORITY_LOW: Priority = Priority::new("PRIORITY_LOW");
-
-        pub const PRIORITY_MEDIUM: Priority = Priority::new("PRIORITY_MEDIUM");
-
-        pub const PRIORITY_HIGH: Priority = Priority::new("PRIORITY_HIGH");
-    }
-
-    impl std::convert::From<std::string::String> for Priority {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Priority {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Priority {
         fn default() -> Self {
-            priority::PRIORITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -7038,63 +7152,83 @@ pub mod table {
 
         /// Table replication states.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ReplicationState(std::borrow::Cow<'static, str>);
+        pub struct ReplicationState(i32);
 
         impl ReplicationState {
-            /// Creates a new ReplicationState instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [ReplicationState](ReplicationState)
-        pub mod replication_state {
-            use super::ReplicationState;
-
             /// The replication state of the table is unknown in this cluster.
-            pub const STATE_NOT_KNOWN: ReplicationState = ReplicationState::new("STATE_NOT_KNOWN");
+            pub const STATE_NOT_KNOWN: ReplicationState = ReplicationState::new(0);
 
             /// The cluster was recently created, and the table must finish copying
             /// over pre-existing data from other clusters before it can begin
             /// receiving live replication updates and serving Data API requests.
-            pub const INITIALIZING: ReplicationState = ReplicationState::new("INITIALIZING");
+            pub const INITIALIZING: ReplicationState = ReplicationState::new(1);
 
             /// The table is temporarily unable to serve Data API requests from this
             /// cluster due to planned internal maintenance.
-            pub const PLANNED_MAINTENANCE: ReplicationState =
-                ReplicationState::new("PLANNED_MAINTENANCE");
+            pub const PLANNED_MAINTENANCE: ReplicationState = ReplicationState::new(2);
 
             /// The table is temporarily unable to serve Data API requests from this
             /// cluster due to unplanned or emergency maintenance.
-            pub const UNPLANNED_MAINTENANCE: ReplicationState =
-                ReplicationState::new("UNPLANNED_MAINTENANCE");
+            pub const UNPLANNED_MAINTENANCE: ReplicationState = ReplicationState::new(3);
 
             /// The table can serve Data API requests from this cluster. Depending on
             /// replication delay, reads may not immediately reflect the state of the
             /// table in other clusters.
-            pub const READY: ReplicationState = ReplicationState::new("READY");
+            pub const READY: ReplicationState = ReplicationState::new(4);
 
             /// The table is fully created and ready for use after a restore, and is
             /// being optimized for performance. When optimizations are complete, the
             /// table will transition to `READY` state.
-            pub const READY_OPTIMIZING: ReplicationState =
-                ReplicationState::new("READY_OPTIMIZING");
+            pub const READY_OPTIMIZING: ReplicationState = ReplicationState::new(5);
+
+            /// Creates a new ReplicationState instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("STATE_NOT_KNOWN"),
+                    1 => std::borrow::Cow::Borrowed("INITIALIZING"),
+                    2 => std::borrow::Cow::Borrowed("PLANNED_MAINTENANCE"),
+                    3 => std::borrow::Cow::Borrowed("UNPLANNED_MAINTENANCE"),
+                    4 => std::borrow::Cow::Borrowed("READY"),
+                    5 => std::borrow::Cow::Borrowed("READY_OPTIMIZING"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "STATE_NOT_KNOWN" => std::option::Option::Some(Self::STATE_NOT_KNOWN),
+                    "INITIALIZING" => std::option::Option::Some(Self::INITIALIZING),
+                    "PLANNED_MAINTENANCE" => std::option::Option::Some(Self::PLANNED_MAINTENANCE),
+                    "UNPLANNED_MAINTENANCE" => {
+                        std::option::Option::Some(Self::UNPLANNED_MAINTENANCE)
+                    }
+                    "READY" => std::option::Option::Some(Self::READY),
+                    "READY_OPTIMIZING" => std::option::Option::Some(Self::READY_OPTIMIZING),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for ReplicationState {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for ReplicationState {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for ReplicationState {
             fn default() -> Self {
-                replication_state::STATE_NOT_KNOWN
+                Self::new(0)
             }
         }
     }
@@ -7149,94 +7283,130 @@ pub mod table {
     /// Possible timestamp granularities to use when keeping multiple versions
     /// of data in a table.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TimestampGranularity(std::borrow::Cow<'static, str>);
+    pub struct TimestampGranularity(i32);
 
     impl TimestampGranularity {
-        /// Creates a new TimestampGranularity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [TimestampGranularity](TimestampGranularity)
-    pub mod timestamp_granularity {
-        use super::TimestampGranularity;
-
         /// The user did not specify a granularity. Should not be returned.
         /// When specified during table creation, MILLIS will be used.
         pub const TIMESTAMP_GRANULARITY_UNSPECIFIED: TimestampGranularity =
-            TimestampGranularity::new("TIMESTAMP_GRANULARITY_UNSPECIFIED");
+            TimestampGranularity::new(0);
 
         /// The table keeps data versioned at a granularity of 1ms.
-        pub const MILLIS: TimestampGranularity = TimestampGranularity::new("MILLIS");
+        pub const MILLIS: TimestampGranularity = TimestampGranularity::new(1);
+
+        /// Creates a new TimestampGranularity instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TIMESTAMP_GRANULARITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MILLIS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TIMESTAMP_GRANULARITY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::TIMESTAMP_GRANULARITY_UNSPECIFIED)
+                }
+                "MILLIS" => std::option::Option::Some(Self::MILLIS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for TimestampGranularity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TimestampGranularity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TimestampGranularity {
         fn default() -> Self {
-            timestamp_granularity::TIMESTAMP_GRANULARITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Defines a view over a table's fields.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct View(std::borrow::Cow<'static, str>);
+    pub struct View(i32);
 
     impl View {
-        /// Creates a new View instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [View](View)
-    pub mod view {
-        use super::View;
-
         /// Uses the default view for each method as documented in its request.
-        pub const VIEW_UNSPECIFIED: View = View::new("VIEW_UNSPECIFIED");
+        pub const VIEW_UNSPECIFIED: View = View::new(0);
 
         /// Only populates `name`.
-        pub const NAME_ONLY: View = View::new("NAME_ONLY");
+        pub const NAME_ONLY: View = View::new(1);
 
         /// Only populates `name` and fields related to the table's schema.
-        pub const SCHEMA_VIEW: View = View::new("SCHEMA_VIEW");
+        pub const SCHEMA_VIEW: View = View::new(2);
 
         /// Only populates `name` and fields related to the table's replication
         /// state.
-        pub const REPLICATION_VIEW: View = View::new("REPLICATION_VIEW");
+        pub const REPLICATION_VIEW: View = View::new(3);
 
         /// Only populates `name` and fields related to the table's encryption state.
-        pub const ENCRYPTION_VIEW: View = View::new("ENCRYPTION_VIEW");
+        pub const ENCRYPTION_VIEW: View = View::new(5);
 
         /// Populates all fields.
-        pub const FULL: View = View::new("FULL");
+        pub const FULL: View = View::new(4);
+
+        /// Creates a new View instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VIEW_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NAME_ONLY"),
+                2 => std::borrow::Cow::Borrowed("SCHEMA_VIEW"),
+                3 => std::borrow::Cow::Borrowed("REPLICATION_VIEW"),
+                4 => std::borrow::Cow::Borrowed("FULL"),
+                5 => std::borrow::Cow::Borrowed("ENCRYPTION_VIEW"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VIEW_UNSPECIFIED" => std::option::Option::Some(Self::VIEW_UNSPECIFIED),
+                "NAME_ONLY" => std::option::Option::Some(Self::NAME_ONLY),
+                "SCHEMA_VIEW" => std::option::Option::Some(Self::SCHEMA_VIEW),
+                "REPLICATION_VIEW" => std::option::Option::Some(Self::REPLICATION_VIEW),
+                "ENCRYPTION_VIEW" => std::option::Option::Some(Self::ENCRYPTION_VIEW),
+                "FULL" => std::option::Option::Some(Self::FULL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for View {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for View {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for View {
         fn default() -> Self {
-            view::VIEW_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -7471,48 +7641,66 @@ pub mod authorized_view {
 
     /// Defines a subset of an AuthorizedView's fields.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ResponseView(std::borrow::Cow<'static, str>);
+    pub struct ResponseView(i32);
 
     impl ResponseView {
-        /// Creates a new ResponseView instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ResponseView](ResponseView)
-    pub mod response_view {
-        use super::ResponseView;
-
         /// Uses the default view for each method as documented in the request.
-        pub const RESPONSE_VIEW_UNSPECIFIED: ResponseView =
-            ResponseView::new("RESPONSE_VIEW_UNSPECIFIED");
+        pub const RESPONSE_VIEW_UNSPECIFIED: ResponseView = ResponseView::new(0);
 
         /// Only populates `name`.
-        pub const NAME_ONLY: ResponseView = ResponseView::new("NAME_ONLY");
+        pub const NAME_ONLY: ResponseView = ResponseView::new(1);
 
         /// Only populates the AuthorizedView's basic metadata. This includes:
         /// name, deletion_protection, etag.
-        pub const BASIC: ResponseView = ResponseView::new("BASIC");
+        pub const BASIC: ResponseView = ResponseView::new(2);
 
         /// Populates every fields.
-        pub const FULL: ResponseView = ResponseView::new("FULL");
+        pub const FULL: ResponseView = ResponseView::new(3);
+
+        /// Creates a new ResponseView instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RESPONSE_VIEW_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NAME_ONLY"),
+                2 => std::borrow::Cow::Borrowed("BASIC"),
+                3 => std::borrow::Cow::Borrowed("FULL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RESPONSE_VIEW_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RESPONSE_VIEW_UNSPECIFIED)
+                }
+                "NAME_ONLY" => std::option::Option::Some(Self::NAME_ONLY),
+                "BASIC" => std::option::Option::Some(Self::BASIC),
+                "FULL" => std::option::Option::Some(Self::FULL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ResponseView {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ResponseView {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ResponseView {
         fn default() -> Self {
-            response_view::RESPONSE_VIEW_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -7875,33 +8063,16 @@ pub mod encryption_info {
 
     /// Possible encryption types for a resource.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EncryptionType(std::borrow::Cow<'static, str>);
+    pub struct EncryptionType(i32);
 
     impl EncryptionType {
-        /// Creates a new EncryptionType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [EncryptionType](EncryptionType)
-    pub mod encryption_type {
-        use super::EncryptionType;
-
         /// Encryption type was not specified, though data at rest remains encrypted.
-        pub const ENCRYPTION_TYPE_UNSPECIFIED: EncryptionType =
-            EncryptionType::new("ENCRYPTION_TYPE_UNSPECIFIED");
+        pub const ENCRYPTION_TYPE_UNSPECIFIED: EncryptionType = EncryptionType::new(0);
 
         /// The data backing this resource is encrypted at rest with a key that is
         /// fully managed by Google. No key version or status will be populated.
         /// This is the default state.
-        pub const GOOGLE_DEFAULT_ENCRYPTION: EncryptionType =
-            EncryptionType::new("GOOGLE_DEFAULT_ENCRYPTION");
+        pub const GOOGLE_DEFAULT_ENCRYPTION: EncryptionType = EncryptionType::new(1);
 
         /// The data backing this resource is encrypted at rest with a key that is
         /// managed by the customer.
@@ -7910,19 +8081,54 @@ pub mod encryption_info {
         /// CMEK-protected backups are pinned to the key version that was in use at
         /// the time the backup was taken. This key version is populated but its
         /// status is not tracked and is reported as `UNKNOWN`.
-        pub const CUSTOMER_MANAGED_ENCRYPTION: EncryptionType =
-            EncryptionType::new("CUSTOMER_MANAGED_ENCRYPTION");
+        pub const CUSTOMER_MANAGED_ENCRYPTION: EncryptionType = EncryptionType::new(2);
+
+        /// Creates a new EncryptionType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ENCRYPTION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GOOGLE_DEFAULT_ENCRYPTION"),
+                2 => std::borrow::Cow::Borrowed("CUSTOMER_MANAGED_ENCRYPTION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ENCRYPTION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ENCRYPTION_TYPE_UNSPECIFIED)
+                }
+                "GOOGLE_DEFAULT_ENCRYPTION" => {
+                    std::option::Option::Some(Self::GOOGLE_DEFAULT_ENCRYPTION)
+                }
+                "CUSTOMER_MANAGED_ENCRYPTION" => {
+                    std::option::Option::Some(Self::CUSTOMER_MANAGED_ENCRYPTION)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for EncryptionType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EncryptionType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EncryptionType {
         fn default() -> Self {
-            encryption_type::ENCRYPTION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8044,45 +8250,60 @@ pub mod snapshot {
 
     /// Possible states of a snapshot.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The state of the snapshot could not be determined.
-        pub const STATE_NOT_KNOWN: State = State::new("STATE_NOT_KNOWN");
+        pub const STATE_NOT_KNOWN: State = State::new(0);
 
         /// The snapshot has been successfully created and can serve all requests.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(1);
 
         /// The snapshot is currently being created, and may be destroyed if the
         /// creation process encounters an error. A snapshot may not be restored to a
         /// table while it is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_NOT_KNOWN"),
+                1 => std::borrow::Cow::Borrowed("READY"),
+                2 => std::borrow::Cow::Borrowed("CREATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_NOT_KNOWN" => std::option::Option::Some(Self::STATE_NOT_KNOWN),
+                "READY" => std::option::Option::Some(Self::READY),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_NOT_KNOWN
+            Self::new(0)
         }
     }
 }
@@ -8277,91 +8498,123 @@ pub mod backup {
 
     /// Indicates the current state of the backup.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Not specified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The pending backup is still being created. Operations on the
         /// backup may fail with `FAILED_PRECONDITION` in this state.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The backup is complete and ready for use.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The type of the backup.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BackupType(std::borrow::Cow<'static, str>);
+    pub struct BackupType(i32);
 
     impl BackupType {
-        /// Creates a new BackupType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [BackupType](BackupType)
-    pub mod backup_type {
-        use super::BackupType;
-
         /// Not specified.
-        pub const BACKUP_TYPE_UNSPECIFIED: BackupType = BackupType::new("BACKUP_TYPE_UNSPECIFIED");
+        pub const BACKUP_TYPE_UNSPECIFIED: BackupType = BackupType::new(0);
 
         /// The default type for Cloud Bigtable managed backups. Supported for
         /// backups created in both HDD and SSD instances. Requires optimization when
         /// restored to a table in an SSD instance.
-        pub const STANDARD: BackupType = BackupType::new("STANDARD");
+        pub const STANDARD: BackupType = BackupType::new(1);
 
         /// A backup type with faster restore to SSD performance. Only supported for
         /// backups created in SSD instances. A new SSD table restored from a hot
         /// backup reaches production performance more quickly than a standard
         /// backup.
-        pub const HOT: BackupType = BackupType::new("HOT");
+        pub const HOT: BackupType = BackupType::new(2);
+
+        /// Creates a new BackupType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("BACKUP_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STANDARD"),
+                2 => std::borrow::Cow::Borrowed("HOT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "BACKUP_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::BACKUP_TYPE_UNSPECIFIED)
+                }
+                "STANDARD" => std::option::Option::Some(Self::STANDARD),
+                "HOT" => std::option::Option::Some(Self::HOT),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for BackupType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for BackupType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for BackupType {
         fn default() -> Self {
-            backup_type::BACKUP_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -10470,82 +10723,111 @@ pub mod r#type {
 
 /// Storage media types for persisting Bigtable data.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct StorageType(std::borrow::Cow<'static, str>);
+pub struct StorageType(i32);
 
 impl StorageType {
+    /// The user did not specify a storage type.
+    pub const STORAGE_TYPE_UNSPECIFIED: StorageType = StorageType::new(0);
+
+    /// Flash (SSD) storage should be used.
+    pub const SSD: StorageType = StorageType::new(1);
+
+    /// Magnetic drive (HDD) storage should be used.
+    pub const HDD: StorageType = StorageType::new(2);
+
     /// Creates a new StorageType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("STORAGE_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SSD"),
+            2 => std::borrow::Cow::Borrowed("HDD"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "STORAGE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::STORAGE_TYPE_UNSPECIFIED),
+            "SSD" => std::option::Option::Some(Self::SSD),
+            "HDD" => std::option::Option::Some(Self::HDD),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [StorageType](StorageType)
-pub mod storage_type {
-    use super::StorageType;
-
-    /// The user did not specify a storage type.
-    pub const STORAGE_TYPE_UNSPECIFIED: StorageType = StorageType::new("STORAGE_TYPE_UNSPECIFIED");
-
-    /// Flash (SSD) storage should be used.
-    pub const SSD: StorageType = StorageType::new("SSD");
-
-    /// Magnetic drive (HDD) storage should be used.
-    pub const HDD: StorageType = StorageType::new("HDD");
-}
-
-impl std::convert::From<std::string::String> for StorageType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for StorageType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for StorageType {
     fn default() -> Self {
-        storage_type::STORAGE_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Indicates the type of the restore source.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RestoreSourceType(std::borrow::Cow<'static, str>);
+pub struct RestoreSourceType(i32);
 
 impl RestoreSourceType {
+    /// No restore associated.
+    pub const RESTORE_SOURCE_TYPE_UNSPECIFIED: RestoreSourceType = RestoreSourceType::new(0);
+
+    /// A backup was used as the source of the restore.
+    pub const BACKUP: RestoreSourceType = RestoreSourceType::new(1);
+
     /// Creates a new RestoreSourceType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("RESTORE_SOURCE_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("BACKUP"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "RESTORE_SOURCE_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::RESTORE_SOURCE_TYPE_UNSPECIFIED)
+            }
+            "BACKUP" => std::option::Option::Some(Self::BACKUP),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [RestoreSourceType](RestoreSourceType)
-pub mod restore_source_type {
-    use super::RestoreSourceType;
-
-    /// No restore associated.
-    pub const RESTORE_SOURCE_TYPE_UNSPECIFIED: RestoreSourceType =
-        RestoreSourceType::new("RESTORE_SOURCE_TYPE_UNSPECIFIED");
-
-    /// A backup was used as the source of the restore.
-    pub const BACKUP: RestoreSourceType = RestoreSourceType::new("BACKUP");
-}
-
-impl std::convert::From<std::string::String> for RestoreSourceType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for RestoreSourceType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for RestoreSourceType {
     fn default() -> Self {
-        restore_source_type::RESTORE_SOURCE_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/bigtable/admin/v2/src/transport.rs
+++ b/src/generated/bigtable/admin/v2/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 reqwest::Method::POST,
                 format!("/v2/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -69,7 +69,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -91,7 +91,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 reqwest::Method::GET,
                 format!("/v2/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -111,7 +111,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::PUT, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -137,7 +137,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -166,7 +166,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -188,7 +188,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 reqwest::Method::POST,
                 format!("/v2/{}/clusters", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -208,7 +208,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -227,7 +227,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/clusters", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -247,7 +247,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::PUT, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -273,7 +273,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -302,7 +302,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -324,7 +324,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 reqwest::Method::POST,
                 format!("/v2/{}/appProfiles", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -345,7 +345,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -367,7 +367,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 reqwest::Method::GET,
                 format!("/v2/{}/appProfiles", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -397,7 +397,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -427,7 +427,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -450,7 +450,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 reqwest::Method::POST,
                 format!("/v2/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -470,7 +470,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 reqwest::Method::POST,
                 format!("/v2/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -490,7 +490,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 reqwest::Method::POST,
                 format!("/v2/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -510,7 +510,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 reqwest::Method::GET,
                 format!("/v2/{}/hotTablets", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -551,7 +551,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -573,7 +573,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -592,7 +592,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -611,7 +611,7 @@ impl crate::stubs::BigtableInstanceAdmin for BigtableInstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -667,7 +667,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}/tables", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -687,7 +687,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
                 reqwest::Method::POST,
                 format!("/v2/{}/tables:createFromSnapshot", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -704,7 +704,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/tables", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -726,7 +726,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -755,7 +755,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -783,7 +783,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -802,7 +802,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:undelete", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -822,7 +822,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
                 reqwest::Method::POST,
                 format!("/v2/{}/authorizedViews", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -845,7 +845,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
                 reqwest::Method::GET,
                 format!("/v2/{}/authorizedViews", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -867,7 +867,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -896,7 +896,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -926,7 +926,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -949,7 +949,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
                 reqwest::Method::POST,
                 format!("/v2/{}:modifyColumnFamilies", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -969,7 +969,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
                 reqwest::Method::POST,
                 format!("/v2/{}:dropRowRange", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -989,7 +989,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
                 reqwest::Method::POST,
                 format!("/v2/{}:generateConsistencyToken", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1009,7 +1009,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
                 reqwest::Method::POST,
                 format!("/v2/{}:checkConsistency", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1026,7 +1026,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:snapshot", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1043,7 +1043,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1065,7 +1065,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
                 reqwest::Method::GET,
                 format!("/v2/{}/snapshots", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1086,7 +1086,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1105,7 +1105,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}/backups", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1123,7 +1123,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1151,7 +1151,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1178,7 +1178,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1197,7 +1197,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/backups", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1223,7 +1223,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
                 reqwest::Method::POST,
                 format!("/v2/{}/tables:restore", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1243,7 +1243,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
                 reqwest::Method::POST,
                 format!("/v2/{}/backups:copy", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1263,7 +1263,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
                 reqwest::Method::POST,
                 format!("/v2/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1283,7 +1283,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
                 reqwest::Method::POST,
                 format!("/v2/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1303,7 +1303,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
                 reqwest::Method::POST,
                 format!("/v2/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1320,7 +1320,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1342,7 +1342,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1361,7 +1361,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1380,7 +1380,7 @@ impl crate::stubs::BigtableTableAdmin for BigtableTableAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/accessapproval/v1/src/model.rs
+++ b/src/generated/cloud/accessapproval/v1/src/model.rs
@@ -148,26 +148,11 @@ pub mod access_reason {
 
     /// Type of access justification.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// Default value for proto, shouldn't be used.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// Customer made a request or raised an issue that required the principal to
         /// access customer data. `detail` is of the form ("#####" is the issue ID):
@@ -178,38 +163,83 @@ pub mod access_reason {
         /// * "E-PIN Reference: #####"
         /// * "Google-#####"
         /// * "T-#####"
-        pub const CUSTOMER_INITIATED_SUPPORT: Type = Type::new("CUSTOMER_INITIATED_SUPPORT");
+        pub const CUSTOMER_INITIATED_SUPPORT: Type = Type::new(1);
 
         /// The principal accessed customer data in order to diagnose or resolve a
         /// suspected issue in services. Often this access is used to confirm that
         /// customers are not affected by a suspected service issue or to remediate a
         /// reversible system issue.
-        pub const GOOGLE_INITIATED_SERVICE: Type = Type::new("GOOGLE_INITIATED_SERVICE");
+        pub const GOOGLE_INITIATED_SERVICE: Type = Type::new(2);
 
         /// Google initiated service for security, fraud, abuse, or compliance
         /// purposes.
-        pub const GOOGLE_INITIATED_REVIEW: Type = Type::new("GOOGLE_INITIATED_REVIEW");
+        pub const GOOGLE_INITIATED_REVIEW: Type = Type::new(3);
 
         /// The principal was compelled to access customer data in order to respond
         /// to a legal third party data request or process, including legal processes
         /// from customers themselves.
-        pub const THIRD_PARTY_DATA_REQUEST: Type = Type::new("THIRD_PARTY_DATA_REQUEST");
+        pub const THIRD_PARTY_DATA_REQUEST: Type = Type::new(4);
 
         /// The principal accessed customer data in order to diagnose or resolve a
         /// suspected issue in services or a known outage.
-        pub const GOOGLE_RESPONSE_TO_PRODUCTION_ALERT: Type =
-            Type::new("GOOGLE_RESPONSE_TO_PRODUCTION_ALERT");
+        pub const GOOGLE_RESPONSE_TO_PRODUCTION_ALERT: Type = Type::new(5);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CUSTOMER_INITIATED_SUPPORT"),
+                2 => std::borrow::Cow::Borrowed("GOOGLE_INITIATED_SERVICE"),
+                3 => std::borrow::Cow::Borrowed("GOOGLE_INITIATED_REVIEW"),
+                4 => std::borrow::Cow::Borrowed("THIRD_PARTY_DATA_REQUEST"),
+                5 => std::borrow::Cow::Borrowed("GOOGLE_RESPONSE_TO_PRODUCTION_ALERT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "CUSTOMER_INITIATED_SUPPORT" => {
+                    std::option::Option::Some(Self::CUSTOMER_INITIATED_SUPPORT)
+                }
+                "GOOGLE_INITIATED_SERVICE" => {
+                    std::option::Option::Some(Self::GOOGLE_INITIATED_SERVICE)
+                }
+                "GOOGLE_INITIATED_REVIEW" => {
+                    std::option::Option::Some(Self::GOOGLE_INITIATED_REVIEW)
+                }
+                "THIRD_PARTY_DATA_REQUEST" => {
+                    std::option::Option::Some(Self::THIRD_PARTY_DATA_REQUEST)
+                }
+                "GOOGLE_RESPONSE_TO_PRODUCTION_ALERT" => {
+                    std::option::Option::Some(Self::GOOGLE_RESPONSE_TO_PRODUCTION_ALERT)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1379,40 +1409,54 @@ impl wkt::message::Message for GetAccessApprovalServiceAccountMessage {
 
 /// Represents the type of enrollment for a given service to Access Approval.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EnrollmentLevel(std::borrow::Cow<'static, str>);
+pub struct EnrollmentLevel(i32);
 
 impl EnrollmentLevel {
+    /// Default value for proto, shouldn't be used.
+    pub const ENROLLMENT_LEVEL_UNSPECIFIED: EnrollmentLevel = EnrollmentLevel::new(0);
+
+    /// Service is enrolled in Access Approval for all requests
+    pub const BLOCK_ALL: EnrollmentLevel = EnrollmentLevel::new(1);
+
     /// Creates a new EnrollmentLevel instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ENROLLMENT_LEVEL_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("BLOCK_ALL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ENROLLMENT_LEVEL_UNSPECIFIED" => {
+                std::option::Option::Some(Self::ENROLLMENT_LEVEL_UNSPECIFIED)
+            }
+            "BLOCK_ALL" => std::option::Option::Some(Self::BLOCK_ALL),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [EnrollmentLevel](EnrollmentLevel)
-pub mod enrollment_level {
-    use super::EnrollmentLevel;
-
-    /// Default value for proto, shouldn't be used.
-    pub const ENROLLMENT_LEVEL_UNSPECIFIED: EnrollmentLevel =
-        EnrollmentLevel::new("ENROLLMENT_LEVEL_UNSPECIFIED");
-
-    /// Service is enrolled in Access Approval for all requests
-    pub const BLOCK_ALL: EnrollmentLevel = EnrollmentLevel::new("BLOCK_ALL");
-}
-
-impl std::convert::From<std::string::String> for EnrollmentLevel {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for EnrollmentLevel {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for EnrollmentLevel {
     fn default() -> Self {
-        enrollment_level::ENROLLMENT_LEVEL_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/accessapproval/v1/src/transport.rs
+++ b/src/generated/cloud/accessapproval/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::AccessApproval for AccessApproval {
                 reqwest::Method::GET,
                 format!("/v1/{}/approvalRequests", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -74,7 +74,7 @@ impl crate::stubs::AccessApproval for AccessApproval {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -93,7 +93,7 @@ impl crate::stubs::AccessApproval for AccessApproval {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:approve", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -110,7 +110,7 @@ impl crate::stubs::AccessApproval for AccessApproval {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:dismiss", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -130,7 +130,7 @@ impl crate::stubs::AccessApproval for AccessApproval {
                 reqwest::Method::POST,
                 format!("/v1/{}:invalidate", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -147,7 +147,7 @@ impl crate::stubs::AccessApproval for AccessApproval {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -175,7 +175,7 @@ impl crate::stubs::AccessApproval for AccessApproval {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -204,7 +204,7 @@ impl crate::stubs::AccessApproval for AccessApproval {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -223,7 +223,7 @@ impl crate::stubs::AccessApproval for AccessApproval {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/advisorynotifications/v1/src/model.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/model.rs
@@ -832,72 +832,72 @@ impl wkt::message::Message for UpdateSettingsRequest {
 
 /// Notification view.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct NotificationView(std::borrow::Cow<'static, str>);
+pub struct NotificationView(i32);
 
 impl NotificationView {
-    /// Creates a new NotificationView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [NotificationView](NotificationView)
-pub mod notification_view {
-    use super::NotificationView;
-
     /// Not specified, equivalent to BASIC.
-    pub const NOTIFICATION_VIEW_UNSPECIFIED: NotificationView =
-        NotificationView::new("NOTIFICATION_VIEW_UNSPECIFIED");
+    pub const NOTIFICATION_VIEW_UNSPECIFIED: NotificationView = NotificationView::new(0);
 
     /// Server responses only include title, creation time and Notification ID.
     /// Note: for internal use responses also include the last update time,
     /// the latest message text and whether notification has attachments.
-    pub const BASIC: NotificationView = NotificationView::new("BASIC");
+    pub const BASIC: NotificationView = NotificationView::new(1);
 
     /// Include everything.
-    pub const FULL: NotificationView = NotificationView::new("FULL");
+    pub const FULL: NotificationView = NotificationView::new(2);
+
+    /// Creates a new NotificationView instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("NOTIFICATION_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("BASIC"),
+            2 => std::borrow::Cow::Borrowed("FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "NOTIFICATION_VIEW_UNSPECIFIED" => {
+                std::option::Option::Some(Self::NOTIFICATION_VIEW_UNSPECIFIED)
+            }
+            "BASIC" => std::option::Option::Some(Self::BASIC),
+            "FULL" => std::option::Option::Some(Self::FULL),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for NotificationView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for NotificationView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for NotificationView {
     fn default() -> Self {
-        notification_view::NOTIFICATION_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Status of localized text.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LocalizationState(std::borrow::Cow<'static, str>);
+pub struct LocalizationState(i32);
 
 impl LocalizationState {
-    /// Creates a new LocalizationState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [LocalizationState](LocalizationState)
-pub mod localization_state {
-    use super::LocalizationState;
-
     /// Not used.
-    pub const LOCALIZATION_STATE_UNSPECIFIED: LocalizationState =
-        LocalizationState::new("LOCALIZATION_STATE_UNSPECIFIED");
+    pub const LOCALIZATION_STATE_UNSPECIFIED: LocalizationState = LocalizationState::new(0);
 
     /// Localization is not applicable for requested language. This can happen
     /// when:
@@ -906,79 +906,141 @@ pub mod localization_state {
     ///   time of localization (including notifications created before the
     ///   localization feature was launched).
     /// - The requested language is English, so only the English text is returned.
-    pub const LOCALIZATION_STATE_NOT_APPLICABLE: LocalizationState =
-        LocalizationState::new("LOCALIZATION_STATE_NOT_APPLICABLE");
+    pub const LOCALIZATION_STATE_NOT_APPLICABLE: LocalizationState = LocalizationState::new(1);
 
     /// Localization for requested language is in progress, and not ready yet.
-    pub const LOCALIZATION_STATE_PENDING: LocalizationState =
-        LocalizationState::new("LOCALIZATION_STATE_PENDING");
+    pub const LOCALIZATION_STATE_PENDING: LocalizationState = LocalizationState::new(2);
 
     /// Localization for requested language is completed.
-    pub const LOCALIZATION_STATE_COMPLETED: LocalizationState =
-        LocalizationState::new("LOCALIZATION_STATE_COMPLETED");
+    pub const LOCALIZATION_STATE_COMPLETED: LocalizationState = LocalizationState::new(3);
+
+    /// Creates a new LocalizationState instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("LOCALIZATION_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("LOCALIZATION_STATE_NOT_APPLICABLE"),
+            2 => std::borrow::Cow::Borrowed("LOCALIZATION_STATE_PENDING"),
+            3 => std::borrow::Cow::Borrowed("LOCALIZATION_STATE_COMPLETED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "LOCALIZATION_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::LOCALIZATION_STATE_UNSPECIFIED)
+            }
+            "LOCALIZATION_STATE_NOT_APPLICABLE" => {
+                std::option::Option::Some(Self::LOCALIZATION_STATE_NOT_APPLICABLE)
+            }
+            "LOCALIZATION_STATE_PENDING" => {
+                std::option::Option::Some(Self::LOCALIZATION_STATE_PENDING)
+            }
+            "LOCALIZATION_STATE_COMPLETED" => {
+                std::option::Option::Some(Self::LOCALIZATION_STATE_COMPLETED)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for LocalizationState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for LocalizationState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for LocalizationState {
     fn default() -> Self {
-        localization_state::LOCALIZATION_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Type of notification
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct NotificationType(std::borrow::Cow<'static, str>);
+pub struct NotificationType(i32);
 
 impl NotificationType {
-    /// Creates a new NotificationType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [NotificationType](NotificationType)
-pub mod notification_type {
-    use super::NotificationType;
-
     /// Default type
-    pub const NOTIFICATION_TYPE_UNSPECIFIED: NotificationType =
-        NotificationType::new("NOTIFICATION_TYPE_UNSPECIFIED");
+    pub const NOTIFICATION_TYPE_UNSPECIFIED: NotificationType = NotificationType::new(0);
 
     /// Security and privacy advisory notifications
     pub const NOTIFICATION_TYPE_SECURITY_PRIVACY_ADVISORY: NotificationType =
-        NotificationType::new("NOTIFICATION_TYPE_SECURITY_PRIVACY_ADVISORY");
+        NotificationType::new(1);
 
     /// Sensitive action notifications
-    pub const NOTIFICATION_TYPE_SENSITIVE_ACTIONS: NotificationType =
-        NotificationType::new("NOTIFICATION_TYPE_SENSITIVE_ACTIONS");
+    pub const NOTIFICATION_TYPE_SENSITIVE_ACTIONS: NotificationType = NotificationType::new(2);
 
     /// General security MSA
-    pub const NOTIFICATION_TYPE_SECURITY_MSA: NotificationType =
-        NotificationType::new("NOTIFICATION_TYPE_SECURITY_MSA");
+    pub const NOTIFICATION_TYPE_SECURITY_MSA: NotificationType = NotificationType::new(3);
 
     /// Threat horizons MSA
-    pub const NOTIFICATION_TYPE_THREAT_HORIZONS: NotificationType =
-        NotificationType::new("NOTIFICATION_TYPE_THREAT_HORIZONS");
+    pub const NOTIFICATION_TYPE_THREAT_HORIZONS: NotificationType = NotificationType::new(4);
+
+    /// Creates a new NotificationType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("NOTIFICATION_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("NOTIFICATION_TYPE_SECURITY_PRIVACY_ADVISORY"),
+            2 => std::borrow::Cow::Borrowed("NOTIFICATION_TYPE_SENSITIVE_ACTIONS"),
+            3 => std::borrow::Cow::Borrowed("NOTIFICATION_TYPE_SECURITY_MSA"),
+            4 => std::borrow::Cow::Borrowed("NOTIFICATION_TYPE_THREAT_HORIZONS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "NOTIFICATION_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::NOTIFICATION_TYPE_UNSPECIFIED)
+            }
+            "NOTIFICATION_TYPE_SECURITY_PRIVACY_ADVISORY" => {
+                std::option::Option::Some(Self::NOTIFICATION_TYPE_SECURITY_PRIVACY_ADVISORY)
+            }
+            "NOTIFICATION_TYPE_SENSITIVE_ACTIONS" => {
+                std::option::Option::Some(Self::NOTIFICATION_TYPE_SENSITIVE_ACTIONS)
+            }
+            "NOTIFICATION_TYPE_SECURITY_MSA" => {
+                std::option::Option::Some(Self::NOTIFICATION_TYPE_SECURITY_MSA)
+            }
+            "NOTIFICATION_TYPE_THREAT_HORIZONS" => {
+                std::option::Option::Some(Self::NOTIFICATION_TYPE_THREAT_HORIZONS)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for NotificationType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for NotificationType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for NotificationType {
     fn default() -> Self {
-        notification_type::NOTIFICATION_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/advisorynotifications/v1/src/transport.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::AdvisoryNotificationsService for AdvisoryNotificationsService
                 reqwest::Method::GET,
                 format!("/v1/{}/notifications", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::AdvisoryNotificationsService for AdvisoryNotificationsService
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -95,7 +95,7 @@ impl crate::stubs::AdvisoryNotificationsService for AdvisoryNotificationsService
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -123,7 +123,7 @@ impl crate::stubs::AdvisoryNotificationsService for AdvisoryNotificationsService
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/aiplatform/v1/src/model.rs
+++ b/src/generated/cloud/aiplatform/v1/src/model.rs
@@ -568,45 +568,60 @@ pub mod artifact {
 
     /// Describes the state of the Artifact.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified state for the Artifact.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// A state used by systems like Vertex AI Pipelines to indicate that the
         /// underlying data item represented by this Artifact is being created.
-        pub const PENDING: State = State::new("PENDING");
+        pub const PENDING: State = State::new(1);
 
         /// A state indicating that the Artifact should exist, unless something
         /// external to the system deletes it.
-        pub const LIVE: State = State::new("LIVE");
+        pub const LIVE: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("LIVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "LIVE" => std::option::Option::Some(Self::LIVE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3007,49 +3022,64 @@ pub mod generation_config {
 
             /// The model routing preference.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct ModelRoutingPreference(std::borrow::Cow<'static, str>);
+            pub struct ModelRoutingPreference(i32);
 
             impl ModelRoutingPreference {
-                /// Creates a new ModelRoutingPreference instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [ModelRoutingPreference](ModelRoutingPreference)
-            pub mod model_routing_preference {
-                use super::ModelRoutingPreference;
-
                 /// Unspecified model routing preference.
-                pub const UNKNOWN: ModelRoutingPreference = ModelRoutingPreference::new("UNKNOWN");
+                pub const UNKNOWN: ModelRoutingPreference = ModelRoutingPreference::new(0);
 
                 /// Prefer higher quality over low cost.
                 pub const PRIORITIZE_QUALITY: ModelRoutingPreference =
-                    ModelRoutingPreference::new("PRIORITIZE_QUALITY");
+                    ModelRoutingPreference::new(1);
 
                 /// Balanced model routing preference.
-                pub const BALANCED: ModelRoutingPreference =
-                    ModelRoutingPreference::new("BALANCED");
+                pub const BALANCED: ModelRoutingPreference = ModelRoutingPreference::new(2);
 
                 /// Prefer lower cost over higher quality.
-                pub const PRIORITIZE_COST: ModelRoutingPreference =
-                    ModelRoutingPreference::new("PRIORITIZE_COST");
+                pub const PRIORITIZE_COST: ModelRoutingPreference = ModelRoutingPreference::new(3);
+
+                /// Creates a new ModelRoutingPreference instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                        1 => std::borrow::Cow::Borrowed("PRIORITIZE_QUALITY"),
+                        2 => std::borrow::Cow::Borrowed("BALANCED"),
+                        3 => std::borrow::Cow::Borrowed("PRIORITIZE_COST"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                        "PRIORITIZE_QUALITY" => std::option::Option::Some(Self::PRIORITIZE_QUALITY),
+                        "BALANCED" => std::option::Option::Some(Self::BALANCED),
+                        "PRIORITIZE_COST" => std::option::Option::Some(Self::PRIORITIZE_COST),
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for ModelRoutingPreference {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for ModelRoutingPreference {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for ModelRoutingPreference {
                 fn default() -> Self {
-                    model_routing_preference::UNKNOWN
+                    Self::new(0)
                 }
             }
         }
@@ -3168,98 +3198,134 @@ pub mod safety_setting {
 
     /// Probability based thresholds levels for blocking.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HarmBlockThreshold(std::borrow::Cow<'static, str>);
+    pub struct HarmBlockThreshold(i32);
 
     impl HarmBlockThreshold {
+        /// Unspecified harm block threshold.
+        pub const HARM_BLOCK_THRESHOLD_UNSPECIFIED: HarmBlockThreshold = HarmBlockThreshold::new(0);
+
+        /// Block low threshold and above (i.e. block more).
+        pub const BLOCK_LOW_AND_ABOVE: HarmBlockThreshold = HarmBlockThreshold::new(1);
+
+        /// Block medium threshold and above.
+        pub const BLOCK_MEDIUM_AND_ABOVE: HarmBlockThreshold = HarmBlockThreshold::new(2);
+
+        /// Block only high threshold (i.e. block less).
+        pub const BLOCK_ONLY_HIGH: HarmBlockThreshold = HarmBlockThreshold::new(3);
+
+        /// Block none.
+        pub const BLOCK_NONE: HarmBlockThreshold = HarmBlockThreshold::new(4);
+
+        /// Turn off the safety filter.
+        pub const OFF: HarmBlockThreshold = HarmBlockThreshold::new(5);
+
         /// Creates a new HarmBlockThreshold instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("HARM_BLOCK_THRESHOLD_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BLOCK_LOW_AND_ABOVE"),
+                2 => std::borrow::Cow::Borrowed("BLOCK_MEDIUM_AND_ABOVE"),
+                3 => std::borrow::Cow::Borrowed("BLOCK_ONLY_HIGH"),
+                4 => std::borrow::Cow::Borrowed("BLOCK_NONE"),
+                5 => std::borrow::Cow::Borrowed("OFF"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "HARM_BLOCK_THRESHOLD_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::HARM_BLOCK_THRESHOLD_UNSPECIFIED)
+                }
+                "BLOCK_LOW_AND_ABOVE" => std::option::Option::Some(Self::BLOCK_LOW_AND_ABOVE),
+                "BLOCK_MEDIUM_AND_ABOVE" => std::option::Option::Some(Self::BLOCK_MEDIUM_AND_ABOVE),
+                "BLOCK_ONLY_HIGH" => std::option::Option::Some(Self::BLOCK_ONLY_HIGH),
+                "BLOCK_NONE" => std::option::Option::Some(Self::BLOCK_NONE),
+                "OFF" => std::option::Option::Some(Self::OFF),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [HarmBlockThreshold](HarmBlockThreshold)
-    pub mod harm_block_threshold {
-        use super::HarmBlockThreshold;
-
-        /// Unspecified harm block threshold.
-        pub const HARM_BLOCK_THRESHOLD_UNSPECIFIED: HarmBlockThreshold =
-            HarmBlockThreshold::new("HARM_BLOCK_THRESHOLD_UNSPECIFIED");
-
-        /// Block low threshold and above (i.e. block more).
-        pub const BLOCK_LOW_AND_ABOVE: HarmBlockThreshold =
-            HarmBlockThreshold::new("BLOCK_LOW_AND_ABOVE");
-
-        /// Block medium threshold and above.
-        pub const BLOCK_MEDIUM_AND_ABOVE: HarmBlockThreshold =
-            HarmBlockThreshold::new("BLOCK_MEDIUM_AND_ABOVE");
-
-        /// Block only high threshold (i.e. block less).
-        pub const BLOCK_ONLY_HIGH: HarmBlockThreshold = HarmBlockThreshold::new("BLOCK_ONLY_HIGH");
-
-        /// Block none.
-        pub const BLOCK_NONE: HarmBlockThreshold = HarmBlockThreshold::new("BLOCK_NONE");
-
-        /// Turn off the safety filter.
-        pub const OFF: HarmBlockThreshold = HarmBlockThreshold::new("OFF");
-    }
-
-    impl std::convert::From<std::string::String> for HarmBlockThreshold {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for HarmBlockThreshold {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for HarmBlockThreshold {
         fn default() -> Self {
-            harm_block_threshold::HARM_BLOCK_THRESHOLD_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Probability vs severity.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HarmBlockMethod(std::borrow::Cow<'static, str>);
+    pub struct HarmBlockMethod(i32);
 
     impl HarmBlockMethod {
+        /// The harm block method is unspecified.
+        pub const HARM_BLOCK_METHOD_UNSPECIFIED: HarmBlockMethod = HarmBlockMethod::new(0);
+
+        /// The harm block method uses both probability and severity scores.
+        pub const SEVERITY: HarmBlockMethod = HarmBlockMethod::new(1);
+
+        /// The harm block method uses the probability score.
+        pub const PROBABILITY: HarmBlockMethod = HarmBlockMethod::new(2);
+
         /// Creates a new HarmBlockMethod instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("HARM_BLOCK_METHOD_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SEVERITY"),
+                2 => std::borrow::Cow::Borrowed("PROBABILITY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "HARM_BLOCK_METHOD_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::HARM_BLOCK_METHOD_UNSPECIFIED)
+                }
+                "SEVERITY" => std::option::Option::Some(Self::SEVERITY),
+                "PROBABILITY" => std::option::Option::Some(Self::PROBABILITY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [HarmBlockMethod](HarmBlockMethod)
-    pub mod harm_block_method {
-        use super::HarmBlockMethod;
-
-        /// The harm block method is unspecified.
-        pub const HARM_BLOCK_METHOD_UNSPECIFIED: HarmBlockMethod =
-            HarmBlockMethod::new("HARM_BLOCK_METHOD_UNSPECIFIED");
-
-        /// The harm block method uses both probability and severity scores.
-        pub const SEVERITY: HarmBlockMethod = HarmBlockMethod::new("SEVERITY");
-
-        /// The harm block method uses the probability score.
-        pub const PROBABILITY: HarmBlockMethod = HarmBlockMethod::new("PROBABILITY");
-    }
-
-    impl std::convert::From<std::string::String> for HarmBlockMethod {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for HarmBlockMethod {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for HarmBlockMethod {
         fn default() -> Self {
-            harm_block_method::HARM_BLOCK_METHOD_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3351,100 +3417,141 @@ pub mod safety_rating {
 
     /// Harm probability levels in the content.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HarmProbability(std::borrow::Cow<'static, str>);
+    pub struct HarmProbability(i32);
 
     impl HarmProbability {
+        /// Harm probability unspecified.
+        pub const HARM_PROBABILITY_UNSPECIFIED: HarmProbability = HarmProbability::new(0);
+
+        /// Negligible level of harm.
+        pub const NEGLIGIBLE: HarmProbability = HarmProbability::new(1);
+
+        /// Low level of harm.
+        pub const LOW: HarmProbability = HarmProbability::new(2);
+
+        /// Medium level of harm.
+        pub const MEDIUM: HarmProbability = HarmProbability::new(3);
+
+        /// High level of harm.
+        pub const HIGH: HarmProbability = HarmProbability::new(4);
+
         /// Creates a new HarmProbability instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("HARM_PROBABILITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NEGLIGIBLE"),
+                2 => std::borrow::Cow::Borrowed("LOW"),
+                3 => std::borrow::Cow::Borrowed("MEDIUM"),
+                4 => std::borrow::Cow::Borrowed("HIGH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "HARM_PROBABILITY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::HARM_PROBABILITY_UNSPECIFIED)
+                }
+                "NEGLIGIBLE" => std::option::Option::Some(Self::NEGLIGIBLE),
+                "LOW" => std::option::Option::Some(Self::LOW),
+                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
+                "HIGH" => std::option::Option::Some(Self::HIGH),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [HarmProbability](HarmProbability)
-    pub mod harm_probability {
-        use super::HarmProbability;
-
-        /// Harm probability unspecified.
-        pub const HARM_PROBABILITY_UNSPECIFIED: HarmProbability =
-            HarmProbability::new("HARM_PROBABILITY_UNSPECIFIED");
-
-        /// Negligible level of harm.
-        pub const NEGLIGIBLE: HarmProbability = HarmProbability::new("NEGLIGIBLE");
-
-        /// Low level of harm.
-        pub const LOW: HarmProbability = HarmProbability::new("LOW");
-
-        /// Medium level of harm.
-        pub const MEDIUM: HarmProbability = HarmProbability::new("MEDIUM");
-
-        /// High level of harm.
-        pub const HIGH: HarmProbability = HarmProbability::new("HIGH");
-    }
-
-    impl std::convert::From<std::string::String> for HarmProbability {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for HarmProbability {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for HarmProbability {
         fn default() -> Self {
-            harm_probability::HARM_PROBABILITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Harm severity levels.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HarmSeverity(std::borrow::Cow<'static, str>);
+    pub struct HarmSeverity(i32);
 
     impl HarmSeverity {
+        /// Harm severity unspecified.
+        pub const HARM_SEVERITY_UNSPECIFIED: HarmSeverity = HarmSeverity::new(0);
+
+        /// Negligible level of harm severity.
+        pub const HARM_SEVERITY_NEGLIGIBLE: HarmSeverity = HarmSeverity::new(1);
+
+        /// Low level of harm severity.
+        pub const HARM_SEVERITY_LOW: HarmSeverity = HarmSeverity::new(2);
+
+        /// Medium level of harm severity.
+        pub const HARM_SEVERITY_MEDIUM: HarmSeverity = HarmSeverity::new(3);
+
+        /// High level of harm severity.
+        pub const HARM_SEVERITY_HIGH: HarmSeverity = HarmSeverity::new(4);
+
         /// Creates a new HarmSeverity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("HARM_SEVERITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("HARM_SEVERITY_NEGLIGIBLE"),
+                2 => std::borrow::Cow::Borrowed("HARM_SEVERITY_LOW"),
+                3 => std::borrow::Cow::Borrowed("HARM_SEVERITY_MEDIUM"),
+                4 => std::borrow::Cow::Borrowed("HARM_SEVERITY_HIGH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "HARM_SEVERITY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::HARM_SEVERITY_UNSPECIFIED)
+                }
+                "HARM_SEVERITY_NEGLIGIBLE" => {
+                    std::option::Option::Some(Self::HARM_SEVERITY_NEGLIGIBLE)
+                }
+                "HARM_SEVERITY_LOW" => std::option::Option::Some(Self::HARM_SEVERITY_LOW),
+                "HARM_SEVERITY_MEDIUM" => std::option::Option::Some(Self::HARM_SEVERITY_MEDIUM),
+                "HARM_SEVERITY_HIGH" => std::option::Option::Some(Self::HARM_SEVERITY_HIGH),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [HarmSeverity](HarmSeverity)
-    pub mod harm_severity {
-        use super::HarmSeverity;
-
-        /// Harm severity unspecified.
-        pub const HARM_SEVERITY_UNSPECIFIED: HarmSeverity =
-            HarmSeverity::new("HARM_SEVERITY_UNSPECIFIED");
-
-        /// Negligible level of harm severity.
-        pub const HARM_SEVERITY_NEGLIGIBLE: HarmSeverity =
-            HarmSeverity::new("HARM_SEVERITY_NEGLIGIBLE");
-
-        /// Low level of harm severity.
-        pub const HARM_SEVERITY_LOW: HarmSeverity = HarmSeverity::new("HARM_SEVERITY_LOW");
-
-        /// Medium level of harm severity.
-        pub const HARM_SEVERITY_MEDIUM: HarmSeverity = HarmSeverity::new("HARM_SEVERITY_MEDIUM");
-
-        /// High level of harm severity.
-        pub const HARM_SEVERITY_HIGH: HarmSeverity = HarmSeverity::new("HARM_SEVERITY_HIGH");
-    }
-
-    impl std::convert::From<std::string::String> for HarmSeverity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for HarmSeverity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for HarmSeverity {
         fn default() -> Self {
-            harm_severity::HARM_SEVERITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3719,34 +3826,18 @@ pub mod candidate {
     /// The reason why the model stopped generating tokens.
     /// If empty, the model has not stopped generating the tokens.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FinishReason(std::borrow::Cow<'static, str>);
+    pub struct FinishReason(i32);
 
     impl FinishReason {
-        /// Creates a new FinishReason instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [FinishReason](FinishReason)
-    pub mod finish_reason {
-        use super::FinishReason;
-
         /// The finish reason is unspecified.
-        pub const FINISH_REASON_UNSPECIFIED: FinishReason =
-            FinishReason::new("FINISH_REASON_UNSPECIFIED");
+        pub const FINISH_REASON_UNSPECIFIED: FinishReason = FinishReason::new(0);
 
         /// Token generation reached a natural stopping point or a configured stop
         /// sequence.
-        pub const STOP: FinishReason = FinishReason::new("STOP");
+        pub const STOP: FinishReason = FinishReason::new(1);
 
         /// Token generation reached the configured maximum output tokens.
-        pub const MAX_TOKENS: FinishReason = FinishReason::new("MAX_TOKENS");
+        pub const MAX_TOKENS: FinishReason = FinishReason::new(2);
 
         /// Token generation stopped because the content potentially contains safety
         /// violations. NOTE: When streaming,
@@ -3754,39 +3845,86 @@ pub mod candidate {
         /// content filters blocks the output.
         ///
         /// [google.cloud.aiplatform.v1.Candidate.content]: crate::model::Candidate::content
-        pub const SAFETY: FinishReason = FinishReason::new("SAFETY");
+        pub const SAFETY: FinishReason = FinishReason::new(3);
 
         /// Token generation stopped because the content potentially contains
         /// copyright violations.
-        pub const RECITATION: FinishReason = FinishReason::new("RECITATION");
+        pub const RECITATION: FinishReason = FinishReason::new(4);
 
         /// All other reasons that stopped the token generation.
-        pub const OTHER: FinishReason = FinishReason::new("OTHER");
+        pub const OTHER: FinishReason = FinishReason::new(5);
 
         /// Token generation stopped because the content contains forbidden terms.
-        pub const BLOCKLIST: FinishReason = FinishReason::new("BLOCKLIST");
+        pub const BLOCKLIST: FinishReason = FinishReason::new(6);
 
         /// Token generation stopped for potentially containing prohibited content.
-        pub const PROHIBITED_CONTENT: FinishReason = FinishReason::new("PROHIBITED_CONTENT");
+        pub const PROHIBITED_CONTENT: FinishReason = FinishReason::new(7);
 
         /// Token generation stopped because the content potentially contains
         /// Sensitive Personally Identifiable Information (SPII).
-        pub const SPII: FinishReason = FinishReason::new("SPII");
+        pub const SPII: FinishReason = FinishReason::new(8);
 
         /// The function call generated by the model is invalid.
-        pub const MALFORMED_FUNCTION_CALL: FinishReason =
-            FinishReason::new("MALFORMED_FUNCTION_CALL");
+        pub const MALFORMED_FUNCTION_CALL: FinishReason = FinishReason::new(9);
+
+        /// Creates a new FinishReason instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FINISH_REASON_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STOP"),
+                2 => std::borrow::Cow::Borrowed("MAX_TOKENS"),
+                3 => std::borrow::Cow::Borrowed("SAFETY"),
+                4 => std::borrow::Cow::Borrowed("RECITATION"),
+                5 => std::borrow::Cow::Borrowed("OTHER"),
+                6 => std::borrow::Cow::Borrowed("BLOCKLIST"),
+                7 => std::borrow::Cow::Borrowed("PROHIBITED_CONTENT"),
+                8 => std::borrow::Cow::Borrowed("SPII"),
+                9 => std::borrow::Cow::Borrowed("MALFORMED_FUNCTION_CALL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FINISH_REASON_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::FINISH_REASON_UNSPECIFIED)
+                }
+                "STOP" => std::option::Option::Some(Self::STOP),
+                "MAX_TOKENS" => std::option::Option::Some(Self::MAX_TOKENS),
+                "SAFETY" => std::option::Option::Some(Self::SAFETY),
+                "RECITATION" => std::option::Option::Some(Self::RECITATION),
+                "OTHER" => std::option::Option::Some(Self::OTHER),
+                "BLOCKLIST" => std::option::Option::Some(Self::BLOCKLIST),
+                "PROHIBITED_CONTENT" => std::option::Option::Some(Self::PROHIBITED_CONTENT),
+                "SPII" => std::option::Option::Some(Self::SPII),
+                "MALFORMED_FUNCTION_CALL" => {
+                    std::option::Option::Some(Self::MALFORMED_FUNCTION_CALL)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for FinishReason {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for FinishReason {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for FinishReason {
         fn default() -> Self {
-            finish_reason::FINISH_REASON_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5598,52 +5736,73 @@ pub mod scheduling {
     /// leverage spot resources alongwith regular resources to schedule
     /// the job.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Strategy(std::borrow::Cow<'static, str>);
+    pub struct Strategy(i32);
 
     impl Strategy {
+        /// Strategy will default to STANDARD.
+        pub const STRATEGY_UNSPECIFIED: Strategy = Strategy::new(0);
+
+        /// Deprecated. Regular on-demand provisioning strategy.
+        pub const ON_DEMAND: Strategy = Strategy::new(1);
+
+        /// Deprecated. Low cost by making potential use of spot resources.
+        pub const LOW_COST: Strategy = Strategy::new(2);
+
+        /// Standard provisioning strategy uses regular on-demand resources.
+        pub const STANDARD: Strategy = Strategy::new(3);
+
+        /// Spot provisioning strategy uses spot resources.
+        pub const SPOT: Strategy = Strategy::new(4);
+
+        /// Flex Start strategy uses DWS to queue for resources.
+        pub const FLEX_START: Strategy = Strategy::new(6);
+
         /// Creates a new Strategy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STRATEGY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ON_DEMAND"),
+                2 => std::borrow::Cow::Borrowed("LOW_COST"),
+                3 => std::borrow::Cow::Borrowed("STANDARD"),
+                4 => std::borrow::Cow::Borrowed("SPOT"),
+                6 => std::borrow::Cow::Borrowed("FLEX_START"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STRATEGY_UNSPECIFIED" => std::option::Option::Some(Self::STRATEGY_UNSPECIFIED),
+                "ON_DEMAND" => std::option::Option::Some(Self::ON_DEMAND),
+                "LOW_COST" => std::option::Option::Some(Self::LOW_COST),
+                "STANDARD" => std::option::Option::Some(Self::STANDARD),
+                "SPOT" => std::option::Option::Some(Self::SPOT),
+                "FLEX_START" => std::option::Option::Some(Self::FLEX_START),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Strategy](Strategy)
-    pub mod strategy {
-        use super::Strategy;
-
-        /// Strategy will default to STANDARD.
-        pub const STRATEGY_UNSPECIFIED: Strategy = Strategy::new("STRATEGY_UNSPECIFIED");
-
-        /// Deprecated. Regular on-demand provisioning strategy.
-        pub const ON_DEMAND: Strategy = Strategy::new("ON_DEMAND");
-
-        /// Deprecated. Low cost by making potential use of spot resources.
-        pub const LOW_COST: Strategy = Strategy::new("LOW_COST");
-
-        /// Standard provisioning strategy uses regular on-demand resources.
-        pub const STANDARD: Strategy = Strategy::new("STANDARD");
-
-        /// Spot provisioning strategy uses spot resources.
-        pub const SPOT: Strategy = Strategy::new("SPOT");
-
-        /// Flex Start strategy uses DWS to queue for resources.
-        pub const FLEX_START: Strategy = Strategy::new("FLEX_START");
-    }
-
-    impl std::convert::From<std::string::String> for Strategy {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Strategy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Strategy {
         fn default() -> Self {
-            strategy::STRATEGY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6342,41 +6501,55 @@ pub mod sample_config {
     /// Sample strategy decides which subset of DataItems should be selected for
     /// human labeling in every batch.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SampleStrategy(std::borrow::Cow<'static, str>);
+    pub struct SampleStrategy(i32);
 
     impl SampleStrategy {
+        /// Default will be treated as UNCERTAINTY.
+        pub const SAMPLE_STRATEGY_UNSPECIFIED: SampleStrategy = SampleStrategy::new(0);
+
+        /// Sample the most uncertain data to label.
+        pub const UNCERTAINTY: SampleStrategy = SampleStrategy::new(1);
+
         /// Creates a new SampleStrategy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SAMPLE_STRATEGY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("UNCERTAINTY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SAMPLE_STRATEGY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SAMPLE_STRATEGY_UNSPECIFIED)
+                }
+                "UNCERTAINTY" => std::option::Option::Some(Self::UNCERTAINTY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SampleStrategy](SampleStrategy)
-    pub mod sample_strategy {
-        use super::SampleStrategy;
-
-        /// Default will be treated as UNCERTAINTY.
-        pub const SAMPLE_STRATEGY_UNSPECIFIED: SampleStrategy =
-            SampleStrategy::new("SAMPLE_STRATEGY_UNSPECIFIED");
-
-        /// Sample the most uncertain data to label.
-        pub const UNCERTAINTY: SampleStrategy = SampleStrategy::new("UNCERTAINTY");
-    }
-
-    impl std::convert::From<std::string::String> for SampleStrategy {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SampleStrategy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SampleStrategy {
         fn default() -> Self {
-            sample_strategy::SAMPLE_STRATEGY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -7090,40 +7263,53 @@ pub mod export_data_config {
     /// unannotated data to be exported and whether to clone files to temp Cloud
     /// Storage bucket.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ExportUse(std::borrow::Cow<'static, str>);
+    pub struct ExportUse(i32);
 
     impl ExportUse {
+        /// Regular user export.
+        pub const EXPORT_USE_UNSPECIFIED: ExportUse = ExportUse::new(0);
+
+        /// Export for custom code training.
+        pub const CUSTOM_CODE_TRAINING: ExportUse = ExportUse::new(6);
+
         /// Creates a new ExportUse instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EXPORT_USE_UNSPECIFIED"),
+                6 => std::borrow::Cow::Borrowed("CUSTOM_CODE_TRAINING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EXPORT_USE_UNSPECIFIED" => std::option::Option::Some(Self::EXPORT_USE_UNSPECIFIED),
+                "CUSTOM_CODE_TRAINING" => std::option::Option::Some(Self::CUSTOM_CODE_TRAINING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ExportUse](ExportUse)
-    pub mod export_use {
-        use super::ExportUse;
-
-        /// Regular user export.
-        pub const EXPORT_USE_UNSPECIFIED: ExportUse = ExportUse::new("EXPORT_USE_UNSPECIFIED");
-
-        /// Export for custom code training.
-        pub const CUSTOM_CODE_TRAINING: ExportUse = ExportUse::new("CUSTOM_CODE_TRAINING");
-    }
-
-    impl std::convert::From<std::string::String> for ExportUse {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ExportUse {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ExportUse {
         fn default() -> Self {
-            export_use::EXPORT_USE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -12787,53 +12973,69 @@ pub mod evaluated_annotation {
 
     /// Describes the type of the EvaluatedAnnotation. The type is determined
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EvaluatedAnnotationType(std::borrow::Cow<'static, str>);
+    pub struct EvaluatedAnnotationType(i32);
 
     impl EvaluatedAnnotationType {
-        /// Creates a new EvaluatedAnnotationType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [EvaluatedAnnotationType](EvaluatedAnnotationType)
-    pub mod evaluated_annotation_type {
-        use super::EvaluatedAnnotationType;
-
         /// Invalid value.
         pub const EVALUATED_ANNOTATION_TYPE_UNSPECIFIED: EvaluatedAnnotationType =
-            EvaluatedAnnotationType::new("EVALUATED_ANNOTATION_TYPE_UNSPECIFIED");
+            EvaluatedAnnotationType::new(0);
 
         /// The EvaluatedAnnotation is a true positive. It has a prediction created
         /// by the Model and a ground truth Annotation which the prediction matches.
-        pub const TRUE_POSITIVE: EvaluatedAnnotationType =
-            EvaluatedAnnotationType::new("TRUE_POSITIVE");
+        pub const TRUE_POSITIVE: EvaluatedAnnotationType = EvaluatedAnnotationType::new(1);
 
         /// The EvaluatedAnnotation is false positive. It has a prediction created by
         /// the Model which does not match any ground truth annotation.
-        pub const FALSE_POSITIVE: EvaluatedAnnotationType =
-            EvaluatedAnnotationType::new("FALSE_POSITIVE");
+        pub const FALSE_POSITIVE: EvaluatedAnnotationType = EvaluatedAnnotationType::new(2);
 
         /// The EvaluatedAnnotation is false negative. It has a ground truth
         /// annotation which is not matched by any of the model created predictions.
-        pub const FALSE_NEGATIVE: EvaluatedAnnotationType =
-            EvaluatedAnnotationType::new("FALSE_NEGATIVE");
+        pub const FALSE_NEGATIVE: EvaluatedAnnotationType = EvaluatedAnnotationType::new(3);
+
+        /// Creates a new EvaluatedAnnotationType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EVALUATED_ANNOTATION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TRUE_POSITIVE"),
+                2 => std::borrow::Cow::Borrowed("FALSE_POSITIVE"),
+                3 => std::borrow::Cow::Borrowed("FALSE_NEGATIVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EVALUATED_ANNOTATION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::EVALUATED_ANNOTATION_TYPE_UNSPECIFIED)
+                }
+                "TRUE_POSITIVE" => std::option::Option::Some(Self::TRUE_POSITIVE),
+                "FALSE_POSITIVE" => std::option::Option::Some(Self::FALSE_POSITIVE),
+                "FALSE_NEGATIVE" => std::option::Option::Some(Self::FALSE_NEGATIVE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for EvaluatedAnnotationType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EvaluatedAnnotationType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EvaluatedAnnotationType {
         fn default() -> Self {
-            evaluated_annotation_type::EVALUATED_ANNOTATION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -13008,46 +13210,63 @@ pub mod error_analysis_annotation {
 
     /// The query type used for finding the attributed items.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct QueryType(std::borrow::Cow<'static, str>);
+    pub struct QueryType(i32);
 
     impl QueryType {
+        /// Unspecified query type for model error analysis.
+        pub const QUERY_TYPE_UNSPECIFIED: QueryType = QueryType::new(0);
+
+        /// Query similar samples across all classes in the dataset.
+        pub const ALL_SIMILAR: QueryType = QueryType::new(1);
+
+        /// Query similar samples from the same class of the input sample.
+        pub const SAME_CLASS_SIMILAR: QueryType = QueryType::new(2);
+
+        /// Query dissimilar samples from the same class of the input sample.
+        pub const SAME_CLASS_DISSIMILAR: QueryType = QueryType::new(3);
+
         /// Creates a new QueryType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("QUERY_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALL_SIMILAR"),
+                2 => std::borrow::Cow::Borrowed("SAME_CLASS_SIMILAR"),
+                3 => std::borrow::Cow::Borrowed("SAME_CLASS_DISSIMILAR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "QUERY_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::QUERY_TYPE_UNSPECIFIED),
+                "ALL_SIMILAR" => std::option::Option::Some(Self::ALL_SIMILAR),
+                "SAME_CLASS_SIMILAR" => std::option::Option::Some(Self::SAME_CLASS_SIMILAR),
+                "SAME_CLASS_DISSIMILAR" => std::option::Option::Some(Self::SAME_CLASS_DISSIMILAR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [QueryType](QueryType)
-    pub mod query_type {
-        use super::QueryType;
-
-        /// Unspecified query type for model error analysis.
-        pub const QUERY_TYPE_UNSPECIFIED: QueryType = QueryType::new("QUERY_TYPE_UNSPECIFIED");
-
-        /// Query similar samples across all classes in the dataset.
-        pub const ALL_SIMILAR: QueryType = QueryType::new("ALL_SIMILAR");
-
-        /// Query similar samples from the same class of the input sample.
-        pub const SAME_CLASS_SIMILAR: QueryType = QueryType::new("SAME_CLASS_SIMILAR");
-
-        /// Query dissimilar samples from the same class of the input sample.
-        pub const SAME_CLASS_DISSIMILAR: QueryType = QueryType::new("SAME_CLASS_DISSIMILAR");
-    }
-
-    impl std::convert::From<std::string::String> for QueryType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for QueryType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for QueryType {
         fn default() -> Self {
-            query_type::QUERY_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -19411,42 +19630,56 @@ pub mod comet_spec {
 
     /// Comet version options.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CometVersion(std::borrow::Cow<'static, str>);
+    pub struct CometVersion(i32);
 
     impl CometVersion {
-        /// Creates a new CometVersion instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CometVersion](CometVersion)
-    pub mod comet_version {
-        use super::CometVersion;
-
         /// Comet version unspecified.
-        pub const COMET_VERSION_UNSPECIFIED: CometVersion =
-            CometVersion::new("COMET_VERSION_UNSPECIFIED");
+        pub const COMET_VERSION_UNSPECIFIED: CometVersion = CometVersion::new(0);
 
         /// Comet 22 for translation + source + reference
         /// (source-reference-combined).
-        pub const COMET_22_SRC_REF: CometVersion = CometVersion::new("COMET_22_SRC_REF");
+        pub const COMET_22_SRC_REF: CometVersion = CometVersion::new(2);
+
+        /// Creates a new CometVersion instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COMET_VERSION_UNSPECIFIED"),
+                2 => std::borrow::Cow::Borrowed("COMET_22_SRC_REF"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COMET_VERSION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::COMET_VERSION_UNSPECIFIED)
+                }
+                "COMET_22_SRC_REF" => std::option::Option::Some(Self::COMET_22_SRC_REF),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CometVersion {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CometVersion {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CometVersion {
         fn default() -> Self {
-            comet_version::COMET_VERSION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -19651,48 +19884,66 @@ pub mod metricx_spec {
 
     /// MetricX Version options.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MetricxVersion(std::borrow::Cow<'static, str>);
+    pub struct MetricxVersion(i32);
 
     impl MetricxVersion {
-        /// Creates a new MetricxVersion instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [MetricxVersion](MetricxVersion)
-    pub mod metricx_version {
-        use super::MetricxVersion;
-
         /// MetricX version unspecified.
-        pub const METRICX_VERSION_UNSPECIFIED: MetricxVersion =
-            MetricxVersion::new("METRICX_VERSION_UNSPECIFIED");
+        pub const METRICX_VERSION_UNSPECIFIED: MetricxVersion = MetricxVersion::new(0);
 
         /// MetricX 2024 (2.6) for translation + reference (reference-based).
-        pub const METRICX_24_REF: MetricxVersion = MetricxVersion::new("METRICX_24_REF");
+        pub const METRICX_24_REF: MetricxVersion = MetricxVersion::new(1);
 
         /// MetricX 2024 (2.6) for translation + source (QE).
-        pub const METRICX_24_SRC: MetricxVersion = MetricxVersion::new("METRICX_24_SRC");
+        pub const METRICX_24_SRC: MetricxVersion = MetricxVersion::new(2);
 
         /// MetricX 2024 (2.6) for translation + source + reference
         /// (source-reference-combined).
-        pub const METRICX_24_SRC_REF: MetricxVersion = MetricxVersion::new("METRICX_24_SRC_REF");
+        pub const METRICX_24_SRC_REF: MetricxVersion = MetricxVersion::new(3);
+
+        /// Creates a new MetricxVersion instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("METRICX_VERSION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("METRICX_24_REF"),
+                2 => std::borrow::Cow::Borrowed("METRICX_24_SRC"),
+                3 => std::borrow::Cow::Borrowed("METRICX_24_SRC_REF"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "METRICX_VERSION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::METRICX_VERSION_UNSPECIFIED)
+                }
+                "METRICX_24_REF" => std::option::Option::Some(Self::METRICX_24_REF),
+                "METRICX_24_SRC" => std::option::Option::Some(Self::METRICX_24_SRC),
+                "METRICX_24_SRC_REF" => std::option::Option::Some(Self::METRICX_24_SRC_REF),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for MetricxVersion {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MetricxVersion {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MetricxVersion {
         fn default() -> Self {
-            metricx_version::METRICX_VERSION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -19882,43 +20133,58 @@ pub mod event {
 
     /// Describes whether an Event's Artifact is the Execution's input or output.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Unspecified whether input or output of the Execution.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// An input of the Execution.
+        pub const INPUT: Type = Type::new(1);
+
+        /// An output of the Execution.
+        pub const OUTPUT: Type = Type::new(2);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INPUT"),
+                2 => std::borrow::Cow::Borrowed("OUTPUT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "INPUT" => std::option::Option::Some(Self::INPUT),
+                "OUTPUT" => std::option::Option::Some(Self::OUTPUT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Unspecified whether input or output of the Execution.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// An input of the Execution.
-        pub const INPUT: Type = Type::new("INPUT");
-
-        /// An output of the Execution.
-        pub const OUTPUT: Type = Type::new("OUTPUT");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -20097,55 +20363,78 @@ pub mod execution {
 
     /// Describes the state of the Execution.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified Execution state
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The Execution is new
+        pub const NEW: State = State::new(1);
+
+        /// The Execution is running
+        pub const RUNNING: State = State::new(2);
+
+        /// The Execution has finished running
+        pub const COMPLETE: State = State::new(3);
+
+        /// The Execution has failed
+        pub const FAILED: State = State::new(4);
+
+        /// The Execution completed through Cache hit.
+        pub const CACHED: State = State::new(5);
+
+        /// The Execution was cancelled.
+        pub const CANCELLED: State = State::new(6);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NEW"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("COMPLETE"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                5 => std::borrow::Cow::Borrowed("CACHED"),
+                6 => std::borrow::Cow::Borrowed("CANCELLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "NEW" => std::option::Option::Some(Self::NEW),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "COMPLETE" => std::option::Option::Some(Self::COMPLETE),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "CACHED" => std::option::Option::Some(Self::CACHED),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified Execution state
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The Execution is new
-        pub const NEW: State = State::new("NEW");
-
-        /// The Execution is running
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// The Execution has finished running
-        pub const COMPLETE: State = State::new("COMPLETE");
-
-        /// The Execution has failed
-        pub const FAILED: State = State::new("FAILED");
-
-        /// The Execution completed through Cache hit.
-        pub const CACHED: State = State::new("CACHED");
-
-        /// The Execution was cancelled.
-        pub const CANCELLED: State = State::new("CANCELLED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -21495,41 +21784,55 @@ pub mod examples {
 
         /// The format of the input example instances.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct DataFormat(std::borrow::Cow<'static, str>);
+        pub struct DataFormat(i32);
 
         impl DataFormat {
+            /// Format unspecified, used when unset.
+            pub const DATA_FORMAT_UNSPECIFIED: DataFormat = DataFormat::new(0);
+
+            /// Examples are stored in JSONL files.
+            pub const JSONL: DataFormat = DataFormat::new(1);
+
             /// Creates a new DataFormat instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("DATA_FORMAT_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("JSONL"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "DATA_FORMAT_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::DATA_FORMAT_UNSPECIFIED)
+                    }
+                    "JSONL" => std::option::Option::Some(Self::JSONL),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [DataFormat](DataFormat)
-        pub mod data_format {
-            use super::DataFormat;
-
-            /// Format unspecified, used when unset.
-            pub const DATA_FORMAT_UNSPECIFIED: DataFormat =
-                DataFormat::new("DATA_FORMAT_UNSPECIFIED");
-
-            /// Examples are stored in JSONL files.
-            pub const JSONL: DataFormat = DataFormat::new("JSONL");
-        }
-
-        impl std::convert::From<std::string::String> for DataFormat {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for DataFormat {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for DataFormat {
             fn default() -> Self {
-                data_format::DATA_FORMAT_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -21614,85 +21917,115 @@ pub mod presets {
 
     /// Preset option controlling parameters for query speed-precision trade-off
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Query(std::borrow::Cow<'static, str>);
+    pub struct Query(i32);
 
     impl Query {
+        /// More precise neighbors as a trade-off against slower response.
+        pub const PRECISE: Query = Query::new(0);
+
+        /// Faster response as a trade-off against less precise neighbors.
+        pub const FAST: Query = Query::new(1);
+
         /// Creates a new Query instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PRECISE"),
+                1 => std::borrow::Cow::Borrowed("FAST"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PRECISE" => std::option::Option::Some(Self::PRECISE),
+                "FAST" => std::option::Option::Some(Self::FAST),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Query](Query)
-    pub mod query {
-        use super::Query;
-
-        /// More precise neighbors as a trade-off against slower response.
-        pub const PRECISE: Query = Query::new("PRECISE");
-
-        /// Faster response as a trade-off against less precise neighbors.
-        pub const FAST: Query = Query::new("FAST");
-    }
-
-    impl std::convert::From<std::string::String> for Query {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Query {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Query {
         fn default() -> Self {
-            query::PRECISE
+            Self::new(0)
         }
     }
 
     /// Preset option controlling parameters for different modalities
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Modality(std::borrow::Cow<'static, str>);
+    pub struct Modality(i32);
 
     impl Modality {
+        /// Should not be set. Added as a recommended best practice for enums
+        pub const MODALITY_UNSPECIFIED: Modality = Modality::new(0);
+
+        /// IMAGE modality
+        pub const IMAGE: Modality = Modality::new(1);
+
+        /// TEXT modality
+        pub const TEXT: Modality = Modality::new(2);
+
+        /// TABULAR modality
+        pub const TABULAR: Modality = Modality::new(3);
+
         /// Creates a new Modality instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MODALITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IMAGE"),
+                2 => std::borrow::Cow::Borrowed("TEXT"),
+                3 => std::borrow::Cow::Borrowed("TABULAR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MODALITY_UNSPECIFIED" => std::option::Option::Some(Self::MODALITY_UNSPECIFIED),
+                "IMAGE" => std::option::Option::Some(Self::IMAGE),
+                "TEXT" => std::option::Option::Some(Self::TEXT),
+                "TABULAR" => std::option::Option::Some(Self::TABULAR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Modality](Modality)
-    pub mod modality {
-        use super::Modality;
-
-        /// Should not be set. Added as a recommended best practice for enums
-        pub const MODALITY_UNSPECIFIED: Modality = Modality::new("MODALITY_UNSPECIFIED");
-
-        /// IMAGE modality
-        pub const IMAGE: Modality = Modality::new("IMAGE");
-
-        /// TEXT modality
-        pub const TEXT: Modality = Modality::new("TEXT");
-
-        /// TABULAR modality
-        pub const TABULAR: Modality = Modality::new("TABULAR");
-    }
-
-    impl std::convert::From<std::string::String> for Modality {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Modality {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Modality {
         fn default() -> Self {
-            modality::MODALITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -21949,43 +22282,60 @@ pub mod examples_override {
 
     /// Data format enum.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataFormat(std::borrow::Cow<'static, str>);
+    pub struct DataFormat(i32);
 
     impl DataFormat {
+        /// Unspecified format. Must not be used.
+        pub const DATA_FORMAT_UNSPECIFIED: DataFormat = DataFormat::new(0);
+
+        /// Provided data is a set of model inputs.
+        pub const INSTANCES: DataFormat = DataFormat::new(1);
+
+        /// Provided data is a set of embeddings.
+        pub const EMBEDDINGS: DataFormat = DataFormat::new(2);
+
         /// Creates a new DataFormat instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATA_FORMAT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INSTANCES"),
+                2 => std::borrow::Cow::Borrowed("EMBEDDINGS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATA_FORMAT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DATA_FORMAT_UNSPECIFIED)
+                }
+                "INSTANCES" => std::option::Option::Some(Self::INSTANCES),
+                "EMBEDDINGS" => std::option::Option::Some(Self::EMBEDDINGS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DataFormat](DataFormat)
-    pub mod data_format {
-        use super::DataFormat;
-
-        /// Unspecified format. Must not be used.
-        pub const DATA_FORMAT_UNSPECIFIED: DataFormat = DataFormat::new("DATA_FORMAT_UNSPECIFIED");
-
-        /// Provided data is a set of model inputs.
-        pub const INSTANCES: DataFormat = DataFormat::new("INSTANCES");
-
-        /// Provided data is a set of embeddings.
-        pub const EMBEDDINGS: DataFormat = DataFormat::new("EMBEDDINGS");
-    }
-
-    impl std::convert::From<std::string::String> for DataFormat {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DataFormat {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DataFormat {
         fn default() -> Self {
-            data_format::DATA_FORMAT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -22646,228 +22996,292 @@ pub mod explanation_metadata {
             ///
             /// [google.cloud.aiplatform.v1.ExplanationParameters.integrated_gradients_attribution]: crate::model::ExplanationParameters::method
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct Type(std::borrow::Cow<'static, str>);
+            pub struct Type(i32);
 
             impl Type {
-                /// Creates a new Type instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [Type](Type)
-            pub mod r#type {
-                use super::Type;
-
                 /// Should not be used.
-                pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+                pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
                 /// Shows which pixel contributed to the image prediction.
-                pub const PIXELS: Type = Type::new("PIXELS");
+                pub const PIXELS: Type = Type::new(1);
 
                 /// Shows which region contributed to the image prediction by outlining
                 /// the region.
-                pub const OUTLINES: Type = Type::new("OUTLINES");
+                pub const OUTLINES: Type = Type::new(2);
+
+                /// Creates a new Type instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("PIXELS"),
+                        2 => std::borrow::Cow::Borrowed("OUTLINES"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                        "PIXELS" => std::option::Option::Some(Self::PIXELS),
+                        "OUTLINES" => std::option::Option::Some(Self::OUTLINES),
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for Type {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for Type {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for Type {
                 fn default() -> Self {
-                    r#type::TYPE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
 
             /// Whether to only highlight pixels with positive contributions, negative
             /// or both. Defaults to POSITIVE.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct Polarity(std::borrow::Cow<'static, str>);
+            pub struct Polarity(i32);
 
             impl Polarity {
-                /// Creates a new Polarity instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [Polarity](Polarity)
-            pub mod polarity {
-                use super::Polarity;
-
                 /// Default value. This is the same as POSITIVE.
-                pub const POLARITY_UNSPECIFIED: Polarity = Polarity::new("POLARITY_UNSPECIFIED");
+                pub const POLARITY_UNSPECIFIED: Polarity = Polarity::new(0);
 
                 /// Highlights the pixels/outlines that were most influential to the
                 /// model's prediction.
-                pub const POSITIVE: Polarity = Polarity::new("POSITIVE");
+                pub const POSITIVE: Polarity = Polarity::new(1);
 
                 /// Setting polarity to negative highlights areas that does not lead to
                 /// the models's current prediction.
-                pub const NEGATIVE: Polarity = Polarity::new("NEGATIVE");
+                pub const NEGATIVE: Polarity = Polarity::new(2);
 
                 /// Shows both positive and negative attributions.
-                pub const BOTH: Polarity = Polarity::new("BOTH");
+                pub const BOTH: Polarity = Polarity::new(3);
+
+                /// Creates a new Polarity instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("POLARITY_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("POSITIVE"),
+                        2 => std::borrow::Cow::Borrowed("NEGATIVE"),
+                        3 => std::borrow::Cow::Borrowed("BOTH"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "POLARITY_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::POLARITY_UNSPECIFIED)
+                        }
+                        "POSITIVE" => std::option::Option::Some(Self::POSITIVE),
+                        "NEGATIVE" => std::option::Option::Some(Self::NEGATIVE),
+                        "BOTH" => std::option::Option::Some(Self::BOTH),
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for Polarity {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for Polarity {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for Polarity {
                 fn default() -> Self {
-                    polarity::POLARITY_UNSPECIFIED
+                    Self::new(0)
                 }
             }
 
             /// The color scheme used for highlighting areas.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct ColorMap(std::borrow::Cow<'static, str>);
+            pub struct ColorMap(i32);
 
             impl ColorMap {
-                /// Creates a new ColorMap instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [ColorMap](ColorMap)
-            pub mod color_map {
-                use super::ColorMap;
-
                 /// Should not be used.
-                pub const COLOR_MAP_UNSPECIFIED: ColorMap = ColorMap::new("COLOR_MAP_UNSPECIFIED");
+                pub const COLOR_MAP_UNSPECIFIED: ColorMap = ColorMap::new(0);
 
                 /// Positive: green. Negative: pink.
-                pub const PINK_GREEN: ColorMap = ColorMap::new("PINK_GREEN");
+                pub const PINK_GREEN: ColorMap = ColorMap::new(1);
 
                 /// Viridis color map: A perceptually uniform color mapping which is
                 /// easier to see by those with colorblindness and progresses from yellow
                 /// to green to blue. Positive: yellow. Negative: blue.
-                pub const VIRIDIS: ColorMap = ColorMap::new("VIRIDIS");
+                pub const VIRIDIS: ColorMap = ColorMap::new(2);
 
                 /// Positive: red. Negative: red.
-                pub const RED: ColorMap = ColorMap::new("RED");
+                pub const RED: ColorMap = ColorMap::new(3);
 
                 /// Positive: green. Negative: green.
-                pub const GREEN: ColorMap = ColorMap::new("GREEN");
+                pub const GREEN: ColorMap = ColorMap::new(4);
 
                 /// Positive: green. Negative: red.
-                pub const RED_GREEN: ColorMap = ColorMap::new("RED_GREEN");
+                pub const RED_GREEN: ColorMap = ColorMap::new(6);
 
                 /// PiYG palette.
-                pub const PINK_WHITE_GREEN: ColorMap = ColorMap::new("PINK_WHITE_GREEN");
+                pub const PINK_WHITE_GREEN: ColorMap = ColorMap::new(5);
+
+                /// Creates a new ColorMap instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("COLOR_MAP_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("PINK_GREEN"),
+                        2 => std::borrow::Cow::Borrowed("VIRIDIS"),
+                        3 => std::borrow::Cow::Borrowed("RED"),
+                        4 => std::borrow::Cow::Borrowed("GREEN"),
+                        5 => std::borrow::Cow::Borrowed("PINK_WHITE_GREEN"),
+                        6 => std::borrow::Cow::Borrowed("RED_GREEN"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "COLOR_MAP_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::COLOR_MAP_UNSPECIFIED)
+                        }
+                        "PINK_GREEN" => std::option::Option::Some(Self::PINK_GREEN),
+                        "VIRIDIS" => std::option::Option::Some(Self::VIRIDIS),
+                        "RED" => std::option::Option::Some(Self::RED),
+                        "GREEN" => std::option::Option::Some(Self::GREEN),
+                        "RED_GREEN" => std::option::Option::Some(Self::RED_GREEN),
+                        "PINK_WHITE_GREEN" => std::option::Option::Some(Self::PINK_WHITE_GREEN),
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for ColorMap {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for ColorMap {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for ColorMap {
                 fn default() -> Self {
-                    color_map::COLOR_MAP_UNSPECIFIED
+                    Self::new(0)
                 }
             }
 
             /// How the original image is displayed in the visualization.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct OverlayType(std::borrow::Cow<'static, str>);
+            pub struct OverlayType(i32);
 
             impl OverlayType {
-                /// Creates a new OverlayType instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [OverlayType](OverlayType)
-            pub mod overlay_type {
-                use super::OverlayType;
-
                 /// Default value. This is the same as NONE.
-                pub const OVERLAY_TYPE_UNSPECIFIED: OverlayType =
-                    OverlayType::new("OVERLAY_TYPE_UNSPECIFIED");
+                pub const OVERLAY_TYPE_UNSPECIFIED: OverlayType = OverlayType::new(0);
 
                 /// No overlay.
-                pub const NONE: OverlayType = OverlayType::new("NONE");
+                pub const NONE: OverlayType = OverlayType::new(1);
 
                 /// The attributions are shown on top of the original image.
-                pub const ORIGINAL: OverlayType = OverlayType::new("ORIGINAL");
+                pub const ORIGINAL: OverlayType = OverlayType::new(2);
 
                 /// The attributions are shown on top of grayscaled version of the
                 /// original image.
-                pub const GRAYSCALE: OverlayType = OverlayType::new("GRAYSCALE");
+                pub const GRAYSCALE: OverlayType = OverlayType::new(3);
 
                 /// The attributions are used as a mask to reveal predictive parts of
                 /// the image and hide the un-predictive parts.
-                pub const MASK_BLACK: OverlayType = OverlayType::new("MASK_BLACK");
+                pub const MASK_BLACK: OverlayType = OverlayType::new(4);
+
+                /// Creates a new OverlayType instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("OVERLAY_TYPE_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("NONE"),
+                        2 => std::borrow::Cow::Borrowed("ORIGINAL"),
+                        3 => std::borrow::Cow::Borrowed("GRAYSCALE"),
+                        4 => std::borrow::Cow::Borrowed("MASK_BLACK"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "OVERLAY_TYPE_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::OVERLAY_TYPE_UNSPECIFIED)
+                        }
+                        "NONE" => std::option::Option::Some(Self::NONE),
+                        "ORIGINAL" => std::option::Option::Some(Self::ORIGINAL),
+                        "GRAYSCALE" => std::option::Option::Some(Self::GRAYSCALE),
+                        "MASK_BLACK" => std::option::Option::Some(Self::MASK_BLACK),
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for OverlayType {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for OverlayType {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for OverlayType {
                 fn default() -> Self {
-                    overlay_type::OVERLAY_TYPE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
 
         /// Defines how a feature is encoded. Defaults to IDENTITY.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Encoding(std::borrow::Cow<'static, str>);
+        pub struct Encoding(i32);
 
         impl Encoding {
-            /// Creates a new Encoding instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [Encoding](Encoding)
-        pub mod encoding {
-            use super::Encoding;
-
             /// Default value. This is the same as IDENTITY.
-            pub const ENCODING_UNSPECIFIED: Encoding = Encoding::new("ENCODING_UNSPECIFIED");
+            pub const ENCODING_UNSPECIFIED: Encoding = Encoding::new(0);
 
             /// The tensor represents one feature.
-            pub const IDENTITY: Encoding = Encoding::new("IDENTITY");
+            pub const IDENTITY: Encoding = Encoding::new(1);
 
             /// The tensor represents a bag of features where each index maps to
             /// a feature.
@@ -22880,7 +23294,7 @@ pub mod explanation_metadata {
             /// ```
             ///
             /// [google.cloud.aiplatform.v1.ExplanationMetadata.InputMetadata.index_feature_mapping]: crate::model::explanation_metadata::InputMetadata::index_feature_mapping
-            pub const BAG_OF_FEATURES: Encoding = Encoding::new("BAG_OF_FEATURES");
+            pub const BAG_OF_FEATURES: Encoding = Encoding::new(2);
 
             /// The tensor represents a bag of features where each index maps to a
             /// feature. Zero values in the tensor indicates feature being
@@ -22894,7 +23308,7 @@ pub mod explanation_metadata {
             /// ```
             ///
             /// [google.cloud.aiplatform.v1.ExplanationMetadata.InputMetadata.index_feature_mapping]: crate::model::explanation_metadata::InputMetadata::index_feature_mapping
-            pub const BAG_OF_FEATURES_SPARSE: Encoding = Encoding::new("BAG_OF_FEATURES_SPARSE");
+            pub const BAG_OF_FEATURES_SPARSE: Encoding = Encoding::new(3);
 
             /// The tensor is a list of binaries representing whether a feature exists
             /// or not (1 indicates existence).
@@ -22907,7 +23321,7 @@ pub mod explanation_metadata {
             /// ```
             ///
             /// [google.cloud.aiplatform.v1.ExplanationMetadata.InputMetadata.index_feature_mapping]: crate::model::explanation_metadata::InputMetadata::index_feature_mapping
-            pub const INDICATOR: Encoding = Encoding::new("INDICATOR");
+            pub const INDICATOR: Encoding = Encoding::new(4);
 
             /// The tensor is encoded into a 1-dimensional array represented by an
             /// encoded tensor.
@@ -22920,7 +23334,7 @@ pub mod explanation_metadata {
             /// ```
             ///
             /// [google.cloud.aiplatform.v1.ExplanationMetadata.InputMetadata.encoded_tensor_name]: crate::model::explanation_metadata::InputMetadata::encoded_tensor_name
-            pub const COMBINED_EMBEDDING: Encoding = Encoding::new("COMBINED_EMBEDDING");
+            pub const COMBINED_EMBEDDING: Encoding = Encoding::new(5);
 
             /// Select this encoding when the input tensor is encoded into a
             /// 2-dimensional array represented by an encoded tensor.
@@ -22938,18 +23352,58 @@ pub mod explanation_metadata {
             /// ```
             ///
             /// [google.cloud.aiplatform.v1.ExplanationMetadata.InputMetadata.encoded_tensor_name]: crate::model::explanation_metadata::InputMetadata::encoded_tensor_name
-            pub const CONCAT_EMBEDDING: Encoding = Encoding::new("CONCAT_EMBEDDING");
+            pub const CONCAT_EMBEDDING: Encoding = Encoding::new(6);
+
+            /// Creates a new Encoding instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("ENCODING_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("IDENTITY"),
+                    2 => std::borrow::Cow::Borrowed("BAG_OF_FEATURES"),
+                    3 => std::borrow::Cow::Borrowed("BAG_OF_FEATURES_SPARSE"),
+                    4 => std::borrow::Cow::Borrowed("INDICATOR"),
+                    5 => std::borrow::Cow::Borrowed("COMBINED_EMBEDDING"),
+                    6 => std::borrow::Cow::Borrowed("CONCAT_EMBEDDING"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "ENCODING_UNSPECIFIED" => std::option::Option::Some(Self::ENCODING_UNSPECIFIED),
+                    "IDENTITY" => std::option::Option::Some(Self::IDENTITY),
+                    "BAG_OF_FEATURES" => std::option::Option::Some(Self::BAG_OF_FEATURES),
+                    "BAG_OF_FEATURES_SPARSE" => {
+                        std::option::Option::Some(Self::BAG_OF_FEATURES_SPARSE)
+                    }
+                    "INDICATOR" => std::option::Option::Some(Self::INDICATOR),
+                    "COMBINED_EMBEDDING" => std::option::Option::Some(Self::COMBINED_EMBEDDING),
+                    "CONCAT_EMBEDDING" => std::option::Option::Some(Self::CONCAT_EMBEDDING),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for Encoding {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Encoding {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Encoding {
             fn default() -> Self {
-                encoding::ENCODING_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -23394,44 +23848,62 @@ pub mod feature {
         /// one of them. Otherwise, this objective should be the same as the
         /// objective in the request.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Objective(std::borrow::Cow<'static, str>);
+        pub struct Objective(i32);
 
         impl Objective {
+            /// If it's OBJECTIVE_UNSPECIFIED, monitoring_stats will be empty.
+            pub const OBJECTIVE_UNSPECIFIED: Objective = Objective::new(0);
+
+            /// Stats are generated by Import Feature Analysis.
+            pub const IMPORT_FEATURE_ANALYSIS: Objective = Objective::new(1);
+
+            /// Stats are generated by Snapshot Analysis.
+            pub const SNAPSHOT_ANALYSIS: Objective = Objective::new(2);
+
             /// Creates a new Objective instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("OBJECTIVE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("IMPORT_FEATURE_ANALYSIS"),
+                    2 => std::borrow::Cow::Borrowed("SNAPSHOT_ANALYSIS"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "OBJECTIVE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::OBJECTIVE_UNSPECIFIED)
+                    }
+                    "IMPORT_FEATURE_ANALYSIS" => {
+                        std::option::Option::Some(Self::IMPORT_FEATURE_ANALYSIS)
+                    }
+                    "SNAPSHOT_ANALYSIS" => std::option::Option::Some(Self::SNAPSHOT_ANALYSIS),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Objective](Objective)
-        pub mod objective {
-            use super::Objective;
-
-            /// If it's OBJECTIVE_UNSPECIFIED, monitoring_stats will be empty.
-            pub const OBJECTIVE_UNSPECIFIED: Objective = Objective::new("OBJECTIVE_UNSPECIFIED");
-
-            /// Stats are generated by Import Feature Analysis.
-            pub const IMPORT_FEATURE_ANALYSIS: Objective =
-                Objective::new("IMPORT_FEATURE_ANALYSIS");
-
-            /// Stats are generated by Snapshot Analysis.
-            pub const SNAPSHOT_ANALYSIS: Objective = Objective::new("SNAPSHOT_ANALYSIS");
-        }
-
-        impl std::convert::From<std::string::String> for Objective {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Objective {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Objective {
             fn default() -> Self {
-                objective::OBJECTIVE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -23439,67 +23911,98 @@ pub mod feature {
     /// Only applicable for Vertex AI Legacy Feature Store.
     /// An enum representing the value type of a feature.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ValueType(std::borrow::Cow<'static, str>);
+    pub struct ValueType(i32);
 
     impl ValueType {
+        /// The value type is unspecified.
+        pub const VALUE_TYPE_UNSPECIFIED: ValueType = ValueType::new(0);
+
+        /// Used for Feature that is a boolean.
+        pub const BOOL: ValueType = ValueType::new(1);
+
+        /// Used for Feature that is a list of boolean.
+        pub const BOOL_ARRAY: ValueType = ValueType::new(2);
+
+        /// Used for Feature that is double.
+        pub const DOUBLE: ValueType = ValueType::new(3);
+
+        /// Used for Feature that is a list of double.
+        pub const DOUBLE_ARRAY: ValueType = ValueType::new(4);
+
+        /// Used for Feature that is INT64.
+        pub const INT64: ValueType = ValueType::new(9);
+
+        /// Used for Feature that is a list of INT64.
+        pub const INT64_ARRAY: ValueType = ValueType::new(10);
+
+        /// Used for Feature that is string.
+        pub const STRING: ValueType = ValueType::new(11);
+
+        /// Used for Feature that is a list of String.
+        pub const STRING_ARRAY: ValueType = ValueType::new(12);
+
+        /// Used for Feature that is bytes.
+        pub const BYTES: ValueType = ValueType::new(13);
+
+        /// Used for Feature that is struct.
+        pub const STRUCT: ValueType = ValueType::new(14);
+
         /// Creates a new ValueType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VALUE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BOOL"),
+                2 => std::borrow::Cow::Borrowed("BOOL_ARRAY"),
+                3 => std::borrow::Cow::Borrowed("DOUBLE"),
+                4 => std::borrow::Cow::Borrowed("DOUBLE_ARRAY"),
+                9 => std::borrow::Cow::Borrowed("INT64"),
+                10 => std::borrow::Cow::Borrowed("INT64_ARRAY"),
+                11 => std::borrow::Cow::Borrowed("STRING"),
+                12 => std::borrow::Cow::Borrowed("STRING_ARRAY"),
+                13 => std::borrow::Cow::Borrowed("BYTES"),
+                14 => std::borrow::Cow::Borrowed("STRUCT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VALUE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::VALUE_TYPE_UNSPECIFIED),
+                "BOOL" => std::option::Option::Some(Self::BOOL),
+                "BOOL_ARRAY" => std::option::Option::Some(Self::BOOL_ARRAY),
+                "DOUBLE" => std::option::Option::Some(Self::DOUBLE),
+                "DOUBLE_ARRAY" => std::option::Option::Some(Self::DOUBLE_ARRAY),
+                "INT64" => std::option::Option::Some(Self::INT64),
+                "INT64_ARRAY" => std::option::Option::Some(Self::INT64_ARRAY),
+                "STRING" => std::option::Option::Some(Self::STRING),
+                "STRING_ARRAY" => std::option::Option::Some(Self::STRING_ARRAY),
+                "BYTES" => std::option::Option::Some(Self::BYTES),
+                "STRUCT" => std::option::Option::Some(Self::STRUCT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ValueType](ValueType)
-    pub mod value_type {
-        use super::ValueType;
-
-        /// The value type is unspecified.
-        pub const VALUE_TYPE_UNSPECIFIED: ValueType = ValueType::new("VALUE_TYPE_UNSPECIFIED");
-
-        /// Used for Feature that is a boolean.
-        pub const BOOL: ValueType = ValueType::new("BOOL");
-
-        /// Used for Feature that is a list of boolean.
-        pub const BOOL_ARRAY: ValueType = ValueType::new("BOOL_ARRAY");
-
-        /// Used for Feature that is double.
-        pub const DOUBLE: ValueType = ValueType::new("DOUBLE");
-
-        /// Used for Feature that is a list of double.
-        pub const DOUBLE_ARRAY: ValueType = ValueType::new("DOUBLE_ARRAY");
-
-        /// Used for Feature that is INT64.
-        pub const INT64: ValueType = ValueType::new("INT64");
-
-        /// Used for Feature that is a list of INT64.
-        pub const INT64_ARRAY: ValueType = ValueType::new("INT64_ARRAY");
-
-        /// Used for Feature that is string.
-        pub const STRING: ValueType = ValueType::new("STRING");
-
-        /// Used for Feature that is a list of String.
-        pub const STRING_ARRAY: ValueType = ValueType::new("STRING_ARRAY");
-
-        /// Used for Feature that is bytes.
-        pub const BYTES: ValueType = ValueType::new("BYTES");
-
-        /// Used for Feature that is struct.
-        pub const STRUCT: ValueType = ValueType::new("STRUCT");
-    }
-
-    impl std::convert::From<std::string::String> for ValueType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ValueType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ValueType {
         fn default() -> Self {
-            value_type::VALUE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -24373,48 +24876,63 @@ pub mod feature_online_store {
 
     /// Possible states a featureOnlineStore can have.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// State when the featureOnlineStore configuration is not being updated and
         /// the fields reflect the current configuration of the featureOnlineStore.
         /// The featureOnlineStore is usable in this state.
-        pub const STABLE: State = State::new("STABLE");
+        pub const STABLE: State = State::new(1);
 
         /// The state of the featureOnlineStore configuration when it is being
         /// updated. During an update, the fields reflect either the original
         /// configuration or the updated configuration of the featureOnlineStore. The
         /// featureOnlineStore is still usable in this state.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STABLE"),
+                2 => std::borrow::Cow::Borrowed("UPDATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "STABLE" => std::option::Option::Some(Self::STABLE),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -26500,55 +27018,78 @@ pub mod nearest_neighbor_query {
         /// Datapoints for which Operator is true relative to the query's Value
         /// field will be allowlisted.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Operator(std::borrow::Cow<'static, str>);
+        pub struct Operator(i32);
 
         impl Operator {
+            /// Unspecified operator.
+            pub const OPERATOR_UNSPECIFIED: Operator = Operator::new(0);
+
+            /// Entities are eligible if their value is < the query's.
+            pub const LESS: Operator = Operator::new(1);
+
+            /// Entities are eligible if their value is <= the query's.
+            pub const LESS_EQUAL: Operator = Operator::new(2);
+
+            /// Entities are eligible if their value is == the query's.
+            pub const EQUAL: Operator = Operator::new(3);
+
+            /// Entities are eligible if their value is >= the query's.
+            pub const GREATER_EQUAL: Operator = Operator::new(4);
+
+            /// Entities are eligible if their value is > the query's.
+            pub const GREATER: Operator = Operator::new(5);
+
+            /// Entities are eligible if their value is != the query's.
+            pub const NOT_EQUAL: Operator = Operator::new(6);
+
             /// Creates a new Operator instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("OPERATOR_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("LESS"),
+                    2 => std::borrow::Cow::Borrowed("LESS_EQUAL"),
+                    3 => std::borrow::Cow::Borrowed("EQUAL"),
+                    4 => std::borrow::Cow::Borrowed("GREATER_EQUAL"),
+                    5 => std::borrow::Cow::Borrowed("GREATER"),
+                    6 => std::borrow::Cow::Borrowed("NOT_EQUAL"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "OPERATOR_UNSPECIFIED" => std::option::Option::Some(Self::OPERATOR_UNSPECIFIED),
+                    "LESS" => std::option::Option::Some(Self::LESS),
+                    "LESS_EQUAL" => std::option::Option::Some(Self::LESS_EQUAL),
+                    "EQUAL" => std::option::Option::Some(Self::EQUAL),
+                    "GREATER_EQUAL" => std::option::Option::Some(Self::GREATER_EQUAL),
+                    "GREATER" => std::option::Option::Some(Self::GREATER),
+                    "NOT_EQUAL" => std::option::Option::Some(Self::NOT_EQUAL),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Operator](Operator)
-        pub mod operator {
-            use super::Operator;
-
-            /// Unspecified operator.
-            pub const OPERATOR_UNSPECIFIED: Operator = Operator::new("OPERATOR_UNSPECIFIED");
-
-            /// Entities are eligible if their value is < the query's.
-            pub const LESS: Operator = Operator::new("LESS");
-
-            /// Entities are eligible if their value is <= the query's.
-            pub const LESS_EQUAL: Operator = Operator::new("LESS_EQUAL");
-
-            /// Entities are eligible if their value is == the query's.
-            pub const EQUAL: Operator = Operator::new("EQUAL");
-
-            /// Entities are eligible if their value is >= the query's.
-            pub const GREATER_EQUAL: Operator = Operator::new("GREATER_EQUAL");
-
-            /// Entities are eligible if their value is > the query's.
-            pub const GREATER: Operator = Operator::new("GREATER");
-
-            /// Entities are eligible if their value is != the query's.
-            pub const NOT_EQUAL: Operator = Operator::new("NOT_EQUAL");
-        }
-
-        impl std::convert::From<std::string::String> for Operator {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Operator {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Operator {
             fn default() -> Self {
-                operator::OPERATOR_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -28059,31 +28600,15 @@ pub mod feature_view {
 
         /// The distance measure used in nearest neighbor search.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct DistanceMeasureType(std::borrow::Cow<'static, str>);
+        pub struct DistanceMeasureType(i32);
 
         impl DistanceMeasureType {
-            /// Creates a new DistanceMeasureType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [DistanceMeasureType](DistanceMeasureType)
-        pub mod distance_measure_type {
-            use super::DistanceMeasureType;
-
             /// Should not be set.
             pub const DISTANCE_MEASURE_TYPE_UNSPECIFIED: DistanceMeasureType =
-                DistanceMeasureType::new("DISTANCE_MEASURE_TYPE_UNSPECIFIED");
+                DistanceMeasureType::new(0);
 
             /// Euclidean (L_2) Distance.
-            pub const SQUARED_L2_DISTANCE: DistanceMeasureType =
-                DistanceMeasureType::new("SQUARED_L2_DISTANCE");
+            pub const SQUARED_L2_DISTANCE: DistanceMeasureType = DistanceMeasureType::new(1);
 
             /// Cosine Distance. Defined as 1 - cosine similarity.
             ///
@@ -28092,23 +28617,55 @@ pub mod feature_view {
             /// DOT_PRODUCT distance which, when combined with UNIT_L2_NORM, is
             /// mathematically equivalent to COSINE distance and results in the same
             /// ranking.
-            pub const COSINE_DISTANCE: DistanceMeasureType =
-                DistanceMeasureType::new("COSINE_DISTANCE");
+            pub const COSINE_DISTANCE: DistanceMeasureType = DistanceMeasureType::new(2);
 
             /// Dot Product Distance. Defined as a negative of the dot product.
-            pub const DOT_PRODUCT_DISTANCE: DistanceMeasureType =
-                DistanceMeasureType::new("DOT_PRODUCT_DISTANCE");
+            pub const DOT_PRODUCT_DISTANCE: DistanceMeasureType = DistanceMeasureType::new(3);
+
+            /// Creates a new DistanceMeasureType instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("DISTANCE_MEASURE_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("SQUARED_L2_DISTANCE"),
+                    2 => std::borrow::Cow::Borrowed("COSINE_DISTANCE"),
+                    3 => std::borrow::Cow::Borrowed("DOT_PRODUCT_DISTANCE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "DISTANCE_MEASURE_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::DISTANCE_MEASURE_TYPE_UNSPECIFIED)
+                    }
+                    "SQUARED_L2_DISTANCE" => std::option::Option::Some(Self::SQUARED_L2_DISTANCE),
+                    "COSINE_DISTANCE" => std::option::Option::Some(Self::COSINE_DISTANCE),
+                    "DOT_PRODUCT_DISTANCE" => std::option::Option::Some(Self::DOT_PRODUCT_DISTANCE),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for DistanceMeasureType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for DistanceMeasureType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for DistanceMeasureType {
             fn default() -> Self {
-                distance_measure_type::DISTANCE_MEASURE_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -28329,50 +28886,68 @@ pub mod feature_view {
 
     /// Service agent type used during data sync.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ServiceAgentType(std::borrow::Cow<'static, str>);
+    pub struct ServiceAgentType(i32);
 
     impl ServiceAgentType {
-        /// Creates a new ServiceAgentType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ServiceAgentType](ServiceAgentType)
-    pub mod service_agent_type {
-        use super::ServiceAgentType;
-
         /// By default, the project-level Vertex AI Service Agent is enabled.
-        pub const SERVICE_AGENT_TYPE_UNSPECIFIED: ServiceAgentType =
-            ServiceAgentType::new("SERVICE_AGENT_TYPE_UNSPECIFIED");
+        pub const SERVICE_AGENT_TYPE_UNSPECIFIED: ServiceAgentType = ServiceAgentType::new(0);
 
         /// Indicates the project-level Vertex AI Service Agent
         /// (<https://cloud.google.com/vertex-ai/docs/general/access-control#service-agents>)
         /// will be used during sync jobs.
-        pub const SERVICE_AGENT_TYPE_PROJECT: ServiceAgentType =
-            ServiceAgentType::new("SERVICE_AGENT_TYPE_PROJECT");
+        pub const SERVICE_AGENT_TYPE_PROJECT: ServiceAgentType = ServiceAgentType::new(1);
 
         /// Enable a FeatureView service account to be created by Vertex AI and
         /// output in the field `service_account_email`. This service account will
         /// be used to read from the source BigQuery table during sync.
-        pub const SERVICE_AGENT_TYPE_FEATURE_VIEW: ServiceAgentType =
-            ServiceAgentType::new("SERVICE_AGENT_TYPE_FEATURE_VIEW");
+        pub const SERVICE_AGENT_TYPE_FEATURE_VIEW: ServiceAgentType = ServiceAgentType::new(2);
+
+        /// Creates a new ServiceAgentType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SERVICE_AGENT_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SERVICE_AGENT_TYPE_PROJECT"),
+                2 => std::borrow::Cow::Borrowed("SERVICE_AGENT_TYPE_FEATURE_VIEW"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SERVICE_AGENT_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SERVICE_AGENT_TYPE_UNSPECIFIED)
+                }
+                "SERVICE_AGENT_TYPE_PROJECT" => {
+                    std::option::Option::Some(Self::SERVICE_AGENT_TYPE_PROJECT)
+                }
+                "SERVICE_AGENT_TYPE_FEATURE_VIEW" => {
+                    std::option::Option::Some(Self::SERVICE_AGENT_TYPE_FEATURE_VIEW)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ServiceAgentType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ServiceAgentType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ServiceAgentType {
         fn default() -> Self {
-            service_agent_type::SERVICE_AGENT_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -28853,31 +29428,16 @@ pub mod featurestore {
 
     /// Possible states a featurestore can have.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// State when the featurestore configuration is not being updated and the
         /// fields reflect the current configuration of the featurestore. The
         /// featurestore is usable in this state.
-        pub const STABLE: State = State::new("STABLE");
+        pub const STABLE: State = State::new(1);
 
         /// The state of the featurestore configuration when it is being updated.
         /// During an update, the fields reflect either the original configuration
@@ -28889,18 +29449,48 @@ pub mod featurestore {
         /// update completes, the actual number of nodes can still be the original
         /// value of `fixed_node_count`. The featurestore is still usable in this
         /// state.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STABLE"),
+                2 => std::borrow::Cow::Borrowed("UPDATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "STABLE" => std::option::Option::Some(Self::STABLE),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -29144,55 +29734,72 @@ pub mod featurestore_monitoring_config {
 
         /// The state defines whether to enable ImportFeature analysis.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(std::borrow::Cow<'static, str>);
+        pub struct State(i32);
 
         impl State {
-            /// Creates a new State instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [State](State)
-        pub mod state {
-            use super::State;
-
             /// Should not be used.
-            pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+            pub const STATE_UNSPECIFIED: State = State::new(0);
 
             /// The default behavior of whether to enable the monitoring.
             /// EntityType-level config: disabled.
             /// Feature-level config: inherited from the configuration of EntityType
             /// this Feature belongs to.
-            pub const DEFAULT: State = State::new("DEFAULT");
+            pub const DEFAULT: State = State::new(1);
 
             /// Explicitly enables import features analysis.
             /// EntityType-level config: by default enables import features analysis
             /// for all Features under it. Feature-level config: enables import
             /// features analysis regardless of the EntityType-level config.
-            pub const ENABLED: State = State::new("ENABLED");
+            pub const ENABLED: State = State::new(2);
 
             /// Explicitly disables import features analysis.
             /// EntityType-level config: by default disables import features analysis
             /// for all Features under it. Feature-level config: disables import
             /// features analysis regardless of the EntityType-level config.
-            pub const DISABLED: State = State::new("DISABLED");
+            pub const DISABLED: State = State::new(3);
+
+            /// Creates a new State instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("DEFAULT"),
+                    2 => std::borrow::Cow::Borrowed("ENABLED"),
+                    3 => std::borrow::Cow::Borrowed("DISABLED"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                    "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
+                    "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                    "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for State {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                state::STATE_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -29203,52 +29810,71 @@ pub mod featurestore_monitoring_config {
         ///
         /// [google.cloud.aiplatform.v1.FeaturestoreService.ImportFeatureValues]: crate::client::FeaturestoreService::import_feature_values
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Baseline(std::borrow::Cow<'static, str>);
+        pub struct Baseline(i32);
 
         impl Baseline {
-            /// Creates a new Baseline instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [Baseline](Baseline)
-        pub mod baseline {
-            use super::Baseline;
-
             /// Should not be used.
-            pub const BASELINE_UNSPECIFIED: Baseline = Baseline::new("BASELINE_UNSPECIFIED");
+            pub const BASELINE_UNSPECIFIED: Baseline = Baseline::new(0);
 
             /// Choose the later one statistics generated by either most recent
             /// snapshot analysis or previous import features analysis. If non of them
             /// exists, skip anomaly detection and only generate a statistics.
-            pub const LATEST_STATS: Baseline = Baseline::new("LATEST_STATS");
+            pub const LATEST_STATS: Baseline = Baseline::new(1);
 
             /// Use the statistics generated by the most recent snapshot analysis if
             /// exists.
-            pub const MOST_RECENT_SNAPSHOT_STATS: Baseline =
-                Baseline::new("MOST_RECENT_SNAPSHOT_STATS");
+            pub const MOST_RECENT_SNAPSHOT_STATS: Baseline = Baseline::new(2);
 
             /// Use the statistics generated by the previous import features analysis
             /// if exists.
-            pub const PREVIOUS_IMPORT_FEATURES_STATS: Baseline =
-                Baseline::new("PREVIOUS_IMPORT_FEATURES_STATS");
+            pub const PREVIOUS_IMPORT_FEATURES_STATS: Baseline = Baseline::new(3);
+
+            /// Creates a new Baseline instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("BASELINE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("LATEST_STATS"),
+                    2 => std::borrow::Cow::Borrowed("MOST_RECENT_SNAPSHOT_STATS"),
+                    3 => std::borrow::Cow::Borrowed("PREVIOUS_IMPORT_FEATURES_STATS"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "BASELINE_UNSPECIFIED" => std::option::Option::Some(Self::BASELINE_UNSPECIFIED),
+                    "LATEST_STATS" => std::option::Option::Some(Self::LATEST_STATS),
+                    "MOST_RECENT_SNAPSHOT_STATS" => {
+                        std::option::Option::Some(Self::MOST_RECENT_SNAPSHOT_STATS)
+                    }
+                    "PREVIOUS_IMPORT_FEATURES_STATS" => {
+                        std::option::Option::Some(Self::PREVIOUS_IMPORT_FEATURES_STATS)
+                    }
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for Baseline {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Baseline {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Baseline {
             fn default() -> Self {
-                baseline::BASELINE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -35337,47 +35963,63 @@ pub mod index {
 
     /// The update method of an Index.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IndexUpdateMethod(std::borrow::Cow<'static, str>);
+    pub struct IndexUpdateMethod(i32);
 
     impl IndexUpdateMethod {
-        /// Creates a new IndexUpdateMethod instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [IndexUpdateMethod](IndexUpdateMethod)
-    pub mod index_update_method {
-        use super::IndexUpdateMethod;
-
         /// Should not be used.
-        pub const INDEX_UPDATE_METHOD_UNSPECIFIED: IndexUpdateMethod =
-            IndexUpdateMethod::new("INDEX_UPDATE_METHOD_UNSPECIFIED");
+        pub const INDEX_UPDATE_METHOD_UNSPECIFIED: IndexUpdateMethod = IndexUpdateMethod::new(0);
 
         /// BatchUpdate: user can call UpdateIndex with files on Cloud Storage of
         /// Datapoints to update.
-        pub const BATCH_UPDATE: IndexUpdateMethod = IndexUpdateMethod::new("BATCH_UPDATE");
+        pub const BATCH_UPDATE: IndexUpdateMethod = IndexUpdateMethod::new(1);
 
         /// StreamUpdate: user can call UpsertDatapoints/DeleteDatapoints to update
         /// the Index and the updates will be applied in corresponding
         /// DeployedIndexes in nearly real-time.
-        pub const STREAM_UPDATE: IndexUpdateMethod = IndexUpdateMethod::new("STREAM_UPDATE");
+        pub const STREAM_UPDATE: IndexUpdateMethod = IndexUpdateMethod::new(2);
+
+        /// Creates a new IndexUpdateMethod instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("INDEX_UPDATE_METHOD_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BATCH_UPDATE"),
+                2 => std::borrow::Cow::Borrowed("STREAM_UPDATE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "INDEX_UPDATE_METHOD_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::INDEX_UPDATE_METHOD_UNSPECIFIED)
+                }
+                "BATCH_UPDATE" => std::option::Option::Some(Self::BATCH_UPDATE),
+                "STREAM_UPDATE" => std::option::Option::Some(Self::STREAM_UPDATE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for IndexUpdateMethod {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for IndexUpdateMethod {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for IndexUpdateMethod {
         fn default() -> Self {
-            index_update_method::INDEX_UPDATE_METHOD_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -35759,55 +36401,78 @@ pub mod index_datapoint {
         /// Datapoints for which Operator is true relative to the query's Value
         /// field will be allowlisted.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Operator(std::borrow::Cow<'static, str>);
+        pub struct Operator(i32);
 
         impl Operator {
+            /// Default value of the enum.
+            pub const OPERATOR_UNSPECIFIED: Operator = Operator::new(0);
+
+            /// Datapoints are eligible iff their value is < the query's.
+            pub const LESS: Operator = Operator::new(1);
+
+            /// Datapoints are eligible iff their value is <= the query's.
+            pub const LESS_EQUAL: Operator = Operator::new(2);
+
+            /// Datapoints are eligible iff their value is == the query's.
+            pub const EQUAL: Operator = Operator::new(3);
+
+            /// Datapoints are eligible iff their value is >= the query's.
+            pub const GREATER_EQUAL: Operator = Operator::new(4);
+
+            /// Datapoints are eligible iff their value is > the query's.
+            pub const GREATER: Operator = Operator::new(5);
+
+            /// Datapoints are eligible iff their value is != the query's.
+            pub const NOT_EQUAL: Operator = Operator::new(6);
+
             /// Creates a new Operator instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("OPERATOR_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("LESS"),
+                    2 => std::borrow::Cow::Borrowed("LESS_EQUAL"),
+                    3 => std::borrow::Cow::Borrowed("EQUAL"),
+                    4 => std::borrow::Cow::Borrowed("GREATER_EQUAL"),
+                    5 => std::borrow::Cow::Borrowed("GREATER"),
+                    6 => std::borrow::Cow::Borrowed("NOT_EQUAL"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "OPERATOR_UNSPECIFIED" => std::option::Option::Some(Self::OPERATOR_UNSPECIFIED),
+                    "LESS" => std::option::Option::Some(Self::LESS),
+                    "LESS_EQUAL" => std::option::Option::Some(Self::LESS_EQUAL),
+                    "EQUAL" => std::option::Option::Some(Self::EQUAL),
+                    "GREATER_EQUAL" => std::option::Option::Some(Self::GREATER_EQUAL),
+                    "GREATER" => std::option::Option::Some(Self::GREATER),
+                    "NOT_EQUAL" => std::option::Option::Some(Self::NOT_EQUAL),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Operator](Operator)
-        pub mod operator {
-            use super::Operator;
-
-            /// Default value of the enum.
-            pub const OPERATOR_UNSPECIFIED: Operator = Operator::new("OPERATOR_UNSPECIFIED");
-
-            /// Datapoints are eligible iff their value is < the query's.
-            pub const LESS: Operator = Operator::new("LESS");
-
-            /// Datapoints are eligible iff their value is <= the query's.
-            pub const LESS_EQUAL: Operator = Operator::new("LESS_EQUAL");
-
-            /// Datapoints are eligible iff their value is == the query's.
-            pub const EQUAL: Operator = Operator::new("EQUAL");
-
-            /// Datapoints are eligible iff their value is >= the query's.
-            pub const GREATER_EQUAL: Operator = Operator::new("GREATER_EQUAL");
-
-            /// Datapoints are eligible iff their value is > the query's.
-            pub const GREATER: Operator = Operator::new("GREATER");
-
-            /// Datapoints are eligible iff their value is != the query's.
-            pub const NOT_EQUAL: Operator = Operator::new("NOT_EQUAL");
-        }
-
-        impl std::convert::From<std::string::String> for Operator {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Operator {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Operator {
             fn default() -> Self {
-                operator::OPERATOR_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -38097,103 +38762,145 @@ pub mod nearest_neighbor_search_operation_metadata {
         use super::*;
 
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct RecordErrorType(std::borrow::Cow<'static, str>);
+        pub struct RecordErrorType(i32);
 
         impl RecordErrorType {
-            /// Creates a new RecordErrorType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [RecordErrorType](RecordErrorType)
-        pub mod record_error_type {
-            use super::RecordErrorType;
-
             /// Default, shall not be used.
-            pub const ERROR_TYPE_UNSPECIFIED: RecordErrorType =
-                RecordErrorType::new("ERROR_TYPE_UNSPECIFIED");
+            pub const ERROR_TYPE_UNSPECIFIED: RecordErrorType = RecordErrorType::new(0);
 
             /// The record is empty.
-            pub const EMPTY_LINE: RecordErrorType = RecordErrorType::new("EMPTY_LINE");
+            pub const EMPTY_LINE: RecordErrorType = RecordErrorType::new(1);
 
             /// Invalid json format.
-            pub const INVALID_JSON_SYNTAX: RecordErrorType =
-                RecordErrorType::new("INVALID_JSON_SYNTAX");
+            pub const INVALID_JSON_SYNTAX: RecordErrorType = RecordErrorType::new(2);
 
             /// Invalid csv format.
-            pub const INVALID_CSV_SYNTAX: RecordErrorType =
-                RecordErrorType::new("INVALID_CSV_SYNTAX");
+            pub const INVALID_CSV_SYNTAX: RecordErrorType = RecordErrorType::new(3);
 
             /// Invalid avro format.
-            pub const INVALID_AVRO_SYNTAX: RecordErrorType =
-                RecordErrorType::new("INVALID_AVRO_SYNTAX");
+            pub const INVALID_AVRO_SYNTAX: RecordErrorType = RecordErrorType::new(4);
 
             /// The embedding id is not valid.
-            pub const INVALID_EMBEDDING_ID: RecordErrorType =
-                RecordErrorType::new("INVALID_EMBEDDING_ID");
+            pub const INVALID_EMBEDDING_ID: RecordErrorType = RecordErrorType::new(5);
 
             /// The size of the dense embedding vectors does not match with the
             /// specified dimension.
-            pub const EMBEDDING_SIZE_MISMATCH: RecordErrorType =
-                RecordErrorType::new("EMBEDDING_SIZE_MISMATCH");
+            pub const EMBEDDING_SIZE_MISMATCH: RecordErrorType = RecordErrorType::new(6);
 
             /// The `namespace` field is missing.
-            pub const NAMESPACE_MISSING: RecordErrorType =
-                RecordErrorType::new("NAMESPACE_MISSING");
+            pub const NAMESPACE_MISSING: RecordErrorType = RecordErrorType::new(7);
 
             /// Generic catch-all error. Only used for validation failure where the
             /// root cause cannot be easily retrieved programmatically.
-            pub const PARSING_ERROR: RecordErrorType = RecordErrorType::new("PARSING_ERROR");
+            pub const PARSING_ERROR: RecordErrorType = RecordErrorType::new(8);
 
             /// There are multiple restricts with the same `namespace` value.
-            pub const DUPLICATE_NAMESPACE: RecordErrorType =
-                RecordErrorType::new("DUPLICATE_NAMESPACE");
+            pub const DUPLICATE_NAMESPACE: RecordErrorType = RecordErrorType::new(9);
 
             /// Numeric restrict has operator specified in datapoint.
-            pub const OP_IN_DATAPOINT: RecordErrorType = RecordErrorType::new("OP_IN_DATAPOINT");
+            pub const OP_IN_DATAPOINT: RecordErrorType = RecordErrorType::new(10);
 
             /// Numeric restrict has multiple values specified.
-            pub const MULTIPLE_VALUES: RecordErrorType = RecordErrorType::new("MULTIPLE_VALUES");
+            pub const MULTIPLE_VALUES: RecordErrorType = RecordErrorType::new(11);
 
             /// Numeric restrict has invalid numeric value specified.
-            pub const INVALID_NUMERIC_VALUE: RecordErrorType =
-                RecordErrorType::new("INVALID_NUMERIC_VALUE");
+            pub const INVALID_NUMERIC_VALUE: RecordErrorType = RecordErrorType::new(12);
 
             /// File is not in UTF_8 format.
-            pub const INVALID_ENCODING: RecordErrorType = RecordErrorType::new("INVALID_ENCODING");
+            pub const INVALID_ENCODING: RecordErrorType = RecordErrorType::new(13);
 
             /// Error parsing sparse dimensions field.
-            pub const INVALID_SPARSE_DIMENSIONS: RecordErrorType =
-                RecordErrorType::new("INVALID_SPARSE_DIMENSIONS");
+            pub const INVALID_SPARSE_DIMENSIONS: RecordErrorType = RecordErrorType::new(14);
 
             /// Token restrict value is invalid.
-            pub const INVALID_TOKEN_VALUE: RecordErrorType =
-                RecordErrorType::new("INVALID_TOKEN_VALUE");
+            pub const INVALID_TOKEN_VALUE: RecordErrorType = RecordErrorType::new(15);
 
             /// Invalid sparse embedding.
-            pub const INVALID_SPARSE_EMBEDDING: RecordErrorType =
-                RecordErrorType::new("INVALID_SPARSE_EMBEDDING");
+            pub const INVALID_SPARSE_EMBEDDING: RecordErrorType = RecordErrorType::new(16);
 
             /// Invalid dense embedding.
-            pub const INVALID_EMBEDDING: RecordErrorType =
-                RecordErrorType::new("INVALID_EMBEDDING");
+            pub const INVALID_EMBEDDING: RecordErrorType = RecordErrorType::new(17);
+
+            /// Creates a new RecordErrorType instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("ERROR_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("EMPTY_LINE"),
+                    2 => std::borrow::Cow::Borrowed("INVALID_JSON_SYNTAX"),
+                    3 => std::borrow::Cow::Borrowed("INVALID_CSV_SYNTAX"),
+                    4 => std::borrow::Cow::Borrowed("INVALID_AVRO_SYNTAX"),
+                    5 => std::borrow::Cow::Borrowed("INVALID_EMBEDDING_ID"),
+                    6 => std::borrow::Cow::Borrowed("EMBEDDING_SIZE_MISMATCH"),
+                    7 => std::borrow::Cow::Borrowed("NAMESPACE_MISSING"),
+                    8 => std::borrow::Cow::Borrowed("PARSING_ERROR"),
+                    9 => std::borrow::Cow::Borrowed("DUPLICATE_NAMESPACE"),
+                    10 => std::borrow::Cow::Borrowed("OP_IN_DATAPOINT"),
+                    11 => std::borrow::Cow::Borrowed("MULTIPLE_VALUES"),
+                    12 => std::borrow::Cow::Borrowed("INVALID_NUMERIC_VALUE"),
+                    13 => std::borrow::Cow::Borrowed("INVALID_ENCODING"),
+                    14 => std::borrow::Cow::Borrowed("INVALID_SPARSE_DIMENSIONS"),
+                    15 => std::borrow::Cow::Borrowed("INVALID_TOKEN_VALUE"),
+                    16 => std::borrow::Cow::Borrowed("INVALID_SPARSE_EMBEDDING"),
+                    17 => std::borrow::Cow::Borrowed("INVALID_EMBEDDING"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "ERROR_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::ERROR_TYPE_UNSPECIFIED)
+                    }
+                    "EMPTY_LINE" => std::option::Option::Some(Self::EMPTY_LINE),
+                    "INVALID_JSON_SYNTAX" => std::option::Option::Some(Self::INVALID_JSON_SYNTAX),
+                    "INVALID_CSV_SYNTAX" => std::option::Option::Some(Self::INVALID_CSV_SYNTAX),
+                    "INVALID_AVRO_SYNTAX" => std::option::Option::Some(Self::INVALID_AVRO_SYNTAX),
+                    "INVALID_EMBEDDING_ID" => std::option::Option::Some(Self::INVALID_EMBEDDING_ID),
+                    "EMBEDDING_SIZE_MISMATCH" => {
+                        std::option::Option::Some(Self::EMBEDDING_SIZE_MISMATCH)
+                    }
+                    "NAMESPACE_MISSING" => std::option::Option::Some(Self::NAMESPACE_MISSING),
+                    "PARSING_ERROR" => std::option::Option::Some(Self::PARSING_ERROR),
+                    "DUPLICATE_NAMESPACE" => std::option::Option::Some(Self::DUPLICATE_NAMESPACE),
+                    "OP_IN_DATAPOINT" => std::option::Option::Some(Self::OP_IN_DATAPOINT),
+                    "MULTIPLE_VALUES" => std::option::Option::Some(Self::MULTIPLE_VALUES),
+                    "INVALID_NUMERIC_VALUE" => {
+                        std::option::Option::Some(Self::INVALID_NUMERIC_VALUE)
+                    }
+                    "INVALID_ENCODING" => std::option::Option::Some(Self::INVALID_ENCODING),
+                    "INVALID_SPARSE_DIMENSIONS" => {
+                        std::option::Option::Some(Self::INVALID_SPARSE_DIMENSIONS)
+                    }
+                    "INVALID_TOKEN_VALUE" => std::option::Option::Some(Self::INVALID_TOKEN_VALUE),
+                    "INVALID_SPARSE_EMBEDDING" => {
+                        std::option::Option::Some(Self::INVALID_SPARSE_EMBEDDING)
+                    }
+                    "INVALID_EMBEDDING" => std::option::Option::Some(Self::INVALID_EMBEDDING),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for RecordErrorType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for RecordErrorType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for RecordErrorType {
             fn default() -> Self {
-                record_error_type::ERROR_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -38693,45 +39400,60 @@ pub mod google_drive_source {
 
         /// The type of the Google Drive resource.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ResourceType(std::borrow::Cow<'static, str>);
+        pub struct ResourceType(i32);
 
         impl ResourceType {
+            /// Unspecified resource type.
+            pub const RESOURCE_TYPE_UNSPECIFIED: ResourceType = ResourceType::new(0);
+
+            /// File resource type.
+            pub const RESOURCE_TYPE_FILE: ResourceType = ResourceType::new(1);
+
+            /// Folder resource type.
+            pub const RESOURCE_TYPE_FOLDER: ResourceType = ResourceType::new(2);
+
             /// Creates a new ResourceType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("RESOURCE_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("RESOURCE_TYPE_FILE"),
+                    2 => std::borrow::Cow::Borrowed("RESOURCE_TYPE_FOLDER"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "RESOURCE_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::RESOURCE_TYPE_UNSPECIFIED)
+                    }
+                    "RESOURCE_TYPE_FILE" => std::option::Option::Some(Self::RESOURCE_TYPE_FILE),
+                    "RESOURCE_TYPE_FOLDER" => std::option::Option::Some(Self::RESOURCE_TYPE_FOLDER),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [ResourceType](ResourceType)
-        pub mod resource_type {
-            use super::ResourceType;
-
-            /// Unspecified resource type.
-            pub const RESOURCE_TYPE_UNSPECIFIED: ResourceType =
-                ResourceType::new("RESOURCE_TYPE_UNSPECIFIED");
-
-            /// File resource type.
-            pub const RESOURCE_TYPE_FILE: ResourceType = ResourceType::new("RESOURCE_TYPE_FILE");
-
-            /// Folder resource type.
-            pub const RESOURCE_TYPE_FOLDER: ResourceType =
-                ResourceType::new("RESOURCE_TYPE_FOLDER");
-        }
-
-        impl std::convert::From<std::string::String> for ResourceType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for ResourceType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for ResourceType {
             fn default() -> Self {
-                resource_type::RESOURCE_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -43292,47 +44014,65 @@ pub mod metadata_schema {
 
     /// Describes the type of the MetadataSchema.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MetadataSchemaType(std::borrow::Cow<'static, str>);
+    pub struct MetadataSchemaType(i32);
 
     impl MetadataSchemaType {
+        /// Unspecified type for the MetadataSchema.
+        pub const METADATA_SCHEMA_TYPE_UNSPECIFIED: MetadataSchemaType = MetadataSchemaType::new(0);
+
+        /// A type indicating that the MetadataSchema will be used by Artifacts.
+        pub const ARTIFACT_TYPE: MetadataSchemaType = MetadataSchemaType::new(1);
+
+        /// A typee indicating that the MetadataSchema will be used by Executions.
+        pub const EXECUTION_TYPE: MetadataSchemaType = MetadataSchemaType::new(2);
+
+        /// A state indicating that the MetadataSchema will be used by Contexts.
+        pub const CONTEXT_TYPE: MetadataSchemaType = MetadataSchemaType::new(3);
+
         /// Creates a new MetadataSchemaType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("METADATA_SCHEMA_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ARTIFACT_TYPE"),
+                2 => std::borrow::Cow::Borrowed("EXECUTION_TYPE"),
+                3 => std::borrow::Cow::Borrowed("CONTEXT_TYPE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "METADATA_SCHEMA_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::METADATA_SCHEMA_TYPE_UNSPECIFIED)
+                }
+                "ARTIFACT_TYPE" => std::option::Option::Some(Self::ARTIFACT_TYPE),
+                "EXECUTION_TYPE" => std::option::Option::Some(Self::EXECUTION_TYPE),
+                "CONTEXT_TYPE" => std::option::Option::Some(Self::CONTEXT_TYPE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [MetadataSchemaType](MetadataSchemaType)
-    pub mod metadata_schema_type {
-        use super::MetadataSchemaType;
-
-        /// Unspecified type for the MetadataSchema.
-        pub const METADATA_SCHEMA_TYPE_UNSPECIFIED: MetadataSchemaType =
-            MetadataSchemaType::new("METADATA_SCHEMA_TYPE_UNSPECIFIED");
-
-        /// A type indicating that the MetadataSchema will be used by Artifacts.
-        pub const ARTIFACT_TYPE: MetadataSchemaType = MetadataSchemaType::new("ARTIFACT_TYPE");
-
-        /// A typee indicating that the MetadataSchema will be used by Executions.
-        pub const EXECUTION_TYPE: MetadataSchemaType = MetadataSchemaType::new("EXECUTION_TYPE");
-
-        /// A state indicating that the MetadataSchema will be used by Contexts.
-        pub const CONTEXT_TYPE: MetadataSchemaType = MetadataSchemaType::new("CONTEXT_TYPE");
-    }
-
-    impl std::convert::From<std::string::String> for MetadataSchemaType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MetadataSchemaType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MetadataSchemaType {
         fn default() -> Self {
-            metadata_schema_type::METADATA_SCHEMA_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -48482,27 +49222,11 @@ pub mod model {
 
         /// The Model content that can be exported.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ExportableContent(std::borrow::Cow<'static, str>);
+        pub struct ExportableContent(i32);
 
         impl ExportableContent {
-            /// Creates a new ExportableContent instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [ExportableContent](ExportableContent)
-        pub mod exportable_content {
-            use super::ExportableContent;
-
             /// Should not be used.
-            pub const EXPORTABLE_CONTENT_UNSPECIFIED: ExportableContent =
-                ExportableContent::new("EXPORTABLE_CONTENT_UNSPECIFIED");
+            pub const EXPORTABLE_CONTENT_UNSPECIFIED: ExportableContent = ExportableContent::new(0);
 
             /// Model artifact and any of its supported files. Will be exported to the
             /// location specified by the `artifactDestination` field of the
@@ -48510,7 +49234,7 @@ pub mod model {
             /// object.
             ///
             /// [google.cloud.aiplatform.v1.ExportModelRequest.output_config]: crate::model::ExportModelRequest::output_config
-            pub const ARTIFACT: ExportableContent = ExportableContent::new("ARTIFACT");
+            pub const ARTIFACT: ExportableContent = ExportableContent::new(1);
 
             /// The container image that is to be used when deploying this Model. Will
             /// be exported to the location specified by the `imageDestination` field
@@ -48519,18 +49243,50 @@ pub mod model {
             /// object.
             ///
             /// [google.cloud.aiplatform.v1.ExportModelRequest.output_config]: crate::model::ExportModelRequest::output_config
-            pub const IMAGE: ExportableContent = ExportableContent::new("IMAGE");
+            pub const IMAGE: ExportableContent = ExportableContent::new(2);
+
+            /// Creates a new ExportableContent instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("EXPORTABLE_CONTENT_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("ARTIFACT"),
+                    2 => std::borrow::Cow::Borrowed("IMAGE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "EXPORTABLE_CONTENT_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::EXPORTABLE_CONTENT_UNSPECIFIED)
+                    }
+                    "ARTIFACT" => std::option::Option::Some(Self::ARTIFACT),
+                    "IMAGE" => std::option::Option::Some(Self::IMAGE),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for ExportableContent {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for ExportableContent {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for ExportableContent {
             fn default() -> Self {
-                exportable_content::EXPORTABLE_CONTENT_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -48772,40 +49528,23 @@ pub mod model {
 
     /// Identifies a type of Model's prediction resources.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DeploymentResourcesType(std::borrow::Cow<'static, str>);
+    pub struct DeploymentResourcesType(i32);
 
     impl DeploymentResourcesType {
-        /// Creates a new DeploymentResourcesType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DeploymentResourcesType](DeploymentResourcesType)
-    pub mod deployment_resources_type {
-        use super::DeploymentResourcesType;
-
         /// Should not be used.
         pub const DEPLOYMENT_RESOURCES_TYPE_UNSPECIFIED: DeploymentResourcesType =
-            DeploymentResourcesType::new("DEPLOYMENT_RESOURCES_TYPE_UNSPECIFIED");
+            DeploymentResourcesType::new(0);
 
         /// Resources that are dedicated to the
         /// [DeployedModel][google.cloud.aiplatform.v1.DeployedModel], and that need
         /// a higher degree of manual configuration.
         ///
         /// [google.cloud.aiplatform.v1.DeployedModel]: crate::model::DeployedModel
-        pub const DEDICATED_RESOURCES: DeploymentResourcesType =
-            DeploymentResourcesType::new("DEDICATED_RESOURCES");
+        pub const DEDICATED_RESOURCES: DeploymentResourcesType = DeploymentResourcesType::new(1);
 
         /// Resources that to large degree are decided by Vertex AI, and require
         /// only a modest additional configuration.
-        pub const AUTOMATIC_RESOURCES: DeploymentResourcesType =
-            DeploymentResourcesType::new("AUTOMATIC_RESOURCES");
+        pub const AUTOMATIC_RESOURCES: DeploymentResourcesType = DeploymentResourcesType::new(2);
 
         /// Resources that can be shared by multiple
         /// [DeployedModels][google.cloud.aiplatform.v1.DeployedModel]. A
@@ -48815,19 +49554,52 @@ pub mod model {
         ///
         /// [google.cloud.aiplatform.v1.DeployedModel]: crate::model::DeployedModel
         /// [google.cloud.aiplatform.v1.DeploymentResourcePool]: crate::model::DeploymentResourcePool
-        pub const SHARED_RESOURCES: DeploymentResourcesType =
-            DeploymentResourcesType::new("SHARED_RESOURCES");
+        pub const SHARED_RESOURCES: DeploymentResourcesType = DeploymentResourcesType::new(3);
+
+        /// Creates a new DeploymentResourcesType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DEPLOYMENT_RESOURCES_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DEDICATED_RESOURCES"),
+                2 => std::borrow::Cow::Borrowed("AUTOMATIC_RESOURCES"),
+                3 => std::borrow::Cow::Borrowed("SHARED_RESOURCES"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DEPLOYMENT_RESOURCES_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DEPLOYMENT_RESOURCES_TYPE_UNSPECIFIED)
+                }
+                "DEDICATED_RESOURCES" => std::option::Option::Some(Self::DEDICATED_RESOURCES),
+                "AUTOMATIC_RESOURCES" => std::option::Option::Some(Self::AUTOMATIC_RESOURCES),
+                "SHARED_RESOURCES" => std::option::Option::Some(Self::SHARED_RESOURCES),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DeploymentResourcesType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DeploymentResourcesType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DeploymentResourcesType {
         fn default() -> Self {
-            deployment_resources_type::DEPLOYMENT_RESOURCES_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -49553,60 +50325,85 @@ pub mod model_source_info {
     /// whereas the `objective` indicates the overall aim or function of this
     /// model.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ModelSourceType(std::borrow::Cow<'static, str>);
+    pub struct ModelSourceType(i32);
 
     impl ModelSourceType {
+        /// Should not be used.
+        pub const MODEL_SOURCE_TYPE_UNSPECIFIED: ModelSourceType = ModelSourceType::new(0);
+
+        /// The Model is uploaded by automl training pipeline.
+        pub const AUTOML: ModelSourceType = ModelSourceType::new(1);
+
+        /// The Model is uploaded by user or custom training pipeline.
+        pub const CUSTOM: ModelSourceType = ModelSourceType::new(2);
+
+        /// The Model is registered and sync'ed from BigQuery ML.
+        pub const BQML: ModelSourceType = ModelSourceType::new(3);
+
+        /// The Model is saved or tuned from Model Garden.
+        pub const MODEL_GARDEN: ModelSourceType = ModelSourceType::new(4);
+
+        /// The Model is saved or tuned from Genie.
+        pub const GENIE: ModelSourceType = ModelSourceType::new(5);
+
+        /// The Model is uploaded by text embedding finetuning pipeline.
+        pub const CUSTOM_TEXT_EMBEDDING: ModelSourceType = ModelSourceType::new(6);
+
+        /// The Model is saved or tuned from Marketplace.
+        pub const MARKETPLACE: ModelSourceType = ModelSourceType::new(7);
+
         /// Creates a new ModelSourceType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MODEL_SOURCE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AUTOML"),
+                2 => std::borrow::Cow::Borrowed("CUSTOM"),
+                3 => std::borrow::Cow::Borrowed("BQML"),
+                4 => std::borrow::Cow::Borrowed("MODEL_GARDEN"),
+                5 => std::borrow::Cow::Borrowed("GENIE"),
+                6 => std::borrow::Cow::Borrowed("CUSTOM_TEXT_EMBEDDING"),
+                7 => std::borrow::Cow::Borrowed("MARKETPLACE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MODEL_SOURCE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MODEL_SOURCE_TYPE_UNSPECIFIED)
+                }
+                "AUTOML" => std::option::Option::Some(Self::AUTOML),
+                "CUSTOM" => std::option::Option::Some(Self::CUSTOM),
+                "BQML" => std::option::Option::Some(Self::BQML),
+                "MODEL_GARDEN" => std::option::Option::Some(Self::MODEL_GARDEN),
+                "GENIE" => std::option::Option::Some(Self::GENIE),
+                "CUSTOM_TEXT_EMBEDDING" => std::option::Option::Some(Self::CUSTOM_TEXT_EMBEDDING),
+                "MARKETPLACE" => std::option::Option::Some(Self::MARKETPLACE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ModelSourceType](ModelSourceType)
-    pub mod model_source_type {
-        use super::ModelSourceType;
-
-        /// Should not be used.
-        pub const MODEL_SOURCE_TYPE_UNSPECIFIED: ModelSourceType =
-            ModelSourceType::new("MODEL_SOURCE_TYPE_UNSPECIFIED");
-
-        /// The Model is uploaded by automl training pipeline.
-        pub const AUTOML: ModelSourceType = ModelSourceType::new("AUTOML");
-
-        /// The Model is uploaded by user or custom training pipeline.
-        pub const CUSTOM: ModelSourceType = ModelSourceType::new("CUSTOM");
-
-        /// The Model is registered and sync'ed from BigQuery ML.
-        pub const BQML: ModelSourceType = ModelSourceType::new("BQML");
-
-        /// The Model is saved or tuned from Model Garden.
-        pub const MODEL_GARDEN: ModelSourceType = ModelSourceType::new("MODEL_GARDEN");
-
-        /// The Model is saved or tuned from Genie.
-        pub const GENIE: ModelSourceType = ModelSourceType::new("GENIE");
-
-        /// The Model is uploaded by text embedding finetuning pipeline.
-        pub const CUSTOM_TEXT_EMBEDDING: ModelSourceType =
-            ModelSourceType::new("CUSTOM_TEXT_EMBEDDING");
-
-        /// The Model is saved or tuned from Marketplace.
-        pub const MARKETPLACE: ModelSourceType = ModelSourceType::new("MARKETPLACE");
-    }
-
-    impl std::convert::From<std::string::String> for ModelSourceType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ModelSourceType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ModelSourceType {
         fn default() -> Self {
-            model_source_type::MODEL_SOURCE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -50539,47 +51336,66 @@ pub mod model_deployment_monitoring_job {
 
     /// The state to Specify the monitoring pipeline.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MonitoringScheduleState(std::borrow::Cow<'static, str>);
+    pub struct MonitoringScheduleState(i32);
 
     impl MonitoringScheduleState {
+        /// Unspecified state.
+        pub const MONITORING_SCHEDULE_STATE_UNSPECIFIED: MonitoringScheduleState =
+            MonitoringScheduleState::new(0);
+
+        /// The pipeline is picked up and wait to run.
+        pub const PENDING: MonitoringScheduleState = MonitoringScheduleState::new(1);
+
+        /// The pipeline is offline and will be scheduled for next run.
+        pub const OFFLINE: MonitoringScheduleState = MonitoringScheduleState::new(2);
+
+        /// The pipeline is running.
+        pub const RUNNING: MonitoringScheduleState = MonitoringScheduleState::new(3);
+
         /// Creates a new MonitoringScheduleState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MONITORING_SCHEDULE_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("OFFLINE"),
+                3 => std::borrow::Cow::Borrowed("RUNNING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MONITORING_SCHEDULE_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MONITORING_SCHEDULE_STATE_UNSPECIFIED)
+                }
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "OFFLINE" => std::option::Option::Some(Self::OFFLINE),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [MonitoringScheduleState](MonitoringScheduleState)
-    pub mod monitoring_schedule_state {
-        use super::MonitoringScheduleState;
-
-        /// Unspecified state.
-        pub const MONITORING_SCHEDULE_STATE_UNSPECIFIED: MonitoringScheduleState =
-            MonitoringScheduleState::new("MONITORING_SCHEDULE_STATE_UNSPECIFIED");
-
-        /// The pipeline is picked up and wait to run.
-        pub const PENDING: MonitoringScheduleState = MonitoringScheduleState::new("PENDING");
-
-        /// The pipeline is offline and will be scheduled for next run.
-        pub const OFFLINE: MonitoringScheduleState = MonitoringScheduleState::new("OFFLINE");
-
-        /// The pipeline is running.
-        pub const RUNNING: MonitoringScheduleState = MonitoringScheduleState::new("RUNNING");
-    }
-
-    impl std::convert::From<std::string::String> for MonitoringScheduleState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MonitoringScheduleState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MonitoringScheduleState {
         fn default() -> Self {
-            monitoring_schedule_state::MONITORING_SCHEDULE_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -50670,85 +51486,115 @@ pub mod model_deployment_monitoring_big_query_table {
 
     /// Indicates where does the log come from.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LogSource(std::borrow::Cow<'static, str>);
+    pub struct LogSource(i32);
 
     impl LogSource {
+        /// Unspecified source.
+        pub const LOG_SOURCE_UNSPECIFIED: LogSource = LogSource::new(0);
+
+        /// Logs coming from Training dataset.
+        pub const TRAINING: LogSource = LogSource::new(1);
+
+        /// Logs coming from Serving traffic.
+        pub const SERVING: LogSource = LogSource::new(2);
+
         /// Creates a new LogSource instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LOG_SOURCE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TRAINING"),
+                2 => std::borrow::Cow::Borrowed("SERVING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LOG_SOURCE_UNSPECIFIED" => std::option::Option::Some(Self::LOG_SOURCE_UNSPECIFIED),
+                "TRAINING" => std::option::Option::Some(Self::TRAINING),
+                "SERVING" => std::option::Option::Some(Self::SERVING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [LogSource](LogSource)
-    pub mod log_source {
-        use super::LogSource;
-
-        /// Unspecified source.
-        pub const LOG_SOURCE_UNSPECIFIED: LogSource = LogSource::new("LOG_SOURCE_UNSPECIFIED");
-
-        /// Logs coming from Training dataset.
-        pub const TRAINING: LogSource = LogSource::new("TRAINING");
-
-        /// Logs coming from Serving traffic.
-        pub const SERVING: LogSource = LogSource::new("SERVING");
-    }
-
-    impl std::convert::From<std::string::String> for LogSource {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LogSource {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LogSource {
         fn default() -> Self {
-            log_source::LOG_SOURCE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Indicates what type of traffic does the log belong to.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LogType(std::borrow::Cow<'static, str>);
+    pub struct LogType(i32);
 
     impl LogType {
+        /// Unspecified type.
+        pub const LOG_TYPE_UNSPECIFIED: LogType = LogType::new(0);
+
+        /// Predict logs.
+        pub const PREDICT: LogType = LogType::new(1);
+
+        /// Explain logs.
+        pub const EXPLAIN: LogType = LogType::new(2);
+
         /// Creates a new LogType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LOG_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PREDICT"),
+                2 => std::borrow::Cow::Borrowed("EXPLAIN"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LOG_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::LOG_TYPE_UNSPECIFIED),
+                "PREDICT" => std::option::Option::Some(Self::PREDICT),
+                "EXPLAIN" => std::option::Option::Some(Self::EXPLAIN),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [LogType](LogType)
-    pub mod log_type {
-        use super::LogType;
-
-        /// Unspecified type.
-        pub const LOG_TYPE_UNSPECIFIED: LogType = LogType::new("LOG_TYPE_UNSPECIFIED");
-
-        /// Predict logs.
-        pub const PREDICT: LogType = LogType::new("PREDICT");
-
-        /// Explain logs.
-        pub const EXPLAIN: LogType = LogType::new("EXPLAIN");
-    }
-
-    impl std::convert::From<std::string::String> for LogType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LogType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LogType {
         fn default() -> Self {
-            log_type::LOG_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -52592,44 +53438,61 @@ pub mod model_monitoring_objective_config {
 
             /// The storage format of the predictions generated BatchPrediction job.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct PredictionFormat(std::borrow::Cow<'static, str>);
+            pub struct PredictionFormat(i32);
 
             impl PredictionFormat {
+                /// Should not be set.
+                pub const PREDICTION_FORMAT_UNSPECIFIED: PredictionFormat =
+                    PredictionFormat::new(0);
+
+                /// Predictions are in JSONL files.
+                pub const JSONL: PredictionFormat = PredictionFormat::new(2);
+
+                /// Predictions are in BigQuery.
+                pub const BIGQUERY: PredictionFormat = PredictionFormat::new(3);
+
                 /// Creates a new PredictionFormat instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
                 }
 
                 /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("PREDICTION_FORMAT_UNSPECIFIED"),
+                        2 => std::borrow::Cow::Borrowed("JSONL"),
+                        3 => std::borrow::Cow::Borrowed("BIGQUERY"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "PREDICTION_FORMAT_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::PREDICTION_FORMAT_UNSPECIFIED)
+                        }
+                        "JSONL" => std::option::Option::Some(Self::JSONL),
+                        "BIGQUERY" => std::option::Option::Some(Self::BIGQUERY),
+                        _ => std::option::Option::None,
+                    }
                 }
             }
 
-            /// Useful constants to work with [PredictionFormat](PredictionFormat)
-            pub mod prediction_format {
-                use super::PredictionFormat;
-
-                /// Should not be set.
-                pub const PREDICTION_FORMAT_UNSPECIFIED: PredictionFormat =
-                    PredictionFormat::new("PREDICTION_FORMAT_UNSPECIFIED");
-
-                /// Predictions are in JSONL files.
-                pub const JSONL: PredictionFormat = PredictionFormat::new("JSONL");
-
-                /// Predictions are in BigQuery.
-                pub const BIGQUERY: PredictionFormat = PredictionFormat::new("BIGQUERY");
-            }
-
-            impl std::convert::From<std::string::String> for PredictionFormat {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for PredictionFormat {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for PredictionFormat {
                 fn default() -> Self {
-                    prediction_format::PREDICTION_FORMAT_UNSPECIFIED
+                    Self::new(0)
                 }
             }
 
@@ -55654,43 +56517,60 @@ pub mod nas_job_spec {
 
             /// The available types of optimization goals.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct GoalType(std::borrow::Cow<'static, str>);
+            pub struct GoalType(i32);
 
             impl GoalType {
+                /// Goal Type will default to maximize.
+                pub const GOAL_TYPE_UNSPECIFIED: GoalType = GoalType::new(0);
+
+                /// Maximize the goal metric.
+                pub const MAXIMIZE: GoalType = GoalType::new(1);
+
+                /// Minimize the goal metric.
+                pub const MINIMIZE: GoalType = GoalType::new(2);
+
                 /// Creates a new GoalType instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
                 }
 
                 /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("GOAL_TYPE_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("MAXIMIZE"),
+                        2 => std::borrow::Cow::Borrowed("MINIMIZE"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "GOAL_TYPE_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::GOAL_TYPE_UNSPECIFIED)
+                        }
+                        "MAXIMIZE" => std::option::Option::Some(Self::MAXIMIZE),
+                        "MINIMIZE" => std::option::Option::Some(Self::MINIMIZE),
+                        _ => std::option::Option::None,
+                    }
                 }
             }
 
-            /// Useful constants to work with [GoalType](GoalType)
-            pub mod goal_type {
-                use super::GoalType;
-
-                /// Goal Type will default to maximize.
-                pub const GOAL_TYPE_UNSPECIFIED: GoalType = GoalType::new("GOAL_TYPE_UNSPECIFIED");
-
-                /// Maximize the goal metric.
-                pub const MAXIMIZE: GoalType = GoalType::new("MAXIMIZE");
-
-                /// Minimize the goal metric.
-                pub const MINIMIZE: GoalType = GoalType::new("MINIMIZE");
-            }
-
-            impl std::convert::From<std::string::String> for GoalType {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for GoalType {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for GoalType {
                 fn default() -> Self {
-                    goal_type::GOAL_TYPE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -55826,47 +56706,65 @@ pub mod nas_job_spec {
 
         /// The available types of multi-trial algorithms.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct MultiTrialAlgorithm(std::borrow::Cow<'static, str>);
+        pub struct MultiTrialAlgorithm(i32);
 
         impl MultiTrialAlgorithm {
-            /// Creates a new MultiTrialAlgorithm instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [MultiTrialAlgorithm](MultiTrialAlgorithm)
-        pub mod multi_trial_algorithm {
-            use super::MultiTrialAlgorithm;
-
             /// Defaults to `REINFORCEMENT_LEARNING`.
             pub const MULTI_TRIAL_ALGORITHM_UNSPECIFIED: MultiTrialAlgorithm =
-                MultiTrialAlgorithm::new("MULTI_TRIAL_ALGORITHM_UNSPECIFIED");
+                MultiTrialAlgorithm::new(0);
 
             /// The Reinforcement Learning Algorithm for Multi-trial Neural
             /// Architecture Search (NAS).
-            pub const REINFORCEMENT_LEARNING: MultiTrialAlgorithm =
-                MultiTrialAlgorithm::new("REINFORCEMENT_LEARNING");
+            pub const REINFORCEMENT_LEARNING: MultiTrialAlgorithm = MultiTrialAlgorithm::new(1);
 
             /// The Grid Search Algorithm for Multi-trial Neural
             /// Architecture Search (NAS).
-            pub const GRID_SEARCH: MultiTrialAlgorithm = MultiTrialAlgorithm::new("GRID_SEARCH");
+            pub const GRID_SEARCH: MultiTrialAlgorithm = MultiTrialAlgorithm::new(2);
+
+            /// Creates a new MultiTrialAlgorithm instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("MULTI_TRIAL_ALGORITHM_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("REINFORCEMENT_LEARNING"),
+                    2 => std::borrow::Cow::Borrowed("GRID_SEARCH"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "MULTI_TRIAL_ALGORITHM_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::MULTI_TRIAL_ALGORITHM_UNSPECIFIED)
+                    }
+                    "REINFORCEMENT_LEARNING" => {
+                        std::option::Option::Some(Self::REINFORCEMENT_LEARNING)
+                    }
+                    "GRID_SEARCH" => std::option::Option::Some(Self::GRID_SEARCH),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for MultiTrialAlgorithm {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for MultiTrialAlgorithm {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for MultiTrialAlgorithm {
             fn default() -> Self {
-                multi_trial_algorithm::MULTI_TRIAL_ALGORITHM_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -56105,55 +57003,76 @@ pub mod nas_trial {
 
     /// Describes a NasTrial state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The NasTrial state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Indicates that a specific NasTrial has been requested, but it has not yet
         /// been suggested by the service.
-        pub const REQUESTED: State = State::new("REQUESTED");
+        pub const REQUESTED: State = State::new(1);
 
         /// Indicates that the NasTrial has been suggested.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(2);
 
         /// Indicates that the NasTrial should stop according to the service.
-        pub const STOPPING: State = State::new("STOPPING");
+        pub const STOPPING: State = State::new(3);
 
         /// Indicates that the NasTrial is completed successfully.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
+        pub const SUCCEEDED: State = State::new(4);
 
         /// Indicates that the NasTrial should not be attempted again.
         /// The service will set a NasTrial to INFEASIBLE when it's done but missing
         /// the final_measurement.
-        pub const INFEASIBLE: State = State::new("INFEASIBLE");
+        pub const INFEASIBLE: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REQUESTED"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("STOPPING"),
+                4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                5 => std::borrow::Cow::Borrowed("INFEASIBLE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "REQUESTED" => std::option::Option::Some(Self::REQUESTED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "STOPPING" => std::option::Option::Some(Self::STOPPING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "INFEASIBLE" => std::option::Option::Some(Self::INFEASIBLE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -57824,104 +58743,146 @@ pub mod notebook_runtime {
 
     /// The substate of the NotebookRuntime to display health information.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HealthState(std::borrow::Cow<'static, str>);
+    pub struct HealthState(i32);
 
     impl HealthState {
+        /// Unspecified health state.
+        pub const HEALTH_STATE_UNSPECIFIED: HealthState = HealthState::new(0);
+
+        /// NotebookRuntime is in healthy state. Applies to ACTIVE state.
+        pub const HEALTHY: HealthState = HealthState::new(1);
+
+        /// NotebookRuntime is in unhealthy state. Applies to ACTIVE state.
+        pub const UNHEALTHY: HealthState = HealthState::new(2);
+
         /// Creates a new HealthState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("HEALTH_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("HEALTHY"),
+                2 => std::borrow::Cow::Borrowed("UNHEALTHY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "HEALTH_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::HEALTH_STATE_UNSPECIFIED)
+                }
+                "HEALTHY" => std::option::Option::Some(Self::HEALTHY),
+                "UNHEALTHY" => std::option::Option::Some(Self::UNHEALTHY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [HealthState](HealthState)
-    pub mod health_state {
-        use super::HealthState;
-
-        /// Unspecified health state.
-        pub const HEALTH_STATE_UNSPECIFIED: HealthState =
-            HealthState::new("HEALTH_STATE_UNSPECIFIED");
-
-        /// NotebookRuntime is in healthy state. Applies to ACTIVE state.
-        pub const HEALTHY: HealthState = HealthState::new("HEALTHY");
-
-        /// NotebookRuntime is in unhealthy state. Applies to ACTIVE state.
-        pub const UNHEALTHY: HealthState = HealthState::new("UNHEALTHY");
-    }
-
-    impl std::convert::From<std::string::String> for HealthState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for HealthState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for HealthState {
         fn default() -> Self {
-            health_state::HEALTH_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The substate of the NotebookRuntime to display state of runtime.
     /// The resource of NotebookRuntime is in ACTIVE state for these sub state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RuntimeState(std::borrow::Cow<'static, str>);
+    pub struct RuntimeState(i32);
 
     impl RuntimeState {
-        /// Creates a new RuntimeState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RuntimeState](RuntimeState)
-    pub mod runtime_state {
-        use super::RuntimeState;
-
         /// Unspecified runtime state.
-        pub const RUNTIME_STATE_UNSPECIFIED: RuntimeState =
-            RuntimeState::new("RUNTIME_STATE_UNSPECIFIED");
+        pub const RUNTIME_STATE_UNSPECIFIED: RuntimeState = RuntimeState::new(0);
 
         /// NotebookRuntime is in running state.
-        pub const RUNNING: RuntimeState = RuntimeState::new("RUNNING");
+        pub const RUNNING: RuntimeState = RuntimeState::new(1);
 
         /// NotebookRuntime is in starting state.
-        pub const BEING_STARTED: RuntimeState = RuntimeState::new("BEING_STARTED");
+        pub const BEING_STARTED: RuntimeState = RuntimeState::new(2);
 
         /// NotebookRuntime is in stopping state.
-        pub const BEING_STOPPED: RuntimeState = RuntimeState::new("BEING_STOPPED");
+        pub const BEING_STOPPED: RuntimeState = RuntimeState::new(3);
 
         /// NotebookRuntime is in stopped state.
-        pub const STOPPED: RuntimeState = RuntimeState::new("STOPPED");
+        pub const STOPPED: RuntimeState = RuntimeState::new(4);
 
         /// NotebookRuntime is in upgrading state. It is in the middle of upgrading
         /// process.
-        pub const BEING_UPGRADED: RuntimeState = RuntimeState::new("BEING_UPGRADED");
+        pub const BEING_UPGRADED: RuntimeState = RuntimeState::new(5);
 
         /// NotebookRuntime was unable to start/stop properly.
-        pub const ERROR: RuntimeState = RuntimeState::new("ERROR");
+        pub const ERROR: RuntimeState = RuntimeState::new(100);
 
         /// NotebookRuntime is in invalid state. Cannot be recovered.
-        pub const INVALID: RuntimeState = RuntimeState::new("INVALID");
+        pub const INVALID: RuntimeState = RuntimeState::new(101);
+
+        /// Creates a new RuntimeState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RUNTIME_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RUNNING"),
+                2 => std::borrow::Cow::Borrowed("BEING_STARTED"),
+                3 => std::borrow::Cow::Borrowed("BEING_STOPPED"),
+                4 => std::borrow::Cow::Borrowed("STOPPED"),
+                5 => std::borrow::Cow::Borrowed("BEING_UPGRADED"),
+                100 => std::borrow::Cow::Borrowed("ERROR"),
+                101 => std::borrow::Cow::Borrowed("INVALID"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RUNTIME_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RUNTIME_STATE_UNSPECIFIED)
+                }
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "BEING_STARTED" => std::option::Option::Some(Self::BEING_STARTED),
+                "BEING_STOPPED" => std::option::Option::Some(Self::BEING_STOPPED),
+                "STOPPED" => std::option::Option::Some(Self::STOPPED),
+                "BEING_UPGRADED" => std::option::Option::Some(Self::BEING_UPGRADED),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "INVALID" => std::option::Option::Some(Self::INVALID),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RuntimeState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RuntimeState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RuntimeState {
         fn default() -> Self {
-            runtime_state::RUNTIME_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -59501,49 +60462,69 @@ pub mod post_startup_script_config {
 
     /// Represents a notebook runtime post startup script behavior.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PostStartupScriptBehavior(std::borrow::Cow<'static, str>);
+    pub struct PostStartupScriptBehavior(i32);
 
     impl PostStartupScriptBehavior {
-        /// Creates a new PostStartupScriptBehavior instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PostStartupScriptBehavior](PostStartupScriptBehavior)
-    pub mod post_startup_script_behavior {
-        use super::PostStartupScriptBehavior;
-
         /// Unspecified post startup script behavior.
         pub const POST_STARTUP_SCRIPT_BEHAVIOR_UNSPECIFIED: PostStartupScriptBehavior =
-            PostStartupScriptBehavior::new("POST_STARTUP_SCRIPT_BEHAVIOR_UNSPECIFIED");
+            PostStartupScriptBehavior::new(0);
 
         /// Run post startup script after runtime is started.
-        pub const RUN_ONCE: PostStartupScriptBehavior = PostStartupScriptBehavior::new("RUN_ONCE");
+        pub const RUN_ONCE: PostStartupScriptBehavior = PostStartupScriptBehavior::new(1);
 
         /// Run post startup script after runtime is stopped.
-        pub const RUN_EVERY_START: PostStartupScriptBehavior =
-            PostStartupScriptBehavior::new("RUN_EVERY_START");
+        pub const RUN_EVERY_START: PostStartupScriptBehavior = PostStartupScriptBehavior::new(2);
 
         /// Download and run post startup script every time runtime is started.
         pub const DOWNLOAD_AND_RUN_EVERY_START: PostStartupScriptBehavior =
-            PostStartupScriptBehavior::new("DOWNLOAD_AND_RUN_EVERY_START");
+            PostStartupScriptBehavior::new(3);
+
+        /// Creates a new PostStartupScriptBehavior instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("POST_STARTUP_SCRIPT_BEHAVIOR_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RUN_ONCE"),
+                2 => std::borrow::Cow::Borrowed("RUN_EVERY_START"),
+                3 => std::borrow::Cow::Borrowed("DOWNLOAD_AND_RUN_EVERY_START"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "POST_STARTUP_SCRIPT_BEHAVIOR_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::POST_STARTUP_SCRIPT_BEHAVIOR_UNSPECIFIED)
+                }
+                "RUN_ONCE" => std::option::Option::Some(Self::RUN_ONCE),
+                "RUN_EVERY_START" => std::option::Option::Some(Self::RUN_EVERY_START),
+                "DOWNLOAD_AND_RUN_EVERY_START" => {
+                    std::option::Option::Some(Self::DOWNLOAD_AND_RUN_EVERY_START)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PostStartupScriptBehavior {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PostStartupScriptBehavior {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PostStartupScriptBehavior {
         fn default() -> Self {
-            post_startup_script_behavior::POST_STARTUP_SCRIPT_BEHAVIOR_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -60242,59 +61223,82 @@ pub mod persistent_resource {
 
     /// Describes the PersistentResource state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The PROVISIONING state indicates the persistent resources is being
         /// created.
-        pub const PROVISIONING: State = State::new("PROVISIONING");
+        pub const PROVISIONING: State = State::new(1);
 
         /// The RUNNING state indicates the persistent resource is healthy and fully
         /// usable.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(3);
 
         /// The STOPPING state indicates the persistent resource is being deleted.
-        pub const STOPPING: State = State::new("STOPPING");
+        pub const STOPPING: State = State::new(4);
 
         /// The ERROR state indicates the persistent resource may be unusable.
         /// Details can be found in the `error` field.
-        pub const ERROR: State = State::new("ERROR");
+        pub const ERROR: State = State::new(5);
 
         /// The REBOOTING state indicates the persistent resource is being rebooted
         /// (PR is not available right now but is expected to be ready again later).
-        pub const REBOOTING: State = State::new("REBOOTING");
+        pub const REBOOTING: State = State::new(6);
 
         /// The UPDATING state indicates the persistent resource is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(7);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
+                3 => std::borrow::Cow::Borrowed("RUNNING"),
+                4 => std::borrow::Cow::Borrowed("STOPPING"),
+                5 => std::borrow::Cow::Borrowed("ERROR"),
+                6 => std::borrow::Cow::Borrowed("REBOOTING"),
+                7 => std::borrow::Cow::Borrowed("UPDATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "STOPPING" => std::option::Option::Some(Self::STOPPING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "REBOOTING" => std::option::Option::Some(Self::REBOOTING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -62196,50 +63200,35 @@ pub mod pipeline_task_detail {
 
     /// Specifies state of TaskExecution
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Specifies pending state for the task.
-        pub const PENDING: State = State::new("PENDING");
+        pub const PENDING: State = State::new(1);
 
         /// Specifies task is being executed.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(2);
 
         /// Specifies task completed successfully.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
+        pub const SUCCEEDED: State = State::new(3);
 
         /// Specifies Task cancel is in pending state.
-        pub const CANCEL_PENDING: State = State::new("CANCEL_PENDING");
+        pub const CANCEL_PENDING: State = State::new(4);
 
         /// Specifies task is being cancelled.
-        pub const CANCELLING: State = State::new("CANCELLING");
+        pub const CANCELLING: State = State::new(5);
 
         /// Specifies task was cancelled.
-        pub const CANCELLED: State = State::new("CANCELLED");
+        pub const CANCELLED: State = State::new(6);
 
         /// Specifies task failed.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(7);
 
         /// Specifies task was skipped due to cache hit.
-        pub const SKIPPED: State = State::new("SKIPPED");
+        pub const SKIPPED: State = State::new(8);
 
         /// Specifies that the task was not triggered because the task's trigger
         /// policy is not satisfied. The trigger policy is specified in the
@@ -62247,18 +63236,62 @@ pub mod pipeline_task_detail {
         /// [PipelineJob.pipeline_spec][google.cloud.aiplatform.v1.PipelineJob.pipeline_spec].
         ///
         /// [google.cloud.aiplatform.v1.PipelineJob.pipeline_spec]: crate::model::PipelineJob::pipeline_spec
-        pub const NOT_TRIGGERED: State = State::new("NOT_TRIGGERED");
+        pub const NOT_TRIGGERED: State = State::new(9);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                4 => std::borrow::Cow::Borrowed("CANCEL_PENDING"),
+                5 => std::borrow::Cow::Borrowed("CANCELLING"),
+                6 => std::borrow::Cow::Borrowed("CANCELLED"),
+                7 => std::borrow::Cow::Borrowed("FAILED"),
+                8 => std::borrow::Cow::Borrowed("SKIPPED"),
+                9 => std::borrow::Cow::Borrowed("NOT_TRIGGERED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "CANCEL_PENDING" => std::option::Option::Some(Self::CANCEL_PENDING),
+                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "SKIPPED" => std::option::Option::Some(Self::SKIPPED),
+                "NOT_TRIGGERED" => std::option::Option::Some(Self::NOT_TRIGGERED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -65122,51 +66155,71 @@ pub mod generate_content_response {
 
         /// Blocked reason enumeration.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct BlockedReason(std::borrow::Cow<'static, str>);
+        pub struct BlockedReason(i32);
 
         impl BlockedReason {
-            /// Creates a new BlockedReason instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [BlockedReason](BlockedReason)
-        pub mod blocked_reason {
-            use super::BlockedReason;
-
             /// Unspecified blocked reason.
-            pub const BLOCKED_REASON_UNSPECIFIED: BlockedReason =
-                BlockedReason::new("BLOCKED_REASON_UNSPECIFIED");
+            pub const BLOCKED_REASON_UNSPECIFIED: BlockedReason = BlockedReason::new(0);
 
             /// Candidates blocked due to safety.
-            pub const SAFETY: BlockedReason = BlockedReason::new("SAFETY");
+            pub const SAFETY: BlockedReason = BlockedReason::new(1);
 
             /// Candidates blocked due to other reason.
-            pub const OTHER: BlockedReason = BlockedReason::new("OTHER");
+            pub const OTHER: BlockedReason = BlockedReason::new(2);
 
             /// Candidates blocked due to the terms which are included from the
             /// terminology blocklist.
-            pub const BLOCKLIST: BlockedReason = BlockedReason::new("BLOCKLIST");
+            pub const BLOCKLIST: BlockedReason = BlockedReason::new(3);
 
             /// Candidates blocked due to prohibited content.
-            pub const PROHIBITED_CONTENT: BlockedReason = BlockedReason::new("PROHIBITED_CONTENT");
+            pub const PROHIBITED_CONTENT: BlockedReason = BlockedReason::new(4);
+
+            /// Creates a new BlockedReason instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("BLOCKED_REASON_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("SAFETY"),
+                    2 => std::borrow::Cow::Borrowed("OTHER"),
+                    3 => std::borrow::Cow::Borrowed("BLOCKLIST"),
+                    4 => std::borrow::Cow::Borrowed("PROHIBITED_CONTENT"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "BLOCKED_REASON_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::BLOCKED_REASON_UNSPECIFIED)
+                    }
+                    "SAFETY" => std::option::Option::Some(Self::SAFETY),
+                    "OTHER" => std::option::Option::Some(Self::OTHER),
+                    "BLOCKLIST" => std::option::Option::Some(Self::BLOCKLIST),
+                    "PROHIBITED_CONTENT" => std::option::Option::Some(Self::PROHIBITED_CONTENT),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for BlockedReason {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for BlockedReason {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for BlockedReason {
             fn default() -> Self {
-                blocked_reason::BLOCKED_REASON_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -66491,160 +67544,219 @@ pub mod publisher_model {
 
     /// An enum representing the open source category of a PublisherModel.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OpenSourceCategory(std::borrow::Cow<'static, str>);
+    pub struct OpenSourceCategory(i32);
 
     impl OpenSourceCategory {
-        /// Creates a new OpenSourceCategory instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [OpenSourceCategory](OpenSourceCategory)
-    pub mod open_source_category {
-        use super::OpenSourceCategory;
-
         /// The open source category is unspecified, which should not be used.
-        pub const OPEN_SOURCE_CATEGORY_UNSPECIFIED: OpenSourceCategory =
-            OpenSourceCategory::new("OPEN_SOURCE_CATEGORY_UNSPECIFIED");
+        pub const OPEN_SOURCE_CATEGORY_UNSPECIFIED: OpenSourceCategory = OpenSourceCategory::new(0);
 
         /// Used to indicate the PublisherModel is not open sourced.
-        pub const PROPRIETARY: OpenSourceCategory = OpenSourceCategory::new("PROPRIETARY");
+        pub const PROPRIETARY: OpenSourceCategory = OpenSourceCategory::new(1);
 
         /// Used to indicate the PublisherModel is a Google-owned open source model
         /// w/ Google checkpoint.
         pub const GOOGLE_OWNED_OSS_WITH_GOOGLE_CHECKPOINT: OpenSourceCategory =
-            OpenSourceCategory::new("GOOGLE_OWNED_OSS_WITH_GOOGLE_CHECKPOINT");
+            OpenSourceCategory::new(2);
 
         /// Used to indicate the PublisherModel is a 3p-owned open source model w/
         /// Google checkpoint.
         pub const THIRD_PARTY_OWNED_OSS_WITH_GOOGLE_CHECKPOINT: OpenSourceCategory =
-            OpenSourceCategory::new("THIRD_PARTY_OWNED_OSS_WITH_GOOGLE_CHECKPOINT");
+            OpenSourceCategory::new(3);
 
         /// Used to indicate the PublisherModel is a Google-owned pure open source
         /// model.
-        pub const GOOGLE_OWNED_OSS: OpenSourceCategory =
-            OpenSourceCategory::new("GOOGLE_OWNED_OSS");
+        pub const GOOGLE_OWNED_OSS: OpenSourceCategory = OpenSourceCategory::new(4);
 
         /// Used to indicate the PublisherModel is a 3p-owned pure open source model.
-        pub const THIRD_PARTY_OWNED_OSS: OpenSourceCategory =
-            OpenSourceCategory::new("THIRD_PARTY_OWNED_OSS");
+        pub const THIRD_PARTY_OWNED_OSS: OpenSourceCategory = OpenSourceCategory::new(5);
+
+        /// Creates a new OpenSourceCategory instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("OPEN_SOURCE_CATEGORY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROPRIETARY"),
+                2 => std::borrow::Cow::Borrowed("GOOGLE_OWNED_OSS_WITH_GOOGLE_CHECKPOINT"),
+                3 => std::borrow::Cow::Borrowed("THIRD_PARTY_OWNED_OSS_WITH_GOOGLE_CHECKPOINT"),
+                4 => std::borrow::Cow::Borrowed("GOOGLE_OWNED_OSS"),
+                5 => std::borrow::Cow::Borrowed("THIRD_PARTY_OWNED_OSS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "OPEN_SOURCE_CATEGORY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::OPEN_SOURCE_CATEGORY_UNSPECIFIED)
+                }
+                "PROPRIETARY" => std::option::Option::Some(Self::PROPRIETARY),
+                "GOOGLE_OWNED_OSS_WITH_GOOGLE_CHECKPOINT" => {
+                    std::option::Option::Some(Self::GOOGLE_OWNED_OSS_WITH_GOOGLE_CHECKPOINT)
+                }
+                "THIRD_PARTY_OWNED_OSS_WITH_GOOGLE_CHECKPOINT" => {
+                    std::option::Option::Some(Self::THIRD_PARTY_OWNED_OSS_WITH_GOOGLE_CHECKPOINT)
+                }
+                "GOOGLE_OWNED_OSS" => std::option::Option::Some(Self::GOOGLE_OWNED_OSS),
+                "THIRD_PARTY_OWNED_OSS" => std::option::Option::Some(Self::THIRD_PARTY_OWNED_OSS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for OpenSourceCategory {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for OpenSourceCategory {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for OpenSourceCategory {
         fn default() -> Self {
-            open_source_category::OPEN_SOURCE_CATEGORY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// An enum representing the launch stage of a PublisherModel.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LaunchStage(std::borrow::Cow<'static, str>);
+    pub struct LaunchStage(i32);
 
     impl LaunchStage {
-        /// Creates a new LaunchStage instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [LaunchStage](LaunchStage)
-    pub mod launch_stage {
-        use super::LaunchStage;
-
         /// The model launch stage is unspecified.
-        pub const LAUNCH_STAGE_UNSPECIFIED: LaunchStage =
-            LaunchStage::new("LAUNCH_STAGE_UNSPECIFIED");
+        pub const LAUNCH_STAGE_UNSPECIFIED: LaunchStage = LaunchStage::new(0);
 
         /// Used to indicate the PublisherModel is at Experimental launch stage,
         /// available to a small set of customers.
-        pub const EXPERIMENTAL: LaunchStage = LaunchStage::new("EXPERIMENTAL");
+        pub const EXPERIMENTAL: LaunchStage = LaunchStage::new(1);
 
         /// Used to indicate the PublisherModel is at Private Preview launch stage,
         /// only available to a small set of customers, although a larger set of
         /// customers than an Experimental launch. Previews are the first launch
         /// stage used to get feedback from customers.
-        pub const PRIVATE_PREVIEW: LaunchStage = LaunchStage::new("PRIVATE_PREVIEW");
+        pub const PRIVATE_PREVIEW: LaunchStage = LaunchStage::new(2);
 
         /// Used to indicate the PublisherModel is at Public Preview launch stage,
         /// available to all customers, although not supported for production
         /// workloads.
-        pub const PUBLIC_PREVIEW: LaunchStage = LaunchStage::new("PUBLIC_PREVIEW");
+        pub const PUBLIC_PREVIEW: LaunchStage = LaunchStage::new(3);
 
         /// Used to indicate the PublisherModel is at GA launch stage, available to
         /// all customers and ready for production workload.
-        pub const GA: LaunchStage = LaunchStage::new("GA");
+        pub const GA: LaunchStage = LaunchStage::new(4);
+
+        /// Creates a new LaunchStage instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LAUNCH_STAGE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("EXPERIMENTAL"),
+                2 => std::borrow::Cow::Borrowed("PRIVATE_PREVIEW"),
+                3 => std::borrow::Cow::Borrowed("PUBLIC_PREVIEW"),
+                4 => std::borrow::Cow::Borrowed("GA"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LAUNCH_STAGE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::LAUNCH_STAGE_UNSPECIFIED)
+                }
+                "EXPERIMENTAL" => std::option::Option::Some(Self::EXPERIMENTAL),
+                "PRIVATE_PREVIEW" => std::option::Option::Some(Self::PRIVATE_PREVIEW),
+                "PUBLIC_PREVIEW" => std::option::Option::Some(Self::PUBLIC_PREVIEW),
+                "GA" => std::option::Option::Some(Self::GA),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for LaunchStage {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LaunchStage {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LaunchStage {
         fn default() -> Self {
-            launch_stage::LAUNCH_STAGE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// An enum representing the state of the PublicModelVersion.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VersionState(std::borrow::Cow<'static, str>);
+    pub struct VersionState(i32);
 
     impl VersionState {
+        /// The version state is unspecified.
+        pub const VERSION_STATE_UNSPECIFIED: VersionState = VersionState::new(0);
+
+        /// Used to indicate the version is stable.
+        pub const VERSION_STATE_STABLE: VersionState = VersionState::new(1);
+
+        /// Used to indicate the version is unstable.
+        pub const VERSION_STATE_UNSTABLE: VersionState = VersionState::new(2);
+
         /// Creates a new VersionState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VERSION_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("VERSION_STATE_STABLE"),
+                2 => std::borrow::Cow::Borrowed("VERSION_STATE_UNSTABLE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VERSION_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::VERSION_STATE_UNSPECIFIED)
+                }
+                "VERSION_STATE_STABLE" => std::option::Option::Some(Self::VERSION_STATE_STABLE),
+                "VERSION_STATE_UNSTABLE" => std::option::Option::Some(Self::VERSION_STATE_UNSTABLE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [VersionState](VersionState)
-    pub mod version_state {
-        use super::VersionState;
-
-        /// The version state is unspecified.
-        pub const VERSION_STATE_UNSPECIFIED: VersionState =
-            VersionState::new("VERSION_STATE_UNSPECIFIED");
-
-        /// Used to indicate the version is stable.
-        pub const VERSION_STATE_STABLE: VersionState = VersionState::new("VERSION_STATE_STABLE");
-
-        /// Used to indicate the version is unstable.
-        pub const VERSION_STATE_UNSTABLE: VersionState =
-            VersionState::new("VERSION_STATE_UNSTABLE");
-    }
-
-    impl std::convert::From<std::string::String> for VersionState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for VersionState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for VersionState {
         fn default() -> Self {
-            version_state::VERSION_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -67464,47 +68576,64 @@ pub mod reservation_affinity {
 
     /// Identifies a type of reservation affinity.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// Default value. This should not be used.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// Do not consume from any reserved capacity, only use on-demand.
-        pub const NO_RESERVATION: Type = Type::new("NO_RESERVATION");
+        pub const NO_RESERVATION: Type = Type::new(1);
 
         /// Consume any reservation available, falling back to on-demand.
-        pub const ANY_RESERVATION: Type = Type::new("ANY_RESERVATION");
+        pub const ANY_RESERVATION: Type = Type::new(2);
 
         /// Consume from a specific reservation. When chosen, the reservation
         /// must be identified via the `key` and `values` fields.
-        pub const SPECIFIC_RESERVATION: Type = Type::new("SPECIFIC_RESERVATION");
+        pub const SPECIFIC_RESERVATION: Type = Type::new(3);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NO_RESERVATION"),
+                2 => std::borrow::Cow::Borrowed("ANY_RESERVATION"),
+                3 => std::borrow::Cow::Borrowed("SPECIFIC_RESERVATION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "NO_RESERVATION" => std::option::Option::Some(Self::NO_RESERVATION),
+                "ANY_RESERVATION" => std::option::Option::Some(Self::ANY_RESERVATION),
+                "SPECIFIC_RESERVATION" => std::option::Option::Some(Self::SPECIFIC_RESERVATION),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -68058,50 +69187,67 @@ pub mod schedule {
 
     /// Possible state of the schedule.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The Schedule is active. Runs are being scheduled on the user-specified
         /// timespec.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(1);
 
         /// The schedule is paused. No new runs will be created until the schedule
         /// is resumed. Already started runs will be allowed to complete.
-        pub const PAUSED: State = State::new("PAUSED");
+        pub const PAUSED: State = State::new(2);
 
         /// The Schedule is completed. No new runs will be scheduled. Already started
         /// runs will be allowed to complete. Schedules in completed state cannot be
         /// paused or resumed.
-        pub const COMPLETED: State = State::new("COMPLETED");
+        pub const COMPLETED: State = State::new(3);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("PAUSED"),
+                3 => std::borrow::Cow::Borrowed("COMPLETED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "PAUSED" => std::option::Option::Some(Self::PAUSED),
+                "COMPLETED" => std::option::Option::Some(Self::COMPLETED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -69330,47 +70476,64 @@ pub mod study {
 
     /// Describes the Study state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The study state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The study is active.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(1);
 
         /// The study is stopped due to an internal error.
-        pub const INACTIVE: State = State::new("INACTIVE");
+        pub const INACTIVE: State = State::new(2);
 
         /// The study is done when the service exhausts the parameter search space
         /// or max_trial_count is reached.
-        pub const COMPLETED: State = State::new("COMPLETED");
+        pub const COMPLETED: State = State::new(3);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("INACTIVE"),
+                3 => std::borrow::Cow::Borrowed("COMPLETED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
+                "COMPLETED" => std::option::Option::Some(Self::COMPLETED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -69634,55 +70797,76 @@ pub mod trial {
 
     /// Describes a Trial state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The Trial state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Indicates that a specific Trial has been requested, but it has not yet
         /// been suggested by the service.
-        pub const REQUESTED: State = State::new("REQUESTED");
+        pub const REQUESTED: State = State::new(1);
 
         /// Indicates that the Trial has been suggested.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(2);
 
         /// Indicates that the Trial should stop according to the service.
-        pub const STOPPING: State = State::new("STOPPING");
+        pub const STOPPING: State = State::new(3);
 
         /// Indicates that the Trial is completed successfully.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
+        pub const SUCCEEDED: State = State::new(4);
 
         /// Indicates that the Trial should not be attempted again.
         /// The service will set a Trial to INFEASIBLE when it's done but missing
         /// the final_measurement.
-        pub const INFEASIBLE: State = State::new("INFEASIBLE");
+        pub const INFEASIBLE: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REQUESTED"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("STOPPING"),
+                4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                5 => std::borrow::Cow::Borrowed("INFEASIBLE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "REQUESTED" => std::option::Option::Some(Self::REQUESTED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "STOPPING" => std::option::Option::Some(Self::STOPPING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "INFEASIBLE" => std::option::Option::Some(Self::INFEASIBLE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -70190,43 +71374,60 @@ pub mod study_spec {
 
         /// The available types of optimization goals.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct GoalType(std::borrow::Cow<'static, str>);
+        pub struct GoalType(i32);
 
         impl GoalType {
+            /// Goal Type will default to maximize.
+            pub const GOAL_TYPE_UNSPECIFIED: GoalType = GoalType::new(0);
+
+            /// Maximize the goal metric.
+            pub const MAXIMIZE: GoalType = GoalType::new(1);
+
+            /// Minimize the goal metric.
+            pub const MINIMIZE: GoalType = GoalType::new(2);
+
             /// Creates a new GoalType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("GOAL_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("MAXIMIZE"),
+                    2 => std::borrow::Cow::Borrowed("MINIMIZE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "GOAL_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::GOAL_TYPE_UNSPECIFIED)
+                    }
+                    "MAXIMIZE" => std::option::Option::Some(Self::MAXIMIZE),
+                    "MINIMIZE" => std::option::Option::Some(Self::MINIMIZE),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [GoalType](GoalType)
-        pub mod goal_type {
-            use super::GoalType;
-
-            /// Goal Type will default to maximize.
-            pub const GOAL_TYPE_UNSPECIFIED: GoalType = GoalType::new("GOAL_TYPE_UNSPECIFIED");
-
-            /// Maximize the goal metric.
-            pub const MAXIMIZE: GoalType = GoalType::new("MAXIMIZE");
-
-            /// Minimize the goal metric.
-            pub const MINIMIZE: GoalType = GoalType::new("MINIMIZE");
-        }
-
-        impl std::convert::From<std::string::String> for GoalType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for GoalType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for GoalType {
             fn default() -> Self {
-                goal_type::GOAL_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -70954,50 +72155,71 @@ pub mod study_spec {
 
         /// The type of scaling that should be applied to this parameter.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ScaleType(std::borrow::Cow<'static, str>);
+        pub struct ScaleType(i32);
 
         impl ScaleType {
-            /// Creates a new ScaleType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [ScaleType](ScaleType)
-        pub mod scale_type {
-            use super::ScaleType;
-
             /// By default, no scaling is applied.
-            pub const SCALE_TYPE_UNSPECIFIED: ScaleType = ScaleType::new("SCALE_TYPE_UNSPECIFIED");
+            pub const SCALE_TYPE_UNSPECIFIED: ScaleType = ScaleType::new(0);
 
             /// Scales the feasible space to (0, 1) linearly.
-            pub const UNIT_LINEAR_SCALE: ScaleType = ScaleType::new("UNIT_LINEAR_SCALE");
+            pub const UNIT_LINEAR_SCALE: ScaleType = ScaleType::new(1);
 
             /// Scales the feasible space logarithmically to (0, 1). The entire
             /// feasible space must be strictly positive.
-            pub const UNIT_LOG_SCALE: ScaleType = ScaleType::new("UNIT_LOG_SCALE");
+            pub const UNIT_LOG_SCALE: ScaleType = ScaleType::new(2);
 
             /// Scales the feasible space "reverse" logarithmically to (0, 1). The
             /// result is that values close to the top of the feasible space are spread
             /// out more than points near the bottom. The entire feasible space must be
             /// strictly positive.
-            pub const UNIT_REVERSE_LOG_SCALE: ScaleType = ScaleType::new("UNIT_REVERSE_LOG_SCALE");
+            pub const UNIT_REVERSE_LOG_SCALE: ScaleType = ScaleType::new(3);
+
+            /// Creates a new ScaleType instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("SCALE_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("UNIT_LINEAR_SCALE"),
+                    2 => std::borrow::Cow::Borrowed("UNIT_LOG_SCALE"),
+                    3 => std::borrow::Cow::Borrowed("UNIT_REVERSE_LOG_SCALE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "SCALE_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::SCALE_TYPE_UNSPECIFIED)
+                    }
+                    "UNIT_LINEAR_SCALE" => std::option::Option::Some(Self::UNIT_LINEAR_SCALE),
+                    "UNIT_LOG_SCALE" => std::option::Option::Some(Self::UNIT_LOG_SCALE),
+                    "UNIT_REVERSE_LOG_SCALE" => {
+                        std::option::Option::Some(Self::UNIT_REVERSE_LOG_SCALE)
+                    }
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for ScaleType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for ScaleType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for ScaleType {
             fn default() -> Self {
-                scale_type::SCALE_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -71373,46 +72595,61 @@ pub mod study_spec {
 
     /// The available search algorithms for the Study.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Algorithm(std::borrow::Cow<'static, str>);
+    pub struct Algorithm(i32);
 
     impl Algorithm {
-        /// Creates a new Algorithm instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Algorithm](Algorithm)
-    pub mod algorithm {
-        use super::Algorithm;
-
         /// The default algorithm used by Vertex AI for [hyperparameter
         /// tuning](https://cloud.google.com/vertex-ai/docs/training/hyperparameter-tuning-overview)
         /// and [Vertex AI Vizier](https://cloud.google.com/vertex-ai/docs/vizier).
-        pub const ALGORITHM_UNSPECIFIED: Algorithm = Algorithm::new("ALGORITHM_UNSPECIFIED");
+        pub const ALGORITHM_UNSPECIFIED: Algorithm = Algorithm::new(0);
 
         /// Simple grid search within the feasible space. To use grid search,
         /// all parameters must be `INTEGER`, `CATEGORICAL`, or `DISCRETE`.
-        pub const GRID_SEARCH: Algorithm = Algorithm::new("GRID_SEARCH");
+        pub const GRID_SEARCH: Algorithm = Algorithm::new(2);
 
         /// Simple random search within the feasible space.
-        pub const RANDOM_SEARCH: Algorithm = Algorithm::new("RANDOM_SEARCH");
+        pub const RANDOM_SEARCH: Algorithm = Algorithm::new(3);
+
+        /// Creates a new Algorithm instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ALGORITHM_UNSPECIFIED"),
+                2 => std::borrow::Cow::Borrowed("GRID_SEARCH"),
+                3 => std::borrow::Cow::Borrowed("RANDOM_SEARCH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ALGORITHM_UNSPECIFIED" => std::option::Option::Some(Self::ALGORITHM_UNSPECIFIED),
+                "GRID_SEARCH" => std::option::Option::Some(Self::GRID_SEARCH),
+                "RANDOM_SEARCH" => std::option::Option::Some(Self::RANDOM_SEARCH),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Algorithm {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Algorithm {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Algorithm {
         fn default() -> Self {
-            algorithm::ALGORITHM_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -71421,47 +72658,63 @@ pub mod study_spec {
     /// "Noisy" means that the repeated observations with the same Trial parameters
     /// may lead to different metric evaluations.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ObservationNoise(std::borrow::Cow<'static, str>);
+    pub struct ObservationNoise(i32);
 
     impl ObservationNoise {
-        /// Creates a new ObservationNoise instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ObservationNoise](ObservationNoise)
-    pub mod observation_noise {
-        use super::ObservationNoise;
-
         /// The default noise level chosen by Vertex AI.
-        pub const OBSERVATION_NOISE_UNSPECIFIED: ObservationNoise =
-            ObservationNoise::new("OBSERVATION_NOISE_UNSPECIFIED");
+        pub const OBSERVATION_NOISE_UNSPECIFIED: ObservationNoise = ObservationNoise::new(0);
 
         /// Vertex AI assumes that the objective function is (nearly)
         /// perfectly reproducible, and will never repeat the same Trial
         /// parameters.
-        pub const LOW: ObservationNoise = ObservationNoise::new("LOW");
+        pub const LOW: ObservationNoise = ObservationNoise::new(1);
 
         /// Vertex AI will estimate the amount of noise in metric
         /// evaluations, it may repeat the same Trial parameters more than once.
-        pub const HIGH: ObservationNoise = ObservationNoise::new("HIGH");
+        pub const HIGH: ObservationNoise = ObservationNoise::new(2);
+
+        /// Creates a new ObservationNoise instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("OBSERVATION_NOISE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LOW"),
+                2 => std::borrow::Cow::Borrowed("HIGH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "OBSERVATION_NOISE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::OBSERVATION_NOISE_UNSPECIFIED)
+                }
+                "LOW" => std::option::Option::Some(Self::LOW),
+                "HIGH" => std::option::Option::Some(Self::HIGH),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ObservationNoise {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ObservationNoise {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ObservationNoise {
         fn default() -> Self {
-            observation_noise::OBSERVATION_NOISE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -71479,46 +72732,61 @@ pub mod study_spec {
     /// If both or neither of (A) and (B) apply, it doesn't matter which
     /// selection type is chosen.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MeasurementSelectionType(std::borrow::Cow<'static, str>);
+    pub struct MeasurementSelectionType(i32);
 
     impl MeasurementSelectionType {
+        /// Will be treated as LAST_MEASUREMENT.
+        pub const MEASUREMENT_SELECTION_TYPE_UNSPECIFIED: MeasurementSelectionType =
+            MeasurementSelectionType::new(0);
+
+        /// Use the last measurement reported.
+        pub const LAST_MEASUREMENT: MeasurementSelectionType = MeasurementSelectionType::new(1);
+
+        /// Use the best measurement reported.
+        pub const BEST_MEASUREMENT: MeasurementSelectionType = MeasurementSelectionType::new(2);
+
         /// Creates a new MeasurementSelectionType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MEASUREMENT_SELECTION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LAST_MEASUREMENT"),
+                2 => std::borrow::Cow::Borrowed("BEST_MEASUREMENT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MEASUREMENT_SELECTION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MEASUREMENT_SELECTION_TYPE_UNSPECIFIED)
+                }
+                "LAST_MEASUREMENT" => std::option::Option::Some(Self::LAST_MEASUREMENT),
+                "BEST_MEASUREMENT" => std::option::Option::Some(Self::BEST_MEASUREMENT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [MeasurementSelectionType](MeasurementSelectionType)
-    pub mod measurement_selection_type {
-        use super::MeasurementSelectionType;
-
-        /// Will be treated as LAST_MEASUREMENT.
-        pub const MEASUREMENT_SELECTION_TYPE_UNSPECIFIED: MeasurementSelectionType =
-            MeasurementSelectionType::new("MEASUREMENT_SELECTION_TYPE_UNSPECIFIED");
-
-        /// Use the last measurement reported.
-        pub const LAST_MEASUREMENT: MeasurementSelectionType =
-            MeasurementSelectionType::new("LAST_MEASUREMENT");
-
-        /// Use the best measurement reported.
-        pub const BEST_MEASUREMENT: MeasurementSelectionType =
-            MeasurementSelectionType::new("BEST_MEASUREMENT");
-    }
-
-    impl std::convert::From<std::string::String> for MeasurementSelectionType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MeasurementSelectionType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MeasurementSelectionType {
         fn default() -> Self {
-            measurement_selection_type::MEASUREMENT_SELECTION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -75104,49 +76372,66 @@ pub mod tensorboard_time_series {
 
     /// An enum representing the value type of a TensorboardTimeSeries.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ValueType(std::borrow::Cow<'static, str>);
+    pub struct ValueType(i32);
 
     impl ValueType {
-        /// Creates a new ValueType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ValueType](ValueType)
-    pub mod value_type {
-        use super::ValueType;
-
         /// The value type is unspecified.
-        pub const VALUE_TYPE_UNSPECIFIED: ValueType = ValueType::new("VALUE_TYPE_UNSPECIFIED");
+        pub const VALUE_TYPE_UNSPECIFIED: ValueType = ValueType::new(0);
 
         /// Used for TensorboardTimeSeries that is a list of scalars.
         /// E.g. accuracy of a model over epochs/time.
-        pub const SCALAR: ValueType = ValueType::new("SCALAR");
+        pub const SCALAR: ValueType = ValueType::new(1);
 
         /// Used for TensorboardTimeSeries that is a list of tensors.
         /// E.g. histograms of weights of layer in a model over epoch/time.
-        pub const TENSOR: ValueType = ValueType::new("TENSOR");
+        pub const TENSOR: ValueType = ValueType::new(2);
 
         /// Used for TensorboardTimeSeries that is a list of blob sequences.
         /// E.g. set of sample images with labels over epochs/time.
-        pub const BLOB_SEQUENCE: ValueType = ValueType::new("BLOB_SEQUENCE");
+        pub const BLOB_SEQUENCE: ValueType = ValueType::new(3);
+
+        /// Creates a new ValueType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VALUE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SCALAR"),
+                2 => std::borrow::Cow::Borrowed("TENSOR"),
+                3 => std::borrow::Cow::Borrowed("BLOB_SEQUENCE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VALUE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::VALUE_TYPE_UNSPECIFIED),
+                "SCALAR" => std::option::Option::Some(Self::SCALAR),
+                "TENSOR" => std::option::Option::Some(Self::TENSOR),
+                "BLOB_SEQUENCE" => std::option::Option::Some(Self::BLOB_SEQUENCE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ValueType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ValueType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ValueType {
         fn default() -> Self {
-            value_type::VALUE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -75567,40 +76852,53 @@ pub mod executable_code {
 
     /// Supported programming languages for the generated code.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Language(std::borrow::Cow<'static, str>);
+    pub struct Language(i32);
 
     impl Language {
+        /// Unspecified language. This value should not be used.
+        pub const LANGUAGE_UNSPECIFIED: Language = Language::new(0);
+
+        /// Python >= 3.10, with numpy and simpy available.
+        pub const PYTHON: Language = Language::new(1);
+
         /// Creates a new Language instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LANGUAGE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PYTHON"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LANGUAGE_UNSPECIFIED" => std::option::Option::Some(Self::LANGUAGE_UNSPECIFIED),
+                "PYTHON" => std::option::Option::Some(Self::PYTHON),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Language](Language)
-    pub mod language {
-        use super::Language;
-
-        /// Unspecified language. This value should not be used.
-        pub const LANGUAGE_UNSPECIFIED: Language = Language::new("LANGUAGE_UNSPECIFIED");
-
-        /// Python >= 3.10, with numpy and simpy available.
-        pub const PYTHON: Language = Language::new("PYTHON");
-    }
-
-    impl std::convert::From<std::string::String> for Language {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Language {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Language {
         fn default() -> Self {
-            language::LANGUAGE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -75656,48 +76954,67 @@ pub mod code_execution_result {
 
     /// Enumeration of possible outcomes of the code execution.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Outcome(std::borrow::Cow<'static, str>);
+    pub struct Outcome(i32);
 
     impl Outcome {
-        /// Creates a new Outcome instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Outcome](Outcome)
-    pub mod outcome {
-        use super::Outcome;
-
         /// Unspecified status. This value should not be used.
-        pub const OUTCOME_UNSPECIFIED: Outcome = Outcome::new("OUTCOME_UNSPECIFIED");
+        pub const OUTCOME_UNSPECIFIED: Outcome = Outcome::new(0);
 
         /// Code execution completed successfully.
-        pub const OUTCOME_OK: Outcome = Outcome::new("OUTCOME_OK");
+        pub const OUTCOME_OK: Outcome = Outcome::new(1);
 
         /// Code execution finished but with a failure. `stderr` should contain the
         /// reason.
-        pub const OUTCOME_FAILED: Outcome = Outcome::new("OUTCOME_FAILED");
+        pub const OUTCOME_FAILED: Outcome = Outcome::new(2);
 
         /// Code execution ran for too long, and was cancelled. There may or may not
         /// be a partial output present.
-        pub const OUTCOME_DEADLINE_EXCEEDED: Outcome = Outcome::new("OUTCOME_DEADLINE_EXCEEDED");
+        pub const OUTCOME_DEADLINE_EXCEEDED: Outcome = Outcome::new(3);
+
+        /// Creates a new Outcome instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("OUTCOME_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("OUTCOME_OK"),
+                2 => std::borrow::Cow::Borrowed("OUTCOME_FAILED"),
+                3 => std::borrow::Cow::Borrowed("OUTCOME_DEADLINE_EXCEEDED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "OUTCOME_UNSPECIFIED" => std::option::Option::Some(Self::OUTCOME_UNSPECIFIED),
+                "OUTCOME_OK" => std::option::Option::Some(Self::OUTCOME_OK),
+                "OUTCOME_FAILED" => std::option::Option::Some(Self::OUTCOME_FAILED),
+                "OUTCOME_DEADLINE_EXCEEDED" => {
+                    std::option::Option::Some(Self::OUTCOME_DEADLINE_EXCEEDED)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Outcome {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Outcome {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Outcome {
         fn default() -> Self {
-            outcome::OUTCOME_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -76091,40 +77408,53 @@ pub mod dynamic_retrieval_config {
 
     /// The mode of the predictor to be used in dynamic retrieval.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(std::borrow::Cow<'static, str>);
+    pub struct Mode(i32);
 
     impl Mode {
+        /// Always trigger retrieval.
+        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
+
+        /// Run retrieval only when system decides it is necessary.
+        pub const MODE_DYNAMIC: Mode = Mode::new(1);
+
         /// Creates a new Mode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MODE_DYNAMIC"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
+                "MODE_DYNAMIC" => std::option::Option::Some(Self::MODE_DYNAMIC),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Mode](Mode)
-    pub mod mode {
-        use super::Mode;
-
-        /// Always trigger retrieval.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new("MODE_UNSPECIFIED");
-
-        /// Run retrieval only when system decides it is necessary.
-        pub const MODE_DYNAMIC: Mode = Mode::new("MODE_DYNAMIC");
-    }
-
-    impl std::convert::From<std::string::String> for Mode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            mode::MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -76233,51 +77563,68 @@ pub mod function_calling_config {
 
     /// Function calling mode.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(std::borrow::Cow<'static, str>);
+    pub struct Mode(i32);
 
     impl Mode {
-        /// Creates a new Mode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Mode](Mode)
-    pub mod mode {
-        use super::Mode;
-
         /// Unspecified function calling mode. This value should not be used.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new("MODE_UNSPECIFIED");
+        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
 
         /// Default model behavior, model decides to predict either function calls
         /// or natural language response.
-        pub const AUTO: Mode = Mode::new("AUTO");
+        pub const AUTO: Mode = Mode::new(1);
 
         /// Model is constrained to always predicting function calls only.
         /// If "allowed_function_names" are set, the predicted function calls will be
         /// limited to any one of "allowed_function_names", else the predicted
         /// function calls will be any one of the provided "function_declarations".
-        pub const ANY: Mode = Mode::new("ANY");
+        pub const ANY: Mode = Mode::new(2);
 
         /// Model will not predict any function calls. Model behavior is same as when
         /// not passing any function declarations.
-        pub const NONE: Mode = Mode::new("NONE");
+        pub const NONE: Mode = Mode::new(3);
+
+        /// Creates a new Mode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AUTO"),
+                2 => std::borrow::Cow::Borrowed("ANY"),
+                3 => std::borrow::Cow::Borrowed("NONE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
+                "AUTO" => std::option::Option::Some(Self::AUTO),
+                "ANY" => std::option::Option::Some(Self::ANY),
+                "NONE" => std::option::Option::Some(Self::NONE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Mode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            mode::MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -78498,50 +79845,70 @@ pub mod supervised_hyper_parameters {
 
     /// Supported adapter sizes for tuning.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AdapterSize(std::borrow::Cow<'static, str>);
+    pub struct AdapterSize(i32);
 
     impl AdapterSize {
+        /// Adapter size is unspecified.
+        pub const ADAPTER_SIZE_UNSPECIFIED: AdapterSize = AdapterSize::new(0);
+
+        /// Adapter size 1.
+        pub const ADAPTER_SIZE_ONE: AdapterSize = AdapterSize::new(1);
+
+        /// Adapter size 4.
+        pub const ADAPTER_SIZE_FOUR: AdapterSize = AdapterSize::new(2);
+
+        /// Adapter size 8.
+        pub const ADAPTER_SIZE_EIGHT: AdapterSize = AdapterSize::new(3);
+
+        /// Adapter size 16.
+        pub const ADAPTER_SIZE_SIXTEEN: AdapterSize = AdapterSize::new(4);
+
         /// Creates a new AdapterSize instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ADAPTER_SIZE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ADAPTER_SIZE_ONE"),
+                2 => std::borrow::Cow::Borrowed("ADAPTER_SIZE_FOUR"),
+                3 => std::borrow::Cow::Borrowed("ADAPTER_SIZE_EIGHT"),
+                4 => std::borrow::Cow::Borrowed("ADAPTER_SIZE_SIXTEEN"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ADAPTER_SIZE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ADAPTER_SIZE_UNSPECIFIED)
+                }
+                "ADAPTER_SIZE_ONE" => std::option::Option::Some(Self::ADAPTER_SIZE_ONE),
+                "ADAPTER_SIZE_FOUR" => std::option::Option::Some(Self::ADAPTER_SIZE_FOUR),
+                "ADAPTER_SIZE_EIGHT" => std::option::Option::Some(Self::ADAPTER_SIZE_EIGHT),
+                "ADAPTER_SIZE_SIXTEEN" => std::option::Option::Some(Self::ADAPTER_SIZE_SIXTEEN),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AdapterSize](AdapterSize)
-    pub mod adapter_size {
-        use super::AdapterSize;
-
-        /// Adapter size is unspecified.
-        pub const ADAPTER_SIZE_UNSPECIFIED: AdapterSize =
-            AdapterSize::new("ADAPTER_SIZE_UNSPECIFIED");
-
-        /// Adapter size 1.
-        pub const ADAPTER_SIZE_ONE: AdapterSize = AdapterSize::new("ADAPTER_SIZE_ONE");
-
-        /// Adapter size 4.
-        pub const ADAPTER_SIZE_FOUR: AdapterSize = AdapterSize::new("ADAPTER_SIZE_FOUR");
-
-        /// Adapter size 8.
-        pub const ADAPTER_SIZE_EIGHT: AdapterSize = AdapterSize::new("ADAPTER_SIZE_EIGHT");
-
-        /// Adapter size 16.
-        pub const ADAPTER_SIZE_SIXTEEN: AdapterSize = AdapterSize::new("ADAPTER_SIZE_SIXTEEN");
-    }
-
-    impl std::convert::From<std::string::String> for AdapterSize {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AdapterSize {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AdapterSize {
         fn default() -> Self {
-            adapter_size::ADAPTER_SIZE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -79140,64 +80507,99 @@ pub mod tensor {
 
     /// Data type of the tensor.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataType(std::borrow::Cow<'static, str>);
+    pub struct DataType(i32);
 
     impl DataType {
-        /// Creates a new DataType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DataType](DataType)
-    pub mod data_type {
-        use super::DataType;
-
         /// Not a legal value for DataType. Used to indicate a DataType field has not
         /// been set.
-        pub const DATA_TYPE_UNSPECIFIED: DataType = DataType::new("DATA_TYPE_UNSPECIFIED");
+        pub const DATA_TYPE_UNSPECIFIED: DataType = DataType::new(0);
 
         /// Data types that all computation devices are expected to be
         /// capable to support.
-        pub const BOOL: DataType = DataType::new("BOOL");
+        pub const BOOL: DataType = DataType::new(1);
 
-        pub const STRING: DataType = DataType::new("STRING");
+        pub const STRING: DataType = DataType::new(2);
 
-        pub const FLOAT: DataType = DataType::new("FLOAT");
+        pub const FLOAT: DataType = DataType::new(3);
 
-        pub const DOUBLE: DataType = DataType::new("DOUBLE");
+        pub const DOUBLE: DataType = DataType::new(4);
 
-        pub const INT8: DataType = DataType::new("INT8");
+        pub const INT8: DataType = DataType::new(5);
 
-        pub const INT16: DataType = DataType::new("INT16");
+        pub const INT16: DataType = DataType::new(6);
 
-        pub const INT32: DataType = DataType::new("INT32");
+        pub const INT32: DataType = DataType::new(7);
 
-        pub const INT64: DataType = DataType::new("INT64");
+        pub const INT64: DataType = DataType::new(8);
 
-        pub const UINT8: DataType = DataType::new("UINT8");
+        pub const UINT8: DataType = DataType::new(9);
 
-        pub const UINT16: DataType = DataType::new("UINT16");
+        pub const UINT16: DataType = DataType::new(10);
 
-        pub const UINT32: DataType = DataType::new("UINT32");
+        pub const UINT32: DataType = DataType::new(11);
 
-        pub const UINT64: DataType = DataType::new("UINT64");
+        pub const UINT64: DataType = DataType::new(12);
+
+        /// Creates a new DataType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATA_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BOOL"),
+                2 => std::borrow::Cow::Borrowed("STRING"),
+                3 => std::borrow::Cow::Borrowed("FLOAT"),
+                4 => std::borrow::Cow::Borrowed("DOUBLE"),
+                5 => std::borrow::Cow::Borrowed("INT8"),
+                6 => std::borrow::Cow::Borrowed("INT16"),
+                7 => std::borrow::Cow::Borrowed("INT32"),
+                8 => std::borrow::Cow::Borrowed("INT64"),
+                9 => std::borrow::Cow::Borrowed("UINT8"),
+                10 => std::borrow::Cow::Borrowed("UINT16"),
+                11 => std::borrow::Cow::Borrowed("UINT32"),
+                12 => std::borrow::Cow::Borrowed("UINT64"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATA_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::DATA_TYPE_UNSPECIFIED),
+                "BOOL" => std::option::Option::Some(Self::BOOL),
+                "STRING" => std::option::Option::Some(Self::STRING),
+                "FLOAT" => std::option::Option::Some(Self::FLOAT),
+                "DOUBLE" => std::option::Option::Some(Self::DOUBLE),
+                "INT8" => std::option::Option::Some(Self::INT8),
+                "INT16" => std::option::Option::Some(Self::INT16),
+                "INT32" => std::option::Option::Some(Self::INT32),
+                "INT64" => std::option::Option::Some(Self::INT64),
+                "UINT8" => std::option::Option::Some(Self::UINT8),
+                "UINT16" => std::option::Option::Some(Self::UINT16),
+                "UINT32" => std::option::Option::Some(Self::UINT32),
+                "UINT64" => std::option::Option::Some(Self::UINT64),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DataType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DataType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DataType {
         fn default() -> Self {
-            data_type::DATA_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -79973,44 +81375,59 @@ pub mod file_status {
 
     /// RagFile state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// RagFile state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// RagFile resource has been created and indexed successfully.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(1);
 
         /// RagFile resource is in a problematic state.
         /// See `error_message` field for details.
-        pub const ERROR: State = State::new("ERROR");
+        pub const ERROR: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -80063,47 +81480,64 @@ pub mod corpus_status {
 
     /// RagCorpus life state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// This state is not supposed to happen.
-        pub const UNKNOWN: State = State::new("UNKNOWN");
+        pub const UNKNOWN: State = State::new(0);
 
         /// RagCorpus resource entry is initialized, but hasn't done validation.
-        pub const INITIALIZED: State = State::new("INITIALIZED");
+        pub const INITIALIZED: State = State::new(1);
 
         /// RagCorpus is provisioned successfully and is ready to serve.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(2);
 
         /// RagCorpus is in a problematic situation.
         /// See `error_message` field for details.
-        pub const ERROR: State = State::new("ERROR");
+        pub const ERROR: State = State::new(3);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("INITIALIZED"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                "INITIALIZED" => std::option::Option::Some(Self::INITIALIZED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::UNKNOWN
+            Self::new(0)
         }
     }
 }
@@ -84361,604 +85795,862 @@ impl wkt::message::Message for ListOptimalTrialsResponse {
 
 /// Represents a hardware accelerator type.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AcceleratorType(std::borrow::Cow<'static, str>);
+pub struct AcceleratorType(i32);
 
 impl AcceleratorType {
-    /// Creates a new AcceleratorType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [AcceleratorType](AcceleratorType)
-pub mod accelerator_type {
-    use super::AcceleratorType;
-
     /// Unspecified accelerator type, which means no accelerator.
-    pub const ACCELERATOR_TYPE_UNSPECIFIED: AcceleratorType =
-        AcceleratorType::new("ACCELERATOR_TYPE_UNSPECIFIED");
+    pub const ACCELERATOR_TYPE_UNSPECIFIED: AcceleratorType = AcceleratorType::new(0);
 
     /// Deprecated: Nvidia Tesla K80 GPU has reached end of support,
     /// see <https://cloud.google.com/compute/docs/eol/k80-eol>.
-    pub const NVIDIA_TESLA_K80: AcceleratorType = AcceleratorType::new("NVIDIA_TESLA_K80");
+    pub const NVIDIA_TESLA_K80: AcceleratorType = AcceleratorType::new(1);
 
     /// Nvidia Tesla P100 GPU.
-    pub const NVIDIA_TESLA_P100: AcceleratorType = AcceleratorType::new("NVIDIA_TESLA_P100");
+    pub const NVIDIA_TESLA_P100: AcceleratorType = AcceleratorType::new(2);
 
     /// Nvidia Tesla V100 GPU.
-    pub const NVIDIA_TESLA_V100: AcceleratorType = AcceleratorType::new("NVIDIA_TESLA_V100");
+    pub const NVIDIA_TESLA_V100: AcceleratorType = AcceleratorType::new(3);
 
     /// Nvidia Tesla P4 GPU.
-    pub const NVIDIA_TESLA_P4: AcceleratorType = AcceleratorType::new("NVIDIA_TESLA_P4");
+    pub const NVIDIA_TESLA_P4: AcceleratorType = AcceleratorType::new(4);
 
     /// Nvidia Tesla T4 GPU.
-    pub const NVIDIA_TESLA_T4: AcceleratorType = AcceleratorType::new("NVIDIA_TESLA_T4");
+    pub const NVIDIA_TESLA_T4: AcceleratorType = AcceleratorType::new(5);
 
     /// Nvidia Tesla A100 GPU.
-    pub const NVIDIA_TESLA_A100: AcceleratorType = AcceleratorType::new("NVIDIA_TESLA_A100");
+    pub const NVIDIA_TESLA_A100: AcceleratorType = AcceleratorType::new(8);
 
     /// Nvidia A100 80GB GPU.
-    pub const NVIDIA_A100_80GB: AcceleratorType = AcceleratorType::new("NVIDIA_A100_80GB");
+    pub const NVIDIA_A100_80GB: AcceleratorType = AcceleratorType::new(9);
 
     /// Nvidia L4 GPU.
-    pub const NVIDIA_L4: AcceleratorType = AcceleratorType::new("NVIDIA_L4");
+    pub const NVIDIA_L4: AcceleratorType = AcceleratorType::new(11);
 
     /// Nvidia H100 80Gb GPU.
-    pub const NVIDIA_H100_80GB: AcceleratorType = AcceleratorType::new("NVIDIA_H100_80GB");
+    pub const NVIDIA_H100_80GB: AcceleratorType = AcceleratorType::new(13);
 
     /// Nvidia H100 Mega 80Gb GPU.
-    pub const NVIDIA_H100_MEGA_80GB: AcceleratorType =
-        AcceleratorType::new("NVIDIA_H100_MEGA_80GB");
+    pub const NVIDIA_H100_MEGA_80GB: AcceleratorType = AcceleratorType::new(14);
 
     /// TPU v2.
-    pub const TPU_V2: AcceleratorType = AcceleratorType::new("TPU_V2");
+    pub const TPU_V2: AcceleratorType = AcceleratorType::new(6);
 
     /// TPU v3.
-    pub const TPU_V3: AcceleratorType = AcceleratorType::new("TPU_V3");
+    pub const TPU_V3: AcceleratorType = AcceleratorType::new(7);
 
     /// TPU v4.
-    pub const TPU_V4_POD: AcceleratorType = AcceleratorType::new("TPU_V4_POD");
+    pub const TPU_V4_POD: AcceleratorType = AcceleratorType::new(10);
 
     /// TPU v5.
-    pub const TPU_V5_LITEPOD: AcceleratorType = AcceleratorType::new("TPU_V5_LITEPOD");
+    pub const TPU_V5_LITEPOD: AcceleratorType = AcceleratorType::new(12);
+
+    /// Creates a new AcceleratorType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ACCELERATOR_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_K80"),
+            2 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_P100"),
+            3 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_V100"),
+            4 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_P4"),
+            5 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_T4"),
+            6 => std::borrow::Cow::Borrowed("TPU_V2"),
+            7 => std::borrow::Cow::Borrowed("TPU_V3"),
+            8 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_A100"),
+            9 => std::borrow::Cow::Borrowed("NVIDIA_A100_80GB"),
+            10 => std::borrow::Cow::Borrowed("TPU_V4_POD"),
+            11 => std::borrow::Cow::Borrowed("NVIDIA_L4"),
+            12 => std::borrow::Cow::Borrowed("TPU_V5_LITEPOD"),
+            13 => std::borrow::Cow::Borrowed("NVIDIA_H100_80GB"),
+            14 => std::borrow::Cow::Borrowed("NVIDIA_H100_MEGA_80GB"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ACCELERATOR_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::ACCELERATOR_TYPE_UNSPECIFIED)
+            }
+            "NVIDIA_TESLA_K80" => std::option::Option::Some(Self::NVIDIA_TESLA_K80),
+            "NVIDIA_TESLA_P100" => std::option::Option::Some(Self::NVIDIA_TESLA_P100),
+            "NVIDIA_TESLA_V100" => std::option::Option::Some(Self::NVIDIA_TESLA_V100),
+            "NVIDIA_TESLA_P4" => std::option::Option::Some(Self::NVIDIA_TESLA_P4),
+            "NVIDIA_TESLA_T4" => std::option::Option::Some(Self::NVIDIA_TESLA_T4),
+            "NVIDIA_TESLA_A100" => std::option::Option::Some(Self::NVIDIA_TESLA_A100),
+            "NVIDIA_A100_80GB" => std::option::Option::Some(Self::NVIDIA_A100_80GB),
+            "NVIDIA_L4" => std::option::Option::Some(Self::NVIDIA_L4),
+            "NVIDIA_H100_80GB" => std::option::Option::Some(Self::NVIDIA_H100_80GB),
+            "NVIDIA_H100_MEGA_80GB" => std::option::Option::Some(Self::NVIDIA_H100_MEGA_80GB),
+            "TPU_V2" => std::option::Option::Some(Self::TPU_V2),
+            "TPU_V3" => std::option::Option::Some(Self::TPU_V3),
+            "TPU_V4_POD" => std::option::Option::Some(Self::TPU_V4_POD),
+            "TPU_V5_LITEPOD" => std::option::Option::Some(Self::TPU_V5_LITEPOD),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for AcceleratorType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for AcceleratorType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for AcceleratorType {
     fn default() -> Self {
-        accelerator_type::ACCELERATOR_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Harm categories that will block the content.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct HarmCategory(std::borrow::Cow<'static, str>);
+pub struct HarmCategory(i32);
 
 impl HarmCategory {
+    /// The harm category is unspecified.
+    pub const HARM_CATEGORY_UNSPECIFIED: HarmCategory = HarmCategory::new(0);
+
+    /// The harm category is hate speech.
+    pub const HARM_CATEGORY_HATE_SPEECH: HarmCategory = HarmCategory::new(1);
+
+    /// The harm category is dangerous content.
+    pub const HARM_CATEGORY_DANGEROUS_CONTENT: HarmCategory = HarmCategory::new(2);
+
+    /// The harm category is harassment.
+    pub const HARM_CATEGORY_HARASSMENT: HarmCategory = HarmCategory::new(3);
+
+    /// The harm category is sexually explicit content.
+    pub const HARM_CATEGORY_SEXUALLY_EXPLICIT: HarmCategory = HarmCategory::new(4);
+
+    /// The harm category is civic integrity.
+    pub const HARM_CATEGORY_CIVIC_INTEGRITY: HarmCategory = HarmCategory::new(5);
+
     /// Creates a new HarmCategory instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("HARM_CATEGORY_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("HARM_CATEGORY_HATE_SPEECH"),
+            2 => std::borrow::Cow::Borrowed("HARM_CATEGORY_DANGEROUS_CONTENT"),
+            3 => std::borrow::Cow::Borrowed("HARM_CATEGORY_HARASSMENT"),
+            4 => std::borrow::Cow::Borrowed("HARM_CATEGORY_SEXUALLY_EXPLICIT"),
+            5 => std::borrow::Cow::Borrowed("HARM_CATEGORY_CIVIC_INTEGRITY"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "HARM_CATEGORY_UNSPECIFIED" => {
+                std::option::Option::Some(Self::HARM_CATEGORY_UNSPECIFIED)
+            }
+            "HARM_CATEGORY_HATE_SPEECH" => {
+                std::option::Option::Some(Self::HARM_CATEGORY_HATE_SPEECH)
+            }
+            "HARM_CATEGORY_DANGEROUS_CONTENT" => {
+                std::option::Option::Some(Self::HARM_CATEGORY_DANGEROUS_CONTENT)
+            }
+            "HARM_CATEGORY_HARASSMENT" => std::option::Option::Some(Self::HARM_CATEGORY_HARASSMENT),
+            "HARM_CATEGORY_SEXUALLY_EXPLICIT" => {
+                std::option::Option::Some(Self::HARM_CATEGORY_SEXUALLY_EXPLICIT)
+            }
+            "HARM_CATEGORY_CIVIC_INTEGRITY" => {
+                std::option::Option::Some(Self::HARM_CATEGORY_CIVIC_INTEGRITY)
+            }
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [HarmCategory](HarmCategory)
-pub mod harm_category {
-    use super::HarmCategory;
-
-    /// The harm category is unspecified.
-    pub const HARM_CATEGORY_UNSPECIFIED: HarmCategory =
-        HarmCategory::new("HARM_CATEGORY_UNSPECIFIED");
-
-    /// The harm category is hate speech.
-    pub const HARM_CATEGORY_HATE_SPEECH: HarmCategory =
-        HarmCategory::new("HARM_CATEGORY_HATE_SPEECH");
-
-    /// The harm category is dangerous content.
-    pub const HARM_CATEGORY_DANGEROUS_CONTENT: HarmCategory =
-        HarmCategory::new("HARM_CATEGORY_DANGEROUS_CONTENT");
-
-    /// The harm category is harassment.
-    pub const HARM_CATEGORY_HARASSMENT: HarmCategory =
-        HarmCategory::new("HARM_CATEGORY_HARASSMENT");
-
-    /// The harm category is sexually explicit content.
-    pub const HARM_CATEGORY_SEXUALLY_EXPLICIT: HarmCategory =
-        HarmCategory::new("HARM_CATEGORY_SEXUALLY_EXPLICIT");
-
-    /// The harm category is civic integrity.
-    pub const HARM_CATEGORY_CIVIC_INTEGRITY: HarmCategory =
-        HarmCategory::new("HARM_CATEGORY_CIVIC_INTEGRITY");
-}
-
-impl std::convert::From<std::string::String> for HarmCategory {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for HarmCategory {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for HarmCategory {
     fn default() -> Self {
-        harm_category::HARM_CATEGORY_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Content Part modality
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Modality(std::borrow::Cow<'static, str>);
+pub struct Modality(i32);
 
 impl Modality {
+    /// Unspecified modality.
+    pub const MODALITY_UNSPECIFIED: Modality = Modality::new(0);
+
+    /// Plain text.
+    pub const TEXT: Modality = Modality::new(1);
+
+    /// Image.
+    pub const IMAGE: Modality = Modality::new(2);
+
+    /// Video.
+    pub const VIDEO: Modality = Modality::new(3);
+
+    /// Audio.
+    pub const AUDIO: Modality = Modality::new(4);
+
+    /// Document, e.g. PDF.
+    pub const DOCUMENT: Modality = Modality::new(5);
+
     /// Creates a new Modality instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("MODALITY_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("TEXT"),
+            2 => std::borrow::Cow::Borrowed("IMAGE"),
+            3 => std::borrow::Cow::Borrowed("VIDEO"),
+            4 => std::borrow::Cow::Borrowed("AUDIO"),
+            5 => std::borrow::Cow::Borrowed("DOCUMENT"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "MODALITY_UNSPECIFIED" => std::option::Option::Some(Self::MODALITY_UNSPECIFIED),
+            "TEXT" => std::option::Option::Some(Self::TEXT),
+            "IMAGE" => std::option::Option::Some(Self::IMAGE),
+            "VIDEO" => std::option::Option::Some(Self::VIDEO),
+            "AUDIO" => std::option::Option::Some(Self::AUDIO),
+            "DOCUMENT" => std::option::Option::Some(Self::DOCUMENT),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [Modality](Modality)
-pub mod modality {
-    use super::Modality;
-
-    /// Unspecified modality.
-    pub const MODALITY_UNSPECIFIED: Modality = Modality::new("MODALITY_UNSPECIFIED");
-
-    /// Plain text.
-    pub const TEXT: Modality = Modality::new("TEXT");
-
-    /// Image.
-    pub const IMAGE: Modality = Modality::new("IMAGE");
-
-    /// Video.
-    pub const VIDEO: Modality = Modality::new("VIDEO");
-
-    /// Audio.
-    pub const AUDIO: Modality = Modality::new("AUDIO");
-
-    /// Document, e.g. PDF.
-    pub const DOCUMENT: Modality = Modality::new("DOCUMENT");
-}
-
-impl std::convert::From<std::string::String> for Modality {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Modality {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Modality {
     fn default() -> Self {
-        modality::MODALITY_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Pairwise prediction autorater preference.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PairwiseChoice(std::borrow::Cow<'static, str>);
+pub struct PairwiseChoice(i32);
 
 impl PairwiseChoice {
+    /// Unspecified prediction choice.
+    pub const PAIRWISE_CHOICE_UNSPECIFIED: PairwiseChoice = PairwiseChoice::new(0);
+
+    /// Baseline prediction wins
+    pub const BASELINE: PairwiseChoice = PairwiseChoice::new(1);
+
+    /// Candidate prediction wins
+    pub const CANDIDATE: PairwiseChoice = PairwiseChoice::new(2);
+
+    /// Winner cannot be determined
+    pub const TIE: PairwiseChoice = PairwiseChoice::new(3);
+
     /// Creates a new PairwiseChoice instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("PAIRWISE_CHOICE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("BASELINE"),
+            2 => std::borrow::Cow::Borrowed("CANDIDATE"),
+            3 => std::borrow::Cow::Borrowed("TIE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "PAIRWISE_CHOICE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::PAIRWISE_CHOICE_UNSPECIFIED)
+            }
+            "BASELINE" => std::option::Option::Some(Self::BASELINE),
+            "CANDIDATE" => std::option::Option::Some(Self::CANDIDATE),
+            "TIE" => std::option::Option::Some(Self::TIE),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [PairwiseChoice](PairwiseChoice)
-pub mod pairwise_choice {
-    use super::PairwiseChoice;
-
-    /// Unspecified prediction choice.
-    pub const PAIRWISE_CHOICE_UNSPECIFIED: PairwiseChoice =
-        PairwiseChoice::new("PAIRWISE_CHOICE_UNSPECIFIED");
-
-    /// Baseline prediction wins
-    pub const BASELINE: PairwiseChoice = PairwiseChoice::new("BASELINE");
-
-    /// Candidate prediction wins
-    pub const CANDIDATE: PairwiseChoice = PairwiseChoice::new("CANDIDATE");
-
-    /// Winner cannot be determined
-    pub const TIE: PairwiseChoice = PairwiseChoice::new("TIE");
-}
-
-impl std::convert::From<std::string::String> for PairwiseChoice {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for PairwiseChoice {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for PairwiseChoice {
     fn default() -> Self {
-        pairwise_choice::PAIRWISE_CHOICE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Format of the data in the Feature View.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct FeatureViewDataFormat(std::borrow::Cow<'static, str>);
+pub struct FeatureViewDataFormat(i32);
 
 impl FeatureViewDataFormat {
+    /// Not set. Will be treated as the KeyValue format.
+    pub const FEATURE_VIEW_DATA_FORMAT_UNSPECIFIED: FeatureViewDataFormat =
+        FeatureViewDataFormat::new(0);
+
+    /// Return response data in key-value format.
+    pub const KEY_VALUE: FeatureViewDataFormat = FeatureViewDataFormat::new(1);
+
+    /// Return response data in proto Struct format.
+    pub const PROTO_STRUCT: FeatureViewDataFormat = FeatureViewDataFormat::new(2);
+
     /// Creates a new FeatureViewDataFormat instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("FEATURE_VIEW_DATA_FORMAT_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("KEY_VALUE"),
+            2 => std::borrow::Cow::Borrowed("PROTO_STRUCT"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "FEATURE_VIEW_DATA_FORMAT_UNSPECIFIED" => {
+                std::option::Option::Some(Self::FEATURE_VIEW_DATA_FORMAT_UNSPECIFIED)
+            }
+            "KEY_VALUE" => std::option::Option::Some(Self::KEY_VALUE),
+            "PROTO_STRUCT" => std::option::Option::Some(Self::PROTO_STRUCT),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [FeatureViewDataFormat](FeatureViewDataFormat)
-pub mod feature_view_data_format {
-    use super::FeatureViewDataFormat;
-
-    /// Not set. Will be treated as the KeyValue format.
-    pub const FEATURE_VIEW_DATA_FORMAT_UNSPECIFIED: FeatureViewDataFormat =
-        FeatureViewDataFormat::new("FEATURE_VIEW_DATA_FORMAT_UNSPECIFIED");
-
-    /// Return response data in key-value format.
-    pub const KEY_VALUE: FeatureViewDataFormat = FeatureViewDataFormat::new("KEY_VALUE");
-
-    /// Return response data in proto Struct format.
-    pub const PROTO_STRUCT: FeatureViewDataFormat = FeatureViewDataFormat::new("PROTO_STRUCT");
-}
-
-impl std::convert::From<std::string::String> for FeatureViewDataFormat {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for FeatureViewDataFormat {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for FeatureViewDataFormat {
     fn default() -> Self {
-        feature_view_data_format::FEATURE_VIEW_DATA_FORMAT_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Describes the state of a job.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct JobState(std::borrow::Cow<'static, str>);
+pub struct JobState(i32);
 
 impl JobState {
-    /// Creates a new JobState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [JobState](JobState)
-pub mod job_state {
-    use super::JobState;
-
     /// The job state is unspecified.
-    pub const JOB_STATE_UNSPECIFIED: JobState = JobState::new("JOB_STATE_UNSPECIFIED");
+    pub const JOB_STATE_UNSPECIFIED: JobState = JobState::new(0);
 
     /// The job has been just created or resumed and processing has not yet begun.
-    pub const JOB_STATE_QUEUED: JobState = JobState::new("JOB_STATE_QUEUED");
+    pub const JOB_STATE_QUEUED: JobState = JobState::new(1);
 
     /// The service is preparing to run the job.
-    pub const JOB_STATE_PENDING: JobState = JobState::new("JOB_STATE_PENDING");
+    pub const JOB_STATE_PENDING: JobState = JobState::new(2);
 
     /// The job is in progress.
-    pub const JOB_STATE_RUNNING: JobState = JobState::new("JOB_STATE_RUNNING");
+    pub const JOB_STATE_RUNNING: JobState = JobState::new(3);
 
     /// The job completed successfully.
-    pub const JOB_STATE_SUCCEEDED: JobState = JobState::new("JOB_STATE_SUCCEEDED");
+    pub const JOB_STATE_SUCCEEDED: JobState = JobState::new(4);
 
     /// The job failed.
-    pub const JOB_STATE_FAILED: JobState = JobState::new("JOB_STATE_FAILED");
+    pub const JOB_STATE_FAILED: JobState = JobState::new(5);
 
     /// The job is being cancelled. From this state the job may only go to
     /// either `JOB_STATE_SUCCEEDED`, `JOB_STATE_FAILED` or `JOB_STATE_CANCELLED`.
-    pub const JOB_STATE_CANCELLING: JobState = JobState::new("JOB_STATE_CANCELLING");
+    pub const JOB_STATE_CANCELLING: JobState = JobState::new(6);
 
     /// The job has been cancelled.
-    pub const JOB_STATE_CANCELLED: JobState = JobState::new("JOB_STATE_CANCELLED");
+    pub const JOB_STATE_CANCELLED: JobState = JobState::new(7);
 
     /// The job has been stopped, and can be resumed.
-    pub const JOB_STATE_PAUSED: JobState = JobState::new("JOB_STATE_PAUSED");
+    pub const JOB_STATE_PAUSED: JobState = JobState::new(8);
 
     /// The job has expired.
-    pub const JOB_STATE_EXPIRED: JobState = JobState::new("JOB_STATE_EXPIRED");
+    pub const JOB_STATE_EXPIRED: JobState = JobState::new(9);
 
     /// The job is being updated. Only jobs in the `RUNNING` state can be updated.
     /// After updating, the job goes back to the `RUNNING` state.
-    pub const JOB_STATE_UPDATING: JobState = JobState::new("JOB_STATE_UPDATING");
+    pub const JOB_STATE_UPDATING: JobState = JobState::new(10);
 
     /// The job is partially succeeded, some results may be missing due to errors.
-    pub const JOB_STATE_PARTIALLY_SUCCEEDED: JobState =
-        JobState::new("JOB_STATE_PARTIALLY_SUCCEEDED");
+    pub const JOB_STATE_PARTIALLY_SUCCEEDED: JobState = JobState::new(11);
+
+    /// Creates a new JobState instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("JOB_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("JOB_STATE_QUEUED"),
+            2 => std::borrow::Cow::Borrowed("JOB_STATE_PENDING"),
+            3 => std::borrow::Cow::Borrowed("JOB_STATE_RUNNING"),
+            4 => std::borrow::Cow::Borrowed("JOB_STATE_SUCCEEDED"),
+            5 => std::borrow::Cow::Borrowed("JOB_STATE_FAILED"),
+            6 => std::borrow::Cow::Borrowed("JOB_STATE_CANCELLING"),
+            7 => std::borrow::Cow::Borrowed("JOB_STATE_CANCELLED"),
+            8 => std::borrow::Cow::Borrowed("JOB_STATE_PAUSED"),
+            9 => std::borrow::Cow::Borrowed("JOB_STATE_EXPIRED"),
+            10 => std::borrow::Cow::Borrowed("JOB_STATE_UPDATING"),
+            11 => std::borrow::Cow::Borrowed("JOB_STATE_PARTIALLY_SUCCEEDED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "JOB_STATE_UNSPECIFIED" => std::option::Option::Some(Self::JOB_STATE_UNSPECIFIED),
+            "JOB_STATE_QUEUED" => std::option::Option::Some(Self::JOB_STATE_QUEUED),
+            "JOB_STATE_PENDING" => std::option::Option::Some(Self::JOB_STATE_PENDING),
+            "JOB_STATE_RUNNING" => std::option::Option::Some(Self::JOB_STATE_RUNNING),
+            "JOB_STATE_SUCCEEDED" => std::option::Option::Some(Self::JOB_STATE_SUCCEEDED),
+            "JOB_STATE_FAILED" => std::option::Option::Some(Self::JOB_STATE_FAILED),
+            "JOB_STATE_CANCELLING" => std::option::Option::Some(Self::JOB_STATE_CANCELLING),
+            "JOB_STATE_CANCELLED" => std::option::Option::Some(Self::JOB_STATE_CANCELLED),
+            "JOB_STATE_PAUSED" => std::option::Option::Some(Self::JOB_STATE_PAUSED),
+            "JOB_STATE_EXPIRED" => std::option::Option::Some(Self::JOB_STATE_EXPIRED),
+            "JOB_STATE_UPDATING" => std::option::Option::Some(Self::JOB_STATE_UPDATING),
+            "JOB_STATE_PARTIALLY_SUCCEEDED" => {
+                std::option::Option::Some(Self::JOB_STATE_PARTIALLY_SUCCEEDED)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for JobState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for JobState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for JobState {
     fn default() -> Self {
-        job_state::JOB_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The Model Monitoring Objective types.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ModelDeploymentMonitoringObjectiveType(std::borrow::Cow<'static, str>);
+pub struct ModelDeploymentMonitoringObjectiveType(i32);
 
 impl ModelDeploymentMonitoringObjectiveType {
-    /// Creates a new ModelDeploymentMonitoringObjectiveType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ModelDeploymentMonitoringObjectiveType](ModelDeploymentMonitoringObjectiveType)
-pub mod model_deployment_monitoring_objective_type {
-    use super::ModelDeploymentMonitoringObjectiveType;
-
     /// Default value, should not be set.
     pub const MODEL_DEPLOYMENT_MONITORING_OBJECTIVE_TYPE_UNSPECIFIED:
-        ModelDeploymentMonitoringObjectiveType = ModelDeploymentMonitoringObjectiveType::new(
-        "MODEL_DEPLOYMENT_MONITORING_OBJECTIVE_TYPE_UNSPECIFIED",
-    );
+        ModelDeploymentMonitoringObjectiveType = ModelDeploymentMonitoringObjectiveType::new(0);
 
     /// Raw feature values' stats to detect skew between Training-Prediction
     /// datasets.
     pub const RAW_FEATURE_SKEW: ModelDeploymentMonitoringObjectiveType =
-        ModelDeploymentMonitoringObjectiveType::new("RAW_FEATURE_SKEW");
+        ModelDeploymentMonitoringObjectiveType::new(1);
 
     /// Raw feature values' stats to detect drift between Serving-Prediction
     /// datasets.
     pub const RAW_FEATURE_DRIFT: ModelDeploymentMonitoringObjectiveType =
-        ModelDeploymentMonitoringObjectiveType::new("RAW_FEATURE_DRIFT");
+        ModelDeploymentMonitoringObjectiveType::new(2);
 
     /// Feature attribution scores to detect skew between Training-Prediction
     /// datasets.
     pub const FEATURE_ATTRIBUTION_SKEW: ModelDeploymentMonitoringObjectiveType =
-        ModelDeploymentMonitoringObjectiveType::new("FEATURE_ATTRIBUTION_SKEW");
+        ModelDeploymentMonitoringObjectiveType::new(3);
 
     /// Feature attribution scores to detect skew between Prediction datasets
     /// collected within different time windows.
     pub const FEATURE_ATTRIBUTION_DRIFT: ModelDeploymentMonitoringObjectiveType =
-        ModelDeploymentMonitoringObjectiveType::new("FEATURE_ATTRIBUTION_DRIFT");
+        ModelDeploymentMonitoringObjectiveType::new(4);
+
+    /// Creates a new ModelDeploymentMonitoringObjectiveType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => {
+                std::borrow::Cow::Borrowed("MODEL_DEPLOYMENT_MONITORING_OBJECTIVE_TYPE_UNSPECIFIED")
+            }
+            1 => std::borrow::Cow::Borrowed("RAW_FEATURE_SKEW"),
+            2 => std::borrow::Cow::Borrowed("RAW_FEATURE_DRIFT"),
+            3 => std::borrow::Cow::Borrowed("FEATURE_ATTRIBUTION_SKEW"),
+            4 => std::borrow::Cow::Borrowed("FEATURE_ATTRIBUTION_DRIFT"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "MODEL_DEPLOYMENT_MONITORING_OBJECTIVE_TYPE_UNSPECIFIED" => std::option::Option::Some(
+                Self::MODEL_DEPLOYMENT_MONITORING_OBJECTIVE_TYPE_UNSPECIFIED,
+            ),
+            "RAW_FEATURE_SKEW" => std::option::Option::Some(Self::RAW_FEATURE_SKEW),
+            "RAW_FEATURE_DRIFT" => std::option::Option::Some(Self::RAW_FEATURE_DRIFT),
+            "FEATURE_ATTRIBUTION_SKEW" => std::option::Option::Some(Self::FEATURE_ATTRIBUTION_SKEW),
+            "FEATURE_ATTRIBUTION_DRIFT" => {
+                std::option::Option::Some(Self::FEATURE_ATTRIBUTION_DRIFT)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ModelDeploymentMonitoringObjectiveType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ModelDeploymentMonitoringObjectiveType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ModelDeploymentMonitoringObjectiveType {
     fn default() -> Self {
-        model_deployment_monitoring_objective_type::MODEL_DEPLOYMENT_MONITORING_OBJECTIVE_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// View enumeration of PublisherModel.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PublisherModelView(std::borrow::Cow<'static, str>);
+pub struct PublisherModelView(i32);
 
 impl PublisherModelView {
-    /// Creates a new PublisherModelView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [PublisherModelView](PublisherModelView)
-pub mod publisher_model_view {
-    use super::PublisherModelView;
-
     /// The default / unset value. The API will default to the BASIC view.
-    pub const PUBLISHER_MODEL_VIEW_UNSPECIFIED: PublisherModelView =
-        PublisherModelView::new("PUBLISHER_MODEL_VIEW_UNSPECIFIED");
+    pub const PUBLISHER_MODEL_VIEW_UNSPECIFIED: PublisherModelView = PublisherModelView::new(0);
 
     /// Include basic metadata about the publisher model, but not the full
     /// contents.
-    pub const PUBLISHER_MODEL_VIEW_BASIC: PublisherModelView =
-        PublisherModelView::new("PUBLISHER_MODEL_VIEW_BASIC");
+    pub const PUBLISHER_MODEL_VIEW_BASIC: PublisherModelView = PublisherModelView::new(1);
 
     /// Include everything.
-    pub const PUBLISHER_MODEL_VIEW_FULL: PublisherModelView =
-        PublisherModelView::new("PUBLISHER_MODEL_VIEW_FULL");
+    pub const PUBLISHER_MODEL_VIEW_FULL: PublisherModelView = PublisherModelView::new(2);
 
     /// Include: VersionId, ModelVersionExternalName, and SupportedActions.
-    pub const PUBLISHER_MODEL_VERSION_VIEW_BASIC: PublisherModelView =
-        PublisherModelView::new("PUBLISHER_MODEL_VERSION_VIEW_BASIC");
+    pub const PUBLISHER_MODEL_VERSION_VIEW_BASIC: PublisherModelView = PublisherModelView::new(3);
+
+    /// Creates a new PublisherModelView instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("PUBLISHER_MODEL_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PUBLISHER_MODEL_VIEW_BASIC"),
+            2 => std::borrow::Cow::Borrowed("PUBLISHER_MODEL_VIEW_FULL"),
+            3 => std::borrow::Cow::Borrowed("PUBLISHER_MODEL_VERSION_VIEW_BASIC"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "PUBLISHER_MODEL_VIEW_UNSPECIFIED" => {
+                std::option::Option::Some(Self::PUBLISHER_MODEL_VIEW_UNSPECIFIED)
+            }
+            "PUBLISHER_MODEL_VIEW_BASIC" => {
+                std::option::Option::Some(Self::PUBLISHER_MODEL_VIEW_BASIC)
+            }
+            "PUBLISHER_MODEL_VIEW_FULL" => {
+                std::option::Option::Some(Self::PUBLISHER_MODEL_VIEW_FULL)
+            }
+            "PUBLISHER_MODEL_VERSION_VIEW_BASIC" => {
+                std::option::Option::Some(Self::PUBLISHER_MODEL_VERSION_VIEW_BASIC)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for PublisherModelView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for PublisherModelView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for PublisherModelView {
     fn default() -> Self {
-        publisher_model_view::PUBLISHER_MODEL_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Represents a notebook runtime type.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct NotebookRuntimeType(std::borrow::Cow<'static, str>);
+pub struct NotebookRuntimeType(i32);
 
 impl NotebookRuntimeType {
+    /// Unspecified notebook runtime type, NotebookRuntimeType will default to
+    /// USER_DEFINED.
+    pub const NOTEBOOK_RUNTIME_TYPE_UNSPECIFIED: NotebookRuntimeType = NotebookRuntimeType::new(0);
+
+    /// runtime or template with coustomized configurations from user.
+    pub const USER_DEFINED: NotebookRuntimeType = NotebookRuntimeType::new(1);
+
+    /// runtime or template with system defined configurations.
+    pub const ONE_CLICK: NotebookRuntimeType = NotebookRuntimeType::new(2);
+
     /// Creates a new NotebookRuntimeType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("NOTEBOOK_RUNTIME_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("USER_DEFINED"),
+            2 => std::borrow::Cow::Borrowed("ONE_CLICK"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "NOTEBOOK_RUNTIME_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::NOTEBOOK_RUNTIME_TYPE_UNSPECIFIED)
+            }
+            "USER_DEFINED" => std::option::Option::Some(Self::USER_DEFINED),
+            "ONE_CLICK" => std::option::Option::Some(Self::ONE_CLICK),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [NotebookRuntimeType](NotebookRuntimeType)
-pub mod notebook_runtime_type {
-    use super::NotebookRuntimeType;
-
-    /// Unspecified notebook runtime type, NotebookRuntimeType will default to
-    /// USER_DEFINED.
-    pub const NOTEBOOK_RUNTIME_TYPE_UNSPECIFIED: NotebookRuntimeType =
-        NotebookRuntimeType::new("NOTEBOOK_RUNTIME_TYPE_UNSPECIFIED");
-
-    /// runtime or template with coustomized configurations from user.
-    pub const USER_DEFINED: NotebookRuntimeType = NotebookRuntimeType::new("USER_DEFINED");
-
-    /// runtime or template with system defined configurations.
-    pub const ONE_CLICK: NotebookRuntimeType = NotebookRuntimeType::new("ONE_CLICK");
-}
-
-impl std::convert::From<std::string::String> for NotebookRuntimeType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for NotebookRuntimeType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for NotebookRuntimeType {
     fn default() -> Self {
-        notebook_runtime_type::NOTEBOOK_RUNTIME_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Views for Get/List NotebookExecutionJob
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct NotebookExecutionJobView(std::borrow::Cow<'static, str>);
+pub struct NotebookExecutionJobView(i32);
 
 impl NotebookExecutionJobView {
-    /// Creates a new NotebookExecutionJobView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [NotebookExecutionJobView](NotebookExecutionJobView)
-pub mod notebook_execution_job_view {
-    use super::NotebookExecutionJobView;
-
     /// When unspecified, the API defaults to the BASIC view.
     pub const NOTEBOOK_EXECUTION_JOB_VIEW_UNSPECIFIED: NotebookExecutionJobView =
-        NotebookExecutionJobView::new("NOTEBOOK_EXECUTION_JOB_VIEW_UNSPECIFIED");
+        NotebookExecutionJobView::new(0);
 
     /// Includes all fields except for direct notebook inputs.
     pub const NOTEBOOK_EXECUTION_JOB_VIEW_BASIC: NotebookExecutionJobView =
-        NotebookExecutionJobView::new("NOTEBOOK_EXECUTION_JOB_VIEW_BASIC");
+        NotebookExecutionJobView::new(1);
 
     /// Includes all fields.
     pub const NOTEBOOK_EXECUTION_JOB_VIEW_FULL: NotebookExecutionJobView =
-        NotebookExecutionJobView::new("NOTEBOOK_EXECUTION_JOB_VIEW_FULL");
+        NotebookExecutionJobView::new(2);
+
+    /// Creates a new NotebookExecutionJobView instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("NOTEBOOK_EXECUTION_JOB_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("NOTEBOOK_EXECUTION_JOB_VIEW_BASIC"),
+            2 => std::borrow::Cow::Borrowed("NOTEBOOK_EXECUTION_JOB_VIEW_FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "NOTEBOOK_EXECUTION_JOB_VIEW_UNSPECIFIED" => {
+                std::option::Option::Some(Self::NOTEBOOK_EXECUTION_JOB_VIEW_UNSPECIFIED)
+            }
+            "NOTEBOOK_EXECUTION_JOB_VIEW_BASIC" => {
+                std::option::Option::Some(Self::NOTEBOOK_EXECUTION_JOB_VIEW_BASIC)
+            }
+            "NOTEBOOK_EXECUTION_JOB_VIEW_FULL" => {
+                std::option::Option::Some(Self::NOTEBOOK_EXECUTION_JOB_VIEW_FULL)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for NotebookExecutionJobView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for NotebookExecutionJobView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for NotebookExecutionJobView {
     fn default() -> Self {
-        notebook_execution_job_view::NOTEBOOK_EXECUTION_JOB_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Type contains the list of OpenAPI data types as defined by
 /// <https://swagger.io/docs/specification/data-models/data-types/>
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Type(std::borrow::Cow<'static, str>);
+pub struct Type(i32);
 
 impl Type {
+    /// Not specified, should not be used.
+    pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+    /// OpenAPI string type
+    pub const STRING: Type = Type::new(1);
+
+    /// OpenAPI number type
+    pub const NUMBER: Type = Type::new(2);
+
+    /// OpenAPI integer type
+    pub const INTEGER: Type = Type::new(3);
+
+    /// OpenAPI boolean type
+    pub const BOOLEAN: Type = Type::new(4);
+
+    /// OpenAPI array type
+    pub const ARRAY: Type = Type::new(5);
+
+    /// OpenAPI object type
+    pub const OBJECT: Type = Type::new(6);
+
     /// Creates a new Type instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("STRING"),
+            2 => std::borrow::Cow::Borrowed("NUMBER"),
+            3 => std::borrow::Cow::Borrowed("INTEGER"),
+            4 => std::borrow::Cow::Borrowed("BOOLEAN"),
+            5 => std::borrow::Cow::Borrowed("ARRAY"),
+            6 => std::borrow::Cow::Borrowed("OBJECT"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+            "STRING" => std::option::Option::Some(Self::STRING),
+            "NUMBER" => std::option::Option::Some(Self::NUMBER),
+            "INTEGER" => std::option::Option::Some(Self::INTEGER),
+            "BOOLEAN" => std::option::Option::Some(Self::BOOLEAN),
+            "ARRAY" => std::option::Option::Some(Self::ARRAY),
+            "OBJECT" => std::option::Option::Some(Self::OBJECT),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [Type](Type)
-pub mod r#type {
-    use super::Type;
-
-    /// Not specified, should not be used.
-    pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-    /// OpenAPI string type
-    pub const STRING: Type = Type::new("STRING");
-
-    /// OpenAPI number type
-    pub const NUMBER: Type = Type::new("NUMBER");
-
-    /// OpenAPI integer type
-    pub const INTEGER: Type = Type::new("INTEGER");
-
-    /// OpenAPI boolean type
-    pub const BOOLEAN: Type = Type::new("BOOLEAN");
-
-    /// OpenAPI array type
-    pub const ARRAY: Type = Type::new("ARRAY");
-
-    /// OpenAPI object type
-    pub const OBJECT: Type = Type::new("OBJECT");
-}
-
-impl std::convert::From<std::string::String> for Type {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Type {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Type {
     fn default() -> Self {
-        r#type::TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -84969,114 +86661,162 @@ impl std::default::Default for Type {
 /// any new tasks when a task has failed. Any scheduled tasks will continue to
 /// completion.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PipelineFailurePolicy(std::borrow::Cow<'static, str>);
+pub struct PipelineFailurePolicy(i32);
 
 impl PipelineFailurePolicy {
-    /// Creates a new PipelineFailurePolicy instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [PipelineFailurePolicy](PipelineFailurePolicy)
-pub mod pipeline_failure_policy {
-    use super::PipelineFailurePolicy;
-
     /// Default value, and follows fail slow behavior.
     pub const PIPELINE_FAILURE_POLICY_UNSPECIFIED: PipelineFailurePolicy =
-        PipelineFailurePolicy::new("PIPELINE_FAILURE_POLICY_UNSPECIFIED");
+        PipelineFailurePolicy::new(0);
 
     /// Indicates that the pipeline should continue to run until all possible
     /// tasks have been scheduled and completed.
     pub const PIPELINE_FAILURE_POLICY_FAIL_SLOW: PipelineFailurePolicy =
-        PipelineFailurePolicy::new("PIPELINE_FAILURE_POLICY_FAIL_SLOW");
+        PipelineFailurePolicy::new(1);
 
     /// Indicates that the pipeline should stop scheduling new tasks after a task
     /// has failed.
     pub const PIPELINE_FAILURE_POLICY_FAIL_FAST: PipelineFailurePolicy =
-        PipelineFailurePolicy::new("PIPELINE_FAILURE_POLICY_FAIL_FAST");
+        PipelineFailurePolicy::new(2);
+
+    /// Creates a new PipelineFailurePolicy instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("PIPELINE_FAILURE_POLICY_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PIPELINE_FAILURE_POLICY_FAIL_SLOW"),
+            2 => std::borrow::Cow::Borrowed("PIPELINE_FAILURE_POLICY_FAIL_FAST"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "PIPELINE_FAILURE_POLICY_UNSPECIFIED" => {
+                std::option::Option::Some(Self::PIPELINE_FAILURE_POLICY_UNSPECIFIED)
+            }
+            "PIPELINE_FAILURE_POLICY_FAIL_SLOW" => {
+                std::option::Option::Some(Self::PIPELINE_FAILURE_POLICY_FAIL_SLOW)
+            }
+            "PIPELINE_FAILURE_POLICY_FAIL_FAST" => {
+                std::option::Option::Some(Self::PIPELINE_FAILURE_POLICY_FAIL_FAST)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for PipelineFailurePolicy {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for PipelineFailurePolicy {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for PipelineFailurePolicy {
     fn default() -> Self {
-        pipeline_failure_policy::PIPELINE_FAILURE_POLICY_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Describes the state of a pipeline.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PipelineState(std::borrow::Cow<'static, str>);
+pub struct PipelineState(i32);
 
 impl PipelineState {
-    /// Creates a new PipelineState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [PipelineState](PipelineState)
-pub mod pipeline_state {
-    use super::PipelineState;
-
     /// The pipeline state is unspecified.
-    pub const PIPELINE_STATE_UNSPECIFIED: PipelineState =
-        PipelineState::new("PIPELINE_STATE_UNSPECIFIED");
+    pub const PIPELINE_STATE_UNSPECIFIED: PipelineState = PipelineState::new(0);
 
     /// The pipeline has been created or resumed, and processing has not yet
     /// begun.
-    pub const PIPELINE_STATE_QUEUED: PipelineState = PipelineState::new("PIPELINE_STATE_QUEUED");
+    pub const PIPELINE_STATE_QUEUED: PipelineState = PipelineState::new(1);
 
     /// The service is preparing to run the pipeline.
-    pub const PIPELINE_STATE_PENDING: PipelineState = PipelineState::new("PIPELINE_STATE_PENDING");
+    pub const PIPELINE_STATE_PENDING: PipelineState = PipelineState::new(2);
 
     /// The pipeline is in progress.
-    pub const PIPELINE_STATE_RUNNING: PipelineState = PipelineState::new("PIPELINE_STATE_RUNNING");
+    pub const PIPELINE_STATE_RUNNING: PipelineState = PipelineState::new(3);
 
     /// The pipeline completed successfully.
-    pub const PIPELINE_STATE_SUCCEEDED: PipelineState =
-        PipelineState::new("PIPELINE_STATE_SUCCEEDED");
+    pub const PIPELINE_STATE_SUCCEEDED: PipelineState = PipelineState::new(4);
 
     /// The pipeline failed.
-    pub const PIPELINE_STATE_FAILED: PipelineState = PipelineState::new("PIPELINE_STATE_FAILED");
+    pub const PIPELINE_STATE_FAILED: PipelineState = PipelineState::new(5);
 
     /// The pipeline is being cancelled. From this state, the pipeline may only go
     /// to either PIPELINE_STATE_SUCCEEDED, PIPELINE_STATE_FAILED or
     /// PIPELINE_STATE_CANCELLED.
-    pub const PIPELINE_STATE_CANCELLING: PipelineState =
-        PipelineState::new("PIPELINE_STATE_CANCELLING");
+    pub const PIPELINE_STATE_CANCELLING: PipelineState = PipelineState::new(6);
 
     /// The pipeline has been cancelled.
-    pub const PIPELINE_STATE_CANCELLED: PipelineState =
-        PipelineState::new("PIPELINE_STATE_CANCELLED");
+    pub const PIPELINE_STATE_CANCELLED: PipelineState = PipelineState::new(7);
 
     /// The pipeline has been stopped, and can be resumed.
-    pub const PIPELINE_STATE_PAUSED: PipelineState = PipelineState::new("PIPELINE_STATE_PAUSED");
+    pub const PIPELINE_STATE_PAUSED: PipelineState = PipelineState::new(8);
+
+    /// Creates a new PipelineState instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("PIPELINE_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PIPELINE_STATE_QUEUED"),
+            2 => std::borrow::Cow::Borrowed("PIPELINE_STATE_PENDING"),
+            3 => std::borrow::Cow::Borrowed("PIPELINE_STATE_RUNNING"),
+            4 => std::borrow::Cow::Borrowed("PIPELINE_STATE_SUCCEEDED"),
+            5 => std::borrow::Cow::Borrowed("PIPELINE_STATE_FAILED"),
+            6 => std::borrow::Cow::Borrowed("PIPELINE_STATE_CANCELLING"),
+            7 => std::borrow::Cow::Borrowed("PIPELINE_STATE_CANCELLED"),
+            8 => std::borrow::Cow::Borrowed("PIPELINE_STATE_PAUSED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "PIPELINE_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::PIPELINE_STATE_UNSPECIFIED)
+            }
+            "PIPELINE_STATE_QUEUED" => std::option::Option::Some(Self::PIPELINE_STATE_QUEUED),
+            "PIPELINE_STATE_PENDING" => std::option::Option::Some(Self::PIPELINE_STATE_PENDING),
+            "PIPELINE_STATE_RUNNING" => std::option::Option::Some(Self::PIPELINE_STATE_RUNNING),
+            "PIPELINE_STATE_SUCCEEDED" => std::option::Option::Some(Self::PIPELINE_STATE_SUCCEEDED),
+            "PIPELINE_STATE_FAILED" => std::option::Option::Some(Self::PIPELINE_STATE_FAILED),
+            "PIPELINE_STATE_CANCELLING" => {
+                std::option::Option::Some(Self::PIPELINE_STATE_CANCELLING)
+            }
+            "PIPELINE_STATE_CANCELLED" => std::option::Option::Some(Self::PIPELINE_STATE_CANCELLED),
+            "PIPELINE_STATE_PAUSED" => std::option::Option::Some(Self::PIPELINE_STATE_PAUSED),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for PipelineState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for PipelineState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for PipelineState {
     fn default() -> Self {
-        pipeline_state::PIPELINE_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/aiplatform/v1/src/transport.rs
+++ b/src/generated/cloud/aiplatform/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::DatasetService for DatasetService {
                 reqwest::Method::POST,
                 format!("/v1/{}/datasets", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -71,7 +71,7 @@ impl crate::stubs::DatasetService for DatasetService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -109,7 +109,7 @@ impl crate::stubs::DatasetService for DatasetService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -138,7 +138,7 @@ impl crate::stubs::DatasetService for DatasetService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/datasets", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -171,7 +171,7 @@ impl crate::stubs::DatasetService for DatasetService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -190,7 +190,7 @@ impl crate::stubs::DatasetService for DatasetService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:import", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -207,7 +207,7 @@ impl crate::stubs::DatasetService for DatasetService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:export", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -227,7 +227,7 @@ impl crate::stubs::DatasetService for DatasetService {
                 reqwest::Method::POST,
                 format!("/v1/{}/datasetVersions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -255,7 +255,7 @@ impl crate::stubs::DatasetService for DatasetService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -284,7 +284,7 @@ impl crate::stubs::DatasetService for DatasetService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -303,7 +303,7 @@ impl crate::stubs::DatasetService for DatasetService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -335,7 +335,7 @@ impl crate::stubs::DatasetService for DatasetService {
                 reqwest::Method::GET,
                 format!("/v1/{}/datasetVersions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -368,7 +368,7 @@ impl crate::stubs::DatasetService for DatasetService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}:restore", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -390,7 +390,7 @@ impl crate::stubs::DatasetService for DatasetService {
                 reqwest::Method::GET,
                 format!("/v1/{}/dataItems", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -426,7 +426,7 @@ impl crate::stubs::DatasetService for DatasetService {
                 reqwest::Method::GET,
                 format!("/v1/{}:searchDataItems", req.dataset),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -484,7 +484,7 @@ impl crate::stubs::DatasetService for DatasetService {
                 reqwest::Method::GET,
                 format!("/v1/{}/savedQueries", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -517,7 +517,7 @@ impl crate::stubs::DatasetService for DatasetService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -536,7 +536,7 @@ impl crate::stubs::DatasetService for DatasetService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -568,7 +568,7 @@ impl crate::stubs::DatasetService for DatasetService {
                 reqwest::Method::GET,
                 format!("/v1/{}/annotations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -601,7 +601,7 @@ impl crate::stubs::DatasetService for DatasetService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -623,7 +623,7 @@ impl crate::stubs::DatasetService for DatasetService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -645,7 +645,7 @@ impl crate::stubs::DatasetService for DatasetService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -665,7 +665,7 @@ impl crate::stubs::DatasetService for DatasetService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -697,7 +697,7 @@ impl crate::stubs::DatasetService for DatasetService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -720,7 +720,7 @@ impl crate::stubs::DatasetService for DatasetService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -742,7 +742,7 @@ impl crate::stubs::DatasetService for DatasetService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -761,7 +761,7 @@ impl crate::stubs::DatasetService for DatasetService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -780,7 +780,7 @@ impl crate::stubs::DatasetService for DatasetService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -799,7 +799,7 @@ impl crate::stubs::DatasetService for DatasetService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -868,7 +868,7 @@ impl crate::stubs::DeploymentResourcePoolService for DeploymentResourcePoolServi
                 reqwest::Method::POST,
                 format!("/v1/{}/deploymentResourcePools", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -885,7 +885,7 @@ impl crate::stubs::DeploymentResourcePoolService for DeploymentResourcePoolServi
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -907,7 +907,7 @@ impl crate::stubs::DeploymentResourcePoolService for DeploymentResourcePoolServi
                 reqwest::Method::GET,
                 format!("/v1/{}/deploymentResourcePools", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -937,7 +937,7 @@ impl crate::stubs::DeploymentResourcePoolService for DeploymentResourcePoolServi
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -966,7 +966,7 @@ impl crate::stubs::DeploymentResourcePoolService for DeploymentResourcePoolServi
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -988,7 +988,7 @@ impl crate::stubs::DeploymentResourcePoolService for DeploymentResourcePoolServi
                 reqwest::Method::GET,
                 format!("/v1/{}:queryDeployedModels", req.deployment_resource_pool),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1009,7 +1009,7 @@ impl crate::stubs::DeploymentResourcePoolService for DeploymentResourcePoolServi
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1031,7 +1031,7 @@ impl crate::stubs::DeploymentResourcePoolService for DeploymentResourcePoolServi
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1053,7 +1053,7 @@ impl crate::stubs::DeploymentResourcePoolService for DeploymentResourcePoolServi
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1073,7 +1073,7 @@ impl crate::stubs::DeploymentResourcePoolService for DeploymentResourcePoolServi
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1105,7 +1105,7 @@ impl crate::stubs::DeploymentResourcePoolService for DeploymentResourcePoolServi
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1128,7 +1128,7 @@ impl crate::stubs::DeploymentResourcePoolService for DeploymentResourcePoolServi
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1150,7 +1150,7 @@ impl crate::stubs::DeploymentResourcePoolService for DeploymentResourcePoolServi
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1169,7 +1169,7 @@ impl crate::stubs::DeploymentResourcePoolService for DeploymentResourcePoolServi
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1188,7 +1188,7 @@ impl crate::stubs::DeploymentResourcePoolService for DeploymentResourcePoolServi
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1207,7 +1207,7 @@ impl crate::stubs::DeploymentResourcePoolService for DeploymentResourcePoolServi
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1276,7 +1276,7 @@ impl crate::stubs::EndpointService for EndpointService {
                 reqwest::Method::POST,
                 format!("/v1/{}/endpoints", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1296,7 +1296,7 @@ impl crate::stubs::EndpointService for EndpointService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1318,7 +1318,7 @@ impl crate::stubs::EndpointService for EndpointService {
                 reqwest::Method::GET,
                 format!("/v1/{}/endpoints", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1360,7 +1360,7 @@ impl crate::stubs::EndpointService for EndpointService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1398,7 +1398,7 @@ impl crate::stubs::EndpointService for EndpointService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1415,7 +1415,7 @@ impl crate::stubs::EndpointService for EndpointService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1437,7 +1437,7 @@ impl crate::stubs::EndpointService for EndpointService {
                 reqwest::Method::POST,
                 format!("/v1/{}:deployModel", req.endpoint),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1457,7 +1457,7 @@ impl crate::stubs::EndpointService for EndpointService {
                 reqwest::Method::POST,
                 format!("/v1/{}:undeployModel", req.endpoint),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1477,7 +1477,7 @@ impl crate::stubs::EndpointService for EndpointService {
                 reqwest::Method::POST,
                 format!("/v1/{}:mutateDeployedModel", req.endpoint),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1494,7 +1494,7 @@ impl crate::stubs::EndpointService for EndpointService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1516,7 +1516,7 @@ impl crate::stubs::EndpointService for EndpointService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1538,7 +1538,7 @@ impl crate::stubs::EndpointService for EndpointService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1558,7 +1558,7 @@ impl crate::stubs::EndpointService for EndpointService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1590,7 +1590,7 @@ impl crate::stubs::EndpointService for EndpointService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1613,7 +1613,7 @@ impl crate::stubs::EndpointService for EndpointService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1635,7 +1635,7 @@ impl crate::stubs::EndpointService for EndpointService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1654,7 +1654,7 @@ impl crate::stubs::EndpointService for EndpointService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1673,7 +1673,7 @@ impl crate::stubs::EndpointService for EndpointService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1692,7 +1692,7 @@ impl crate::stubs::EndpointService for EndpointService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1761,7 +1761,7 @@ impl crate::stubs::EvaluationService for EvaluationService {
                 reqwest::Method::POST,
                 format!("/v1/{}:evaluateInstances", req.location),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1778,7 +1778,7 @@ impl crate::stubs::EvaluationService for EvaluationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1800,7 +1800,7 @@ impl crate::stubs::EvaluationService for EvaluationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1822,7 +1822,7 @@ impl crate::stubs::EvaluationService for EvaluationService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1842,7 +1842,7 @@ impl crate::stubs::EvaluationService for EvaluationService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1874,7 +1874,7 @@ impl crate::stubs::EvaluationService for EvaluationService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1897,7 +1897,7 @@ impl crate::stubs::EvaluationService for EvaluationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1919,7 +1919,7 @@ impl crate::stubs::EvaluationService for EvaluationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1938,7 +1938,7 @@ impl crate::stubs::EvaluationService for EvaluationService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1957,7 +1957,7 @@ impl crate::stubs::EvaluationService for EvaluationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1976,7 +1976,7 @@ impl crate::stubs::EvaluationService for EvaluationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2031,7 +2031,7 @@ impl crate::stubs::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminSer
                 reqwest::Method::POST,
                 format!("/v1/{}/featureOnlineStores", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2051,7 +2051,7 @@ impl crate::stubs::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminSer
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2073,7 +2073,7 @@ impl crate::stubs::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminSer
                 reqwest::Method::GET,
                 format!("/v1/{}/featureOnlineStores", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2105,7 +2105,7 @@ impl crate::stubs::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminSer
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2134,7 +2134,7 @@ impl crate::stubs::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminSer
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2157,7 +2157,7 @@ impl crate::stubs::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminSer
                 reqwest::Method::POST,
                 format!("/v1/{}/featureViews", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2178,7 +2178,7 @@ impl crate::stubs::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminSer
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2200,7 +2200,7 @@ impl crate::stubs::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminSer
                 reqwest::Method::GET,
                 format!("/v1/{}/featureViews", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2232,7 +2232,7 @@ impl crate::stubs::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminSer
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2261,7 +2261,7 @@ impl crate::stubs::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminSer
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2283,7 +2283,7 @@ impl crate::stubs::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminSer
                 reqwest::Method::POST,
                 format!("/v1/{}:sync", req.feature_view),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2300,7 +2300,7 @@ impl crate::stubs::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminSer
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2322,7 +2322,7 @@ impl crate::stubs::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminSer
                 reqwest::Method::GET,
                 format!("/v1/{}/featureViewSyncs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2345,7 +2345,7 @@ impl crate::stubs::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminSer
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2367,7 +2367,7 @@ impl crate::stubs::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminSer
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2389,7 +2389,7 @@ impl crate::stubs::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminSer
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2409,7 +2409,7 @@ impl crate::stubs::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminSer
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2441,7 +2441,7 @@ impl crate::stubs::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminSer
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2464,7 +2464,7 @@ impl crate::stubs::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminSer
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2486,7 +2486,7 @@ impl crate::stubs::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminSer
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2505,7 +2505,7 @@ impl crate::stubs::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminSer
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2524,7 +2524,7 @@ impl crate::stubs::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminSer
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2543,7 +2543,7 @@ impl crate::stubs::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminSer
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2612,7 +2612,7 @@ impl crate::stubs::FeatureOnlineStoreService for FeatureOnlineStoreService {
                 reqwest::Method::POST,
                 format!("/v1/{}:fetchFeatureValues", req.feature_view),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2632,7 +2632,7 @@ impl crate::stubs::FeatureOnlineStoreService for FeatureOnlineStoreService {
                 reqwest::Method::POST,
                 format!("/v1/{}:searchNearestEntities", req.feature_view),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2649,7 +2649,7 @@ impl crate::stubs::FeatureOnlineStoreService for FeatureOnlineStoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2671,7 +2671,7 @@ impl crate::stubs::FeatureOnlineStoreService for FeatureOnlineStoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2693,7 +2693,7 @@ impl crate::stubs::FeatureOnlineStoreService for FeatureOnlineStoreService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2713,7 +2713,7 @@ impl crate::stubs::FeatureOnlineStoreService for FeatureOnlineStoreService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2745,7 +2745,7 @@ impl crate::stubs::FeatureOnlineStoreService for FeatureOnlineStoreService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2768,7 +2768,7 @@ impl crate::stubs::FeatureOnlineStoreService for FeatureOnlineStoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2790,7 +2790,7 @@ impl crate::stubs::FeatureOnlineStoreService for FeatureOnlineStoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2809,7 +2809,7 @@ impl crate::stubs::FeatureOnlineStoreService for FeatureOnlineStoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2828,7 +2828,7 @@ impl crate::stubs::FeatureOnlineStoreService for FeatureOnlineStoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2847,7 +2847,7 @@ impl crate::stubs::FeatureOnlineStoreService for FeatureOnlineStoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2902,7 +2902,7 @@ impl crate::stubs::FeatureRegistryService for FeatureRegistryService {
                 reqwest::Method::POST,
                 format!("/v1/{}/featureGroups", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2922,7 +2922,7 @@ impl crate::stubs::FeatureRegistryService for FeatureRegistryService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2944,7 +2944,7 @@ impl crate::stubs::FeatureRegistryService for FeatureRegistryService {
                 reqwest::Method::GET,
                 format!("/v1/{}/featureGroups", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2976,7 +2976,7 @@ impl crate::stubs::FeatureRegistryService for FeatureRegistryService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3005,7 +3005,7 @@ impl crate::stubs::FeatureRegistryService for FeatureRegistryService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3028,7 +3028,7 @@ impl crate::stubs::FeatureRegistryService for FeatureRegistryService {
                 reqwest::Method::POST,
                 format!("/v1/{}/features", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3051,7 +3051,7 @@ impl crate::stubs::FeatureRegistryService for FeatureRegistryService {
                 reqwest::Method::POST,
                 format!("/v1/{}/features:batchCreate", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3068,7 +3068,7 @@ impl crate::stubs::FeatureRegistryService for FeatureRegistryService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3087,7 +3087,7 @@ impl crate::stubs::FeatureRegistryService for FeatureRegistryService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/features", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3130,7 +3130,7 @@ impl crate::stubs::FeatureRegistryService for FeatureRegistryService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3159,7 +3159,7 @@ impl crate::stubs::FeatureRegistryService for FeatureRegistryService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3178,7 +3178,7 @@ impl crate::stubs::FeatureRegistryService for FeatureRegistryService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3200,7 +3200,7 @@ impl crate::stubs::FeatureRegistryService for FeatureRegistryService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3222,7 +3222,7 @@ impl crate::stubs::FeatureRegistryService for FeatureRegistryService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3242,7 +3242,7 @@ impl crate::stubs::FeatureRegistryService for FeatureRegistryService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3274,7 +3274,7 @@ impl crate::stubs::FeatureRegistryService for FeatureRegistryService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3297,7 +3297,7 @@ impl crate::stubs::FeatureRegistryService for FeatureRegistryService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3319,7 +3319,7 @@ impl crate::stubs::FeatureRegistryService for FeatureRegistryService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3338,7 +3338,7 @@ impl crate::stubs::FeatureRegistryService for FeatureRegistryService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3357,7 +3357,7 @@ impl crate::stubs::FeatureRegistryService for FeatureRegistryService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3376,7 +3376,7 @@ impl crate::stubs::FeatureRegistryService for FeatureRegistryService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3445,7 +3445,7 @@ impl crate::stubs::FeaturestoreOnlineServingService for FeaturestoreOnlineServin
                 reqwest::Method::POST,
                 format!("/v1/{}:readFeatureValues", req.entity_type),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3465,7 +3465,7 @@ impl crate::stubs::FeaturestoreOnlineServingService for FeaturestoreOnlineServin
                 reqwest::Method::POST,
                 format!("/v1/{}:writeFeatureValues", req.entity_type),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3482,7 +3482,7 @@ impl crate::stubs::FeaturestoreOnlineServingService for FeaturestoreOnlineServin
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3504,7 +3504,7 @@ impl crate::stubs::FeaturestoreOnlineServingService for FeaturestoreOnlineServin
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3526,7 +3526,7 @@ impl crate::stubs::FeaturestoreOnlineServingService for FeaturestoreOnlineServin
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3546,7 +3546,7 @@ impl crate::stubs::FeaturestoreOnlineServingService for FeaturestoreOnlineServin
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3578,7 +3578,7 @@ impl crate::stubs::FeaturestoreOnlineServingService for FeaturestoreOnlineServin
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3601,7 +3601,7 @@ impl crate::stubs::FeaturestoreOnlineServingService for FeaturestoreOnlineServin
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3623,7 +3623,7 @@ impl crate::stubs::FeaturestoreOnlineServingService for FeaturestoreOnlineServin
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3642,7 +3642,7 @@ impl crate::stubs::FeaturestoreOnlineServingService for FeaturestoreOnlineServin
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3661,7 +3661,7 @@ impl crate::stubs::FeaturestoreOnlineServingService for FeaturestoreOnlineServin
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3680,7 +3680,7 @@ impl crate::stubs::FeaturestoreOnlineServingService for FeaturestoreOnlineServin
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3735,7 +3735,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
                 reqwest::Method::POST,
                 format!("/v1/{}/featurestores", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3755,7 +3755,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3777,7 +3777,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
                 reqwest::Method::GET,
                 format!("/v1/{}/featurestores", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3819,7 +3819,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3848,7 +3848,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3871,7 +3871,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
                 reqwest::Method::POST,
                 format!("/v1/{}/entityTypes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3891,7 +3891,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3913,7 +3913,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
                 reqwest::Method::GET,
                 format!("/v1/{}/entityTypes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3955,7 +3955,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3984,7 +3984,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4007,7 +4007,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
                 reqwest::Method::POST,
                 format!("/v1/{}/features", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4030,7 +4030,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
                 reqwest::Method::POST,
                 format!("/v1/{}/features:batchCreate", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4047,7 +4047,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4066,7 +4066,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/features", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4109,7 +4109,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4138,7 +4138,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4160,7 +4160,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
                 reqwest::Method::POST,
                 format!("/v1/{}:importFeatureValues", req.entity_type),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4180,7 +4180,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
                 reqwest::Method::POST,
                 format!("/v1/{}:batchReadFeatureValues", req.featurestore),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4200,7 +4200,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
                 reqwest::Method::POST,
                 format!("/v1/{}:exportFeatureValues", req.entity_type),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4220,7 +4220,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
                 reqwest::Method::POST,
                 format!("/v1/{}:deleteFeatureValues", req.entity_type),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4240,7 +4240,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
                 reqwest::Method::GET,
                 format!("/v1/{}/featurestores:searchFeatures", req.location),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4262,7 +4262,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4284,7 +4284,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4306,7 +4306,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4326,7 +4326,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4358,7 +4358,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4381,7 +4381,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4403,7 +4403,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4422,7 +4422,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4441,7 +4441,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4460,7 +4460,7 @@ impl crate::stubs::FeaturestoreService for FeaturestoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4529,7 +4529,7 @@ impl crate::stubs::GenAiCacheService for GenAiCacheService {
                 reqwest::Method::POST,
                 format!("/v1/{}/cachedContents", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4548,7 +4548,7 @@ impl crate::stubs::GenAiCacheService for GenAiCacheService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4576,7 +4576,7 @@ impl crate::stubs::GenAiCacheService for GenAiCacheService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4605,7 +4605,7 @@ impl crate::stubs::GenAiCacheService for GenAiCacheService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4627,7 +4627,7 @@ impl crate::stubs::GenAiCacheService for GenAiCacheService {
                 reqwest::Method::GET,
                 format!("/v1/{}/cachedContents", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4648,7 +4648,7 @@ impl crate::stubs::GenAiCacheService for GenAiCacheService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4670,7 +4670,7 @@ impl crate::stubs::GenAiCacheService for GenAiCacheService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4692,7 +4692,7 @@ impl crate::stubs::GenAiCacheService for GenAiCacheService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4712,7 +4712,7 @@ impl crate::stubs::GenAiCacheService for GenAiCacheService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4744,7 +4744,7 @@ impl crate::stubs::GenAiCacheService for GenAiCacheService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4767,7 +4767,7 @@ impl crate::stubs::GenAiCacheService for GenAiCacheService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4789,7 +4789,7 @@ impl crate::stubs::GenAiCacheService for GenAiCacheService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4808,7 +4808,7 @@ impl crate::stubs::GenAiCacheService for GenAiCacheService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4827,7 +4827,7 @@ impl crate::stubs::GenAiCacheService for GenAiCacheService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4846,7 +4846,7 @@ impl crate::stubs::GenAiCacheService for GenAiCacheService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4901,7 +4901,7 @@ impl crate::stubs::GenAiTuningService for GenAiTuningService {
                 reqwest::Method::POST,
                 format!("/v1/{}/tuningJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4920,7 +4920,7 @@ impl crate::stubs::GenAiTuningService for GenAiTuningService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4942,7 +4942,7 @@ impl crate::stubs::GenAiTuningService for GenAiTuningService {
                 reqwest::Method::GET,
                 format!("/v1/{}/tuningJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4964,7 +4964,7 @@ impl crate::stubs::GenAiTuningService for GenAiTuningService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4984,7 +4984,7 @@ impl crate::stubs::GenAiTuningService for GenAiTuningService {
                 reqwest::Method::POST,
                 format!("/v1/{}/tuningJobs:rebaseTunedModel", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5001,7 +5001,7 @@ impl crate::stubs::GenAiTuningService for GenAiTuningService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5023,7 +5023,7 @@ impl crate::stubs::GenAiTuningService for GenAiTuningService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5045,7 +5045,7 @@ impl crate::stubs::GenAiTuningService for GenAiTuningService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5065,7 +5065,7 @@ impl crate::stubs::GenAiTuningService for GenAiTuningService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5097,7 +5097,7 @@ impl crate::stubs::GenAiTuningService for GenAiTuningService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5120,7 +5120,7 @@ impl crate::stubs::GenAiTuningService for GenAiTuningService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5142,7 +5142,7 @@ impl crate::stubs::GenAiTuningService for GenAiTuningService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5161,7 +5161,7 @@ impl crate::stubs::GenAiTuningService for GenAiTuningService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5180,7 +5180,7 @@ impl crate::stubs::GenAiTuningService for GenAiTuningService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5199,7 +5199,7 @@ impl crate::stubs::GenAiTuningService for GenAiTuningService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5268,7 +5268,7 @@ impl crate::stubs::IndexEndpointService for IndexEndpointService {
                 reqwest::Method::POST,
                 format!("/v1/{}/indexEndpoints", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5287,7 +5287,7 @@ impl crate::stubs::IndexEndpointService for IndexEndpointService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5309,7 +5309,7 @@ impl crate::stubs::IndexEndpointService for IndexEndpointService {
                 reqwest::Method::GET,
                 format!("/v1/{}/indexEndpoints", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5350,7 +5350,7 @@ impl crate::stubs::IndexEndpointService for IndexEndpointService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5379,7 +5379,7 @@ impl crate::stubs::IndexEndpointService for IndexEndpointService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5401,7 +5401,7 @@ impl crate::stubs::IndexEndpointService for IndexEndpointService {
                 reqwest::Method::POST,
                 format!("/v1/{}:deployIndex", req.index_endpoint),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5421,7 +5421,7 @@ impl crate::stubs::IndexEndpointService for IndexEndpointService {
                 reqwest::Method::POST,
                 format!("/v1/{}:undeployIndex", req.index_endpoint),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5441,7 +5441,7 @@ impl crate::stubs::IndexEndpointService for IndexEndpointService {
                 reqwest::Method::POST,
                 format!("/v1/{}:mutateDeployedIndex", req.index_endpoint),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5460,7 +5460,7 @@ impl crate::stubs::IndexEndpointService for IndexEndpointService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5482,7 +5482,7 @@ impl crate::stubs::IndexEndpointService for IndexEndpointService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5504,7 +5504,7 @@ impl crate::stubs::IndexEndpointService for IndexEndpointService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5524,7 +5524,7 @@ impl crate::stubs::IndexEndpointService for IndexEndpointService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5556,7 +5556,7 @@ impl crate::stubs::IndexEndpointService for IndexEndpointService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5579,7 +5579,7 @@ impl crate::stubs::IndexEndpointService for IndexEndpointService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5601,7 +5601,7 @@ impl crate::stubs::IndexEndpointService for IndexEndpointService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5620,7 +5620,7 @@ impl crate::stubs::IndexEndpointService for IndexEndpointService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5639,7 +5639,7 @@ impl crate::stubs::IndexEndpointService for IndexEndpointService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5658,7 +5658,7 @@ impl crate::stubs::IndexEndpointService for IndexEndpointService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5724,7 +5724,7 @@ impl crate::stubs::IndexService for IndexService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/indexes", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5741,7 +5741,7 @@ impl crate::stubs::IndexService for IndexService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5760,7 +5760,7 @@ impl crate::stubs::IndexService for IndexService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/indexes", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5801,7 +5801,7 @@ impl crate::stubs::IndexService for IndexService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5828,7 +5828,7 @@ impl crate::stubs::IndexService for IndexService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5850,7 +5850,7 @@ impl crate::stubs::IndexService for IndexService {
                 reqwest::Method::POST,
                 format!("/v1/{}:upsertDatapoints", req.index),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5870,7 +5870,7 @@ impl crate::stubs::IndexService for IndexService {
                 reqwest::Method::POST,
                 format!("/v1/{}:removeDatapoints", req.index),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5887,7 +5887,7 @@ impl crate::stubs::IndexService for IndexService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5909,7 +5909,7 @@ impl crate::stubs::IndexService for IndexService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5931,7 +5931,7 @@ impl crate::stubs::IndexService for IndexService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5951,7 +5951,7 @@ impl crate::stubs::IndexService for IndexService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5983,7 +5983,7 @@ impl crate::stubs::IndexService for IndexService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6006,7 +6006,7 @@ impl crate::stubs::IndexService for IndexService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6028,7 +6028,7 @@ impl crate::stubs::IndexService for IndexService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6047,7 +6047,7 @@ impl crate::stubs::IndexService for IndexService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6066,7 +6066,7 @@ impl crate::stubs::IndexService for IndexService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6085,7 +6085,7 @@ impl crate::stubs::IndexService for IndexService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6154,7 +6154,7 @@ impl crate::stubs::JobService for JobService {
                 reqwest::Method::POST,
                 format!("/v1/{}/customJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6173,7 +6173,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6195,7 +6195,7 @@ impl crate::stubs::JobService for JobService {
                 reqwest::Method::GET,
                 format!("/v1/{}/customJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6227,7 +6227,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6246,7 +6246,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6266,7 +6266,7 @@ impl crate::stubs::JobService for JobService {
                 reqwest::Method::POST,
                 format!("/v1/{}/dataLabelingJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6285,7 +6285,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6307,7 +6307,7 @@ impl crate::stubs::JobService for JobService {
                 reqwest::Method::GET,
                 format!("/v1/{}/dataLabelingJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6340,7 +6340,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6359,7 +6359,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6379,7 +6379,7 @@ impl crate::stubs::JobService for JobService {
                 reqwest::Method::POST,
                 format!("/v1/{}/hyperparameterTuningJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6398,7 +6398,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6420,7 +6420,7 @@ impl crate::stubs::JobService for JobService {
                 reqwest::Method::GET,
                 format!("/v1/{}/hyperparameterTuningJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6452,7 +6452,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6471,7 +6471,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6488,7 +6488,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/nasJobs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6507,7 +6507,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6526,7 +6526,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/nasJobs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6558,7 +6558,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6577,7 +6577,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6594,7 +6594,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6616,7 +6616,7 @@ impl crate::stubs::JobService for JobService {
                 reqwest::Method::GET,
                 format!("/v1/{}/nasTrialDetails", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6640,7 +6640,7 @@ impl crate::stubs::JobService for JobService {
                 reqwest::Method::POST,
                 format!("/v1/{}/batchPredictionJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6659,7 +6659,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6681,7 +6681,7 @@ impl crate::stubs::JobService for JobService {
                 reqwest::Method::GET,
                 format!("/v1/{}/batchPredictionJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6713,7 +6713,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6732,7 +6732,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6752,7 +6752,7 @@ impl crate::stubs::JobService for JobService {
                 reqwest::Method::POST,
                 format!("/v1/{}/modelDeploymentMonitoringJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6777,7 +6777,7 @@ impl crate::stubs::JobService for JobService {
                     req.model_deployment_monitoring_job
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6794,7 +6794,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6816,7 +6816,7 @@ impl crate::stubs::JobService for JobService {
                 reqwest::Method::GET,
                 format!("/v1/{}/modelDeploymentMonitoringJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6859,7 +6859,7 @@ impl crate::stubs::JobService for JobService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6888,7 +6888,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6907,7 +6907,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:pause", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6924,7 +6924,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:resume", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6941,7 +6941,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6963,7 +6963,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -6985,7 +6985,7 @@ impl crate::stubs::JobService for JobService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7005,7 +7005,7 @@ impl crate::stubs::JobService for JobService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7037,7 +7037,7 @@ impl crate::stubs::JobService for JobService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7060,7 +7060,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7082,7 +7082,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7101,7 +7101,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7120,7 +7120,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7139,7 +7139,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7208,7 +7208,7 @@ impl crate::stubs::LlmUtilityService for LlmUtilityService {
                 reqwest::Method::POST,
                 format!("/v1/{}:countTokens", req.endpoint),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7228,7 +7228,7 @@ impl crate::stubs::LlmUtilityService for LlmUtilityService {
                 reqwest::Method::POST,
                 format!("/v1/{}:computeTokens", req.endpoint),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7245,7 +7245,7 @@ impl crate::stubs::LlmUtilityService for LlmUtilityService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7267,7 +7267,7 @@ impl crate::stubs::LlmUtilityService for LlmUtilityService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7289,7 +7289,7 @@ impl crate::stubs::LlmUtilityService for LlmUtilityService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7309,7 +7309,7 @@ impl crate::stubs::LlmUtilityService for LlmUtilityService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7341,7 +7341,7 @@ impl crate::stubs::LlmUtilityService for LlmUtilityService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7364,7 +7364,7 @@ impl crate::stubs::LlmUtilityService for LlmUtilityService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7386,7 +7386,7 @@ impl crate::stubs::LlmUtilityService for LlmUtilityService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7405,7 +7405,7 @@ impl crate::stubs::LlmUtilityService for LlmUtilityService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7424,7 +7424,7 @@ impl crate::stubs::LlmUtilityService for LlmUtilityService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7443,7 +7443,7 @@ impl crate::stubs::LlmUtilityService for LlmUtilityService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7498,7 +7498,7 @@ impl crate::stubs::MatchService for MatchService {
                 reqwest::Method::POST,
                 format!("/v1/{}:findNeighbors", req.index_endpoint),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7518,7 +7518,7 @@ impl crate::stubs::MatchService for MatchService {
                 reqwest::Method::POST,
                 format!("/v1/{}:readIndexDatapoints", req.index_endpoint),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7535,7 +7535,7 @@ impl crate::stubs::MatchService for MatchService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7557,7 +7557,7 @@ impl crate::stubs::MatchService for MatchService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7579,7 +7579,7 @@ impl crate::stubs::MatchService for MatchService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7599,7 +7599,7 @@ impl crate::stubs::MatchService for MatchService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7631,7 +7631,7 @@ impl crate::stubs::MatchService for MatchService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7654,7 +7654,7 @@ impl crate::stubs::MatchService for MatchService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7676,7 +7676,7 @@ impl crate::stubs::MatchService for MatchService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7695,7 +7695,7 @@ impl crate::stubs::MatchService for MatchService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7714,7 +7714,7 @@ impl crate::stubs::MatchService for MatchService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7733,7 +7733,7 @@ impl crate::stubs::MatchService for MatchService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7788,7 +7788,7 @@ impl crate::stubs::MetadataService for MetadataService {
                 reqwest::Method::POST,
                 format!("/v1/{}/metadataStores", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7808,7 +7808,7 @@ impl crate::stubs::MetadataService for MetadataService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7830,7 +7830,7 @@ impl crate::stubs::MetadataService for MetadataService {
                 reqwest::Method::GET,
                 format!("/v1/{}/metadataStores", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7851,7 +7851,7 @@ impl crate::stubs::MetadataService for MetadataService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7874,7 +7874,7 @@ impl crate::stubs::MetadataService for MetadataService {
                 reqwest::Method::POST,
                 format!("/v1/{}/artifacts", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7894,7 +7894,7 @@ impl crate::stubs::MetadataService for MetadataService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7916,7 +7916,7 @@ impl crate::stubs::MetadataService for MetadataService {
                 reqwest::Method::GET,
                 format!("/v1/{}/artifacts", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7948,7 +7948,7 @@ impl crate::stubs::MetadataService for MetadataService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -7978,7 +7978,7 @@ impl crate::stubs::MetadataService for MetadataService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8001,7 +8001,7 @@ impl crate::stubs::MetadataService for MetadataService {
                 reqwest::Method::POST,
                 format!("/v1/{}/artifacts:purge", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8021,7 +8021,7 @@ impl crate::stubs::MetadataService for MetadataService {
                 reqwest::Method::POST,
                 format!("/v1/{}/contexts", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8041,7 +8041,7 @@ impl crate::stubs::MetadataService for MetadataService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8060,7 +8060,7 @@ impl crate::stubs::MetadataService for MetadataService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/contexts", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8092,7 +8092,7 @@ impl crate::stubs::MetadataService for MetadataService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8122,7 +8122,7 @@ impl crate::stubs::MetadataService for MetadataService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8146,7 +8146,7 @@ impl crate::stubs::MetadataService for MetadataService {
                 reqwest::Method::POST,
                 format!("/v1/{}/contexts:purge", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8166,7 +8166,7 @@ impl crate::stubs::MetadataService for MetadataService {
                 reqwest::Method::POST,
                 format!("/v1/{}:addContextArtifactsAndExecutions", req.context),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8186,7 +8186,7 @@ impl crate::stubs::MetadataService for MetadataService {
                 reqwest::Method::POST,
                 format!("/v1/{}:addContextChildren", req.context),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8206,7 +8206,7 @@ impl crate::stubs::MetadataService for MetadataService {
                 reqwest::Method::POST,
                 format!("/v1/{}:removeContextChildren", req.context),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8226,7 +8226,7 @@ impl crate::stubs::MetadataService for MetadataService {
                 reqwest::Method::GET,
                 format!("/v1/{}:queryContextLineageSubgraph", req.context),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8248,7 +8248,7 @@ impl crate::stubs::MetadataService for MetadataService {
                 reqwest::Method::POST,
                 format!("/v1/{}/executions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8268,7 +8268,7 @@ impl crate::stubs::MetadataService for MetadataService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8290,7 +8290,7 @@ impl crate::stubs::MetadataService for MetadataService {
                 reqwest::Method::GET,
                 format!("/v1/{}/executions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8322,7 +8322,7 @@ impl crate::stubs::MetadataService for MetadataService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8352,7 +8352,7 @@ impl crate::stubs::MetadataService for MetadataService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8375,7 +8375,7 @@ impl crate::stubs::MetadataService for MetadataService {
                 reqwest::Method::POST,
                 format!("/v1/{}/executions:purge", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8395,7 +8395,7 @@ impl crate::stubs::MetadataService for MetadataService {
                 reqwest::Method::POST,
                 format!("/v1/{}:addExecutionEvents", req.execution),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8415,7 +8415,7 @@ impl crate::stubs::MetadataService for MetadataService {
                 reqwest::Method::GET,
                 format!("/v1/{}:queryExecutionInputsAndOutputs", req.execution),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8437,7 +8437,7 @@ impl crate::stubs::MetadataService for MetadataService {
                 reqwest::Method::POST,
                 format!("/v1/{}/metadataSchemas", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8457,7 +8457,7 @@ impl crate::stubs::MetadataService for MetadataService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8479,7 +8479,7 @@ impl crate::stubs::MetadataService for MetadataService {
                 reqwest::Method::GET,
                 format!("/v1/{}/metadataSchemas", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8504,7 +8504,7 @@ impl crate::stubs::MetadataService for MetadataService {
                 reqwest::Method::GET,
                 format!("/v1/{}:queryArtifactLineageSubgraph", req.artifact),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8525,7 +8525,7 @@ impl crate::stubs::MetadataService for MetadataService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8547,7 +8547,7 @@ impl crate::stubs::MetadataService for MetadataService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8569,7 +8569,7 @@ impl crate::stubs::MetadataService for MetadataService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8589,7 +8589,7 @@ impl crate::stubs::MetadataService for MetadataService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8621,7 +8621,7 @@ impl crate::stubs::MetadataService for MetadataService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8644,7 +8644,7 @@ impl crate::stubs::MetadataService for MetadataService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8666,7 +8666,7 @@ impl crate::stubs::MetadataService for MetadataService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8685,7 +8685,7 @@ impl crate::stubs::MetadataService for MetadataService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8704,7 +8704,7 @@ impl crate::stubs::MetadataService for MetadataService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8723,7 +8723,7 @@ impl crate::stubs::MetadataService for MetadataService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8792,7 +8792,7 @@ impl crate::stubs::MigrationService for MigrationService {
                 reqwest::Method::POST,
                 format!("/v1/{}/migratableResources:search", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8812,7 +8812,7 @@ impl crate::stubs::MigrationService for MigrationService {
                 reqwest::Method::POST,
                 format!("/v1/{}/migratableResources:batchMigrate", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8829,7 +8829,7 @@ impl crate::stubs::MigrationService for MigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8851,7 +8851,7 @@ impl crate::stubs::MigrationService for MigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8873,7 +8873,7 @@ impl crate::stubs::MigrationService for MigrationService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8893,7 +8893,7 @@ impl crate::stubs::MigrationService for MigrationService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8925,7 +8925,7 @@ impl crate::stubs::MigrationService for MigrationService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8948,7 +8948,7 @@ impl crate::stubs::MigrationService for MigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8970,7 +8970,7 @@ impl crate::stubs::MigrationService for MigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -8989,7 +8989,7 @@ impl crate::stubs::MigrationService for MigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9008,7 +9008,7 @@ impl crate::stubs::MigrationService for MigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9027,7 +9027,7 @@ impl crate::stubs::MigrationService for MigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9093,7 +9093,7 @@ impl crate::stubs::ModelGardenService for ModelGardenService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9116,7 +9116,7 @@ impl crate::stubs::ModelGardenService for ModelGardenService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9138,7 +9138,7 @@ impl crate::stubs::ModelGardenService for ModelGardenService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9160,7 +9160,7 @@ impl crate::stubs::ModelGardenService for ModelGardenService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9180,7 +9180,7 @@ impl crate::stubs::ModelGardenService for ModelGardenService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9212,7 +9212,7 @@ impl crate::stubs::ModelGardenService for ModelGardenService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9235,7 +9235,7 @@ impl crate::stubs::ModelGardenService for ModelGardenService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9257,7 +9257,7 @@ impl crate::stubs::ModelGardenService for ModelGardenService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9276,7 +9276,7 @@ impl crate::stubs::ModelGardenService for ModelGardenService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9295,7 +9295,7 @@ impl crate::stubs::ModelGardenService for ModelGardenService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9314,7 +9314,7 @@ impl crate::stubs::ModelGardenService for ModelGardenService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9369,7 +9369,7 @@ impl crate::stubs::ModelService for ModelService {
                 reqwest::Method::POST,
                 format!("/v1/{}/models:upload", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9386,7 +9386,7 @@ impl crate::stubs::ModelService for ModelService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9405,7 +9405,7 @@ impl crate::stubs::ModelService for ModelService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/models", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9441,7 +9441,7 @@ impl crate::stubs::ModelService for ModelService {
                 reqwest::Method::GET,
                 format!("/v1/{}:listVersions", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9477,7 +9477,7 @@ impl crate::stubs::ModelService for ModelService {
                 reqwest::Method::GET,
                 format!("/v1/{}:listCheckpoints", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9507,7 +9507,7 @@ impl crate::stubs::ModelService for ModelService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9537,7 +9537,7 @@ impl crate::stubs::ModelService for ModelService {
                 reqwest::Method::POST,
                 format!("/v1/{}:updateExplanationDataset", req.model),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9554,7 +9554,7 @@ impl crate::stubs::ModelService for ModelService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9576,7 +9576,7 @@ impl crate::stubs::ModelService for ModelService {
                 reqwest::Method::DELETE,
                 format!("/v1/{}:deleteVersion", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9598,7 +9598,7 @@ impl crate::stubs::ModelService for ModelService {
                 reqwest::Method::POST,
                 format!("/v1/{}:mergeVersionAliases", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9615,7 +9615,7 @@ impl crate::stubs::ModelService for ModelService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:export", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9635,7 +9635,7 @@ impl crate::stubs::ModelService for ModelService {
                 reqwest::Method::POST,
                 format!("/v1/{}/models:copy", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9655,7 +9655,7 @@ impl crate::stubs::ModelService for ModelService {
                 reqwest::Method::POST,
                 format!("/v1/{}/evaluations:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9675,7 +9675,7 @@ impl crate::stubs::ModelService for ModelService {
                 reqwest::Method::POST,
                 format!("/v1/{}/slices:batchImport", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9695,7 +9695,7 @@ impl crate::stubs::ModelService for ModelService {
                 reqwest::Method::POST,
                 format!("/v1/{}:batchImport", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9712,7 +9712,7 @@ impl crate::stubs::ModelService for ModelService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9734,7 +9734,7 @@ impl crate::stubs::ModelService for ModelService {
                 reqwest::Method::GET,
                 format!("/v1/{}/evaluations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9766,7 +9766,7 @@ impl crate::stubs::ModelService for ModelService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9785,7 +9785,7 @@ impl crate::stubs::ModelService for ModelService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/slices", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9817,7 +9817,7 @@ impl crate::stubs::ModelService for ModelService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9839,7 +9839,7 @@ impl crate::stubs::ModelService for ModelService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9861,7 +9861,7 @@ impl crate::stubs::ModelService for ModelService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9881,7 +9881,7 @@ impl crate::stubs::ModelService for ModelService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9913,7 +9913,7 @@ impl crate::stubs::ModelService for ModelService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9936,7 +9936,7 @@ impl crate::stubs::ModelService for ModelService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9958,7 +9958,7 @@ impl crate::stubs::ModelService for ModelService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9977,7 +9977,7 @@ impl crate::stubs::ModelService for ModelService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -9996,7 +9996,7 @@ impl crate::stubs::ModelService for ModelService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10015,7 +10015,7 @@ impl crate::stubs::ModelService for ModelService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10084,7 +10084,7 @@ impl crate::stubs::NotebookService for NotebookService {
                 reqwest::Method::POST,
                 format!("/v1/{}/notebookRuntimeTemplates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10107,7 +10107,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10129,7 +10129,7 @@ impl crate::stubs::NotebookService for NotebookService {
                 reqwest::Method::GET,
                 format!("/v1/{}/notebookRuntimeTemplates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10162,7 +10162,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10190,7 +10190,7 @@ impl crate::stubs::NotebookService for NotebookService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10222,7 +10222,7 @@ impl crate::stubs::NotebookService for NotebookService {
                 reqwest::Method::POST,
                 format!("/v1/{}/notebookRuntimes:assign", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10239,7 +10239,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10261,7 +10261,7 @@ impl crate::stubs::NotebookService for NotebookService {
                 reqwest::Method::GET,
                 format!("/v1/{}/notebookRuntimes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10294,7 +10294,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10313,7 +10313,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:upgrade", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10330,7 +10330,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:start", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10347,7 +10347,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:stop", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10367,7 +10367,7 @@ impl crate::stubs::NotebookService for NotebookService {
                 reqwest::Method::POST,
                 format!("/v1/{}/notebookExecutionJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10387,7 +10387,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10410,7 +10410,7 @@ impl crate::stubs::NotebookService for NotebookService {
                 reqwest::Method::GET,
                 format!("/v1/{}/notebookExecutionJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10434,7 +10434,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10453,7 +10453,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10475,7 +10475,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10497,7 +10497,7 @@ impl crate::stubs::NotebookService for NotebookService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10517,7 +10517,7 @@ impl crate::stubs::NotebookService for NotebookService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10549,7 +10549,7 @@ impl crate::stubs::NotebookService for NotebookService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10572,7 +10572,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10594,7 +10594,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10613,7 +10613,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10632,7 +10632,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10651,7 +10651,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10720,7 +10720,7 @@ impl crate::stubs::PersistentResourceService for PersistentResourceService {
                 reqwest::Method::POST,
                 format!("/v1/{}/persistentResources", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10740,7 +10740,7 @@ impl crate::stubs::PersistentResourceService for PersistentResourceService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10762,7 +10762,7 @@ impl crate::stubs::PersistentResourceService for PersistentResourceService {
                 reqwest::Method::GET,
                 format!("/v1/{}/persistentResources", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10783,7 +10783,7 @@ impl crate::stubs::PersistentResourceService for PersistentResourceService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10811,7 +10811,7 @@ impl crate::stubs::PersistentResourceService for PersistentResourceService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10840,7 +10840,7 @@ impl crate::stubs::PersistentResourceService for PersistentResourceService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:reboot", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10857,7 +10857,7 @@ impl crate::stubs::PersistentResourceService for PersistentResourceService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10879,7 +10879,7 @@ impl crate::stubs::PersistentResourceService for PersistentResourceService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10901,7 +10901,7 @@ impl crate::stubs::PersistentResourceService for PersistentResourceService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10921,7 +10921,7 @@ impl crate::stubs::PersistentResourceService for PersistentResourceService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10953,7 +10953,7 @@ impl crate::stubs::PersistentResourceService for PersistentResourceService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10976,7 +10976,7 @@ impl crate::stubs::PersistentResourceService for PersistentResourceService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -10998,7 +10998,7 @@ impl crate::stubs::PersistentResourceService for PersistentResourceService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11017,7 +11017,7 @@ impl crate::stubs::PersistentResourceService for PersistentResourceService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11036,7 +11036,7 @@ impl crate::stubs::PersistentResourceService for PersistentResourceService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11055,7 +11055,7 @@ impl crate::stubs::PersistentResourceService for PersistentResourceService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11124,7 +11124,7 @@ impl crate::stubs::PipelineService for PipelineService {
                 reqwest::Method::POST,
                 format!("/v1/{}/trainingPipelines", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11143,7 +11143,7 @@ impl crate::stubs::PipelineService for PipelineService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11165,7 +11165,7 @@ impl crate::stubs::PipelineService for PipelineService {
                 reqwest::Method::GET,
                 format!("/v1/{}/trainingPipelines", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11197,7 +11197,7 @@ impl crate::stubs::PipelineService for PipelineService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11216,7 +11216,7 @@ impl crate::stubs::PipelineService for PipelineService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11236,7 +11236,7 @@ impl crate::stubs::PipelineService for PipelineService {
                 reqwest::Method::POST,
                 format!("/v1/{}/pipelineJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11256,7 +11256,7 @@ impl crate::stubs::PipelineService for PipelineService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11278,7 +11278,7 @@ impl crate::stubs::PipelineService for PipelineService {
                 reqwest::Method::GET,
                 format!("/v1/{}/pipelineJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11311,7 +11311,7 @@ impl crate::stubs::PipelineService for PipelineService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11333,7 +11333,7 @@ impl crate::stubs::PipelineService for PipelineService {
                 reqwest::Method::POST,
                 format!("/v1/{}/pipelineJobs:batchDelete", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11350,7 +11350,7 @@ impl crate::stubs::PipelineService for PipelineService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11370,7 +11370,7 @@ impl crate::stubs::PipelineService for PipelineService {
                 reqwest::Method::POST,
                 format!("/v1/{}/pipelineJobs:batchCancel", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11387,7 +11387,7 @@ impl crate::stubs::PipelineService for PipelineService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11409,7 +11409,7 @@ impl crate::stubs::PipelineService for PipelineService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11431,7 +11431,7 @@ impl crate::stubs::PipelineService for PipelineService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11451,7 +11451,7 @@ impl crate::stubs::PipelineService for PipelineService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11483,7 +11483,7 @@ impl crate::stubs::PipelineService for PipelineService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11506,7 +11506,7 @@ impl crate::stubs::PipelineService for PipelineService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11528,7 +11528,7 @@ impl crate::stubs::PipelineService for PipelineService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11547,7 +11547,7 @@ impl crate::stubs::PipelineService for PipelineService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11566,7 +11566,7 @@ impl crate::stubs::PipelineService for PipelineService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11585,7 +11585,7 @@ impl crate::stubs::PipelineService for PipelineService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11654,7 +11654,7 @@ impl crate::stubs::PredictionService for PredictionService {
                 reqwest::Method::POST,
                 format!("/v1/{}:predict", req.endpoint),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11674,7 +11674,7 @@ impl crate::stubs::PredictionService for PredictionService {
                 reqwest::Method::POST,
                 format!("/v1/{}:rawPredict", req.endpoint),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11694,7 +11694,7 @@ impl crate::stubs::PredictionService for PredictionService {
                 reqwest::Method::POST,
                 format!("/v1/{}:directPredict", req.endpoint),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11714,7 +11714,7 @@ impl crate::stubs::PredictionService for PredictionService {
                 reqwest::Method::POST,
                 format!("/v1/{}:directRawPredict", req.endpoint),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11734,7 +11734,7 @@ impl crate::stubs::PredictionService for PredictionService {
                 reqwest::Method::POST,
                 format!("/v1/{}:explain", req.endpoint),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11754,7 +11754,7 @@ impl crate::stubs::PredictionService for PredictionService {
                 reqwest::Method::POST,
                 format!("/v1/{}:generateContent", req.model),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11771,7 +11771,7 @@ impl crate::stubs::PredictionService for PredictionService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11793,7 +11793,7 @@ impl crate::stubs::PredictionService for PredictionService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11815,7 +11815,7 @@ impl crate::stubs::PredictionService for PredictionService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11835,7 +11835,7 @@ impl crate::stubs::PredictionService for PredictionService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11867,7 +11867,7 @@ impl crate::stubs::PredictionService for PredictionService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11890,7 +11890,7 @@ impl crate::stubs::PredictionService for PredictionService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11912,7 +11912,7 @@ impl crate::stubs::PredictionService for PredictionService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11931,7 +11931,7 @@ impl crate::stubs::PredictionService for PredictionService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11950,7 +11950,7 @@ impl crate::stubs::PredictionService for PredictionService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -11969,7 +11969,7 @@ impl crate::stubs::PredictionService for PredictionService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12021,7 +12021,7 @@ impl crate::stubs::ReasoningEngineExecutionService for ReasoningEngineExecutionS
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:query", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12038,7 +12038,7 @@ impl crate::stubs::ReasoningEngineExecutionService for ReasoningEngineExecutionS
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12060,7 +12060,7 @@ impl crate::stubs::ReasoningEngineExecutionService for ReasoningEngineExecutionS
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12082,7 +12082,7 @@ impl crate::stubs::ReasoningEngineExecutionService for ReasoningEngineExecutionS
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12102,7 +12102,7 @@ impl crate::stubs::ReasoningEngineExecutionService for ReasoningEngineExecutionS
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12134,7 +12134,7 @@ impl crate::stubs::ReasoningEngineExecutionService for ReasoningEngineExecutionS
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12157,7 +12157,7 @@ impl crate::stubs::ReasoningEngineExecutionService for ReasoningEngineExecutionS
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12179,7 +12179,7 @@ impl crate::stubs::ReasoningEngineExecutionService for ReasoningEngineExecutionS
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12198,7 +12198,7 @@ impl crate::stubs::ReasoningEngineExecutionService for ReasoningEngineExecutionS
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12217,7 +12217,7 @@ impl crate::stubs::ReasoningEngineExecutionService for ReasoningEngineExecutionS
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12236,7 +12236,7 @@ impl crate::stubs::ReasoningEngineExecutionService for ReasoningEngineExecutionS
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12291,7 +12291,7 @@ impl crate::stubs::ReasoningEngineService for ReasoningEngineService {
                 reqwest::Method::POST,
                 format!("/v1/{}/reasoningEngines", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12310,7 +12310,7 @@ impl crate::stubs::ReasoningEngineService for ReasoningEngineService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12332,7 +12332,7 @@ impl crate::stubs::ReasoningEngineService for ReasoningEngineService {
                 reqwest::Method::GET,
                 format!("/v1/{}/reasoningEngines", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12363,7 +12363,7 @@ impl crate::stubs::ReasoningEngineService for ReasoningEngineService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12392,7 +12392,7 @@ impl crate::stubs::ReasoningEngineService for ReasoningEngineService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12411,7 +12411,7 @@ impl crate::stubs::ReasoningEngineService for ReasoningEngineService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12433,7 +12433,7 @@ impl crate::stubs::ReasoningEngineService for ReasoningEngineService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12455,7 +12455,7 @@ impl crate::stubs::ReasoningEngineService for ReasoningEngineService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12475,7 +12475,7 @@ impl crate::stubs::ReasoningEngineService for ReasoningEngineService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12507,7 +12507,7 @@ impl crate::stubs::ReasoningEngineService for ReasoningEngineService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12530,7 +12530,7 @@ impl crate::stubs::ReasoningEngineService for ReasoningEngineService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12552,7 +12552,7 @@ impl crate::stubs::ReasoningEngineService for ReasoningEngineService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12571,7 +12571,7 @@ impl crate::stubs::ReasoningEngineService for ReasoningEngineService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12590,7 +12590,7 @@ impl crate::stubs::ReasoningEngineService for ReasoningEngineService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12609,7 +12609,7 @@ impl crate::stubs::ReasoningEngineService for ReasoningEngineService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12678,7 +12678,7 @@ impl crate::stubs::ScheduleService for ScheduleService {
                 reqwest::Method::POST,
                 format!("/v1/{}/schedules", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12697,7 +12697,7 @@ impl crate::stubs::ScheduleService for ScheduleService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12716,7 +12716,7 @@ impl crate::stubs::ScheduleService for ScheduleService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12738,7 +12738,7 @@ impl crate::stubs::ScheduleService for ScheduleService {
                 reqwest::Method::GET,
                 format!("/v1/{}/schedules", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12761,7 +12761,7 @@ impl crate::stubs::ScheduleService for ScheduleService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:pause", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12778,7 +12778,7 @@ impl crate::stubs::ScheduleService for ScheduleService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:resume", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12804,7 +12804,7 @@ impl crate::stubs::ScheduleService for ScheduleService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12833,7 +12833,7 @@ impl crate::stubs::ScheduleService for ScheduleService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12855,7 +12855,7 @@ impl crate::stubs::ScheduleService for ScheduleService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12877,7 +12877,7 @@ impl crate::stubs::ScheduleService for ScheduleService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12897,7 +12897,7 @@ impl crate::stubs::ScheduleService for ScheduleService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12929,7 +12929,7 @@ impl crate::stubs::ScheduleService for ScheduleService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12952,7 +12952,7 @@ impl crate::stubs::ScheduleService for ScheduleService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12974,7 +12974,7 @@ impl crate::stubs::ScheduleService for ScheduleService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -12993,7 +12993,7 @@ impl crate::stubs::ScheduleService for ScheduleService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13012,7 +13012,7 @@ impl crate::stubs::ScheduleService for ScheduleService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13031,7 +13031,7 @@ impl crate::stubs::ScheduleService for ScheduleService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13100,7 +13100,7 @@ impl crate::stubs::SpecialistPoolService for SpecialistPoolService {
                 reqwest::Method::POST,
                 format!("/v1/{}/specialistPools", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13119,7 +13119,7 @@ impl crate::stubs::SpecialistPoolService for SpecialistPoolService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13141,7 +13141,7 @@ impl crate::stubs::SpecialistPoolService for SpecialistPoolService {
                 reqwest::Method::GET,
                 format!("/v1/{}/specialistPools", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13172,7 +13172,7 @@ impl crate::stubs::SpecialistPoolService for SpecialistPoolService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13201,7 +13201,7 @@ impl crate::stubs::SpecialistPoolService for SpecialistPoolService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13230,7 +13230,7 @@ impl crate::stubs::SpecialistPoolService for SpecialistPoolService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13252,7 +13252,7 @@ impl crate::stubs::SpecialistPoolService for SpecialistPoolService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13274,7 +13274,7 @@ impl crate::stubs::SpecialistPoolService for SpecialistPoolService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13294,7 +13294,7 @@ impl crate::stubs::SpecialistPoolService for SpecialistPoolService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13326,7 +13326,7 @@ impl crate::stubs::SpecialistPoolService for SpecialistPoolService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13349,7 +13349,7 @@ impl crate::stubs::SpecialistPoolService for SpecialistPoolService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13371,7 +13371,7 @@ impl crate::stubs::SpecialistPoolService for SpecialistPoolService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13390,7 +13390,7 @@ impl crate::stubs::SpecialistPoolService for SpecialistPoolService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13409,7 +13409,7 @@ impl crate::stubs::SpecialistPoolService for SpecialistPoolService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13428,7 +13428,7 @@ impl crate::stubs::SpecialistPoolService for SpecialistPoolService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13497,7 +13497,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
                 reqwest::Method::POST,
                 format!("/v1/{}/tensorboards", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13516,7 +13516,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13544,7 +13544,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13576,7 +13576,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
                 reqwest::Method::GET,
                 format!("/v1/{}/tensorboards", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13609,7 +13609,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13631,7 +13631,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
                 reqwest::Method::GET,
                 format!("/v1/{}:readUsage", req.tensorboard),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13653,7 +13653,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
                 reqwest::Method::GET,
                 format!("/v1/{}:readSize", req.tensorboard),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13675,7 +13675,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
                 reqwest::Method::POST,
                 format!("/v1/{}/experiments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13695,7 +13695,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13723,7 +13723,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13755,7 +13755,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
                 reqwest::Method::GET,
                 format!("/v1/{}/experiments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13788,7 +13788,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13807,7 +13807,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/runs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13830,7 +13830,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
                 reqwest::Method::POST,
                 format!("/v1/{}/runs:batchCreate", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13847,7 +13847,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13875,7 +13875,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13904,7 +13904,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/runs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13937,7 +13937,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13959,7 +13959,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
                 reqwest::Method::POST,
                 format!("/v1/{}:batchCreate", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -13979,7 +13979,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
                 reqwest::Method::POST,
                 format!("/v1/{}/timeSeries", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14000,7 +14000,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14028,7 +14028,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14060,7 +14060,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
                 reqwest::Method::GET,
                 format!("/v1/{}/timeSeries", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14093,7 +14093,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14115,7 +14115,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
                 reqwest::Method::GET,
                 format!("/v1/{}:batchRead", req.tensorboard),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14141,7 +14141,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
                 reqwest::Method::GET,
                 format!("/v1/{}:read", req.tensorboard_time_series),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14165,7 +14165,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
                 reqwest::Method::POST,
                 format!("/v1/{}:write", req.tensorboard_experiment),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14185,7 +14185,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
                 reqwest::Method::POST,
                 format!("/v1/{}:write", req.tensorboard_run),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14208,7 +14208,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
                     req.tensorboard_time_series
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14225,7 +14225,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14247,7 +14247,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14269,7 +14269,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14289,7 +14289,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14321,7 +14321,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14344,7 +14344,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14366,7 +14366,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14385,7 +14385,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14404,7 +14404,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14423,7 +14423,7 @@ impl crate::stubs::TensorboardService for TensorboardService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14492,7 +14492,7 @@ impl crate::stubs::VertexRagDataService for VertexRagDataService {
                 reqwest::Method::POST,
                 format!("/v1/{}/ragCorpora", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14520,7 +14520,7 @@ impl crate::stubs::VertexRagDataService for VertexRagDataService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14539,7 +14539,7 @@ impl crate::stubs::VertexRagDataService for VertexRagDataService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14561,7 +14561,7 @@ impl crate::stubs::VertexRagDataService for VertexRagDataService {
                 reqwest::Method::GET,
                 format!("/v1/{}/ragCorpora", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14582,7 +14582,7 @@ impl crate::stubs::VertexRagDataService for VertexRagDataService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14605,7 +14605,7 @@ impl crate::stubs::VertexRagDataService for VertexRagDataService {
                 reqwest::Method::POST,
                 format!("/v1/{}/ragFiles:upload", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14625,7 +14625,7 @@ impl crate::stubs::VertexRagDataService for VertexRagDataService {
                 reqwest::Method::POST,
                 format!("/v1/{}/ragFiles:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14642,7 +14642,7 @@ impl crate::stubs::VertexRagDataService for VertexRagDataService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14661,7 +14661,7 @@ impl crate::stubs::VertexRagDataService for VertexRagDataService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/ragFiles", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14682,7 +14682,7 @@ impl crate::stubs::VertexRagDataService for VertexRagDataService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14701,7 +14701,7 @@ impl crate::stubs::VertexRagDataService for VertexRagDataService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14723,7 +14723,7 @@ impl crate::stubs::VertexRagDataService for VertexRagDataService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14745,7 +14745,7 @@ impl crate::stubs::VertexRagDataService for VertexRagDataService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14765,7 +14765,7 @@ impl crate::stubs::VertexRagDataService for VertexRagDataService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14797,7 +14797,7 @@ impl crate::stubs::VertexRagDataService for VertexRagDataService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14820,7 +14820,7 @@ impl crate::stubs::VertexRagDataService for VertexRagDataService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14842,7 +14842,7 @@ impl crate::stubs::VertexRagDataService for VertexRagDataService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14861,7 +14861,7 @@ impl crate::stubs::VertexRagDataService for VertexRagDataService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14880,7 +14880,7 @@ impl crate::stubs::VertexRagDataService for VertexRagDataService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14899,7 +14899,7 @@ impl crate::stubs::VertexRagDataService for VertexRagDataService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14968,7 +14968,7 @@ impl crate::stubs::VertexRagService for VertexRagService {
                 reqwest::Method::POST,
                 format!("/v1/{}:retrieveContexts", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -14988,7 +14988,7 @@ impl crate::stubs::VertexRagService for VertexRagService {
                 reqwest::Method::POST,
                 format!("/v1/{}:augmentPrompt", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15008,7 +15008,7 @@ impl crate::stubs::VertexRagService for VertexRagService {
                 reqwest::Method::POST,
                 format!("/v1/{}:corroborateContent", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15025,7 +15025,7 @@ impl crate::stubs::VertexRagService for VertexRagService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15047,7 +15047,7 @@ impl crate::stubs::VertexRagService for VertexRagService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15069,7 +15069,7 @@ impl crate::stubs::VertexRagService for VertexRagService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15089,7 +15089,7 @@ impl crate::stubs::VertexRagService for VertexRagService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15121,7 +15121,7 @@ impl crate::stubs::VertexRagService for VertexRagService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15144,7 +15144,7 @@ impl crate::stubs::VertexRagService for VertexRagService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15166,7 +15166,7 @@ impl crate::stubs::VertexRagService for VertexRagService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15185,7 +15185,7 @@ impl crate::stubs::VertexRagService for VertexRagService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15204,7 +15204,7 @@ impl crate::stubs::VertexRagService for VertexRagService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15223,7 +15223,7 @@ impl crate::stubs::VertexRagService for VertexRagService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15275,7 +15275,7 @@ impl crate::stubs::VizierService for VizierService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/studies", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15292,7 +15292,7 @@ impl crate::stubs::VizierService for VizierService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15311,7 +15311,7 @@ impl crate::stubs::VizierService for VizierService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/studies", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15332,7 +15332,7 @@ impl crate::stubs::VizierService for VizierService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15354,7 +15354,7 @@ impl crate::stubs::VizierService for VizierService {
                 reqwest::Method::POST,
                 format!("/v1/{}/studies:lookup", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15374,7 +15374,7 @@ impl crate::stubs::VizierService for VizierService {
                 reqwest::Method::POST,
                 format!("/v1/{}/trials:suggest", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15391,7 +15391,7 @@ impl crate::stubs::VizierService for VizierService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/trials", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15408,7 +15408,7 @@ impl crate::stubs::VizierService for VizierService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15427,7 +15427,7 @@ impl crate::stubs::VizierService for VizierService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/trials", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15451,7 +15451,7 @@ impl crate::stubs::VizierService for VizierService {
                 reqwest::Method::POST,
                 format!("/v1/{}:addTrialMeasurement", req.trial_name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15468,7 +15468,7 @@ impl crate::stubs::VizierService for VizierService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:complete", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15485,7 +15485,7 @@ impl crate::stubs::VizierService for VizierService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15507,7 +15507,7 @@ impl crate::stubs::VizierService for VizierService {
                 reqwest::Method::POST,
                 format!("/v1/{}:checkTrialEarlyStoppingState", req.trial_name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15524,7 +15524,7 @@ impl crate::stubs::VizierService for VizierService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:stop", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15544,7 +15544,7 @@ impl crate::stubs::VizierService for VizierService {
                 reqwest::Method::POST,
                 format!("/v1/{}/trials:listOptimalTrials", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15561,7 +15561,7 @@ impl crate::stubs::VizierService for VizierService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15583,7 +15583,7 @@ impl crate::stubs::VizierService for VizierService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15605,7 +15605,7 @@ impl crate::stubs::VizierService for VizierService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15625,7 +15625,7 @@ impl crate::stubs::VizierService for VizierService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15657,7 +15657,7 @@ impl crate::stubs::VizierService for VizierService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15680,7 +15680,7 @@ impl crate::stubs::VizierService for VizierService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15702,7 +15702,7 @@ impl crate::stubs::VizierService for VizierService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15721,7 +15721,7 @@ impl crate::stubs::VizierService for VizierService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15740,7 +15740,7 @@ impl crate::stubs::VizierService for VizierService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -15759,7 +15759,7 @@ impl crate::stubs::VizierService for VizierService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/alloydb/connectors/v1/src/model.rs
+++ b/src/generated/cloud/alloydb/connectors/v1/src/model.rs
@@ -89,43 +89,58 @@ pub mod metadata_exchange_request {
 
     /// AuthType contains all supported authentication types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AuthType(std::borrow::Cow<'static, str>);
+    pub struct AuthType(i32);
 
     impl AuthType {
+        /// Authentication type is unspecified and DB_NATIVE is used by default
+        pub const AUTH_TYPE_UNSPECIFIED: AuthType = AuthType::new(0);
+
+        /// Database native authentication (user/password)
+        pub const DB_NATIVE: AuthType = AuthType::new(1);
+
+        /// Automatic IAM authentication
+        pub const AUTO_IAM: AuthType = AuthType::new(2);
+
         /// Creates a new AuthType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("AUTH_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DB_NATIVE"),
+                2 => std::borrow::Cow::Borrowed("AUTO_IAM"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "AUTH_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::AUTH_TYPE_UNSPECIFIED),
+                "DB_NATIVE" => std::option::Option::Some(Self::DB_NATIVE),
+                "AUTO_IAM" => std::option::Option::Some(Self::AUTO_IAM),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AuthType](AuthType)
-    pub mod auth_type {
-        use super::AuthType;
-
-        /// Authentication type is unspecified and DB_NATIVE is used by default
-        pub const AUTH_TYPE_UNSPECIFIED: AuthType = AuthType::new("AUTH_TYPE_UNSPECIFIED");
-
-        /// Database native authentication (user/password)
-        pub const DB_NATIVE: AuthType = AuthType::new("DB_NATIVE");
-
-        /// Automatic IAM authentication
-        pub const AUTO_IAM: AuthType = AuthType::new("AUTO_IAM");
-    }
-
-    impl std::convert::From<std::string::String> for AuthType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AuthType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AuthType {
         fn default() -> Self {
-            auth_type::AUTH_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -182,44 +197,60 @@ pub mod metadata_exchange_response {
 
     /// Response code.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ResponseCode(std::borrow::Cow<'static, str>);
+    pub struct ResponseCode(i32);
 
     impl ResponseCode {
+        /// Unknown response code
+        pub const RESPONSE_CODE_UNSPECIFIED: ResponseCode = ResponseCode::new(0);
+
+        /// Success
+        pub const OK: ResponseCode = ResponseCode::new(1);
+
+        /// Failure
+        pub const ERROR: ResponseCode = ResponseCode::new(2);
+
         /// Creates a new ResponseCode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RESPONSE_CODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("OK"),
+                2 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RESPONSE_CODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RESPONSE_CODE_UNSPECIFIED)
+                }
+                "OK" => std::option::Option::Some(Self::OK),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ResponseCode](ResponseCode)
-    pub mod response_code {
-        use super::ResponseCode;
-
-        /// Unknown response code
-        pub const RESPONSE_CODE_UNSPECIFIED: ResponseCode =
-            ResponseCode::new("RESPONSE_CODE_UNSPECIFIED");
-
-        /// Success
-        pub const OK: ResponseCode = ResponseCode::new("OK");
-
-        /// Failure
-        pub const ERROR: ResponseCode = ResponseCode::new("ERROR");
-    }
-
-    impl std::convert::From<std::string::String> for ResponseCode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ResponseCode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ResponseCode {
         fn default() -> Self {
-            response_code::RESPONSE_CODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/alloydb/v1/src/model.rs
+++ b/src/generated/cloud/alloydb/v1/src/model.rs
@@ -309,41 +309,56 @@ pub mod migration_source {
 
     /// Denote the type of migration source that created this cluster.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MigrationSourceType(std::borrow::Cow<'static, str>);
+    pub struct MigrationSourceType(i32);
 
     impl MigrationSourceType {
+        /// Migration source is unknown.
+        pub const MIGRATION_SOURCE_TYPE_UNSPECIFIED: MigrationSourceType =
+            MigrationSourceType::new(0);
+
+        /// DMS source means the cluster was created via DMS migration job.
+        pub const DMS: MigrationSourceType = MigrationSourceType::new(1);
+
         /// Creates a new MigrationSourceType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MIGRATION_SOURCE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DMS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MIGRATION_SOURCE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MIGRATION_SOURCE_TYPE_UNSPECIFIED)
+                }
+                "DMS" => std::option::Option::Some(Self::DMS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [MigrationSourceType](MigrationSourceType)
-    pub mod migration_source_type {
-        use super::MigrationSourceType;
-
-        /// Migration source is unknown.
-        pub const MIGRATION_SOURCE_TYPE_UNSPECIFIED: MigrationSourceType =
-            MigrationSourceType::new("MIGRATION_SOURCE_TYPE_UNSPECIFIED");
-
-        /// DMS source means the cluster was created via DMS migration job.
-        pub const DMS: MigrationSourceType = MigrationSourceType::new("DMS");
-    }
-
-    impl std::convert::From<std::string::String> for MigrationSourceType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MigrationSourceType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MigrationSourceType {
         fn default() -> Self {
-            migration_source_type::MIGRATION_SOURCE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -434,45 +449,64 @@ pub mod encryption_info {
 
     /// Possible encryption types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// Encryption type not specified. Defaults to GOOGLE_DEFAULT_ENCRYPTION.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// The data is encrypted at rest with a key that is fully managed by Google.
         /// No key version will be populated. This is the default state.
-        pub const GOOGLE_DEFAULT_ENCRYPTION: Type = Type::new("GOOGLE_DEFAULT_ENCRYPTION");
+        pub const GOOGLE_DEFAULT_ENCRYPTION: Type = Type::new(1);
 
         /// The data is encrypted at rest with a key that is managed by the customer.
         /// KMS key versions will be populated.
-        pub const CUSTOMER_MANAGED_ENCRYPTION: Type = Type::new("CUSTOMER_MANAGED_ENCRYPTION");
+        pub const CUSTOMER_MANAGED_ENCRYPTION: Type = Type::new(2);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GOOGLE_DEFAULT_ENCRYPTION"),
+                2 => std::borrow::Cow::Borrowed("CUSTOMER_MANAGED_ENCRYPTION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "GOOGLE_DEFAULT_ENCRYPTION" => {
+                    std::option::Option::Some(Self::GOOGLE_DEFAULT_ENCRYPTION)
+                }
+                "CUSTOMER_MANAGED_ENCRYPTION" => {
+                    std::option::Option::Some(Self::CUSTOMER_MANAGED_ENCRYPTION)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -528,97 +562,132 @@ pub mod ssl_config {
 
     /// SSL mode options.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SslMode(std::borrow::Cow<'static, str>);
+    pub struct SslMode(i32);
 
     impl SslMode {
-        /// Creates a new SslMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [SslMode](SslMode)
-    pub mod ssl_mode {
-        use super::SslMode;
-
         /// SSL mode is not specified. Defaults to ENCRYPTED_ONLY.
-        pub const SSL_MODE_UNSPECIFIED: SslMode = SslMode::new("SSL_MODE_UNSPECIFIED");
+        pub const SSL_MODE_UNSPECIFIED: SslMode = SslMode::new(0);
 
         /// SSL connections are optional. CA verification not enforced.
-        pub const SSL_MODE_ALLOW: SslMode = SslMode::new("SSL_MODE_ALLOW");
+        pub const SSL_MODE_ALLOW: SslMode = SslMode::new(1);
 
         /// SSL connections are required. CA verification not enforced.
         /// Clients may use locally self-signed certificates (default psql client
         /// behavior).
-        pub const SSL_MODE_REQUIRE: SslMode = SslMode::new("SSL_MODE_REQUIRE");
+        pub const SSL_MODE_REQUIRE: SslMode = SslMode::new(2);
 
         /// SSL connections are required. CA verification enforced.
         /// Clients must have certificates signed by a Cluster CA, for example, using
         /// GenerateClientCertificate.
-        pub const SSL_MODE_VERIFY_CA: SslMode = SslMode::new("SSL_MODE_VERIFY_CA");
+        pub const SSL_MODE_VERIFY_CA: SslMode = SslMode::new(3);
 
         /// SSL connections are optional. CA verification not enforced.
-        pub const ALLOW_UNENCRYPTED_AND_ENCRYPTED: SslMode =
-            SslMode::new("ALLOW_UNENCRYPTED_AND_ENCRYPTED");
+        pub const ALLOW_UNENCRYPTED_AND_ENCRYPTED: SslMode = SslMode::new(4);
 
         /// SSL connections are required. CA verification not enforced.
-        pub const ENCRYPTED_ONLY: SslMode = SslMode::new("ENCRYPTED_ONLY");
+        pub const ENCRYPTED_ONLY: SslMode = SslMode::new(5);
+
+        /// Creates a new SslMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SSL_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SSL_MODE_ALLOW"),
+                2 => std::borrow::Cow::Borrowed("SSL_MODE_REQUIRE"),
+                3 => std::borrow::Cow::Borrowed("SSL_MODE_VERIFY_CA"),
+                4 => std::borrow::Cow::Borrowed("ALLOW_UNENCRYPTED_AND_ENCRYPTED"),
+                5 => std::borrow::Cow::Borrowed("ENCRYPTED_ONLY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SSL_MODE_UNSPECIFIED" => std::option::Option::Some(Self::SSL_MODE_UNSPECIFIED),
+                "SSL_MODE_ALLOW" => std::option::Option::Some(Self::SSL_MODE_ALLOW),
+                "SSL_MODE_REQUIRE" => std::option::Option::Some(Self::SSL_MODE_REQUIRE),
+                "SSL_MODE_VERIFY_CA" => std::option::Option::Some(Self::SSL_MODE_VERIFY_CA),
+                "ALLOW_UNENCRYPTED_AND_ENCRYPTED" => {
+                    std::option::Option::Some(Self::ALLOW_UNENCRYPTED_AND_ENCRYPTED)
+                }
+                "ENCRYPTED_ONLY" => std::option::Option::Some(Self::ENCRYPTED_ONLY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for SslMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SslMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SslMode {
         fn default() -> Self {
-            ssl_mode::SSL_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Certificate Authority (CA) source for SSL/TLS certificates.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CaSource(std::borrow::Cow<'static, str>);
+    pub struct CaSource(i32);
 
     impl CaSource {
+        /// Certificate Authority (CA) source not specified. Defaults to
+        /// CA_SOURCE_MANAGED.
+        pub const CA_SOURCE_UNSPECIFIED: CaSource = CaSource::new(0);
+
+        /// Certificate Authority (CA) managed by the AlloyDB Cluster.
+        pub const CA_SOURCE_MANAGED: CaSource = CaSource::new(1);
+
         /// Creates a new CaSource instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CA_SOURCE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CA_SOURCE_MANAGED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CA_SOURCE_UNSPECIFIED" => std::option::Option::Some(Self::CA_SOURCE_UNSPECIFIED),
+                "CA_SOURCE_MANAGED" => std::option::Option::Some(Self::CA_SOURCE_MANAGED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [CaSource](CaSource)
-    pub mod ca_source {
-        use super::CaSource;
-
-        /// Certificate Authority (CA) source not specified. Defaults to
-        /// CA_SOURCE_MANAGED.
-        pub const CA_SOURCE_UNSPECIFIED: CaSource = CaSource::new("CA_SOURCE_UNSPECIFIED");
-
-        /// Certificate Authority (CA) managed by the AlloyDB Cluster.
-        pub const CA_SOURCE_MANAGED: CaSource = CaSource::new("CA_SOURCE_MANAGED");
-    }
-
-    impl std::convert::From<std::string::String> for CaSource {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CaSource {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CaSource {
         fn default() -> Self {
-            ca_source::CA_SOURCE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2160,116 +2229,161 @@ pub mod cluster {
 
     /// Cluster State
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The state of the cluster is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The cluster is active and running.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(1);
 
         /// The cluster is stopped. All instances in the cluster are stopped.
         /// Customers can start a stopped cluster at any point and all their
         /// instances will come back to life with same names and IP resources. In
         /// this state, customer pays for storage.
         /// Associated backups could also be present in a stopped cluster.
-        pub const STOPPED: State = State::new("STOPPED");
+        pub const STOPPED: State = State::new(2);
 
         /// The cluster is empty and has no associated resources.
         /// All instances, associated storage and backups have been deleted.
-        pub const EMPTY: State = State::new("EMPTY");
+        pub const EMPTY: State = State::new(3);
 
         /// The cluster is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(4);
 
         /// The cluster is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(5);
 
         /// The creation of the cluster failed.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(6);
 
         /// The cluster is bootstrapping with data from some other source.
         /// Direct mutations to the cluster (e.g. adding read pool) are not allowed.
-        pub const BOOTSTRAPPING: State = State::new("BOOTSTRAPPING");
+        pub const BOOTSTRAPPING: State = State::new(7);
 
         /// The cluster is under maintenance. AlloyDB regularly performs maintenance
         /// and upgrades on customer clusters. Updates on the cluster are
         /// not allowed while the cluster is in this state.
-        pub const MAINTENANCE: State = State::new("MAINTENANCE");
+        pub const MAINTENANCE: State = State::new(8);
 
         /// The cluster is being promoted.
-        pub const PROMOTING: State = State::new("PROMOTING");
+        pub const PROMOTING: State = State::new(9);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("READY"),
+                2 => std::borrow::Cow::Borrowed("STOPPED"),
+                3 => std::borrow::Cow::Borrowed("EMPTY"),
+                4 => std::borrow::Cow::Borrowed("CREATING"),
+                5 => std::borrow::Cow::Borrowed("DELETING"),
+                6 => std::borrow::Cow::Borrowed("FAILED"),
+                7 => std::borrow::Cow::Borrowed("BOOTSTRAPPING"),
+                8 => std::borrow::Cow::Borrowed("MAINTENANCE"),
+                9 => std::borrow::Cow::Borrowed("PROMOTING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "READY" => std::option::Option::Some(Self::READY),
+                "STOPPED" => std::option::Option::Some(Self::STOPPED),
+                "EMPTY" => std::option::Option::Some(Self::EMPTY),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "BOOTSTRAPPING" => std::option::Option::Some(Self::BOOTSTRAPPING),
+                "MAINTENANCE" => std::option::Option::Some(Self::MAINTENANCE),
+                "PROMOTING" => std::option::Option::Some(Self::PROMOTING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Type of Cluster
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ClusterType(std::borrow::Cow<'static, str>);
+    pub struct ClusterType(i32);
 
     impl ClusterType {
-        /// Creates a new ClusterType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ClusterType](ClusterType)
-    pub mod cluster_type {
-        use super::ClusterType;
-
         /// The type of the cluster is unknown.
-        pub const CLUSTER_TYPE_UNSPECIFIED: ClusterType =
-            ClusterType::new("CLUSTER_TYPE_UNSPECIFIED");
+        pub const CLUSTER_TYPE_UNSPECIFIED: ClusterType = ClusterType::new(0);
 
         /// Primary cluster that support read and write operations.
-        pub const PRIMARY: ClusterType = ClusterType::new("PRIMARY");
+        pub const PRIMARY: ClusterType = ClusterType::new(1);
 
         /// Secondary cluster that is replicating from another region.
         /// This only supports read.
-        pub const SECONDARY: ClusterType = ClusterType::new("SECONDARY");
+        pub const SECONDARY: ClusterType = ClusterType::new(2);
+
+        /// Creates a new ClusterType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CLUSTER_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PRIMARY"),
+                2 => std::borrow::Cow::Borrowed("SECONDARY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CLUSTER_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CLUSTER_TYPE_UNSPECIFIED)
+                }
+                "PRIMARY" => std::option::Option::Some(Self::PRIMARY),
+                "SECONDARY" => std::option::Option::Some(Self::SECONDARY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ClusterType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ClusterType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ClusterType {
         fn default() -> Self {
-            cluster_type::CLUSTER_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -3108,96 +3222,107 @@ pub mod instance {
 
     /// Instance State
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The state of the instance is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The instance is active and running.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(1);
 
         /// The instance is stopped. Instance name and IP resources are preserved.
-        pub const STOPPED: State = State::new("STOPPED");
+        pub const STOPPED: State = State::new(2);
 
         /// The instance is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(3);
 
         /// The instance is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(4);
 
         /// The instance is down for maintenance.
-        pub const MAINTENANCE: State = State::new("MAINTENANCE");
+        pub const MAINTENANCE: State = State::new(5);
 
         /// The creation of the instance failed or a fatal error occurred during
         /// an operation on the instance.
         /// Note: Instances in this state would tried to be auto-repaired. And
         /// Customers should be able to restart, update or delete these instances.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(6);
 
         /// Index 7 is used in the producer apis for ROLLED_BACK state. Keeping that
         /// index unused in case that state also needs to exposed via consumer apis
         /// in future.
         /// The instance has been configured to sync data from some other source.
-        pub const BOOTSTRAPPING: State = State::new("BOOTSTRAPPING");
+        pub const BOOTSTRAPPING: State = State::new(8);
 
         /// The instance is being promoted.
-        pub const PROMOTING: State = State::new("PROMOTING");
+        pub const PROMOTING: State = State::new(9);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("READY"),
+                2 => std::borrow::Cow::Borrowed("STOPPED"),
+                3 => std::borrow::Cow::Borrowed("CREATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("MAINTENANCE"),
+                6 => std::borrow::Cow::Borrowed("FAILED"),
+                8 => std::borrow::Cow::Borrowed("BOOTSTRAPPING"),
+                9 => std::borrow::Cow::Borrowed("PROMOTING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "READY" => std::option::Option::Some(Self::READY),
+                "STOPPED" => std::option::Option::Some(Self::STOPPED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "MAINTENANCE" => std::option::Option::Some(Self::MAINTENANCE),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "BOOTSTRAPPING" => std::option::Option::Some(Self::BOOTSTRAPPING),
+                "PROMOTING" => std::option::Option::Some(Self::PROMOTING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Type of an Instance
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct InstanceType(std::borrow::Cow<'static, str>);
+    pub struct InstanceType(i32);
 
     impl InstanceType {
-        /// Creates a new InstanceType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [InstanceType](InstanceType)
-    pub mod instance_type {
-        use super::InstanceType;
-
         /// The type of the instance is unknown.
-        pub const INSTANCE_TYPE_UNSPECIFIED: InstanceType =
-            InstanceType::new("INSTANCE_TYPE_UNSPECIFIED");
+        pub const INSTANCE_TYPE_UNSPECIFIED: InstanceType = InstanceType::new(0);
 
         /// PRIMARY instances support read and write operations.
-        pub const PRIMARY: InstanceType = InstanceType::new("PRIMARY");
+        pub const PRIMARY: InstanceType = InstanceType::new(1);
 
         /// READ POOL instances support read operations only. Each read pool instance
         /// consists of one or more homogeneous nodes.
@@ -3205,22 +3330,56 @@ pub mod instance {
         /// * Read pool of size 1 can only have zonal availability.
         /// * Read pools with node count of 2 or more can have regional
         ///   availability (nodes are present in 2 or more zones in a region).
-        pub const READ_POOL: InstanceType = InstanceType::new("READ_POOL");
+        pub const READ_POOL: InstanceType = InstanceType::new(2);
 
         /// SECONDARY instances support read operations only. SECONDARY instance
         /// is a cross-region read replica
-        pub const SECONDARY: InstanceType = InstanceType::new("SECONDARY");
+        pub const SECONDARY: InstanceType = InstanceType::new(3);
+
+        /// Creates a new InstanceType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("INSTANCE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PRIMARY"),
+                2 => std::borrow::Cow::Borrowed("READ_POOL"),
+                3 => std::borrow::Cow::Borrowed("SECONDARY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "INSTANCE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::INSTANCE_TYPE_UNSPECIFIED)
+                }
+                "PRIMARY" => std::option::Option::Some(Self::PRIMARY),
+                "READ_POOL" => std::option::Option::Some(Self::READ_POOL),
+                "SECONDARY" => std::option::Option::Some(Self::SECONDARY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for InstanceType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for InstanceType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for InstanceType {
         fn default() -> Self {
-            instance_type::INSTANCE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -3231,44 +3390,60 @@ pub mod instance {
     /// - REGIONAL: The instance can serve data from more than one zone in a
     ///   region (it is highly available).
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AvailabilityType(std::borrow::Cow<'static, str>);
+    pub struct AvailabilityType(i32);
 
     impl AvailabilityType {
+        /// This is an unknown Availability type.
+        pub const AVAILABILITY_TYPE_UNSPECIFIED: AvailabilityType = AvailabilityType::new(0);
+
+        /// Zonal available instance.
+        pub const ZONAL: AvailabilityType = AvailabilityType::new(1);
+
+        /// Regional (or Highly) available instance.
+        pub const REGIONAL: AvailabilityType = AvailabilityType::new(2);
+
         /// Creates a new AvailabilityType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("AVAILABILITY_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ZONAL"),
+                2 => std::borrow::Cow::Borrowed("REGIONAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "AVAILABILITY_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::AVAILABILITY_TYPE_UNSPECIFIED)
+                }
+                "ZONAL" => std::option::Option::Some(Self::ZONAL),
+                "REGIONAL" => std::option::Option::Some(Self::REGIONAL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AvailabilityType](AvailabilityType)
-    pub mod availability_type {
-        use super::AvailabilityType;
-
-        /// This is an unknown Availability type.
-        pub const AVAILABILITY_TYPE_UNSPECIFIED: AvailabilityType =
-            AvailabilityType::new("AVAILABILITY_TYPE_UNSPECIFIED");
-
-        /// Zonal available instance.
-        pub const ZONAL: AvailabilityType = AvailabilityType::new("ZONAL");
-
-        /// Regional (or Highly) available instance.
-        pub const REGIONAL: AvailabilityType = AvailabilityType::new("REGIONAL");
-    }
-
-    impl std::convert::From<std::string::String> for AvailabilityType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AvailabilityType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AvailabilityType {
         fn default() -> Self {
-            availability_type::AVAILABILITY_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3725,97 +3900,133 @@ pub mod backup {
 
     /// Backup State
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The state of the backup is unknown.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The backup is ready.
+        pub const READY: State = State::new(1);
+
+        /// The backup is creating.
+        pub const CREATING: State = State::new(2);
+
+        /// The backup failed.
+        pub const FAILED: State = State::new(3);
+
+        /// The backup is being deleted.
+        pub const DELETING: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("READY"),
+                2 => std::borrow::Cow::Borrowed("CREATING"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "READY" => std::option::Option::Some(Self::READY),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The state of the backup is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The backup is ready.
-        pub const READY: State = State::new("READY");
-
-        /// The backup is creating.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The backup failed.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// The backup is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Backup Type
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// Backup Type is unknown.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// ON_DEMAND backups that were triggered by the customer (e.g., not
         /// AUTOMATED).
-        pub const ON_DEMAND: Type = Type::new("ON_DEMAND");
+        pub const ON_DEMAND: Type = Type::new(1);
 
         /// AUTOMATED backups triggered by the automated backups scheduler pursuant
         /// to an automated backup policy.
-        pub const AUTOMATED: Type = Type::new("AUTOMATED");
+        pub const AUTOMATED: Type = Type::new(2);
 
         /// CONTINUOUS backups triggered by the automated backups scheduler
         /// due to a continuous backup policy.
-        pub const CONTINUOUS: Type = Type::new("CONTINUOUS");
+        pub const CONTINUOUS: Type = Type::new(3);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ON_DEMAND"),
+                2 => std::borrow::Cow::Borrowed("AUTOMATED"),
+                3 => std::borrow::Cow::Borrowed("CONTINUOUS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "ON_DEMAND" => std::option::Option::Some(Self::ON_DEMAND),
+                "AUTOMATED" => std::option::Option::Some(Self::AUTOMATED),
+                "CONTINUOUS" => std::option::Option::Some(Self::CONTINUOUS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4097,49 +4308,68 @@ pub mod supported_database_flag {
     /// Regardless of the ValueType, the Instance.database_flags field accepts the
     /// stringified version of the value, i.e. "20" or "3.14".
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ValueType(std::borrow::Cow<'static, str>);
+    pub struct ValueType(i32);
 
     impl ValueType {
+        /// This is an unknown flag type.
+        pub const VALUE_TYPE_UNSPECIFIED: ValueType = ValueType::new(0);
+
+        /// String type flag.
+        pub const STRING: ValueType = ValueType::new(1);
+
+        /// Integer type flag.
+        pub const INTEGER: ValueType = ValueType::new(2);
+
+        /// Float type flag.
+        pub const FLOAT: ValueType = ValueType::new(3);
+
+        /// Denotes that the flag does not accept any values.
+        pub const NONE: ValueType = ValueType::new(4);
+
         /// Creates a new ValueType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VALUE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STRING"),
+                2 => std::borrow::Cow::Borrowed("INTEGER"),
+                3 => std::borrow::Cow::Borrowed("FLOAT"),
+                4 => std::borrow::Cow::Borrowed("NONE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VALUE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::VALUE_TYPE_UNSPECIFIED),
+                "STRING" => std::option::Option::Some(Self::STRING),
+                "INTEGER" => std::option::Option::Some(Self::INTEGER),
+                "FLOAT" => std::option::Option::Some(Self::FLOAT),
+                "NONE" => std::option::Option::Some(Self::NONE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ValueType](ValueType)
-    pub mod value_type {
-        use super::ValueType;
-
-        /// This is an unknown flag type.
-        pub const VALUE_TYPE_UNSPECIFIED: ValueType = ValueType::new("VALUE_TYPE_UNSPECIFIED");
-
-        /// String type flag.
-        pub const STRING: ValueType = ValueType::new("STRING");
-
-        /// Integer type flag.
-        pub const INTEGER: ValueType = ValueType::new("INTEGER");
-
-        /// Float type flag.
-        pub const FLOAT: ValueType = ValueType::new("FLOAT");
-
-        /// Denotes that the flag does not accept any values.
-        pub const NONE: ValueType = ValueType::new("NONE");
-    }
-
-    impl std::convert::From<std::string::String> for ValueType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ValueType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ValueType {
         fn default() -> Self {
-            value_type::VALUE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -4244,44 +4474,59 @@ pub mod user {
 
     /// Enum that details the user type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct UserType(std::borrow::Cow<'static, str>);
+    pub struct UserType(i32);
 
     impl UserType {
-        /// Creates a new UserType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [UserType](UserType)
-    pub mod user_type {
-        use super::UserType;
-
         /// Unspecified user type.
-        pub const USER_TYPE_UNSPECIFIED: UserType = UserType::new("USER_TYPE_UNSPECIFIED");
+        pub const USER_TYPE_UNSPECIFIED: UserType = UserType::new(0);
 
         /// The default user type that authenticates via password-based
         /// authentication.
-        pub const ALLOYDB_BUILT_IN: UserType = UserType::new("ALLOYDB_BUILT_IN");
+        pub const ALLOYDB_BUILT_IN: UserType = UserType::new(1);
 
         /// Database user that can authenticate via IAM-Based authentication.
-        pub const ALLOYDB_IAM_USER: UserType = UserType::new("ALLOYDB_IAM_USER");
+        pub const ALLOYDB_IAM_USER: UserType = UserType::new(2);
+
+        /// Creates a new UserType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("USER_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALLOYDB_BUILT_IN"),
+                2 => std::borrow::Cow::Borrowed("ALLOYDB_IAM_USER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "USER_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::USER_TYPE_UNSPECIFIED),
+                "ALLOYDB_BUILT_IN" => std::option::Option::Some(Self::ALLOYDB_BUILT_IN),
+                "ALLOYDB_IAM_USER" => std::option::Option::Some(Self::ALLOYDB_IAM_USER),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for UserType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for UserType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for UserType {
         fn default() -> Self {
-            user_type::USER_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5847,58 +6092,81 @@ pub mod batch_create_instance_status {
     /// operation. This is mainly used for status reporting through the LRO
     /// metadata.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The state of the instance is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Instance is pending creation and has not yet been picked up for
         /// processing in the backend.
-        pub const PENDING_CREATE: State = State::new("PENDING_CREATE");
+        pub const PENDING_CREATE: State = State::new(1);
 
         /// The instance is active and running.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(2);
 
         /// The instance is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(3);
 
         /// The instance is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(4);
 
         /// The creation of the instance failed or a fatal error occurred during
         /// an operation on the instance or a batch of instances.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(5);
 
         /// The instance was created successfully, but was rolled back and deleted
         /// due to some other failure during BatchCreateInstances operation.
-        pub const ROLLED_BACK: State = State::new("ROLLED_BACK");
+        pub const ROLLED_BACK: State = State::new(6);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING_CREATE"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                3 => std::borrow::Cow::Borrowed("CREATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("FAILED"),
+                6 => std::borrow::Cow::Borrowed("ROLLED_BACK"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PENDING_CREATE" => std::option::Option::Some(Self::PENDING_CREATE),
+                "READY" => std::option::Option::Some(Self::READY),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "ROLLED_BACK" => std::option::Option::Some(Self::ROLLED_BACK),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6216,40 +6484,53 @@ pub mod inject_fault_request {
     /// FaultType contains all valid types of faults that can be injected to an
     /// instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FaultType(std::borrow::Cow<'static, str>);
+    pub struct FaultType(i32);
 
     impl FaultType {
+        /// The fault type is unknown.
+        pub const FAULT_TYPE_UNSPECIFIED: FaultType = FaultType::new(0);
+
+        /// Stop the VM
+        pub const STOP_VM: FaultType = FaultType::new(1);
+
         /// Creates a new FaultType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FAULT_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STOP_VM"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FAULT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::FAULT_TYPE_UNSPECIFIED),
+                "STOP_VM" => std::option::Option::Some(Self::STOP_VM),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [FaultType](FaultType)
-    pub mod fault_type {
-        use super::FaultType;
-
-        /// The fault type is unknown.
-        pub const FAULT_TYPE_UNSPECIFIED: FaultType = FaultType::new("FAULT_TYPE_UNSPECIFIED");
-
-        /// Stop the VM
-        pub const STOP_VM: FaultType = FaultType::new("STOP_VM");
-    }
-
-    impl std::convert::From<std::string::String> for FaultType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for FaultType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for FaultType {
         fn default() -> Self {
-            fault_type::FAULT_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6580,35 +6861,20 @@ pub mod execute_sql_metadata {
 
     /// Status contains all valid Status a SQL execution can end up in.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(std::borrow::Cow<'static, str>);
+    pub struct Status(i32);
 
     impl Status {
-        /// Creates a new Status instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Status](Status)
-    pub mod status {
-        use super::Status;
-
         /// The status is unknown.
-        pub const STATUS_UNSPECIFIED: Status = Status::new("STATUS_UNSPECIFIED");
+        pub const STATUS_UNSPECIFIED: Status = Status::new(0);
 
         /// No error during SQL execution i.e. All SQL statements ran to completion.
         /// The "message" will be empty.
-        pub const OK: Status = Status::new("OK");
+        pub const OK: Status = Status::new(1);
 
         /// Same as OK, except indicates that only partial results were
         /// returned. The "message" field will contain details on why results were
         /// truncated.
-        pub const PARTIAL: Status = Status::new("PARTIAL");
+        pub const PARTIAL: Status = Status::new(2);
 
         /// Error during SQL execution. Atleast 1 SQL statement execution resulted in
         /// a error. Side effects of other statements are rolled back.  The "message"
@@ -6616,18 +6882,50 @@ pub mod execute_sql_metadata {
         /// bad SQL statement. SQL execution errors don't constitute API errors as
         /// defined in <https://google.aip.dev/193> but will be returned as part of
         /// this message.
-        pub const ERROR: Status = Status::new("ERROR");
+        pub const ERROR: Status = Status::new(3);
+
+        /// Creates a new Status instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATUS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("OK"),
+                2 => std::borrow::Cow::Borrowed("PARTIAL"),
+                3 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATUS_UNSPECIFIED" => std::option::Option::Some(Self::STATUS_UNSPECIFIED),
+                "OK" => std::option::Option::Some(Self::OK),
+                "PARTIAL" => std::option::Option::Some(Self::PARTIAL),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Status {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            status::STATUS_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8049,144 +8347,196 @@ impl gax::paginator::PageableResponse for ListDatabasesResponse {
 /// View on Instance. Pass this enum to rpcs that returns an Instance message to
 /// control which subsets of fields to get.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct InstanceView(std::borrow::Cow<'static, str>);
+pub struct InstanceView(i32);
 
 impl InstanceView {
-    /// Creates a new InstanceView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [InstanceView](InstanceView)
-pub mod instance_view {
-    use super::InstanceView;
-
     /// INSTANCE_VIEW_UNSPECIFIED Not specified, equivalent to BASIC.
-    pub const INSTANCE_VIEW_UNSPECIFIED: InstanceView =
-        InstanceView::new("INSTANCE_VIEW_UNSPECIFIED");
+    pub const INSTANCE_VIEW_UNSPECIFIED: InstanceView = InstanceView::new(0);
 
     /// BASIC server responses for a primary or read instance include all the
     /// relevant instance details, excluding the details of each node in the
     /// instance. The default value.
-    pub const INSTANCE_VIEW_BASIC: InstanceView = InstanceView::new("INSTANCE_VIEW_BASIC");
+    pub const INSTANCE_VIEW_BASIC: InstanceView = InstanceView::new(1);
 
     /// FULL response is equivalent to BASIC for primary instance (for now).
     /// For read pool instance, this includes details of each node in the pool.
-    pub const INSTANCE_VIEW_FULL: InstanceView = InstanceView::new("INSTANCE_VIEW_FULL");
+    pub const INSTANCE_VIEW_FULL: InstanceView = InstanceView::new(2);
+
+    /// Creates a new InstanceView instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("INSTANCE_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("INSTANCE_VIEW_BASIC"),
+            2 => std::borrow::Cow::Borrowed("INSTANCE_VIEW_FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "INSTANCE_VIEW_UNSPECIFIED" => {
+                std::option::Option::Some(Self::INSTANCE_VIEW_UNSPECIFIED)
+            }
+            "INSTANCE_VIEW_BASIC" => std::option::Option::Some(Self::INSTANCE_VIEW_BASIC),
+            "INSTANCE_VIEW_FULL" => std::option::Option::Some(Self::INSTANCE_VIEW_FULL),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for InstanceView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for InstanceView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for InstanceView {
     fn default() -> Self {
-        instance_view::INSTANCE_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// View on Cluster. Pass this enum to rpcs that returns a cluster message to
 /// control which subsets of fields to get.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ClusterView(std::borrow::Cow<'static, str>);
+pub struct ClusterView(i32);
 
 impl ClusterView {
-    /// Creates a new ClusterView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ClusterView](ClusterView)
-pub mod cluster_view {
-    use super::ClusterView;
-
     /// CLUSTER_VIEW_UNSPECIFIED Not specified, equivalent to BASIC.
-    pub const CLUSTER_VIEW_UNSPECIFIED: ClusterView = ClusterView::new("CLUSTER_VIEW_UNSPECIFIED");
+    pub const CLUSTER_VIEW_UNSPECIFIED: ClusterView = ClusterView::new(0);
 
     /// BASIC server responses include all the relevant cluster details, excluding
     /// Cluster.ContinuousBackupInfo.EarliestRestorableTime and other view-specific
     /// fields. The default value.
-    pub const CLUSTER_VIEW_BASIC: ClusterView = ClusterView::new("CLUSTER_VIEW_BASIC");
+    pub const CLUSTER_VIEW_BASIC: ClusterView = ClusterView::new(1);
 
     /// CONTINUOUS_BACKUP response returns all the fields from BASIC plus
     /// the earliest restorable time if continuous backups are enabled.
     /// May increase latency.
-    pub const CLUSTER_VIEW_CONTINUOUS_BACKUP: ClusterView =
-        ClusterView::new("CLUSTER_VIEW_CONTINUOUS_BACKUP");
+    pub const CLUSTER_VIEW_CONTINUOUS_BACKUP: ClusterView = ClusterView::new(2);
+
+    /// Creates a new ClusterView instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("CLUSTER_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("CLUSTER_VIEW_BASIC"),
+            2 => std::borrow::Cow::Borrowed("CLUSTER_VIEW_CONTINUOUS_BACKUP"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "CLUSTER_VIEW_UNSPECIFIED" => std::option::Option::Some(Self::CLUSTER_VIEW_UNSPECIFIED),
+            "CLUSTER_VIEW_BASIC" => std::option::Option::Some(Self::CLUSTER_VIEW_BASIC),
+            "CLUSTER_VIEW_CONTINUOUS_BACKUP" => {
+                std::option::Option::Some(Self::CLUSTER_VIEW_CONTINUOUS_BACKUP)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ClusterView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ClusterView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ClusterView {
     fn default() -> Self {
-        cluster_view::CLUSTER_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The supported database engine versions.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DatabaseVersion(std::borrow::Cow<'static, str>);
+pub struct DatabaseVersion(i32);
 
 impl DatabaseVersion {
+    /// This is an unknown database version.
+    pub const DATABASE_VERSION_UNSPECIFIED: DatabaseVersion = DatabaseVersion::new(0);
+
+    /// DEPRECATED - The database version is Postgres 13.
+    pub const POSTGRES_13: DatabaseVersion = DatabaseVersion::new(1);
+
+    /// The database version is Postgres 14.
+    pub const POSTGRES_14: DatabaseVersion = DatabaseVersion::new(2);
+
+    /// The database version is Postgres 15.
+    pub const POSTGRES_15: DatabaseVersion = DatabaseVersion::new(3);
+
+    /// The database version is Postgres 16.
+    pub const POSTGRES_16: DatabaseVersion = DatabaseVersion::new(4);
+
     /// Creates a new DatabaseVersion instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DATABASE_VERSION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("POSTGRES_13"),
+            2 => std::borrow::Cow::Borrowed("POSTGRES_14"),
+            3 => std::borrow::Cow::Borrowed("POSTGRES_15"),
+            4 => std::borrow::Cow::Borrowed("POSTGRES_16"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DATABASE_VERSION_UNSPECIFIED" => {
+                std::option::Option::Some(Self::DATABASE_VERSION_UNSPECIFIED)
+            }
+            "POSTGRES_13" => std::option::Option::Some(Self::POSTGRES_13),
+            "POSTGRES_14" => std::option::Option::Some(Self::POSTGRES_14),
+            "POSTGRES_15" => std::option::Option::Some(Self::POSTGRES_15),
+            "POSTGRES_16" => std::option::Option::Some(Self::POSTGRES_16),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [DatabaseVersion](DatabaseVersion)
-pub mod database_version {
-    use super::DatabaseVersion;
-
-    /// This is an unknown database version.
-    pub const DATABASE_VERSION_UNSPECIFIED: DatabaseVersion =
-        DatabaseVersion::new("DATABASE_VERSION_UNSPECIFIED");
-
-    /// DEPRECATED - The database version is Postgres 13.
-    pub const POSTGRES_13: DatabaseVersion = DatabaseVersion::new("POSTGRES_13");
-
-    /// The database version is Postgres 14.
-    pub const POSTGRES_14: DatabaseVersion = DatabaseVersion::new("POSTGRES_14");
-
-    /// The database version is Postgres 15.
-    pub const POSTGRES_15: DatabaseVersion = DatabaseVersion::new("POSTGRES_15");
-
-    /// The database version is Postgres 16.
-    pub const POSTGRES_16: DatabaseVersion = DatabaseVersion::new("POSTGRES_16");
-}
-
-impl std::convert::From<std::string::String> for DatabaseVersion {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DatabaseVersion {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DatabaseVersion {
     fn default() -> Self {
-        database_version::DATABASE_VERSION_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -8194,44 +8544,60 @@ impl std::default::Default for DatabaseVersion {
 /// subscriptions. By default, a subscription type is considered STANDARD unless
 /// explicitly specified.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SubscriptionType(std::borrow::Cow<'static, str>);
+pub struct SubscriptionType(i32);
 
 impl SubscriptionType {
+    /// This is an unknown subscription type. By default, the subscription type is
+    /// STANDARD.
+    pub const SUBSCRIPTION_TYPE_UNSPECIFIED: SubscriptionType = SubscriptionType::new(0);
+
+    /// Standard subscription.
+    pub const STANDARD: SubscriptionType = SubscriptionType::new(1);
+
+    /// Trial subscription.
+    pub const TRIAL: SubscriptionType = SubscriptionType::new(2);
+
     /// Creates a new SubscriptionType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SUBSCRIPTION_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("STANDARD"),
+            2 => std::borrow::Cow::Borrowed("TRIAL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SUBSCRIPTION_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::SUBSCRIPTION_TYPE_UNSPECIFIED)
+            }
+            "STANDARD" => std::option::Option::Some(Self::STANDARD),
+            "TRIAL" => std::option::Option::Some(Self::TRIAL),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [SubscriptionType](SubscriptionType)
-pub mod subscription_type {
-    use super::SubscriptionType;
-
-    /// This is an unknown subscription type. By default, the subscription type is
-    /// STANDARD.
-    pub const SUBSCRIPTION_TYPE_UNSPECIFIED: SubscriptionType =
-        SubscriptionType::new("SUBSCRIPTION_TYPE_UNSPECIFIED");
-
-    /// Standard subscription.
-    pub const STANDARD: SubscriptionType = SubscriptionType::new("STANDARD");
-
-    /// Trial subscription.
-    pub const TRIAL: SubscriptionType = SubscriptionType::new("TRIAL");
-}
-
-impl std::convert::From<std::string::String> for SubscriptionType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SubscriptionType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SubscriptionType {
     fn default() -> Self {
-        subscription_type::SUBSCRIPTION_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/alloydb/v1/src/transport.rs
+++ b/src/generated/cloud/alloydb/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/clusters", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -95,7 +95,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}/clusters", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -126,7 +126,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -158,7 +158,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -181,7 +181,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:promote", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -201,7 +201,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}:switchover", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -221,7 +221,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}/clusters:restore", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -241,7 +241,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}/clusters:createsecondary", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -266,7 +266,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
                 reqwest::Method::GET,
                 format!("/v1/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -289,7 +289,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -312,7 +312,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -337,7 +337,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}/instances:createsecondary", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -362,7 +362,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}/instances:batchCreate", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -391,7 +391,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -423,7 +423,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -445,7 +445,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:failover", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -465,7 +465,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}:injectFault", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -482,7 +482,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:restart", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -502,7 +502,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}:executeSql", req.instance),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -519,7 +519,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/backups", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -542,7 +542,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -561,7 +561,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/backups", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -590,7 +590,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -620,7 +620,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -645,7 +645,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
                 reqwest::Method::GET,
                 format!("/v1/{}/supportedDatabaseFlags", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -669,7 +669,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}:generateClientCertificate", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -689,7 +689,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
                 reqwest::Method::GET,
                 format!("/v1/{}/connectionInfo", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -709,7 +709,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/users", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -732,7 +732,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -751,7 +751,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/users", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -780,7 +780,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -810,7 +810,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -834,7 +834,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
                 reqwest::Method::GET,
                 format!("/v1/{}/databases", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -856,7 +856,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -878,7 +878,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -897,7 +897,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -919,7 +919,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -938,7 +938,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -957,7 +957,7 @@ impl crate::stubs::AlloyDBAdmin for AlloyDBAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/apigateway/v1/src/model.rs
+++ b/src/generated/cloud/apigateway/v1/src/model.rs
@@ -144,52 +144,73 @@ pub mod api {
 
     /// All the possible API states.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// API does not have a state yet.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// API is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// API is active.
+        pub const ACTIVE: State = State::new(2);
+
+        /// API creation failed.
+        pub const FAILED: State = State::new(3);
+
+        /// API is being deleted.
+        pub const DELETING: State = State::new(4);
+
+        /// API is being updated.
+        pub const UPDATING: State = State::new(5);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("UPDATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// API does not have a state yet.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// API is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// API is active.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// API creation failed.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// API is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// API is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -523,56 +544,79 @@ pub mod api_config {
 
     /// All the possible API Config states.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// API Config does not have a state yet.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// API Config is being created and deployed to the API Controller.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// API Config is ready for use by Gateways.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(2);
 
         /// API Config creation failed.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(3);
 
         /// API Config is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(4);
 
         /// API Config is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(5);
 
         /// API Config settings are being activated in downstream systems.
         /// API Configs in this state cannot be used by Gateways.
-        pub const ACTIVATING: State = State::new("ACTIVATING");
+        pub const ACTIVATING: State = State::new(6);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("UPDATING"),
+                6 => std::borrow::Cow::Borrowed("ACTIVATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "ACTIVATING" => std::option::Option::Some(Self::ACTIVATING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -704,52 +748,73 @@ pub mod gateway {
 
     /// All the possible Gateway states.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Gateway does not have a state yet.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Gateway is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// Gateway is running and ready for requests.
+        pub const ACTIVE: State = State::new(2);
+
+        /// Gateway creation failed.
+        pub const FAILED: State = State::new(3);
+
+        /// Gateway is being deleted.
+        pub const DELETING: State = State::new(4);
+
+        /// Gateway is being updated.
+        pub const UPDATING: State = State::new(5);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("UPDATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Gateway does not have a state yet.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Gateway is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// Gateway is running and ready for requests.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// Gateway creation failed.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// Gateway is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// Gateway is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1553,42 +1618,59 @@ pub mod get_api_config_request {
 
     /// Enum to control which fields should be included in the response.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConfigView(std::borrow::Cow<'static, str>);
+    pub struct ConfigView(i32);
 
     impl ConfigView {
+        pub const CONFIG_VIEW_UNSPECIFIED: ConfigView = ConfigView::new(0);
+
+        /// Do not include configuration source files.
+        pub const BASIC: ConfigView = ConfigView::new(1);
+
+        /// Include configuration source files.
+        pub const FULL: ConfigView = ConfigView::new(2);
+
         /// Creates a new ConfigView instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CONFIG_VIEW_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BASIC"),
+                2 => std::borrow::Cow::Borrowed("FULL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CONFIG_VIEW_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CONFIG_VIEW_UNSPECIFIED)
+                }
+                "BASIC" => std::option::Option::Some(Self::BASIC),
+                "FULL" => std::option::Option::Some(Self::FULL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ConfigView](ConfigView)
-    pub mod config_view {
-        use super::ConfigView;
-
-        pub const CONFIG_VIEW_UNSPECIFIED: ConfigView = ConfigView::new("CONFIG_VIEW_UNSPECIFIED");
-
-        /// Do not include configuration source files.
-        pub const BASIC: ConfigView = ConfigView::new("BASIC");
-
-        /// Include configuration source files.
-        pub const FULL: ConfigView = ConfigView::new("FULL");
-    }
-
-    impl std::convert::From<std::string::String> for ConfigView {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ConfigView {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ConfigView {
         fn default() -> Self {
-            config_view::CONFIG_VIEW_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/apigateway/v1/src/transport.rs
+++ b/src/generated/cloud/apigateway/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::ApiGatewayService for ApiGatewayService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/gateways", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::ApiGatewayService for ApiGatewayService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -94,7 +94,7 @@ impl crate::stubs::ApiGatewayService for ApiGatewayService {
                 reqwest::Method::POST,
                 format!("/v1/{}/gateways", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -123,7 +123,7 @@ impl crate::stubs::ApiGatewayService for ApiGatewayService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -152,7 +152,7 @@ impl crate::stubs::ApiGatewayService for ApiGatewayService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -171,7 +171,7 @@ impl crate::stubs::ApiGatewayService for ApiGatewayService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/apis", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -194,7 +194,7 @@ impl crate::stubs::ApiGatewayService for ApiGatewayService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -213,7 +213,7 @@ impl crate::stubs::ApiGatewayService for ApiGatewayService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/apis", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -240,7 +240,7 @@ impl crate::stubs::ApiGatewayService for ApiGatewayService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -267,7 +267,7 @@ impl crate::stubs::ApiGatewayService for ApiGatewayService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -286,7 +286,7 @@ impl crate::stubs::ApiGatewayService for ApiGatewayService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/configs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -309,7 +309,7 @@ impl crate::stubs::ApiGatewayService for ApiGatewayService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -329,7 +329,7 @@ impl crate::stubs::ApiGatewayService for ApiGatewayService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/configs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -358,7 +358,7 @@ impl crate::stubs::ApiGatewayService for ApiGatewayService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -387,7 +387,7 @@ impl crate::stubs::ApiGatewayService for ApiGatewayService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -406,7 +406,7 @@ impl crate::stubs::ApiGatewayService for ApiGatewayService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -428,7 +428,7 @@ impl crate::stubs::ApiGatewayService for ApiGatewayService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -447,7 +447,7 @@ impl crate::stubs::ApiGatewayService for ApiGatewayService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -466,7 +466,7 @@ impl crate::stubs::ApiGatewayService for ApiGatewayService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/apigeeconnect/v1/src/model.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/model.rs
@@ -839,124 +839,168 @@ impl wkt::message::Message for HttpResponse {
 
 /// The action taken by agent.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Action(std::borrow::Cow<'static, str>);
+pub struct Action(i32);
 
 impl Action {
+    /// Unspecified Action.
+    pub const ACTION_UNSPECIFIED: Action = Action::new(0);
+
+    /// Indicates that agent should open a new stream.
+    pub const OPEN_NEW_STREAM: Action = Action::new(1);
+
     /// Creates a new Action instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ACTION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("OPEN_NEW_STREAM"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ACTION_UNSPECIFIED" => std::option::Option::Some(Self::ACTION_UNSPECIFIED),
+            "OPEN_NEW_STREAM" => std::option::Option::Some(Self::OPEN_NEW_STREAM),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [Action](Action)
-pub mod action {
-    use super::Action;
-
-    /// Unspecified Action.
-    pub const ACTION_UNSPECIFIED: Action = Action::new("ACTION_UNSPECIFIED");
-
-    /// Indicates that agent should open a new stream.
-    pub const OPEN_NEW_STREAM: Action = Action::new("OPEN_NEW_STREAM");
-}
-
-impl std::convert::From<std::string::String> for Action {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Action {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Action {
     fn default() -> Self {
-        action::ACTION_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Endpoint indicates where the messages will be delivered.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TetherEndpoint(std::borrow::Cow<'static, str>);
+pub struct TetherEndpoint(i32);
 
 impl TetherEndpoint {
+    /// Unspecified tether endpoint.
+    pub const TETHER_ENDPOINT_UNSPECIFIED: TetherEndpoint = TetherEndpoint::new(0);
+
+    /// Apigee MART endpoint.
+    pub const APIGEE_MART: TetherEndpoint = TetherEndpoint::new(1);
+
+    /// Apigee Runtime endpoint.
+    pub const APIGEE_RUNTIME: TetherEndpoint = TetherEndpoint::new(2);
+
+    /// Apigee Mint Rating endpoint.
+    pub const APIGEE_MINT_RATING: TetherEndpoint = TetherEndpoint::new(3);
+
     /// Creates a new TetherEndpoint instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("TETHER_ENDPOINT_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("APIGEE_MART"),
+            2 => std::borrow::Cow::Borrowed("APIGEE_RUNTIME"),
+            3 => std::borrow::Cow::Borrowed("APIGEE_MINT_RATING"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "TETHER_ENDPOINT_UNSPECIFIED" => {
+                std::option::Option::Some(Self::TETHER_ENDPOINT_UNSPECIFIED)
+            }
+            "APIGEE_MART" => std::option::Option::Some(Self::APIGEE_MART),
+            "APIGEE_RUNTIME" => std::option::Option::Some(Self::APIGEE_RUNTIME),
+            "APIGEE_MINT_RATING" => std::option::Option::Some(Self::APIGEE_MINT_RATING),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [TetherEndpoint](TetherEndpoint)
-pub mod tether_endpoint {
-    use super::TetherEndpoint;
-
-    /// Unspecified tether endpoint.
-    pub const TETHER_ENDPOINT_UNSPECIFIED: TetherEndpoint =
-        TetherEndpoint::new("TETHER_ENDPOINT_UNSPECIFIED");
-
-    /// Apigee MART endpoint.
-    pub const APIGEE_MART: TetherEndpoint = TetherEndpoint::new("APIGEE_MART");
-
-    /// Apigee Runtime endpoint.
-    pub const APIGEE_RUNTIME: TetherEndpoint = TetherEndpoint::new("APIGEE_RUNTIME");
-
-    /// Apigee Mint Rating endpoint.
-    pub const APIGEE_MINT_RATING: TetherEndpoint = TetherEndpoint::new("APIGEE_MINT_RATING");
-}
-
-impl std::convert::From<std::string::String> for TetherEndpoint {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for TetherEndpoint {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for TetherEndpoint {
     fn default() -> Self {
-        tether_endpoint::TETHER_ENDPOINT_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// HTTP Scheme.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Scheme(std::borrow::Cow<'static, str>);
+pub struct Scheme(i32);
 
 impl Scheme {
+    /// Unspecified scheme.
+    pub const SCHEME_UNSPECIFIED: Scheme = Scheme::new(0);
+
+    /// HTTPS protocol.
+    pub const HTTPS: Scheme = Scheme::new(1);
+
     /// Creates a new Scheme instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SCHEME_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("HTTPS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SCHEME_UNSPECIFIED" => std::option::Option::Some(Self::SCHEME_UNSPECIFIED),
+            "HTTPS" => std::option::Option::Some(Self::HTTPS),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [Scheme](Scheme)
-pub mod scheme {
-    use super::Scheme;
-
-    /// Unspecified scheme.
-    pub const SCHEME_UNSPECIFIED: Scheme = Scheme::new("SCHEME_UNSPECIFIED");
-
-    /// HTTPS protocol.
-    pub const HTTPS: Scheme = Scheme::new("HTTPS");
-}
-
-impl std::convert::From<std::string::String> for Scheme {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Scheme {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Scheme {
     fn default() -> Self {
-        scheme::SCHEME_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/apigeeconnect/v1/src/transport.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::ConnectionService for ConnectionService {
                 reqwest::Method::GET,
                 format!("/v1/{}/connections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/apihub/v1/src/model.rs
+++ b/src/generated/cloud/apihub/v1/src/model.rs
@@ -4000,46 +4000,62 @@ pub mod spec {
     ///   of the API call.
     ///   If not specified, defaults to `RELAXED`.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ParsingMode(std::borrow::Cow<'static, str>);
+    pub struct ParsingMode(i32);
 
     impl ParsingMode {
-        /// Creates a new ParsingMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ParsingMode](ParsingMode)
-    pub mod parsing_mode {
-        use super::ParsingMode;
-
         /// Defaults to `RELAXED`.
-        pub const PARSING_MODE_UNSPECIFIED: ParsingMode =
-            ParsingMode::new("PARSING_MODE_UNSPECIFIED");
+        pub const PARSING_MODE_UNSPECIFIED: ParsingMode = ParsingMode::new(0);
 
         /// Parsing of the Spec on create and update is relaxed, meaning that
         /// parsing errors the spec contents will not fail the API call.
-        pub const RELAXED: ParsingMode = ParsingMode::new("RELAXED");
+        pub const RELAXED: ParsingMode = ParsingMode::new(1);
 
         /// Parsing of the Spec on create and update is strict, meaning that
         /// parsing errors in the spec contents will fail the API call.
-        pub const STRICT: ParsingMode = ParsingMode::new("STRICT");
+        pub const STRICT: ParsingMode = ParsingMode::new(2);
+
+        /// Creates a new ParsingMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PARSING_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RELAXED"),
+                2 => std::borrow::Cow::Borrowed("STRICT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PARSING_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PARSING_MODE_UNSPECIFIED)
+                }
+                "RELAXED" => std::option::Option::Some(Self::RELAXED),
+                "STRICT" => std::option::Option::Some(Self::STRICT),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ParsingMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ParsingMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ParsingMode {
         fn default() -> Self {
-            parsing_mode::PARSING_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4527,40 +4543,53 @@ pub mod definition {
 
     /// Enumeration of definition types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Definition type unspecified.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// Definition type schema.
+        pub const SCHEMA: Type = Type::new(1);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SCHEMA"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "SCHEMA" => std::option::Option::Some(Self::SCHEMA),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Definition type unspecified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// Definition type schema.
-        pub const SCHEMA: Type = Type::new("SCHEMA");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -4812,154 +4841,216 @@ pub mod attribute {
 
     /// Enumeration of attribute definition types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DefinitionType(std::borrow::Cow<'static, str>);
+    pub struct DefinitionType(i32);
 
     impl DefinitionType {
-        /// Creates a new DefinitionType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DefinitionType](DefinitionType)
-    pub mod definition_type {
-        use super::DefinitionType;
-
         /// Attribute definition type unspecified.
-        pub const DEFINITION_TYPE_UNSPECIFIED: DefinitionType =
-            DefinitionType::new("DEFINITION_TYPE_UNSPECIFIED");
+        pub const DEFINITION_TYPE_UNSPECIFIED: DefinitionType = DefinitionType::new(0);
 
         /// The attribute is predefined by the API Hub. Note that only the list of
         /// allowed values can be updated in this case via UpdateAttribute method.
-        pub const SYSTEM_DEFINED: DefinitionType = DefinitionType::new("SYSTEM_DEFINED");
+        pub const SYSTEM_DEFINED: DefinitionType = DefinitionType::new(1);
 
         /// The attribute is defined by the user.
-        pub const USER_DEFINED: DefinitionType = DefinitionType::new("USER_DEFINED");
+        pub const USER_DEFINED: DefinitionType = DefinitionType::new(2);
+
+        /// Creates a new DefinitionType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DEFINITION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SYSTEM_DEFINED"),
+                2 => std::borrow::Cow::Borrowed("USER_DEFINED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DEFINITION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DEFINITION_TYPE_UNSPECIFIED)
+                }
+                "SYSTEM_DEFINED" => std::option::Option::Some(Self::SYSTEM_DEFINED),
+                "USER_DEFINED" => std::option::Option::Some(Self::USER_DEFINED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DefinitionType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DefinitionType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DefinitionType {
         fn default() -> Self {
-            definition_type::DEFINITION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Enumeration for the scope of the attribute representing the resource in the
     /// API Hub to which the attribute can be linked.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Scope(std::borrow::Cow<'static, str>);
+    pub struct Scope(i32);
 
     impl Scope {
+        /// Scope Unspecified.
+        pub const SCOPE_UNSPECIFIED: Scope = Scope::new(0);
+
+        /// Attribute can be linked to an API.
+        pub const API: Scope = Scope::new(1);
+
+        /// Attribute can be linked to an API version.
+        pub const VERSION: Scope = Scope::new(2);
+
+        /// Attribute can be linked to a Spec.
+        pub const SPEC: Scope = Scope::new(3);
+
+        /// Attribute can be linked to an API Operation.
+        pub const API_OPERATION: Scope = Scope::new(4);
+
+        /// Attribute can be linked to a Deployment.
+        pub const DEPLOYMENT: Scope = Scope::new(5);
+
+        /// Attribute can be linked to a Dependency.
+        pub const DEPENDENCY: Scope = Scope::new(6);
+
+        /// Attribute can be linked to a definition.
+        pub const DEFINITION: Scope = Scope::new(7);
+
+        /// Attribute can be linked to a ExternalAPI.
+        pub const EXTERNAL_API: Scope = Scope::new(8);
+
+        /// Attribute can be linked to a Plugin.
+        pub const PLUGIN: Scope = Scope::new(9);
+
         /// Creates a new Scope instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SCOPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("API"),
+                2 => std::borrow::Cow::Borrowed("VERSION"),
+                3 => std::borrow::Cow::Borrowed("SPEC"),
+                4 => std::borrow::Cow::Borrowed("API_OPERATION"),
+                5 => std::borrow::Cow::Borrowed("DEPLOYMENT"),
+                6 => std::borrow::Cow::Borrowed("DEPENDENCY"),
+                7 => std::borrow::Cow::Borrowed("DEFINITION"),
+                8 => std::borrow::Cow::Borrowed("EXTERNAL_API"),
+                9 => std::borrow::Cow::Borrowed("PLUGIN"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SCOPE_UNSPECIFIED" => std::option::Option::Some(Self::SCOPE_UNSPECIFIED),
+                "API" => std::option::Option::Some(Self::API),
+                "VERSION" => std::option::Option::Some(Self::VERSION),
+                "SPEC" => std::option::Option::Some(Self::SPEC),
+                "API_OPERATION" => std::option::Option::Some(Self::API_OPERATION),
+                "DEPLOYMENT" => std::option::Option::Some(Self::DEPLOYMENT),
+                "DEPENDENCY" => std::option::Option::Some(Self::DEPENDENCY),
+                "DEFINITION" => std::option::Option::Some(Self::DEFINITION),
+                "EXTERNAL_API" => std::option::Option::Some(Self::EXTERNAL_API),
+                "PLUGIN" => std::option::Option::Some(Self::PLUGIN),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Scope](Scope)
-    pub mod scope {
-        use super::Scope;
-
-        /// Scope Unspecified.
-        pub const SCOPE_UNSPECIFIED: Scope = Scope::new("SCOPE_UNSPECIFIED");
-
-        /// Attribute can be linked to an API.
-        pub const API: Scope = Scope::new("API");
-
-        /// Attribute can be linked to an API version.
-        pub const VERSION: Scope = Scope::new("VERSION");
-
-        /// Attribute can be linked to a Spec.
-        pub const SPEC: Scope = Scope::new("SPEC");
-
-        /// Attribute can be linked to an API Operation.
-        pub const API_OPERATION: Scope = Scope::new("API_OPERATION");
-
-        /// Attribute can be linked to a Deployment.
-        pub const DEPLOYMENT: Scope = Scope::new("DEPLOYMENT");
-
-        /// Attribute can be linked to a Dependency.
-        pub const DEPENDENCY: Scope = Scope::new("DEPENDENCY");
-
-        /// Attribute can be linked to a definition.
-        pub const DEFINITION: Scope = Scope::new("DEFINITION");
-
-        /// Attribute can be linked to a ExternalAPI.
-        pub const EXTERNAL_API: Scope = Scope::new("EXTERNAL_API");
-
-        /// Attribute can be linked to a Plugin.
-        pub const PLUGIN: Scope = Scope::new("PLUGIN");
-    }
-
-    impl std::convert::From<std::string::String> for Scope {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Scope {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Scope {
         fn default() -> Self {
-            scope::SCOPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Enumeration of attribute's data type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataType(std::borrow::Cow<'static, str>);
+    pub struct DataType(i32);
 
     impl DataType {
+        /// Attribute data type unspecified.
+        pub const DATA_TYPE_UNSPECIFIED: DataType = DataType::new(0);
+
+        /// Attribute's value is of type enum.
+        pub const ENUM: DataType = DataType::new(1);
+
+        /// Attribute's value is of type json.
+        pub const JSON: DataType = DataType::new(2);
+
+        /// Attribute's value is of type string.
+        pub const STRING: DataType = DataType::new(3);
+
         /// Creates a new DataType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATA_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENUM"),
+                2 => std::borrow::Cow::Borrowed("JSON"),
+                3 => std::borrow::Cow::Borrowed("STRING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATA_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::DATA_TYPE_UNSPECIFIED),
+                "ENUM" => std::option::Option::Some(Self::ENUM),
+                "JSON" => std::option::Option::Some(Self::JSON),
+                "STRING" => std::option::Option::Some(Self::STRING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DataType](DataType)
-    pub mod data_type {
-        use super::DataType;
-
-        /// Attribute data type unspecified.
-        pub const DATA_TYPE_UNSPECIFIED: DataType = DataType::new("DATA_TYPE_UNSPECIFIED");
-
-        /// Attribute's value is of type enum.
-        pub const ENUM: DataType = DataType::new("ENUM");
-
-        /// Attribute's value is of type json.
-        pub const JSON: DataType = DataType::new("JSON");
-
-        /// Attribute's value is of type string.
-        pub const STRING: DataType = DataType::new("STRING");
-    }
-
-    impl std::convert::From<std::string::String> for DataType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DataType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DataType {
         fn default() -> Self {
-            data_type::DATA_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5168,46 +5259,63 @@ pub mod open_api_spec_details {
 
     /// Enumeration of spec formats.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Format(std::borrow::Cow<'static, str>);
+    pub struct Format(i32);
 
     impl Format {
+        /// SpecFile type unspecified.
+        pub const FORMAT_UNSPECIFIED: Format = Format::new(0);
+
+        /// OpenAPI Spec v2.0.
+        pub const OPEN_API_SPEC_2_0: Format = Format::new(1);
+
+        /// OpenAPI Spec v3.0.
+        pub const OPEN_API_SPEC_3_0: Format = Format::new(2);
+
+        /// OpenAPI Spec v3.1.
+        pub const OPEN_API_SPEC_3_1: Format = Format::new(3);
+
         /// Creates a new Format instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FORMAT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("OPEN_API_SPEC_2_0"),
+                2 => std::borrow::Cow::Borrowed("OPEN_API_SPEC_3_0"),
+                3 => std::borrow::Cow::Borrowed("OPEN_API_SPEC_3_1"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FORMAT_UNSPECIFIED" => std::option::Option::Some(Self::FORMAT_UNSPECIFIED),
+                "OPEN_API_SPEC_2_0" => std::option::Option::Some(Self::OPEN_API_SPEC_2_0),
+                "OPEN_API_SPEC_3_0" => std::option::Option::Some(Self::OPEN_API_SPEC_3_0),
+                "OPEN_API_SPEC_3_1" => std::option::Option::Some(Self::OPEN_API_SPEC_3_1),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Format](Format)
-    pub mod format {
-        use super::Format;
-
-        /// SpecFile type unspecified.
-        pub const FORMAT_UNSPECIFIED: Format = Format::new("FORMAT_UNSPECIFIED");
-
-        /// OpenAPI Spec v2.0.
-        pub const OPEN_API_SPEC_2_0: Format = Format::new("OPEN_API_SPEC_2_0");
-
-        /// OpenAPI Spec v3.0.
-        pub const OPEN_API_SPEC_3_0: Format = Format::new("OPEN_API_SPEC_3_0");
-
-        /// OpenAPI Spec v3.1.
-        pub const OPEN_API_SPEC_3_1: Format = Format::new("OPEN_API_SPEC_3_1");
-    }
-
-    impl std::convert::From<std::string::String> for Format {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Format {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Format {
         fn default() -> Self {
-            format::FORMAT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5380,61 +5488,88 @@ pub mod http_operation {
 
     /// Enumeration of Method types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Method(std::borrow::Cow<'static, str>);
+    pub struct Method(i32);
 
     impl Method {
+        /// Method unspecified.
+        pub const METHOD_UNSPECIFIED: Method = Method::new(0);
+
+        /// Get Operation type.
+        pub const GET: Method = Method::new(1);
+
+        /// Put Operation type.
+        pub const PUT: Method = Method::new(2);
+
+        /// Post Operation type.
+        pub const POST: Method = Method::new(3);
+
+        /// Delete Operation type.
+        pub const DELETE: Method = Method::new(4);
+
+        /// Options Operation type.
+        pub const OPTIONS: Method = Method::new(5);
+
+        /// Head Operation type.
+        pub const HEAD: Method = Method::new(6);
+
+        /// Patch Operation type.
+        pub const PATCH: Method = Method::new(7);
+
+        /// Trace Operation type.
+        pub const TRACE: Method = Method::new(8);
+
         /// Creates a new Method instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("METHOD_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GET"),
+                2 => std::borrow::Cow::Borrowed("PUT"),
+                3 => std::borrow::Cow::Borrowed("POST"),
+                4 => std::borrow::Cow::Borrowed("DELETE"),
+                5 => std::borrow::Cow::Borrowed("OPTIONS"),
+                6 => std::borrow::Cow::Borrowed("HEAD"),
+                7 => std::borrow::Cow::Borrowed("PATCH"),
+                8 => std::borrow::Cow::Borrowed("TRACE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "METHOD_UNSPECIFIED" => std::option::Option::Some(Self::METHOD_UNSPECIFIED),
+                "GET" => std::option::Option::Some(Self::GET),
+                "PUT" => std::option::Option::Some(Self::PUT),
+                "POST" => std::option::Option::Some(Self::POST),
+                "DELETE" => std::option::Option::Some(Self::DELETE),
+                "OPTIONS" => std::option::Option::Some(Self::OPTIONS),
+                "HEAD" => std::option::Option::Some(Self::HEAD),
+                "PATCH" => std::option::Option::Some(Self::PATCH),
+                "TRACE" => std::option::Option::Some(Self::TRACE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Method](Method)
-    pub mod method {
-        use super::Method;
-
-        /// Method unspecified.
-        pub const METHOD_UNSPECIFIED: Method = Method::new("METHOD_UNSPECIFIED");
-
-        /// Get Operation type.
-        pub const GET: Method = Method::new("GET");
-
-        /// Put Operation type.
-        pub const PUT: Method = Method::new("PUT");
-
-        /// Post Operation type.
-        pub const POST: Method = Method::new("POST");
-
-        /// Delete Operation type.
-        pub const DELETE: Method = Method::new("DELETE");
-
-        /// Options Operation type.
-        pub const OPTIONS: Method = Method::new("OPTIONS");
-
-        /// Head Operation type.
-        pub const HEAD: Method = Method::new("HEAD");
-
-        /// Patch Operation type.
-        pub const PATCH: Method = Method::new("PATCH");
-
-        /// Trace Operation type.
-        pub const TRACE: Method = Method::new("TRACE");
-    }
-
-    impl std::convert::From<std::string::String> for Method {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Method {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Method {
         fn default() -> Self {
-            method::METHOD_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5988,85 +6123,114 @@ pub mod dependency {
 
     /// Possible states for a dependency.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Dependency will be in a proposed state when it is newly identified by the
         /// API hub on its own.
-        pub const PROPOSED: State = State::new("PROPOSED");
+        pub const PROPOSED: State = State::new(1);
 
         /// Dependency will be in a validated state when it is validated by the
         /// admin or manually created in the API hub.
-        pub const VALIDATED: State = State::new("VALIDATED");
+        pub const VALIDATED: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROPOSED"),
+                2 => std::borrow::Cow::Borrowed("VALIDATED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PROPOSED" => std::option::Option::Some(Self::PROPOSED),
+                "VALIDATED" => std::option::Option::Some(Self::VALIDATED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Possible modes of discovering the dependency.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DiscoveryMode(std::borrow::Cow<'static, str>);
+    pub struct DiscoveryMode(i32);
 
     impl DiscoveryMode {
+        /// Default value. This value is unused.
+        pub const DISCOVERY_MODE_UNSPECIFIED: DiscoveryMode = DiscoveryMode::new(0);
+
+        /// Manual mode of discovery when the dependency is defined by the user.
+        pub const MANUAL: DiscoveryMode = DiscoveryMode::new(1);
+
         /// Creates a new DiscoveryMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DISCOVERY_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MANUAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DISCOVERY_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DISCOVERY_MODE_UNSPECIFIED)
+                }
+                "MANUAL" => std::option::Option::Some(Self::MANUAL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DiscoveryMode](DiscoveryMode)
-    pub mod discovery_mode {
-        use super::DiscoveryMode;
-
-        /// Default value. This value is unused.
-        pub const DISCOVERY_MODE_UNSPECIFIED: DiscoveryMode =
-            DiscoveryMode::new("DISCOVERY_MODE_UNSPECIFIED");
-
-        /// Manual mode of discovery when the dependency is defined by the user.
-        pub const MANUAL: DiscoveryMode = DiscoveryMode::new("MANUAL");
-    }
-
-    impl std::convert::From<std::string::String> for DiscoveryMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DiscoveryMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DiscoveryMode {
         fn default() -> Self {
-            discovery_mode::DISCOVERY_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6249,43 +6413,58 @@ pub mod dependency_error_detail {
 
     /// Possible values representing an error in the dependency.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Error(std::borrow::Cow<'static, str>);
+    pub struct Error(i32);
 
     impl Error {
+        /// Default value used for no error in the dependency.
+        pub const ERROR_UNSPECIFIED: Error = Error::new(0);
+
+        /// Supplier entity has been deleted.
+        pub const SUPPLIER_NOT_FOUND: Error = Error::new(1);
+
+        /// Supplier entity has been recreated.
+        pub const SUPPLIER_RECREATED: Error = Error::new(2);
+
         /// Creates a new Error instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ERROR_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SUPPLIER_NOT_FOUND"),
+                2 => std::borrow::Cow::Borrowed("SUPPLIER_RECREATED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ERROR_UNSPECIFIED" => std::option::Option::Some(Self::ERROR_UNSPECIFIED),
+                "SUPPLIER_NOT_FOUND" => std::option::Option::Some(Self::SUPPLIER_NOT_FOUND),
+                "SUPPLIER_RECREATED" => std::option::Option::Some(Self::SUPPLIER_RECREATED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Error](Error)
-    pub mod error {
-        use super::Error;
-
-        /// Default value used for no error in the dependency.
-        pub const ERROR_UNSPECIFIED: Error = Error::new("ERROR_UNSPECIFIED");
-
-        /// Supplier entity has been deleted.
-        pub const SUPPLIER_NOT_FOUND: Error = Error::new("SUPPLIER_NOT_FOUND");
-
-        /// Supplier entity has been recreated.
-        pub const SUPPLIER_RECREATED: Error = Error::new("SUPPLIER_RECREATED");
-    }
-
-    impl std::convert::From<std::string::String> for Error {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Error {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Error {
         fn default() -> Self {
-            error::ERROR_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6847,55 +7026,78 @@ pub mod api_hub_instance {
 
     /// State of the ApiHub Instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The default value. This value is used if the state is omitted.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The ApiHub instance has not been initialized or has been deleted.
+        pub const INACTIVE: State = State::new(1);
+
+        /// The ApiHub instance is being created.
+        pub const CREATING: State = State::new(2);
+
+        /// The ApiHub instance has been created and is ready for use.
+        pub const ACTIVE: State = State::new(3);
+
+        /// The ApiHub instance is being updated.
+        pub const UPDATING: State = State::new(4);
+
+        /// The ApiHub instance is being deleted.
+        pub const DELETING: State = State::new(5);
+
+        /// The ApiHub instance encountered an error during a state change.
+        pub const FAILED: State = State::new(6);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INACTIVE"),
+                2 => std::borrow::Cow::Borrowed("CREATING"),
+                3 => std::borrow::Cow::Borrowed("ACTIVE"),
+                4 => std::borrow::Cow::Borrowed("UPDATING"),
+                5 => std::borrow::Cow::Borrowed("DELETING"),
+                6 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The ApiHub instance has not been initialized or has been deleted.
-        pub const INACTIVE: State = State::new("INACTIVE");
-
-        /// The ApiHub instance is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The ApiHub instance has been created and is ready for use.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The ApiHub instance is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// The ApiHub instance is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// The ApiHub instance encountered an error during a state change.
-        pub const FAILED: State = State::new("FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7689,43 +7891,58 @@ pub mod plugin {
     /// values in the future. Consumers are advised to always code against the
     /// enum values expecting new states can be added later on.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The default value. This value is used if the state is omitted.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The plugin is enabled.
+        pub const ENABLED: State = State::new(1);
+
+        /// The plugin is disabled.
+        pub const DISABLED: State = State::new(2);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENABLED"),
+                2 => std::borrow::Cow::Borrowed("DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The plugin is enabled.
-        pub const ENABLED: State = State::new("ENABLED");
-
-        /// The plugin is disabled.
-        pub const DISABLED: State = State::new("DISABLED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8433,132 +8650,181 @@ impl wkt::message::Message for RuntimeProjectAttachment {
 
 /// Lint state represents success or failure for linting.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LintState(std::borrow::Cow<'static, str>);
+pub struct LintState(i32);
 
 impl LintState {
+    /// Lint state unspecified.
+    pub const LINT_STATE_UNSPECIFIED: LintState = LintState::new(0);
+
+    /// Linting was completed successfully.
+    pub const LINT_STATE_SUCCESS: LintState = LintState::new(1);
+
+    /// Linting encountered errors.
+    pub const LINT_STATE_ERROR: LintState = LintState::new(2);
+
     /// Creates a new LintState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("LINT_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("LINT_STATE_SUCCESS"),
+            2 => std::borrow::Cow::Borrowed("LINT_STATE_ERROR"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "LINT_STATE_UNSPECIFIED" => std::option::Option::Some(Self::LINT_STATE_UNSPECIFIED),
+            "LINT_STATE_SUCCESS" => std::option::Option::Some(Self::LINT_STATE_SUCCESS),
+            "LINT_STATE_ERROR" => std::option::Option::Some(Self::LINT_STATE_ERROR),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [LintState](LintState)
-pub mod lint_state {
-    use super::LintState;
-
-    /// Lint state unspecified.
-    pub const LINT_STATE_UNSPECIFIED: LintState = LintState::new("LINT_STATE_UNSPECIFIED");
-
-    /// Linting was completed successfully.
-    pub const LINT_STATE_SUCCESS: LintState = LintState::new("LINT_STATE_SUCCESS");
-
-    /// Linting encountered errors.
-    pub const LINT_STATE_ERROR: LintState = LintState::new("LINT_STATE_ERROR");
-}
-
-impl std::convert::From<std::string::String> for LintState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for LintState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for LintState {
     fn default() -> Self {
-        lint_state::LINT_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Enumeration of linter types.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Linter(std::borrow::Cow<'static, str>);
+pub struct Linter(i32);
 
 impl Linter {
+    /// Linter type unspecified.
+    pub const LINTER_UNSPECIFIED: Linter = Linter::new(0);
+
+    /// Linter type spectral.
+    pub const SPECTRAL: Linter = Linter::new(1);
+
+    /// Linter type other.
+    pub const OTHER: Linter = Linter::new(2);
+
     /// Creates a new Linter instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("LINTER_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SPECTRAL"),
+            2 => std::borrow::Cow::Borrowed("OTHER"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "LINTER_UNSPECIFIED" => std::option::Option::Some(Self::LINTER_UNSPECIFIED),
+            "SPECTRAL" => std::option::Option::Some(Self::SPECTRAL),
+            "OTHER" => std::option::Option::Some(Self::OTHER),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [Linter](Linter)
-pub mod linter {
-    use super::Linter;
-
-    /// Linter type unspecified.
-    pub const LINTER_UNSPECIFIED: Linter = Linter::new("LINTER_UNSPECIFIED");
-
-    /// Linter type spectral.
-    pub const SPECTRAL: Linter = Linter::new("SPECTRAL");
-
-    /// Linter type other.
-    pub const OTHER: Linter = Linter::new("OTHER");
-}
-
-impl std::convert::From<std::string::String> for Linter {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Linter {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Linter {
     fn default() -> Self {
-        linter::LINTER_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Severity of the issue.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Severity(std::borrow::Cow<'static, str>);
+pub struct Severity(i32);
 
 impl Severity {
+    /// Severity unspecified.
+    pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
+
+    /// Severity error.
+    pub const SEVERITY_ERROR: Severity = Severity::new(1);
+
+    /// Severity warning.
+    pub const SEVERITY_WARNING: Severity = Severity::new(2);
+
+    /// Severity info.
+    pub const SEVERITY_INFO: Severity = Severity::new(3);
+
+    /// Severity hint.
+    pub const SEVERITY_HINT: Severity = Severity::new(4);
+
     /// Creates a new Severity instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SEVERITY_ERROR"),
+            2 => std::borrow::Cow::Borrowed("SEVERITY_WARNING"),
+            3 => std::borrow::Cow::Borrowed("SEVERITY_INFO"),
+            4 => std::borrow::Cow::Borrowed("SEVERITY_HINT"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
+            "SEVERITY_ERROR" => std::option::Option::Some(Self::SEVERITY_ERROR),
+            "SEVERITY_WARNING" => std::option::Option::Some(Self::SEVERITY_WARNING),
+            "SEVERITY_INFO" => std::option::Option::Some(Self::SEVERITY_INFO),
+            "SEVERITY_HINT" => std::option::Option::Some(Self::SEVERITY_HINT),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [Severity](Severity)
-pub mod severity {
-    use super::Severity;
-
-    /// Severity unspecified.
-    pub const SEVERITY_UNSPECIFIED: Severity = Severity::new("SEVERITY_UNSPECIFIED");
-
-    /// Severity error.
-    pub const SEVERITY_ERROR: Severity = Severity::new("SEVERITY_ERROR");
-
-    /// Severity warning.
-    pub const SEVERITY_WARNING: Severity = Severity::new("SEVERITY_WARNING");
-
-    /// Severity info.
-    pub const SEVERITY_INFO: Severity = Severity::new("SEVERITY_INFO");
-
-    /// Severity hint.
-    pub const SEVERITY_HINT: Severity = Severity::new("SEVERITY_HINT");
-}
-
-impl std::convert::From<std::string::String> for Severity {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Severity {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Severity {
     fn default() -> Self {
-        severity::SEVERITY_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/apihub/v1/src/transport.rs
+++ b/src/generated/cloud/apihub/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/apis", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -67,7 +67,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -86,7 +86,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/apis", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -117,7 +117,7 @@ impl crate::stubs::ApiHub for ApiHub {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -144,7 +144,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -167,7 +167,7 @@ impl crate::stubs::ApiHub for ApiHub {
                 reqwest::Method::POST,
                 format!("/v1/{}/versions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -187,7 +187,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -206,7 +206,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/versions", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -237,7 +237,7 @@ impl crate::stubs::ApiHub for ApiHub {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -266,7 +266,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -286,7 +286,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/specs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -304,7 +304,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -323,7 +323,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}:contents", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -342,7 +342,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/specs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -373,7 +373,7 @@ impl crate::stubs::ApiHub for ApiHub {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -400,7 +400,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -419,7 +419,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -441,7 +441,7 @@ impl crate::stubs::ApiHub for ApiHub {
                 reqwest::Method::GET,
                 format!("/v1/{}/operations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -463,7 +463,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -485,7 +485,7 @@ impl crate::stubs::ApiHub for ApiHub {
                 reqwest::Method::POST,
                 format!("/v1/{}/deployments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -505,7 +505,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -527,7 +527,7 @@ impl crate::stubs::ApiHub for ApiHub {
                 reqwest::Method::GET,
                 format!("/v1/{}/deployments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -558,7 +558,7 @@ impl crate::stubs::ApiHub for ApiHub {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -587,7 +587,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -609,7 +609,7 @@ impl crate::stubs::ApiHub for ApiHub {
                 reqwest::Method::POST,
                 format!("/v1/{}/attributes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -629,7 +629,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -657,7 +657,7 @@ impl crate::stubs::ApiHub for ApiHub {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -686,7 +686,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -708,7 +708,7 @@ impl crate::stubs::ApiHub for ApiHub {
                 reqwest::Method::GET,
                 format!("/v1/{}/attributes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -733,7 +733,7 @@ impl crate::stubs::ApiHub for ApiHub {
                 reqwest::Method::POST,
                 format!("/v1/{}:searchResources", req.location),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -753,7 +753,7 @@ impl crate::stubs::ApiHub for ApiHub {
                 reqwest::Method::POST,
                 format!("/v1/{}/externalApis", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -773,7 +773,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -801,7 +801,7 @@ impl crate::stubs::ApiHub for ApiHub {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -830,7 +830,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -852,7 +852,7 @@ impl crate::stubs::ApiHub for ApiHub {
                 reqwest::Method::GET,
                 format!("/v1/{}/externalApis", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -873,7 +873,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -895,7 +895,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -914,7 +914,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -936,7 +936,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -955,7 +955,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -974,7 +974,7 @@ impl crate::stubs::ApiHub for ApiHub {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1017,7 +1017,7 @@ impl crate::stubs::ApiHubDependencies for ApiHubDependencies {
                 reqwest::Method::POST,
                 format!("/v1/{}/dependencies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1037,7 +1037,7 @@ impl crate::stubs::ApiHubDependencies for ApiHubDependencies {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1065,7 +1065,7 @@ impl crate::stubs::ApiHubDependencies for ApiHubDependencies {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1094,7 +1094,7 @@ impl crate::stubs::ApiHubDependencies for ApiHubDependencies {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1116,7 +1116,7 @@ impl crate::stubs::ApiHubDependencies for ApiHubDependencies {
                 reqwest::Method::GET,
                 format!("/v1/{}/dependencies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1138,7 +1138,7 @@ impl crate::stubs::ApiHubDependencies for ApiHubDependencies {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1160,7 +1160,7 @@ impl crate::stubs::ApiHubDependencies for ApiHubDependencies {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1179,7 +1179,7 @@ impl crate::stubs::ApiHubDependencies for ApiHubDependencies {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1201,7 +1201,7 @@ impl crate::stubs::ApiHubDependencies for ApiHubDependencies {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1220,7 +1220,7 @@ impl crate::stubs::ApiHubDependencies for ApiHubDependencies {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1239,7 +1239,7 @@ impl crate::stubs::ApiHubDependencies for ApiHubDependencies {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1282,7 +1282,7 @@ impl crate::stubs::HostProjectRegistrationService for HostProjectRegistrationSer
                 reqwest::Method::POST,
                 format!("/v1/{}/hostProjectRegistrations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1305,7 +1305,7 @@ impl crate::stubs::HostProjectRegistrationService for HostProjectRegistrationSer
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1327,7 +1327,7 @@ impl crate::stubs::HostProjectRegistrationService for HostProjectRegistrationSer
                 reqwest::Method::GET,
                 format!("/v1/{}/hostProjectRegistrations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1350,7 +1350,7 @@ impl crate::stubs::HostProjectRegistrationService for HostProjectRegistrationSer
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1372,7 +1372,7 @@ impl crate::stubs::HostProjectRegistrationService for HostProjectRegistrationSer
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1391,7 +1391,7 @@ impl crate::stubs::HostProjectRegistrationService for HostProjectRegistrationSer
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1413,7 +1413,7 @@ impl crate::stubs::HostProjectRegistrationService for HostProjectRegistrationSer
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1432,7 +1432,7 @@ impl crate::stubs::HostProjectRegistrationService for HostProjectRegistrationSer
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1451,7 +1451,7 @@ impl crate::stubs::HostProjectRegistrationService for HostProjectRegistrationSer
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1491,7 +1491,7 @@ impl crate::stubs::LintingService for LintingService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1519,7 +1519,7 @@ impl crate::stubs::LintingService for LintingService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1548,7 +1548,7 @@ impl crate::stubs::LintingService for LintingService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}:contents", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1567,7 +1567,7 @@ impl crate::stubs::LintingService for LintingService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:lint", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1584,7 +1584,7 @@ impl crate::stubs::LintingService for LintingService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1606,7 +1606,7 @@ impl crate::stubs::LintingService for LintingService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1625,7 +1625,7 @@ impl crate::stubs::LintingService for LintingService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1647,7 +1647,7 @@ impl crate::stubs::LintingService for LintingService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1666,7 +1666,7 @@ impl crate::stubs::LintingService for LintingService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1685,7 +1685,7 @@ impl crate::stubs::LintingService for LintingService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1725,7 +1725,7 @@ impl crate::stubs::ApiHubPlugin for ApiHubPlugin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1744,7 +1744,7 @@ impl crate::stubs::ApiHubPlugin for ApiHubPlugin {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:enable", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1761,7 +1761,7 @@ impl crate::stubs::ApiHubPlugin for ApiHubPlugin {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:disable", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1778,7 +1778,7 @@ impl crate::stubs::ApiHubPlugin for ApiHubPlugin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1800,7 +1800,7 @@ impl crate::stubs::ApiHubPlugin for ApiHubPlugin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1819,7 +1819,7 @@ impl crate::stubs::ApiHubPlugin for ApiHubPlugin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1841,7 +1841,7 @@ impl crate::stubs::ApiHubPlugin for ApiHubPlugin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1860,7 +1860,7 @@ impl crate::stubs::ApiHubPlugin for ApiHubPlugin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1879,7 +1879,7 @@ impl crate::stubs::ApiHubPlugin for ApiHubPlugin {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1922,7 +1922,7 @@ impl crate::stubs::Provisioning for Provisioning {
                 reqwest::Method::POST,
                 format!("/v1/{}/apiHubInstances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1942,7 +1942,7 @@ impl crate::stubs::Provisioning for Provisioning {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1964,7 +1964,7 @@ impl crate::stubs::Provisioning for Provisioning {
                 reqwest::Method::GET,
                 format!("/v1/{}/apiHubInstances:lookup", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1983,7 +1983,7 @@ impl crate::stubs::Provisioning for Provisioning {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2005,7 +2005,7 @@ impl crate::stubs::Provisioning for Provisioning {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2024,7 +2024,7 @@ impl crate::stubs::Provisioning for Provisioning {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2046,7 +2046,7 @@ impl crate::stubs::Provisioning for Provisioning {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2065,7 +2065,7 @@ impl crate::stubs::Provisioning for Provisioning {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2084,7 +2084,7 @@ impl crate::stubs::Provisioning for Provisioning {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2141,7 +2141,7 @@ impl crate::stubs::RuntimeProjectAttachmentService for RuntimeProjectAttachmentS
                 reqwest::Method::POST,
                 format!("/v1/{}/runtimeProjectAttachments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2164,7 +2164,7 @@ impl crate::stubs::RuntimeProjectAttachmentService for RuntimeProjectAttachmentS
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2186,7 +2186,7 @@ impl crate::stubs::RuntimeProjectAttachmentService for RuntimeProjectAttachmentS
                 reqwest::Method::GET,
                 format!("/v1/{}/runtimeProjectAttachments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2209,7 +2209,7 @@ impl crate::stubs::RuntimeProjectAttachmentService for RuntimeProjectAttachmentS
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2231,7 +2231,7 @@ impl crate::stubs::RuntimeProjectAttachmentService for RuntimeProjectAttachmentS
                 reqwest::Method::GET,
                 format!("/v1/{}:lookupRuntimeProjectAttachment", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2250,7 +2250,7 @@ impl crate::stubs::RuntimeProjectAttachmentService for RuntimeProjectAttachmentS
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2272,7 +2272,7 @@ impl crate::stubs::RuntimeProjectAttachmentService for RuntimeProjectAttachmentS
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2291,7 +2291,7 @@ impl crate::stubs::RuntimeProjectAttachmentService for RuntimeProjectAttachmentS
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2313,7 +2313,7 @@ impl crate::stubs::RuntimeProjectAttachmentService for RuntimeProjectAttachmentS
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2332,7 +2332,7 @@ impl crate::stubs::RuntimeProjectAttachmentService for RuntimeProjectAttachmentS
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2351,7 +2351,7 @@ impl crate::stubs::RuntimeProjectAttachmentService for RuntimeProjectAttachmentS
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/apphub/v1/src/model.rs
+++ b/src/generated/cloud/apphub/v1/src/model.rs
@@ -2339,46 +2339,63 @@ pub mod application {
 
     /// Application state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The Application is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// The Application is ready to register Services and Workloads.
+        pub const ACTIVE: State = State::new(2);
+
+        /// The Application is being deleted.
+        pub const DELETING: State = State::new(3);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The Application is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The Application is ready to register Services and Workloads.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The Application is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2419,40 +2436,53 @@ pub mod scope {
 
     /// Scope Type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Unspecified type.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// Regional type.
+        pub const REGIONAL: Type = Type::new(1);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REGIONAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "REGIONAL" => std::option::Option::Some(Self::REGIONAL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Unspecified type.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// Regional type.
-        pub const REGIONAL: Type = Type::new("REGIONAL");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2591,49 +2621,68 @@ pub mod criticality {
 
     /// Criticality Type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Unspecified type.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// Mission critical service, application or workload.
+        pub const MISSION_CRITICAL: Type = Type::new(1);
+
+        /// High impact.
+        pub const HIGH: Type = Type::new(2);
+
+        /// Medium impact.
+        pub const MEDIUM: Type = Type::new(3);
+
+        /// Low impact.
+        pub const LOW: Type = Type::new(4);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MISSION_CRITICAL"),
+                2 => std::borrow::Cow::Borrowed("HIGH"),
+                3 => std::borrow::Cow::Borrowed("MEDIUM"),
+                4 => std::borrow::Cow::Borrowed("LOW"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "MISSION_CRITICAL" => std::option::Option::Some(Self::MISSION_CRITICAL),
+                "HIGH" => std::option::Option::Some(Self::HIGH),
+                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
+                "LOW" => std::option::Option::Some(Self::LOW),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Unspecified type.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// Mission critical service, application or workload.
-        pub const MISSION_CRITICAL: Type = Type::new("MISSION_CRITICAL");
-
-        /// High impact.
-        pub const HIGH: Type = Type::new("HIGH");
-
-        /// Medium impact.
-        pub const MEDIUM: Type = Type::new("MEDIUM");
-
-        /// Low impact.
-        pub const LOW: Type = Type::new("LOW");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2677,49 +2726,68 @@ pub mod environment {
 
     /// Environment Type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Unspecified type.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// Production environment.
+        pub const PRODUCTION: Type = Type::new(1);
+
+        /// Staging environment.
+        pub const STAGING: Type = Type::new(2);
+
+        /// Test environment.
+        pub const TEST: Type = Type::new(3);
+
+        /// Development environment.
+        pub const DEVELOPMENT: Type = Type::new(4);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PRODUCTION"),
+                2 => std::borrow::Cow::Borrowed("STAGING"),
+                3 => std::borrow::Cow::Borrowed("TEST"),
+                4 => std::borrow::Cow::Borrowed("DEVELOPMENT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "PRODUCTION" => std::option::Option::Some(Self::PRODUCTION),
+                "STAGING" => std::option::Option::Some(Self::STAGING),
+                "TEST" => std::option::Option::Some(Self::TEST),
+                "DEVELOPMENT" => std::option::Option::Some(Self::DEVELOPMENT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Unspecified type.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// Production environment.
-        pub const PRODUCTION: Type = Type::new("PRODUCTION");
-
-        /// Staging environment.
-        pub const STAGING: Type = Type::new("STAGING");
-
-        /// Test environment.
-        pub const TEST: Type = Type::new("TEST");
-
-        /// Development environment.
-        pub const DEVELOPMENT: Type = Type::new("DEVELOPMENT");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2929,49 +2997,68 @@ pub mod service {
 
     /// Service state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The service is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// The service is ready.
+        pub const ACTIVE: State = State::new(2);
+
+        /// The service is being deleted.
+        pub const DELETING: State = State::new(3);
+
+        /// The underlying networking resources have been deleted.
+        pub const DETACHED: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("DETACHED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "DETACHED" => std::option::Option::Some(Self::DETACHED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The service is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The service is ready.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The service is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// The underlying networking resources have been deleted.
-        pub const DETACHED: State = State::new("DETACHED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3211,48 +3298,65 @@ pub mod service_project_attachment {
 
     /// ServiceProjectAttachment state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The ServiceProjectAttachment is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The ServiceProjectAttachment is ready.
         /// This means Services and Workloads under the corresponding
         /// ServiceProjectAttachment is ready for registration.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(2);
 
         /// The ServiceProjectAttachment is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(3);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3423,49 +3527,68 @@ pub mod workload {
 
     /// Workload state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The Workload is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// The Workload is ready.
+        pub const ACTIVE: State = State::new(2);
+
+        /// The Workload is being deleted.
+        pub const DELETING: State = State::new(3);
+
+        /// The underlying compute resources have been deleted.
+        pub const DETACHED: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("DETACHED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "DETACHED" => std::option::Option::Some(Self::DETACHED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The Workload is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The Workload is ready.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The Workload is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// The underlying compute resources have been deleted.
-        pub const DETACHED: State = State::new("DETACHED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/apphub/v1/src/transport.rs
+++ b/src/generated/cloud/apphub/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::AppHub for AppHub {
                 reqwest::Method::GET,
                 format!("/v1/{}:lookupServiceProjectAttachment", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -74,7 +74,7 @@ impl crate::stubs::AppHub for AppHub {
                 reqwest::Method::GET,
                 format!("/v1/{}/serviceProjectAttachments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -100,7 +100,7 @@ impl crate::stubs::AppHub for AppHub {
                 reqwest::Method::POST,
                 format!("/v1/{}/serviceProjectAttachments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -124,7 +124,7 @@ impl crate::stubs::AppHub for AppHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -143,7 +143,7 @@ impl crate::stubs::AppHub for AppHub {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -166,7 +166,7 @@ impl crate::stubs::AppHub for AppHub {
                 reqwest::Method::POST,
                 format!("/v1/{}:detachServiceProjectAttachment", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -186,7 +186,7 @@ impl crate::stubs::AppHub for AppHub {
                 reqwest::Method::GET,
                 format!("/v1/{}/discoveredServices", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -209,7 +209,7 @@ impl crate::stubs::AppHub for AppHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -231,7 +231,7 @@ impl crate::stubs::AppHub for AppHub {
                 reqwest::Method::GET,
                 format!("/v1/{}/discoveredServices:lookup", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -251,7 +251,7 @@ impl crate::stubs::AppHub for AppHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/services", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -277,7 +277,7 @@ impl crate::stubs::AppHub for AppHub {
                 reqwest::Method::POST,
                 format!("/v1/{}/services", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -298,7 +298,7 @@ impl crate::stubs::AppHub for AppHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -326,7 +326,7 @@ impl crate::stubs::AppHub for AppHub {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -356,7 +356,7 @@ impl crate::stubs::AppHub for AppHub {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -379,7 +379,7 @@ impl crate::stubs::AppHub for AppHub {
                 reqwest::Method::GET,
                 format!("/v1/{}/discoveredWorkloads", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -402,7 +402,7 @@ impl crate::stubs::AppHub for AppHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -424,7 +424,7 @@ impl crate::stubs::AppHub for AppHub {
                 reqwest::Method::GET,
                 format!("/v1/{}/discoveredWorkloads:lookup", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -447,7 +447,7 @@ impl crate::stubs::AppHub for AppHub {
                 reqwest::Method::GET,
                 format!("/v1/{}/workloads", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -473,7 +473,7 @@ impl crate::stubs::AppHub for AppHub {
                 reqwest::Method::POST,
                 format!("/v1/{}/workloads", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -494,7 +494,7 @@ impl crate::stubs::AppHub for AppHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -522,7 +522,7 @@ impl crate::stubs::AppHub for AppHub {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -552,7 +552,7 @@ impl crate::stubs::AppHub for AppHub {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -575,7 +575,7 @@ impl crate::stubs::AppHub for AppHub {
                 reqwest::Method::GET,
                 format!("/v1/{}/applications", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -601,7 +601,7 @@ impl crate::stubs::AppHub for AppHub {
                 reqwest::Method::POST,
                 format!("/v1/{}/applications", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -622,7 +622,7 @@ impl crate::stubs::AppHub for AppHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -650,7 +650,7 @@ impl crate::stubs::AppHub for AppHub {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -680,7 +680,7 @@ impl crate::stubs::AppHub for AppHub {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -700,7 +700,7 @@ impl crate::stubs::AppHub for AppHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -722,7 +722,7 @@ impl crate::stubs::AppHub for AppHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -744,7 +744,7 @@ impl crate::stubs::AppHub for AppHub {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -764,7 +764,7 @@ impl crate::stubs::AppHub for AppHub {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -796,7 +796,7 @@ impl crate::stubs::AppHub for AppHub {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -813,7 +813,7 @@ impl crate::stubs::AppHub for AppHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -835,7 +835,7 @@ impl crate::stubs::AppHub for AppHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -854,7 +854,7 @@ impl crate::stubs::AppHub for AppHub {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -873,7 +873,7 @@ impl crate::stubs::AppHub for AppHub {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/asset/v1/src/model.rs
+++ b/src/generated/cloud/asset/v1/src/model.rs
@@ -1396,51 +1396,67 @@ pub mod partition_spec {
     /// (expressed in UTC. see details in
     /// <https://cloud.google.com/bigquery/docs/partitioned-tables#date_timestamp_partitioned_tables>).
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PartitionKey(std::borrow::Cow<'static, str>);
+    pub struct PartitionKey(i32);
 
     impl PartitionKey {
-        /// Creates a new PartitionKey instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PartitionKey](PartitionKey)
-    pub mod partition_key {
-        use super::PartitionKey;
-
         /// Unspecified partition key. If used, it means using non-partitioned table.
-        pub const PARTITION_KEY_UNSPECIFIED: PartitionKey =
-            PartitionKey::new("PARTITION_KEY_UNSPECIFIED");
+        pub const PARTITION_KEY_UNSPECIFIED: PartitionKey = PartitionKey::new(0);
 
         /// The time when the snapshot is taken. If specified as partition key, the
         /// result table(s) is partitoned by the additional timestamp column,
         /// readTime. If [read_time] in ExportAssetsRequest is specified, the
         /// readTime column's value will be the same as it. Otherwise, its value will
         /// be the current time that is used to take the snapshot.
-        pub const READ_TIME: PartitionKey = PartitionKey::new("READ_TIME");
+        pub const READ_TIME: PartitionKey = PartitionKey::new(1);
 
         /// The time when the request is received and started to be processed. If
         /// specified as partition key, the result table(s) is partitoned by the
         /// requestTime column, an additional timestamp column representing when the
         /// request was received.
-        pub const REQUEST_TIME: PartitionKey = PartitionKey::new("REQUEST_TIME");
+        pub const REQUEST_TIME: PartitionKey = PartitionKey::new(2);
+
+        /// Creates a new PartitionKey instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PARTITION_KEY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("READ_TIME"),
+                2 => std::borrow::Cow::Borrowed("REQUEST_TIME"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PARTITION_KEY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PARTITION_KEY_UNSPECIFIED)
+                }
+                "READ_TIME" => std::option::Option::Some(Self::READ_TIME),
+                "REQUEST_TIME" => std::option::Option::Some(Self::REQUEST_TIME),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PartitionKey {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PartitionKey {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PartitionKey {
         fn default() -> Self {
-            partition_key::PARTITION_KEY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3280,44 +3296,58 @@ pub mod iam_policy_analysis_output_config {
         /// filtering partitions. Refer to
         /// <https://cloud.google.com/bigquery/docs/partitioned-tables> for details.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct PartitionKey(std::borrow::Cow<'static, str>);
+        pub struct PartitionKey(i32);
 
         impl PartitionKey {
-            /// Creates a new PartitionKey instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [PartitionKey](PartitionKey)
-        pub mod partition_key {
-            use super::PartitionKey;
-
             /// Unspecified partition key. Tables won't be partitioned using this
             /// option.
-            pub const PARTITION_KEY_UNSPECIFIED: PartitionKey =
-                PartitionKey::new("PARTITION_KEY_UNSPECIFIED");
+            pub const PARTITION_KEY_UNSPECIFIED: PartitionKey = PartitionKey::new(0);
 
             /// The time when the request is received. If specified as partition key,
             /// the result table(s) is partitoned by the RequestTime column, an
             /// additional timestamp column representing when the request was received.
-            pub const REQUEST_TIME: PartitionKey = PartitionKey::new("REQUEST_TIME");
+            pub const REQUEST_TIME: PartitionKey = PartitionKey::new(1);
+
+            /// Creates a new PartitionKey instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("PARTITION_KEY_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("REQUEST_TIME"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "PARTITION_KEY_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::PARTITION_KEY_UNSPECIFIED)
+                    }
+                    "REQUEST_TIME" => std::option::Option::Some(Self::REQUEST_TIME),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for PartitionKey {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for PartitionKey {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for PartitionKey {
             fn default() -> Self {
-                partition_key::PARTITION_KEY_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -4047,47 +4077,63 @@ pub mod analyze_move_request {
 
     /// View enum for supporting partial analysis responses.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AnalysisView(std::borrow::Cow<'static, str>);
+    pub struct AnalysisView(i32);
 
     impl AnalysisView {
-        /// Creates a new AnalysisView instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [AnalysisView](AnalysisView)
-    pub mod analysis_view {
-        use super::AnalysisView;
-
         /// The default/unset value.
         /// The API will default to the FULL view.
-        pub const ANALYSIS_VIEW_UNSPECIFIED: AnalysisView =
-            AnalysisView::new("ANALYSIS_VIEW_UNSPECIFIED");
+        pub const ANALYSIS_VIEW_UNSPECIFIED: AnalysisView = AnalysisView::new(0);
 
         /// Full analysis including all level of impacts of the specified resource
         /// move.
-        pub const FULL: AnalysisView = AnalysisView::new("FULL");
+        pub const FULL: AnalysisView = AnalysisView::new(1);
 
         /// Basic analysis only including blockers which will prevent the specified
         /// resource move at runtime.
-        pub const BASIC: AnalysisView = AnalysisView::new("BASIC");
+        pub const BASIC: AnalysisView = AnalysisView::new(2);
+
+        /// Creates a new AnalysisView instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ANALYSIS_VIEW_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FULL"),
+                2 => std::borrow::Cow::Borrowed("BASIC"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ANALYSIS_VIEW_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ANALYSIS_VIEW_UNSPECIFIED)
+                }
+                "FULL" => std::option::Option::Some(Self::FULL),
+                "BASIC" => std::option::Option::Some(Self::BASIC),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for AnalysisView {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AnalysisView {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AnalysisView {
         fn default() -> Self {
-            analysis_view::ANALYSIS_VIEW_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6067,47 +6113,63 @@ pub mod analyzer_org_policy_constraint {
         /// Specifies the default behavior in the absence of any `Policy` for the
         /// `Constraint`. This must not be `CONSTRAINT_DEFAULT_UNSPECIFIED`.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ConstraintDefault(std::borrow::Cow<'static, str>);
+        pub struct ConstraintDefault(i32);
 
         impl ConstraintDefault {
-            /// Creates a new ConstraintDefault instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [ConstraintDefault](ConstraintDefault)
-        pub mod constraint_default {
-            use super::ConstraintDefault;
-
             /// This is only used for distinguishing unset values and should never be
             /// used.
-            pub const CONSTRAINT_DEFAULT_UNSPECIFIED: ConstraintDefault =
-                ConstraintDefault::new("CONSTRAINT_DEFAULT_UNSPECIFIED");
+            pub const CONSTRAINT_DEFAULT_UNSPECIFIED: ConstraintDefault = ConstraintDefault::new(0);
 
             /// Indicate that all values are allowed for list constraints.
             /// Indicate that enforcement is off for boolean constraints.
-            pub const ALLOW: ConstraintDefault = ConstraintDefault::new("ALLOW");
+            pub const ALLOW: ConstraintDefault = ConstraintDefault::new(1);
 
             /// Indicate that all values are denied for list constraints.
             /// Indicate that enforcement is on for boolean constraints.
-            pub const DENY: ConstraintDefault = ConstraintDefault::new("DENY");
+            pub const DENY: ConstraintDefault = ConstraintDefault::new(2);
+
+            /// Creates a new ConstraintDefault instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("CONSTRAINT_DEFAULT_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("ALLOW"),
+                    2 => std::borrow::Cow::Borrowed("DENY"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "CONSTRAINT_DEFAULT_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::CONSTRAINT_DEFAULT_UNSPECIFIED)
+                    }
+                    "ALLOW" => std::option::Option::Some(Self::ALLOW),
+                    "DENY" => std::option::Option::Some(Self::DENY),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for ConstraintDefault {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for ConstraintDefault {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for ConstraintDefault {
             fn default() -> Self {
-                constraint_default::CONSTRAINT_DEFAULT_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -6267,90 +6329,124 @@ pub mod analyzer_org_policy_constraint {
         /// "CREATE" only. If the constraint applied when create or delete VMs, the
         /// method_types will be "CREATE" and "DELETE".
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct MethodType(std::borrow::Cow<'static, str>);
+        pub struct MethodType(i32);
 
         impl MethodType {
+            /// Unspecified. Will results in user error.
+            pub const METHOD_TYPE_UNSPECIFIED: MethodType = MethodType::new(0);
+
+            /// Constraint applied when creating the resource.
+            pub const CREATE: MethodType = MethodType::new(1);
+
+            /// Constraint applied when updating the resource.
+            pub const UPDATE: MethodType = MethodType::new(2);
+
+            /// Constraint applied when deleting the resource.
+            pub const DELETE: MethodType = MethodType::new(3);
+
             /// Creates a new MethodType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("METHOD_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("CREATE"),
+                    2 => std::borrow::Cow::Borrowed("UPDATE"),
+                    3 => std::borrow::Cow::Borrowed("DELETE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "METHOD_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::METHOD_TYPE_UNSPECIFIED)
+                    }
+                    "CREATE" => std::option::Option::Some(Self::CREATE),
+                    "UPDATE" => std::option::Option::Some(Self::UPDATE),
+                    "DELETE" => std::option::Option::Some(Self::DELETE),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [MethodType](MethodType)
-        pub mod method_type {
-            use super::MethodType;
-
-            /// Unspecified. Will results in user error.
-            pub const METHOD_TYPE_UNSPECIFIED: MethodType =
-                MethodType::new("METHOD_TYPE_UNSPECIFIED");
-
-            /// Constraint applied when creating the resource.
-            pub const CREATE: MethodType = MethodType::new("CREATE");
-
-            /// Constraint applied when updating the resource.
-            pub const UPDATE: MethodType = MethodType::new("UPDATE");
-
-            /// Constraint applied when deleting the resource.
-            pub const DELETE: MethodType = MethodType::new("DELETE");
-        }
-
-        impl std::convert::From<std::string::String> for MethodType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for MethodType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for MethodType {
             fn default() -> Self {
-                method_type::METHOD_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
 
         /// Allow or deny type.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ActionType(std::borrow::Cow<'static, str>);
+        pub struct ActionType(i32);
 
         impl ActionType {
+            /// Unspecified. Will results in user error.
+            pub const ACTION_TYPE_UNSPECIFIED: ActionType = ActionType::new(0);
+
+            /// Allowed action type.
+            pub const ALLOW: ActionType = ActionType::new(1);
+
+            /// Deny action type.
+            pub const DENY: ActionType = ActionType::new(2);
+
             /// Creates a new ActionType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("ACTION_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("ALLOW"),
+                    2 => std::borrow::Cow::Borrowed("DENY"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "ACTION_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::ACTION_TYPE_UNSPECIFIED)
+                    }
+                    "ALLOW" => std::option::Option::Some(Self::ALLOW),
+                    "DENY" => std::option::Option::Some(Self::DENY),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [ActionType](ActionType)
-        pub mod action_type {
-            use super::ActionType;
-
-            /// Unspecified. Will results in user error.
-            pub const ACTION_TYPE_UNSPECIFIED: ActionType =
-                ActionType::new("ACTION_TYPE_UNSPECIFIED");
-
-            /// Allowed action type.
-            pub const ALLOW: ActionType = ActionType::new("ALLOW");
-
-            /// Deny action type.
-            pub const DENY: ActionType = ActionType::new("DENY");
-        }
-
-        impl std::convert::From<std::string::String> for ActionType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for ActionType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for ActionType {
             fn default() -> Self {
-                action_type::ACTION_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -7716,50 +7812,70 @@ pub mod temporal_asset {
 
     /// State of prior asset.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PriorAssetState(std::borrow::Cow<'static, str>);
+    pub struct PriorAssetState(i32);
 
     impl PriorAssetState {
+        /// prior_asset is not applicable for the current asset.
+        pub const PRIOR_ASSET_STATE_UNSPECIFIED: PriorAssetState = PriorAssetState::new(0);
+
+        /// prior_asset is populated correctly.
+        pub const PRESENT: PriorAssetState = PriorAssetState::new(1);
+
+        /// Failed to set prior_asset.
+        pub const INVALID: PriorAssetState = PriorAssetState::new(2);
+
+        /// Current asset is the first known state.
+        pub const DOES_NOT_EXIST: PriorAssetState = PriorAssetState::new(3);
+
+        /// prior_asset is a deletion.
+        pub const DELETED: PriorAssetState = PriorAssetState::new(4);
+
         /// Creates a new PriorAssetState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PRIOR_ASSET_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PRESENT"),
+                2 => std::borrow::Cow::Borrowed("INVALID"),
+                3 => std::borrow::Cow::Borrowed("DOES_NOT_EXIST"),
+                4 => std::borrow::Cow::Borrowed("DELETED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PRIOR_ASSET_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PRIOR_ASSET_STATE_UNSPECIFIED)
+                }
+                "PRESENT" => std::option::Option::Some(Self::PRESENT),
+                "INVALID" => std::option::Option::Some(Self::INVALID),
+                "DOES_NOT_EXIST" => std::option::Option::Some(Self::DOES_NOT_EXIST),
+                "DELETED" => std::option::Option::Some(Self::DELETED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [PriorAssetState](PriorAssetState)
-    pub mod prior_asset_state {
-        use super::PriorAssetState;
-
-        /// prior_asset is not applicable for the current asset.
-        pub const PRIOR_ASSET_STATE_UNSPECIFIED: PriorAssetState =
-            PriorAssetState::new("PRIOR_ASSET_STATE_UNSPECIFIED");
-
-        /// prior_asset is populated correctly.
-        pub const PRESENT: PriorAssetState = PriorAssetState::new("PRESENT");
-
-        /// Failed to set prior_asset.
-        pub const INVALID: PriorAssetState = PriorAssetState::new("INVALID");
-
-        /// Current asset is the first known state.
-        pub const DOES_NOT_EXIST: PriorAssetState = PriorAssetState::new("DOES_NOT_EXIST");
-
-        /// prior_asset is a deletion.
-        pub const DELETED: PriorAssetState = PriorAssetState::new("DELETED");
-    }
-
-    impl std::convert::From<std::string::String> for PriorAssetState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PriorAssetState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PriorAssetState {
         fn default() -> Self {
-            prior_asset_state::PRIOR_ASSET_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -9772,49 +9888,67 @@ pub mod condition_evaluation {
 
     /// Value of this expression.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EvaluationValue(std::borrow::Cow<'static, str>);
+    pub struct EvaluationValue(i32);
 
     impl EvaluationValue {
-        /// Creates a new EvaluationValue instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [EvaluationValue](EvaluationValue)
-    pub mod evaluation_value {
-        use super::EvaluationValue;
-
         /// Reserved for future use.
-        pub const EVALUATION_VALUE_UNSPECIFIED: EvaluationValue =
-            EvaluationValue::new("EVALUATION_VALUE_UNSPECIFIED");
+        pub const EVALUATION_VALUE_UNSPECIFIED: EvaluationValue = EvaluationValue::new(0);
 
         /// The evaluation result is `true`.
-        pub const TRUE: EvaluationValue = EvaluationValue::new("TRUE");
+        pub const TRUE: EvaluationValue = EvaluationValue::new(1);
 
         /// The evaluation result is `false`.
-        pub const FALSE: EvaluationValue = EvaluationValue::new("FALSE");
+        pub const FALSE: EvaluationValue = EvaluationValue::new(2);
 
         /// The evaluation result is `conditional` when the condition expression
         /// contains variables that are either missing input values or have not been
         /// supported by Policy Analyzer yet.
-        pub const CONDITIONAL: EvaluationValue = EvaluationValue::new("CONDITIONAL");
+        pub const CONDITIONAL: EvaluationValue = EvaluationValue::new(3);
+
+        /// Creates a new EvaluationValue instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EVALUATION_VALUE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TRUE"),
+                2 => std::borrow::Cow::Borrowed("FALSE"),
+                3 => std::borrow::Cow::Borrowed("CONDITIONAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EVALUATION_VALUE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::EVALUATION_VALUE_UNSPECIFIED)
+                }
+                "TRUE" => std::option::Option::Some(Self::TRUE),
+                "FALSE" => std::option::Option::Some(Self::FALSE),
+                "CONDITIONAL" => std::option::Option::Some(Self::CONDITIONAL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for EvaluationValue {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EvaluationValue {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EvaluationValue {
         fn default() -> Self {
-            evaluation_value::EVALUATION_VALUE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -10371,54 +10505,77 @@ pub mod iam_policy_analysis_result {
 
 /// Asset content type.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ContentType(std::borrow::Cow<'static, str>);
+pub struct ContentType(i32);
 
 impl ContentType {
+    /// Unspecified content type.
+    pub const CONTENT_TYPE_UNSPECIFIED: ContentType = ContentType::new(0);
+
+    /// Resource metadata.
+    pub const RESOURCE: ContentType = ContentType::new(1);
+
+    /// The actual IAM policy set on a resource.
+    pub const IAM_POLICY: ContentType = ContentType::new(2);
+
+    /// The organization policy set on an asset.
+    pub const ORG_POLICY: ContentType = ContentType::new(4);
+
+    /// The Access Context Manager policy set on an asset.
+    pub const ACCESS_POLICY: ContentType = ContentType::new(5);
+
+    /// The runtime OS Inventory information.
+    pub const OS_INVENTORY: ContentType = ContentType::new(6);
+
+    /// The related resources.
+    pub const RELATIONSHIP: ContentType = ContentType::new(7);
+
     /// Creates a new ContentType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("CONTENT_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("RESOURCE"),
+            2 => std::borrow::Cow::Borrowed("IAM_POLICY"),
+            4 => std::borrow::Cow::Borrowed("ORG_POLICY"),
+            5 => std::borrow::Cow::Borrowed("ACCESS_POLICY"),
+            6 => std::borrow::Cow::Borrowed("OS_INVENTORY"),
+            7 => std::borrow::Cow::Borrowed("RELATIONSHIP"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "CONTENT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::CONTENT_TYPE_UNSPECIFIED),
+            "RESOURCE" => std::option::Option::Some(Self::RESOURCE),
+            "IAM_POLICY" => std::option::Option::Some(Self::IAM_POLICY),
+            "ORG_POLICY" => std::option::Option::Some(Self::ORG_POLICY),
+            "ACCESS_POLICY" => std::option::Option::Some(Self::ACCESS_POLICY),
+            "OS_INVENTORY" => std::option::Option::Some(Self::OS_INVENTORY),
+            "RELATIONSHIP" => std::option::Option::Some(Self::RELATIONSHIP),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [ContentType](ContentType)
-pub mod content_type {
-    use super::ContentType;
-
-    /// Unspecified content type.
-    pub const CONTENT_TYPE_UNSPECIFIED: ContentType = ContentType::new("CONTENT_TYPE_UNSPECIFIED");
-
-    /// Resource metadata.
-    pub const RESOURCE: ContentType = ContentType::new("RESOURCE");
-
-    /// The actual IAM policy set on a resource.
-    pub const IAM_POLICY: ContentType = ContentType::new("IAM_POLICY");
-
-    /// The organization policy set on an asset.
-    pub const ORG_POLICY: ContentType = ContentType::new("ORG_POLICY");
-
-    /// The Access Context Manager policy set on an asset.
-    pub const ACCESS_POLICY: ContentType = ContentType::new("ACCESS_POLICY");
-
-    /// The runtime OS Inventory information.
-    pub const OS_INVENTORY: ContentType = ContentType::new("OS_INVENTORY");
-
-    /// The related resources.
-    pub const RELATIONSHIP: ContentType = ContentType::new("RELATIONSHIP");
-}
-
-impl std::convert::From<std::string::String> for ContentType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ContentType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ContentType {
     fn default() -> Self {
-        content_type::CONTENT_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/asset/v1/src/transport.rs
+++ b/src/generated/cloud/asset/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::AssetService for AssetService {
                 reqwest::Method::POST,
                 format!("/v1/{}:exportAssets", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -69,7 +69,7 @@ impl crate::stubs::AssetService for AssetService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/assets", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -111,7 +111,7 @@ impl crate::stubs::AssetService for AssetService {
                 reqwest::Method::GET,
                 format!("/v1/{}:batchGetAssetsHistory", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -148,7 +148,7 @@ impl crate::stubs::AssetService for AssetService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/feeds", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -165,7 +165,7 @@ impl crate::stubs::AssetService for AssetService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -184,7 +184,7 @@ impl crate::stubs::AssetService for AssetService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/feeds", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -212,7 +212,7 @@ impl crate::stubs::AssetService for AssetService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -229,7 +229,7 @@ impl crate::stubs::AssetService for AssetService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -251,7 +251,7 @@ impl crate::stubs::AssetService for AssetService {
                 reqwest::Method::GET,
                 format!("/v1/{}:searchAllResources", req.scope),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -291,7 +291,7 @@ impl crate::stubs::AssetService for AssetService {
                 reqwest::Method::GET,
                 format!("/v1/{}:searchAllIamPolicies", req.scope),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -327,7 +327,7 @@ impl crate::stubs::AssetService for AssetService {
                         .scope
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -376,7 +376,7 @@ impl crate::stubs::AssetService for AssetService {
                         .scope
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -396,7 +396,7 @@ impl crate::stubs::AssetService for AssetService {
                 reqwest::Method::GET,
                 format!("/v1/{}:analyzeMove", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -420,7 +420,7 @@ impl crate::stubs::AssetService for AssetService {
                 reqwest::Method::POST,
                 format!("/v1/{}:queryAssets", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -440,7 +440,7 @@ impl crate::stubs::AssetService for AssetService {
                 reqwest::Method::POST,
                 format!("/v1/{}/savedQueries", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -460,7 +460,7 @@ impl crate::stubs::AssetService for AssetService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -482,7 +482,7 @@ impl crate::stubs::AssetService for AssetService {
                 reqwest::Method::GET,
                 format!("/v1/{}/savedQueries", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -513,7 +513,7 @@ impl crate::stubs::AssetService for AssetService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -542,7 +542,7 @@ impl crate::stubs::AssetService for AssetService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -564,7 +564,7 @@ impl crate::stubs::AssetService for AssetService {
                 reqwest::Method::GET,
                 format!("/v1/{}/effectiveIamPolicies:batchGet", req.scope),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -590,7 +590,7 @@ impl crate::stubs::AssetService for AssetService {
                 reqwest::Method::GET,
                 format!("/v1/{}:analyzeOrgPolicies", req.scope),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -619,7 +619,7 @@ impl crate::stubs::AssetService for AssetService {
                 reqwest::Method::GET,
                 format!("/v1/{}:analyzeOrgPolicyGovernedContainers", req.scope),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -648,7 +648,7 @@ impl crate::stubs::AssetService for AssetService {
                 reqwest::Method::GET,
                 format!("/v1/{}:analyzeOrgPolicyGovernedAssets", req.scope),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -674,7 +674,7 @@ impl crate::stubs::AssetService for AssetService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/assuredworkloads/v1/src/model.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/model.rs
@@ -648,55 +648,76 @@ pub mod workload {
 
         /// The type of resource.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ResourceType(std::borrow::Cow<'static, str>);
+        pub struct ResourceType(i32);
 
         impl ResourceType {
-            /// Creates a new ResourceType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [ResourceType](ResourceType)
-        pub mod resource_type {
-            use super::ResourceType;
-
             /// Unknown resource type.
-            pub const RESOURCE_TYPE_UNSPECIFIED: ResourceType =
-                ResourceType::new("RESOURCE_TYPE_UNSPECIFIED");
+            pub const RESOURCE_TYPE_UNSPECIFIED: ResourceType = ResourceType::new(0);
 
             /// Consumer project.
             /// AssuredWorkloads Projects are no longer supported. This field will be
             /// ignored only in CreateWorkload requests. ListWorkloads and GetWorkload
             /// will continue to provide projects information.
             /// Use CONSUMER_FOLDER instead.
-            pub const CONSUMER_PROJECT: ResourceType = ResourceType::new("CONSUMER_PROJECT");
+            pub const CONSUMER_PROJECT: ResourceType = ResourceType::new(1);
 
             /// Consumer Folder.
-            pub const CONSUMER_FOLDER: ResourceType = ResourceType::new("CONSUMER_FOLDER");
+            pub const CONSUMER_FOLDER: ResourceType = ResourceType::new(4);
 
             /// Consumer project containing encryption keys.
-            pub const ENCRYPTION_KEYS_PROJECT: ResourceType =
-                ResourceType::new("ENCRYPTION_KEYS_PROJECT");
+            pub const ENCRYPTION_KEYS_PROJECT: ResourceType = ResourceType::new(2);
 
             /// Keyring resource that hosts encryption keys.
-            pub const KEYRING: ResourceType = ResourceType::new("KEYRING");
+            pub const KEYRING: ResourceType = ResourceType::new(3);
+
+            /// Creates a new ResourceType instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("RESOURCE_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("CONSUMER_PROJECT"),
+                    2 => std::borrow::Cow::Borrowed("ENCRYPTION_KEYS_PROJECT"),
+                    3 => std::borrow::Cow::Borrowed("KEYRING"),
+                    4 => std::borrow::Cow::Borrowed("CONSUMER_FOLDER"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "RESOURCE_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::RESOURCE_TYPE_UNSPECIFIED)
+                    }
+                    "CONSUMER_PROJECT" => std::option::Option::Some(Self::CONSUMER_PROJECT),
+                    "CONSUMER_FOLDER" => std::option::Option::Some(Self::CONSUMER_FOLDER),
+                    "ENCRYPTION_KEYS_PROJECT" => {
+                        std::option::Option::Some(Self::ENCRYPTION_KEYS_PROJECT)
+                    }
+                    "KEYRING" => std::option::Option::Some(Self::KEYRING),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for ResourceType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for ResourceType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for ResourceType {
             fn default() -> Self {
-                resource_type::RESOURCE_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -878,265 +899,371 @@ pub mod workload {
 
         /// Setup state of SAA enrollment.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SetupState(std::borrow::Cow<'static, str>);
+        pub struct SetupState(i32);
 
         impl SetupState {
+            /// Unspecified.
+            pub const SETUP_STATE_UNSPECIFIED: SetupState = SetupState::new(0);
+
+            /// SAA enrollment pending.
+            pub const STATUS_PENDING: SetupState = SetupState::new(1);
+
+            /// SAA enrollment comopleted.
+            pub const STATUS_COMPLETE: SetupState = SetupState::new(2);
+
             /// Creates a new SetupState instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("SETUP_STATE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("STATUS_PENDING"),
+                    2 => std::borrow::Cow::Borrowed("STATUS_COMPLETE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "SETUP_STATE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::SETUP_STATE_UNSPECIFIED)
+                    }
+                    "STATUS_PENDING" => std::option::Option::Some(Self::STATUS_PENDING),
+                    "STATUS_COMPLETE" => std::option::Option::Some(Self::STATUS_COMPLETE),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [SetupState](SetupState)
-        pub mod setup_state {
-            use super::SetupState;
-
-            /// Unspecified.
-            pub const SETUP_STATE_UNSPECIFIED: SetupState =
-                SetupState::new("SETUP_STATE_UNSPECIFIED");
-
-            /// SAA enrollment pending.
-            pub const STATUS_PENDING: SetupState = SetupState::new("STATUS_PENDING");
-
-            /// SAA enrollment comopleted.
-            pub const STATUS_COMPLETE: SetupState = SetupState::new("STATUS_COMPLETE");
-        }
-
-        impl std::convert::From<std::string::String> for SetupState {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for SetupState {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for SetupState {
             fn default() -> Self {
-                setup_state::SETUP_STATE_UNSPECIFIED
+                Self::new(0)
             }
         }
 
         /// Setup error of SAA enrollment.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SetupError(std::borrow::Cow<'static, str>);
+        pub struct SetupError(i32);
 
         impl SetupError {
-            /// Creates a new SetupError instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [SetupError](SetupError)
-        pub mod setup_error {
-            use super::SetupError;
-
             /// Unspecified.
-            pub const SETUP_ERROR_UNSPECIFIED: SetupError =
-                SetupError::new("SETUP_ERROR_UNSPECIFIED");
+            pub const SETUP_ERROR_UNSPECIFIED: SetupError = SetupError::new(0);
 
             /// Invalid states for all customers, to be redirected to AA UI for
             /// additional details.
-            pub const ERROR_INVALID_BASE_SETUP: SetupError =
-                SetupError::new("ERROR_INVALID_BASE_SETUP");
+            pub const ERROR_INVALID_BASE_SETUP: SetupError = SetupError::new(1);
 
             /// Returned when there is not an EKM key configured.
-            pub const ERROR_MISSING_EXTERNAL_SIGNING_KEY: SetupError =
-                SetupError::new("ERROR_MISSING_EXTERNAL_SIGNING_KEY");
+            pub const ERROR_MISSING_EXTERNAL_SIGNING_KEY: SetupError = SetupError::new(2);
 
             /// Returned when there are no enrolled services or the customer is
             /// enrolled in CAA only for a subset of services.
-            pub const ERROR_NOT_ALL_SERVICES_ENROLLED: SetupError =
-                SetupError::new("ERROR_NOT_ALL_SERVICES_ENROLLED");
+            pub const ERROR_NOT_ALL_SERVICES_ENROLLED: SetupError = SetupError::new(3);
 
             /// Returned when exception was encountered during evaluation of other
             /// criteria.
-            pub const ERROR_SETUP_CHECK_FAILED: SetupError =
-                SetupError::new("ERROR_SETUP_CHECK_FAILED");
+            pub const ERROR_SETUP_CHECK_FAILED: SetupError = SetupError::new(4);
+
+            /// Creates a new SetupError instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("SETUP_ERROR_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("ERROR_INVALID_BASE_SETUP"),
+                    2 => std::borrow::Cow::Borrowed("ERROR_MISSING_EXTERNAL_SIGNING_KEY"),
+                    3 => std::borrow::Cow::Borrowed("ERROR_NOT_ALL_SERVICES_ENROLLED"),
+                    4 => std::borrow::Cow::Borrowed("ERROR_SETUP_CHECK_FAILED"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "SETUP_ERROR_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::SETUP_ERROR_UNSPECIFIED)
+                    }
+                    "ERROR_INVALID_BASE_SETUP" => {
+                        std::option::Option::Some(Self::ERROR_INVALID_BASE_SETUP)
+                    }
+                    "ERROR_MISSING_EXTERNAL_SIGNING_KEY" => {
+                        std::option::Option::Some(Self::ERROR_MISSING_EXTERNAL_SIGNING_KEY)
+                    }
+                    "ERROR_NOT_ALL_SERVICES_ENROLLED" => {
+                        std::option::Option::Some(Self::ERROR_NOT_ALL_SERVICES_ENROLLED)
+                    }
+                    "ERROR_SETUP_CHECK_FAILED" => {
+                        std::option::Option::Some(Self::ERROR_SETUP_CHECK_FAILED)
+                    }
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for SetupError {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for SetupError {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for SetupError {
             fn default() -> Self {
-                setup_error::SETUP_ERROR_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// Supported Compliance Regimes.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ComplianceRegime(std::borrow::Cow<'static, str>);
+    pub struct ComplianceRegime(i32);
 
     impl ComplianceRegime {
-        /// Creates a new ComplianceRegime instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ComplianceRegime](ComplianceRegime)
-    pub mod compliance_regime {
-        use super::ComplianceRegime;
-
         /// Unknown compliance regime.
-        pub const COMPLIANCE_REGIME_UNSPECIFIED: ComplianceRegime =
-            ComplianceRegime::new("COMPLIANCE_REGIME_UNSPECIFIED");
+        pub const COMPLIANCE_REGIME_UNSPECIFIED: ComplianceRegime = ComplianceRegime::new(0);
 
         /// Information protection as per DoD IL4 requirements.
-        pub const IL4: ComplianceRegime = ComplianceRegime::new("IL4");
+        pub const IL4: ComplianceRegime = ComplianceRegime::new(1);
 
         /// Criminal Justice Information Services (CJIS) Security policies.
-        pub const CJIS: ComplianceRegime = ComplianceRegime::new("CJIS");
+        pub const CJIS: ComplianceRegime = ComplianceRegime::new(2);
 
         /// FedRAMP High data protection controls
-        pub const FEDRAMP_HIGH: ComplianceRegime = ComplianceRegime::new("FEDRAMP_HIGH");
+        pub const FEDRAMP_HIGH: ComplianceRegime = ComplianceRegime::new(3);
 
         /// FedRAMP Moderate data protection controls
-        pub const FEDRAMP_MODERATE: ComplianceRegime = ComplianceRegime::new("FEDRAMP_MODERATE");
+        pub const FEDRAMP_MODERATE: ComplianceRegime = ComplianceRegime::new(4);
 
         /// Assured Workloads For US Regions data protection controls
-        pub const US_REGIONAL_ACCESS: ComplianceRegime =
-            ComplianceRegime::new("US_REGIONAL_ACCESS");
+        pub const US_REGIONAL_ACCESS: ComplianceRegime = ComplianceRegime::new(5);
 
         /// Health Insurance Portability and Accountability Act controls
-        pub const HIPAA: ComplianceRegime = ComplianceRegime::new("HIPAA");
+        pub const HIPAA: ComplianceRegime = ComplianceRegime::new(6);
 
         /// Health Information Trust Alliance controls
-        pub const HITRUST: ComplianceRegime = ComplianceRegime::new("HITRUST");
+        pub const HITRUST: ComplianceRegime = ComplianceRegime::new(7);
 
         /// Assured Workloads For EU Regions and Support controls
-        pub const EU_REGIONS_AND_SUPPORT: ComplianceRegime =
-            ComplianceRegime::new("EU_REGIONS_AND_SUPPORT");
+        pub const EU_REGIONS_AND_SUPPORT: ComplianceRegime = ComplianceRegime::new(8);
 
         /// Assured Workloads For Canada Regions and Support controls
-        pub const CA_REGIONS_AND_SUPPORT: ComplianceRegime =
-            ComplianceRegime::new("CA_REGIONS_AND_SUPPORT");
+        pub const CA_REGIONS_AND_SUPPORT: ComplianceRegime = ComplianceRegime::new(9);
 
         /// International Traffic in Arms Regulations
-        pub const ITAR: ComplianceRegime = ComplianceRegime::new("ITAR");
+        pub const ITAR: ComplianceRegime = ComplianceRegime::new(10);
 
         /// Assured Workloads for Australia Regions and Support controls
         /// Available for public preview consumption.
         /// Don't create production workloads.
-        pub const AU_REGIONS_AND_US_SUPPORT: ComplianceRegime =
-            ComplianceRegime::new("AU_REGIONS_AND_US_SUPPORT");
+        pub const AU_REGIONS_AND_US_SUPPORT: ComplianceRegime = ComplianceRegime::new(11);
 
         /// Assured Workloads for Partners
-        pub const ASSURED_WORKLOADS_FOR_PARTNERS: ComplianceRegime =
-            ComplianceRegime::new("ASSURED_WORKLOADS_FOR_PARTNERS");
+        pub const ASSURED_WORKLOADS_FOR_PARTNERS: ComplianceRegime = ComplianceRegime::new(12);
+
+        /// Creates a new ComplianceRegime instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COMPLIANCE_REGIME_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IL4"),
+                2 => std::borrow::Cow::Borrowed("CJIS"),
+                3 => std::borrow::Cow::Borrowed("FEDRAMP_HIGH"),
+                4 => std::borrow::Cow::Borrowed("FEDRAMP_MODERATE"),
+                5 => std::borrow::Cow::Borrowed("US_REGIONAL_ACCESS"),
+                6 => std::borrow::Cow::Borrowed("HIPAA"),
+                7 => std::borrow::Cow::Borrowed("HITRUST"),
+                8 => std::borrow::Cow::Borrowed("EU_REGIONS_AND_SUPPORT"),
+                9 => std::borrow::Cow::Borrowed("CA_REGIONS_AND_SUPPORT"),
+                10 => std::borrow::Cow::Borrowed("ITAR"),
+                11 => std::borrow::Cow::Borrowed("AU_REGIONS_AND_US_SUPPORT"),
+                12 => std::borrow::Cow::Borrowed("ASSURED_WORKLOADS_FOR_PARTNERS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COMPLIANCE_REGIME_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::COMPLIANCE_REGIME_UNSPECIFIED)
+                }
+                "IL4" => std::option::Option::Some(Self::IL4),
+                "CJIS" => std::option::Option::Some(Self::CJIS),
+                "FEDRAMP_HIGH" => std::option::Option::Some(Self::FEDRAMP_HIGH),
+                "FEDRAMP_MODERATE" => std::option::Option::Some(Self::FEDRAMP_MODERATE),
+                "US_REGIONAL_ACCESS" => std::option::Option::Some(Self::US_REGIONAL_ACCESS),
+                "HIPAA" => std::option::Option::Some(Self::HIPAA),
+                "HITRUST" => std::option::Option::Some(Self::HITRUST),
+                "EU_REGIONS_AND_SUPPORT" => std::option::Option::Some(Self::EU_REGIONS_AND_SUPPORT),
+                "CA_REGIONS_AND_SUPPORT" => std::option::Option::Some(Self::CA_REGIONS_AND_SUPPORT),
+                "ITAR" => std::option::Option::Some(Self::ITAR),
+                "AU_REGIONS_AND_US_SUPPORT" => {
+                    std::option::Option::Some(Self::AU_REGIONS_AND_US_SUPPORT)
+                }
+                "ASSURED_WORKLOADS_FOR_PARTNERS" => {
+                    std::option::Option::Some(Self::ASSURED_WORKLOADS_FOR_PARTNERS)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ComplianceRegime {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ComplianceRegime {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ComplianceRegime {
         fn default() -> Self {
-            compliance_regime::COMPLIANCE_REGIME_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Key Access Justifications(KAJ) Enrollment State.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct KajEnrollmentState(std::borrow::Cow<'static, str>);
+    pub struct KajEnrollmentState(i32);
 
     impl KajEnrollmentState {
+        /// Default State for KAJ Enrollment.
+        pub const KAJ_ENROLLMENT_STATE_UNSPECIFIED: KajEnrollmentState = KajEnrollmentState::new(0);
+
+        /// Pending State for KAJ Enrollment.
+        pub const KAJ_ENROLLMENT_STATE_PENDING: KajEnrollmentState = KajEnrollmentState::new(1);
+
+        /// Complete State for KAJ Enrollment.
+        pub const KAJ_ENROLLMENT_STATE_COMPLETE: KajEnrollmentState = KajEnrollmentState::new(2);
+
         /// Creates a new KajEnrollmentState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("KAJ_ENROLLMENT_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("KAJ_ENROLLMENT_STATE_PENDING"),
+                2 => std::borrow::Cow::Borrowed("KAJ_ENROLLMENT_STATE_COMPLETE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "KAJ_ENROLLMENT_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::KAJ_ENROLLMENT_STATE_UNSPECIFIED)
+                }
+                "KAJ_ENROLLMENT_STATE_PENDING" => {
+                    std::option::Option::Some(Self::KAJ_ENROLLMENT_STATE_PENDING)
+                }
+                "KAJ_ENROLLMENT_STATE_COMPLETE" => {
+                    std::option::Option::Some(Self::KAJ_ENROLLMENT_STATE_COMPLETE)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [KajEnrollmentState](KajEnrollmentState)
-    pub mod kaj_enrollment_state {
-        use super::KajEnrollmentState;
-
-        /// Default State for KAJ Enrollment.
-        pub const KAJ_ENROLLMENT_STATE_UNSPECIFIED: KajEnrollmentState =
-            KajEnrollmentState::new("KAJ_ENROLLMENT_STATE_UNSPECIFIED");
-
-        /// Pending State for KAJ Enrollment.
-        pub const KAJ_ENROLLMENT_STATE_PENDING: KajEnrollmentState =
-            KajEnrollmentState::new("KAJ_ENROLLMENT_STATE_PENDING");
-
-        /// Complete State for KAJ Enrollment.
-        pub const KAJ_ENROLLMENT_STATE_COMPLETE: KajEnrollmentState =
-            KajEnrollmentState::new("KAJ_ENROLLMENT_STATE_COMPLETE");
-    }
-
-    impl std::convert::From<std::string::String> for KajEnrollmentState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for KajEnrollmentState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for KajEnrollmentState {
         fn default() -> Self {
-            kaj_enrollment_state::KAJ_ENROLLMENT_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Supported Assured Workloads Partners.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Partner(std::borrow::Cow<'static, str>);
+    pub struct Partner(i32);
 
     impl Partner {
+        /// Unknown partner regime/controls.
+        pub const PARTNER_UNSPECIFIED: Partner = Partner::new(0);
+
+        /// S3NS regime/controls.
+        pub const LOCAL_CONTROLS_BY_S3NS: Partner = Partner::new(1);
+
         /// Creates a new Partner instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PARTNER_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LOCAL_CONTROLS_BY_S3NS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PARTNER_UNSPECIFIED" => std::option::Option::Some(Self::PARTNER_UNSPECIFIED),
+                "LOCAL_CONTROLS_BY_S3NS" => std::option::Option::Some(Self::LOCAL_CONTROLS_BY_S3NS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Partner](Partner)
-    pub mod partner {
-        use super::Partner;
-
-        /// Unknown partner regime/controls.
-        pub const PARTNER_UNSPECIFIED: Partner = Partner::new("PARTNER_UNSPECIFIED");
-
-        /// S3NS regime/controls.
-        pub const LOCAL_CONTROLS_BY_S3NS: Partner = Partner::new("LOCAL_CONTROLS_BY_S3NS");
-    }
-
-    impl std::convert::From<std::string::String> for Partner {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Partner {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Partner {
         fn default() -> Self {
-            partner::PARTNER_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1262,50 +1389,68 @@ pub mod restrict_allowed_resources_request {
 
     /// The type of restriction.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RestrictionType(std::borrow::Cow<'static, str>);
+    pub struct RestrictionType(i32);
 
     impl RestrictionType {
-        /// Creates a new RestrictionType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RestrictionType](RestrictionType)
-    pub mod restriction_type {
-        use super::RestrictionType;
-
         /// Unknown restriction type.
-        pub const RESTRICTION_TYPE_UNSPECIFIED: RestrictionType =
-            RestrictionType::new("RESTRICTION_TYPE_UNSPECIFIED");
+        pub const RESTRICTION_TYPE_UNSPECIFIED: RestrictionType = RestrictionType::new(0);
 
         /// Allow the use all of all gcp products, irrespective of the compliance
         /// posture. This effectively removes gcp.restrictServiceUsage OrgPolicy
         /// on the AssuredWorkloads Folder.
-        pub const ALLOW_ALL_GCP_RESOURCES: RestrictionType =
-            RestrictionType::new("ALLOW_ALL_GCP_RESOURCES");
+        pub const ALLOW_ALL_GCP_RESOURCES: RestrictionType = RestrictionType::new(1);
 
         /// Based on Workload's compliance regime, allowed list changes.
         /// See - <https://cloud.google.com/assured-workloads/docs/supported-products>
         /// for the list of supported resources.
-        pub const ALLOW_COMPLIANT_RESOURCES: RestrictionType =
-            RestrictionType::new("ALLOW_COMPLIANT_RESOURCES");
+        pub const ALLOW_COMPLIANT_RESOURCES: RestrictionType = RestrictionType::new(2);
+
+        /// Creates a new RestrictionType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RESTRICTION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALLOW_ALL_GCP_RESOURCES"),
+                2 => std::borrow::Cow::Borrowed("ALLOW_COMPLIANT_RESOURCES"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RESTRICTION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RESTRICTION_TYPE_UNSPECIFIED)
+                }
+                "ALLOW_ALL_GCP_RESOURCES" => {
+                    std::option::Option::Some(Self::ALLOW_ALL_GCP_RESOURCES)
+                }
+                "ALLOW_COMPLIANT_RESOURCES" => {
+                    std::option::Option::Some(Self::ALLOW_COMPLIANT_RESOURCES)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RestrictionType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RestrictionType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RestrictionType {
         fn default() -> Self {
-            restriction_type::RESTRICTION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2092,104 +2237,143 @@ pub mod violation {
         /// policy requires different remediation instructions compared to violation
         /// caused due to changes in allowed values of list org policy.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct RemediationType(std::borrow::Cow<'static, str>);
+        pub struct RemediationType(i32);
 
         impl RemediationType {
-            /// Creates a new RemediationType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [RemediationType](RemediationType)
-        pub mod remediation_type {
-            use super::RemediationType;
-
             /// Unspecified remediation type
-            pub const REMEDIATION_TYPE_UNSPECIFIED: RemediationType =
-                RemediationType::new("REMEDIATION_TYPE_UNSPECIFIED");
+            pub const REMEDIATION_TYPE_UNSPECIFIED: RemediationType = RemediationType::new(0);
 
             /// Remediation type for boolean org policy
             pub const REMEDIATION_BOOLEAN_ORG_POLICY_VIOLATION: RemediationType =
-                RemediationType::new("REMEDIATION_BOOLEAN_ORG_POLICY_VIOLATION");
+                RemediationType::new(1);
 
             /// Remediation type for list org policy which have allowed values in the
             /// monitoring rule
             pub const REMEDIATION_LIST_ALLOWED_VALUES_ORG_POLICY_VIOLATION: RemediationType =
-                RemediationType::new("REMEDIATION_LIST_ALLOWED_VALUES_ORG_POLICY_VIOLATION");
+                RemediationType::new(2);
 
             /// Remediation type for list org policy which have denied values in the
             /// monitoring rule
             pub const REMEDIATION_LIST_DENIED_VALUES_ORG_POLICY_VIOLATION: RemediationType =
-                RemediationType::new("REMEDIATION_LIST_DENIED_VALUES_ORG_POLICY_VIOLATION");
+                RemediationType::new(3);
 
             /// Remediation type for gcp.restrictCmekCryptoKeyProjects
             pub const REMEDIATION_RESTRICT_CMEK_CRYPTO_KEY_PROJECTS_ORG_POLICY_VIOLATION:
-                RemediationType = RemediationType::new(
-                "REMEDIATION_RESTRICT_CMEK_CRYPTO_KEY_PROJECTS_ORG_POLICY_VIOLATION",
-            );
+                RemediationType = RemediationType::new(4);
+
+            /// Creates a new RemediationType instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("REMEDIATION_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("REMEDIATION_BOOLEAN_ORG_POLICY_VIOLATION"),
+                    2 => std::borrow::Cow::Borrowed(
+                        "REMEDIATION_LIST_ALLOWED_VALUES_ORG_POLICY_VIOLATION",
+                    ),
+                    3 => std::borrow::Cow::Borrowed(
+                        "REMEDIATION_LIST_DENIED_VALUES_ORG_POLICY_VIOLATION",
+                    ),
+                    4 => std::borrow::Cow::Borrowed(
+                        "REMEDIATION_RESTRICT_CMEK_CRYPTO_KEY_PROJECTS_ORG_POLICY_VIOLATION",
+                    ),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "REMEDIATION_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::REMEDIATION_TYPE_UNSPECIFIED),
+                    "REMEDIATION_BOOLEAN_ORG_POLICY_VIOLATION" => std::option::Option::Some(Self::REMEDIATION_BOOLEAN_ORG_POLICY_VIOLATION),
+                    "REMEDIATION_LIST_ALLOWED_VALUES_ORG_POLICY_VIOLATION" => std::option::Option::Some(Self::REMEDIATION_LIST_ALLOWED_VALUES_ORG_POLICY_VIOLATION),
+                    "REMEDIATION_LIST_DENIED_VALUES_ORG_POLICY_VIOLATION" => std::option::Option::Some(Self::REMEDIATION_LIST_DENIED_VALUES_ORG_POLICY_VIOLATION),
+                    "REMEDIATION_RESTRICT_CMEK_CRYPTO_KEY_PROJECTS_ORG_POLICY_VIOLATION" => std::option::Option::Some(Self::REMEDIATION_RESTRICT_CMEK_CRYPTO_KEY_PROJECTS_ORG_POLICY_VIOLATION),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for RemediationType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for RemediationType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for RemediationType {
             fn default() -> Self {
-                remediation_type::REMEDIATION_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// Violation State Values
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Violation is resolved.
+        pub const RESOLVED: State = State::new(2);
+
+        /// Violation is Unresolved
+        pub const UNRESOLVED: State = State::new(3);
+
+        /// Violation is Exception
+        pub const EXCEPTION: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                2 => std::borrow::Cow::Borrowed("RESOLVED"),
+                3 => std::borrow::Cow::Borrowed("UNRESOLVED"),
+                4 => std::borrow::Cow::Borrowed("EXCEPTION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "RESOLVED" => std::option::Option::Some(Self::RESOLVED),
+                "UNRESOLVED" => std::option::Option::Some(Self::UNRESOLVED),
+                "EXCEPTION" => std::option::Option::Some(Self::EXCEPTION),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Violation is resolved.
-        pub const RESOLVED: State = State::new("RESOLVED");
-
-        /// Violation is Unresolved
-        pub const UNRESOLVED: State = State::new("UNRESOLVED");
-
-        /// Violation is Exception
-        pub const EXCEPTION: State = State::new("EXCEPTION");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/assuredworkloads/v1/src/transport.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::AssuredWorkloadsService for AssuredWorkloadsService {
                 reqwest::Method::POST,
                 format!("/v1/{}/workloads", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -81,7 +81,7 @@ impl crate::stubs::AssuredWorkloadsService for AssuredWorkloadsService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -113,7 +113,7 @@ impl crate::stubs::AssuredWorkloadsService for AssuredWorkloadsService {
                 reqwest::Method::POST,
                 format!("/v1/{}:restrictAllowedResources", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -130,7 +130,7 @@ impl crate::stubs::AssuredWorkloadsService for AssuredWorkloadsService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -150,7 +150,7 @@ impl crate::stubs::AssuredWorkloadsService for AssuredWorkloadsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -172,7 +172,7 @@ impl crate::stubs::AssuredWorkloadsService for AssuredWorkloadsService {
                 reqwest::Method::GET,
                 format!("/v1/{}/workloads", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -194,7 +194,7 @@ impl crate::stubs::AssuredWorkloadsService for AssuredWorkloadsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -216,7 +216,7 @@ impl crate::stubs::AssuredWorkloadsService for AssuredWorkloadsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/backupdr/v1/src/model.rs
+++ b/src/generated/cloud/backupdr/v1/src/model.rs
@@ -85,43 +85,57 @@ pub mod network_config {
 
     /// VPC peering modes supported by Cloud BackupDR.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PeeringMode(std::borrow::Cow<'static, str>);
+    pub struct PeeringMode(i32);
 
     impl PeeringMode {
-        /// Creates a new PeeringMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PeeringMode](PeeringMode)
-    pub mod peering_mode {
-        use super::PeeringMode;
-
         /// Peering mode not set.
-        pub const PEERING_MODE_UNSPECIFIED: PeeringMode =
-            PeeringMode::new("PEERING_MODE_UNSPECIFIED");
+        pub const PEERING_MODE_UNSPECIFIED: PeeringMode = PeeringMode::new(0);
 
         /// Connect using Private Service Access to the Management Server. Private
         /// services access provides an IP address range for multiple Google Cloud
         /// services, including Cloud BackupDR.
-        pub const PRIVATE_SERVICE_ACCESS: PeeringMode = PeeringMode::new("PRIVATE_SERVICE_ACCESS");
+        pub const PRIVATE_SERVICE_ACCESS: PeeringMode = PeeringMode::new(1);
+
+        /// Creates a new PeeringMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PEERING_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PRIVATE_SERVICE_ACCESS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PEERING_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PEERING_MODE_UNSPECIFIED)
+                }
+                "PRIVATE_SERVICE_ACCESS" => std::option::Option::Some(Self::PRIVATE_SERVICE_ACCESS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PeeringMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PeeringMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PeeringMode {
         fn default() -> Self {
-            peering_mode::PEERING_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -505,102 +519,142 @@ pub mod management_server {
 
     /// Type of backup service resource.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct InstanceType(std::borrow::Cow<'static, str>);
+    pub struct InstanceType(i32);
 
     impl InstanceType {
+        /// Instance type is not mentioned.
+        pub const INSTANCE_TYPE_UNSPECIFIED: InstanceType = InstanceType::new(0);
+
+        /// Instance for backup and restore management (i.e., AGM).
+        pub const BACKUP_RESTORE: InstanceType = InstanceType::new(1);
+
         /// Creates a new InstanceType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("INSTANCE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BACKUP_RESTORE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "INSTANCE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::INSTANCE_TYPE_UNSPECIFIED)
+                }
+                "BACKUP_RESTORE" => std::option::Option::Some(Self::BACKUP_RESTORE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [InstanceType](InstanceType)
-    pub mod instance_type {
-        use super::InstanceType;
-
-        /// Instance type is not mentioned.
-        pub const INSTANCE_TYPE_UNSPECIFIED: InstanceType =
-            InstanceType::new("INSTANCE_TYPE_UNSPECIFIED");
-
-        /// Instance for backup and restore management (i.e., AGM).
-        pub const BACKUP_RESTORE: InstanceType = InstanceType::new("BACKUP_RESTORE");
-    }
-
-    impl std::convert::From<std::string::String> for InstanceType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for InstanceType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for InstanceType {
         fn default() -> Self {
-            instance_type::INSTANCE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// State of Management server instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct InstanceState(std::borrow::Cow<'static, str>);
+    pub struct InstanceState(i32);
 
     impl InstanceState {
-        /// Creates a new InstanceState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [InstanceState](InstanceState)
-    pub mod instance_state {
-        use super::InstanceState;
-
         /// State not set.
-        pub const INSTANCE_STATE_UNSPECIFIED: InstanceState =
-            InstanceState::new("INSTANCE_STATE_UNSPECIFIED");
+        pub const INSTANCE_STATE_UNSPECIFIED: InstanceState = InstanceState::new(0);
 
         /// The instance is being created.
-        pub const CREATING: InstanceState = InstanceState::new("CREATING");
+        pub const CREATING: InstanceState = InstanceState::new(1);
 
         /// The instance has been created and is fully usable.
-        pub const READY: InstanceState = InstanceState::new("READY");
+        pub const READY: InstanceState = InstanceState::new(2);
 
         /// The instance configuration is being updated. Certain kinds of updates
         /// may cause the instance to become unusable while the update is in
         /// progress.
-        pub const UPDATING: InstanceState = InstanceState::new("UPDATING");
+        pub const UPDATING: InstanceState = InstanceState::new(3);
 
         /// The instance is being deleted.
-        pub const DELETING: InstanceState = InstanceState::new("DELETING");
+        pub const DELETING: InstanceState = InstanceState::new(4);
 
         /// The instance is being repaired and may be unstable.
-        pub const REPAIRING: InstanceState = InstanceState::new("REPAIRING");
+        pub const REPAIRING: InstanceState = InstanceState::new(5);
 
         /// Maintenance is being performed on this instance.
-        pub const MAINTENANCE: InstanceState = InstanceState::new("MAINTENANCE");
+        pub const MAINTENANCE: InstanceState = InstanceState::new(6);
 
         /// The instance is experiencing an issue and might be unusable. You can get
         /// further details from the statusMessage field of Instance resource.
-        pub const ERROR: InstanceState = InstanceState::new("ERROR");
+        pub const ERROR: InstanceState = InstanceState::new(7);
+
+        /// Creates a new InstanceState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("INSTANCE_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("REPAIRING"),
+                6 => std::borrow::Cow::Borrowed("MAINTENANCE"),
+                7 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "INSTANCE_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::INSTANCE_STATE_UNSPECIFIED)
+                }
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "REPAIRING" => std::option::Option::Some(Self::REPAIRING),
+                "MAINTENANCE" => std::option::Option::Some(Self::MAINTENANCE),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for InstanceState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for InstanceState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for InstanceState {
         fn default() -> Self {
-            instance_state::INSTANCE_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1341,49 +1395,68 @@ pub mod backup_plan {
 
     /// `State` enumerates the possible states for a `BackupPlan`.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State not set.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The resource is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// The resource has been created and is fully usable.
+        pub const ACTIVE: State = State::new(2);
+
+        /// The resource is being deleted.
+        pub const DELETING: State = State::new(3);
+
+        /// The resource has been created but is not usable.
+        pub const INACTIVE: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("INACTIVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The resource is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The resource has been created and is fully usable.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The resource is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// The resource has been created but is not usable.
-        pub const INACTIVE: State = State::new("INACTIVE");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1676,53 +1749,75 @@ pub mod standard_schedule {
 
     /// `RecurrenceTypes` enumerates the applicable periodicity for the schedule.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RecurrenceType(std::borrow::Cow<'static, str>);
+    pub struct RecurrenceType(i32);
 
     impl RecurrenceType {
+        /// recurrence type not set
+        pub const RECURRENCE_TYPE_UNSPECIFIED: RecurrenceType = RecurrenceType::new(0);
+
+        /// The `BackupRule` is to be applied hourly.
+        pub const HOURLY: RecurrenceType = RecurrenceType::new(1);
+
+        /// The `BackupRule` is to be applied daily.
+        pub const DAILY: RecurrenceType = RecurrenceType::new(2);
+
+        /// The `BackupRule` is to be applied weekly.
+        pub const WEEKLY: RecurrenceType = RecurrenceType::new(3);
+
+        /// The `BackupRule` is to be applied monthly.
+        pub const MONTHLY: RecurrenceType = RecurrenceType::new(4);
+
+        /// The `BackupRule` is to be applied yearly.
+        pub const YEARLY: RecurrenceType = RecurrenceType::new(5);
+
         /// Creates a new RecurrenceType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RECURRENCE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("HOURLY"),
+                2 => std::borrow::Cow::Borrowed("DAILY"),
+                3 => std::borrow::Cow::Borrowed("WEEKLY"),
+                4 => std::borrow::Cow::Borrowed("MONTHLY"),
+                5 => std::borrow::Cow::Borrowed("YEARLY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RECURRENCE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RECURRENCE_TYPE_UNSPECIFIED)
+                }
+                "HOURLY" => std::option::Option::Some(Self::HOURLY),
+                "DAILY" => std::option::Option::Some(Self::DAILY),
+                "WEEKLY" => std::option::Option::Some(Self::WEEKLY),
+                "MONTHLY" => std::option::Option::Some(Self::MONTHLY),
+                "YEARLY" => std::option::Option::Some(Self::YEARLY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RecurrenceType](RecurrenceType)
-    pub mod recurrence_type {
-        use super::RecurrenceType;
-
-        /// recurrence type not set
-        pub const RECURRENCE_TYPE_UNSPECIFIED: RecurrenceType =
-            RecurrenceType::new("RECURRENCE_TYPE_UNSPECIFIED");
-
-        /// The `BackupRule` is to be applied hourly.
-        pub const HOURLY: RecurrenceType = RecurrenceType::new("HOURLY");
-
-        /// The `BackupRule` is to be applied daily.
-        pub const DAILY: RecurrenceType = RecurrenceType::new("DAILY");
-
-        /// The `BackupRule` is to be applied weekly.
-        pub const WEEKLY: RecurrenceType = RecurrenceType::new("WEEKLY");
-
-        /// The `BackupRule` is to be applied monthly.
-        pub const MONTHLY: RecurrenceType = RecurrenceType::new("MONTHLY");
-
-        /// The `BackupRule` is to be applied yearly.
-        pub const YEARLY: RecurrenceType = RecurrenceType::new("YEARLY");
-    }
-
-    impl std::convert::From<std::string::String> for RecurrenceType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RecurrenceType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RecurrenceType {
         fn default() -> Self {
-            recurrence_type::RECURRENCE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1824,53 +1919,75 @@ pub mod week_day_of_month {
     /// `WeekOfMonth` enumerates possible weeks in the month, e.g. the first,
     /// third, or last week of the month.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct WeekOfMonth(std::borrow::Cow<'static, str>);
+    pub struct WeekOfMonth(i32);
 
     impl WeekOfMonth {
+        /// The zero value. Do not use.
+        pub const WEEK_OF_MONTH_UNSPECIFIED: WeekOfMonth = WeekOfMonth::new(0);
+
+        /// The first week of the month.
+        pub const FIRST: WeekOfMonth = WeekOfMonth::new(1);
+
+        /// The second week of the month.
+        pub const SECOND: WeekOfMonth = WeekOfMonth::new(2);
+
+        /// The third week of the month.
+        pub const THIRD: WeekOfMonth = WeekOfMonth::new(3);
+
+        /// The fourth  week of the month.
+        pub const FOURTH: WeekOfMonth = WeekOfMonth::new(4);
+
+        /// The last  week of the month.
+        pub const LAST: WeekOfMonth = WeekOfMonth::new(5);
+
         /// Creates a new WeekOfMonth instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("WEEK_OF_MONTH_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FIRST"),
+                2 => std::borrow::Cow::Borrowed("SECOND"),
+                3 => std::borrow::Cow::Borrowed("THIRD"),
+                4 => std::borrow::Cow::Borrowed("FOURTH"),
+                5 => std::borrow::Cow::Borrowed("LAST"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "WEEK_OF_MONTH_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::WEEK_OF_MONTH_UNSPECIFIED)
+                }
+                "FIRST" => std::option::Option::Some(Self::FIRST),
+                "SECOND" => std::option::Option::Some(Self::SECOND),
+                "THIRD" => std::option::Option::Some(Self::THIRD),
+                "FOURTH" => std::option::Option::Some(Self::FOURTH),
+                "LAST" => std::option::Option::Some(Self::LAST),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [WeekOfMonth](WeekOfMonth)
-    pub mod week_of_month {
-        use super::WeekOfMonth;
-
-        /// The zero value. Do not use.
-        pub const WEEK_OF_MONTH_UNSPECIFIED: WeekOfMonth =
-            WeekOfMonth::new("WEEK_OF_MONTH_UNSPECIFIED");
-
-        /// The first week of the month.
-        pub const FIRST: WeekOfMonth = WeekOfMonth::new("FIRST");
-
-        /// The second week of the month.
-        pub const SECOND: WeekOfMonth = WeekOfMonth::new("SECOND");
-
-        /// The third week of the month.
-        pub const THIRD: WeekOfMonth = WeekOfMonth::new("THIRD");
-
-        /// The fourth  week of the month.
-        pub const FOURTH: WeekOfMonth = WeekOfMonth::new("FOURTH");
-
-        /// The last  week of the month.
-        pub const LAST: WeekOfMonth = WeekOfMonth::new("LAST");
-    }
-
-    impl std::convert::From<std::string::String> for WeekOfMonth {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for WeekOfMonth {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for WeekOfMonth {
         fn default() -> Self {
-            week_of_month::WEEK_OF_MONTH_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2348,49 +2465,68 @@ pub mod backup_plan_association {
 
     /// Enum for State of BackupPlan Association
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State not set.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The resource is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// The resource has been created and is fully usable.
+        pub const ACTIVE: State = State::new(2);
+
+        /// The resource is being deleted.
+        pub const DELETING: State = State::new(3);
+
+        /// The resource has been created but is not usable.
+        pub const INACTIVE: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("INACTIVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The resource is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The resource has been created and is fully usable.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The resource is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// The resource has been created but is not usable.
-        pub const INACTIVE: State = State::new("INACTIVE");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2474,52 +2610,71 @@ pub mod rule_config_info {
 
     /// Enum for LastBackupState
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LastBackupState(std::borrow::Cow<'static, str>);
+    pub struct LastBackupState(i32);
 
     impl LastBackupState {
-        /// Creates a new LastBackupState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [LastBackupState](LastBackupState)
-    pub mod last_backup_state {
-        use super::LastBackupState;
-
         /// State not set.
-        pub const LAST_BACKUP_STATE_UNSPECIFIED: LastBackupState =
-            LastBackupState::new("LAST_BACKUP_STATE_UNSPECIFIED");
+        pub const LAST_BACKUP_STATE_UNSPECIFIED: LastBackupState = LastBackupState::new(0);
 
         /// The first backup is pending.
-        pub const FIRST_BACKUP_PENDING: LastBackupState =
-            LastBackupState::new("FIRST_BACKUP_PENDING");
+        pub const FIRST_BACKUP_PENDING: LastBackupState = LastBackupState::new(1);
 
         /// The most recent backup could not be run/failed because of the lack of
         /// permissions.
-        pub const PERMISSION_DENIED: LastBackupState = LastBackupState::new("PERMISSION_DENIED");
+        pub const PERMISSION_DENIED: LastBackupState = LastBackupState::new(2);
 
         /// The last backup operation succeeded.
-        pub const SUCCEEDED: LastBackupState = LastBackupState::new("SUCCEEDED");
+        pub const SUCCEEDED: LastBackupState = LastBackupState::new(3);
 
         /// The last backup operation failed.
-        pub const FAILED: LastBackupState = LastBackupState::new("FAILED");
+        pub const FAILED: LastBackupState = LastBackupState::new(4);
+
+        /// Creates a new LastBackupState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LAST_BACKUP_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FIRST_BACKUP_PENDING"),
+                2 => std::borrow::Cow::Borrowed("PERMISSION_DENIED"),
+                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LAST_BACKUP_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::LAST_BACKUP_STATE_UNSPECIFIED)
+                }
+                "FIRST_BACKUP_PENDING" => std::option::Option::Some(Self::FIRST_BACKUP_PENDING),
+                "PERMISSION_DENIED" => std::option::Option::Some(Self::PERMISSION_DENIED),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for LastBackupState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LastBackupState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LastBackupState {
         fn default() -> Self {
-            last_backup_state::LAST_BACKUP_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3133,103 +3288,142 @@ pub mod backup_vault {
 
     /// Holds the state of the backup vault resource.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State not set.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The backup vault is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// The backup vault has been created and is fully usable.
+        pub const ACTIVE: State = State::new(2);
+
+        /// The backup vault is being deleted.
+        pub const DELETING: State = State::new(3);
+
+        /// The backup vault is experiencing an issue and might be unusable.
+        pub const ERROR: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The backup vault is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The backup vault has been created and is fully usable.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The backup vault is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// The backup vault is experiencing an issue and might be unusable.
-        pub const ERROR: State = State::new("ERROR");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Holds the access restriction for the backup vault.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AccessRestriction(std::borrow::Cow<'static, str>);
+    pub struct AccessRestriction(i32);
 
     impl AccessRestriction {
-        /// Creates a new AccessRestriction instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [AccessRestriction](AccessRestriction)
-    pub mod access_restriction {
-        use super::AccessRestriction;
-
         /// Access restriction not set. If user does not provide any value or pass
         /// this value, it will be changed to WITHIN_ORGANIZATION.
-        pub const ACCESS_RESTRICTION_UNSPECIFIED: AccessRestriction =
-            AccessRestriction::new("ACCESS_RESTRICTION_UNSPECIFIED");
+        pub const ACCESS_RESTRICTION_UNSPECIFIED: AccessRestriction = AccessRestriction::new(0);
 
         /// Access to or from resources outside your current project will be denied.
-        pub const WITHIN_PROJECT: AccessRestriction = AccessRestriction::new("WITHIN_PROJECT");
+        pub const WITHIN_PROJECT: AccessRestriction = AccessRestriction::new(1);
 
         /// Access to or from resources outside your current organization will be
         /// denied.
-        pub const WITHIN_ORGANIZATION: AccessRestriction =
-            AccessRestriction::new("WITHIN_ORGANIZATION");
+        pub const WITHIN_ORGANIZATION: AccessRestriction = AccessRestriction::new(2);
 
         /// No access restriction.
-        pub const UNRESTRICTED: AccessRestriction = AccessRestriction::new("UNRESTRICTED");
+        pub const UNRESTRICTED: AccessRestriction = AccessRestriction::new(3);
 
         /// Access to or from resources outside your current organization will be
         /// denied except for backup appliance.
-        pub const WITHIN_ORG_BUT_UNRESTRICTED_FOR_BA: AccessRestriction =
-            AccessRestriction::new("WITHIN_ORG_BUT_UNRESTRICTED_FOR_BA");
+        pub const WITHIN_ORG_BUT_UNRESTRICTED_FOR_BA: AccessRestriction = AccessRestriction::new(4);
+
+        /// Creates a new AccessRestriction instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ACCESS_RESTRICTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("WITHIN_PROJECT"),
+                2 => std::borrow::Cow::Borrowed("WITHIN_ORGANIZATION"),
+                3 => std::borrow::Cow::Borrowed("UNRESTRICTED"),
+                4 => std::borrow::Cow::Borrowed("WITHIN_ORG_BUT_UNRESTRICTED_FOR_BA"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ACCESS_RESTRICTION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ACCESS_RESTRICTION_UNSPECIFIED)
+                }
+                "WITHIN_PROJECT" => std::option::Option::Some(Self::WITHIN_PROJECT),
+                "WITHIN_ORGANIZATION" => std::option::Option::Some(Self::WITHIN_ORGANIZATION),
+                "UNRESTRICTED" => std::option::Option::Some(Self::UNRESTRICTED),
+                "WITHIN_ORG_BUT_UNRESTRICTED_FOR_BA" => {
+                    std::option::Option::Some(Self::WITHIN_ORG_BUT_UNRESTRICTED_FOR_BA)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for AccessRestriction {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AccessRestriction {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AccessRestriction {
         fn default() -> Self {
-            access_restriction::ACCESS_RESTRICTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3483,49 +3677,68 @@ pub mod data_source {
 
     /// Holds the state of the data source resource.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State not set.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The data source is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// The data source has been created and is fully usable.
+        pub const ACTIVE: State = State::new(2);
+
+        /// The data source is being deleted.
+        pub const DELETING: State = State::new(3);
+
+        /// The data source is experiencing an issue and might be unusable.
+        pub const ERROR: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The data source is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The data source has been created and is fully usable.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The data source is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// The data source is experiencing an issue and might be unusable.
-        pub const ERROR: State = State::new("ERROR");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -3697,52 +3910,71 @@ pub mod backup_config_info {
     /// LastBackupstate tracks whether the last backup was not yet started,
     /// successful, failed, or could not be run because of the lack of permissions.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LastBackupState(std::borrow::Cow<'static, str>);
+    pub struct LastBackupState(i32);
 
     impl LastBackupState {
-        /// Creates a new LastBackupState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [LastBackupState](LastBackupState)
-    pub mod last_backup_state {
-        use super::LastBackupState;
-
         /// Status not set.
-        pub const LAST_BACKUP_STATE_UNSPECIFIED: LastBackupState =
-            LastBackupState::new("LAST_BACKUP_STATE_UNSPECIFIED");
+        pub const LAST_BACKUP_STATE_UNSPECIFIED: LastBackupState = LastBackupState::new(0);
 
         /// The first backup has not yet completed
-        pub const FIRST_BACKUP_PENDING: LastBackupState =
-            LastBackupState::new("FIRST_BACKUP_PENDING");
+        pub const FIRST_BACKUP_PENDING: LastBackupState = LastBackupState::new(1);
 
         /// The most recent backup was successful
-        pub const SUCCEEDED: LastBackupState = LastBackupState::new("SUCCEEDED");
+        pub const SUCCEEDED: LastBackupState = LastBackupState::new(2);
 
         /// The most recent backup failed
-        pub const FAILED: LastBackupState = LastBackupState::new("FAILED");
+        pub const FAILED: LastBackupState = LastBackupState::new(3);
 
         /// The most recent backup could not be run/failed because of the lack of
         /// permissions
-        pub const PERMISSION_DENIED: LastBackupState = LastBackupState::new("PERMISSION_DENIED");
+        pub const PERMISSION_DENIED: LastBackupState = LastBackupState::new(4);
+
+        /// Creates a new LastBackupState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LAST_BACKUP_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FIRST_BACKUP_PENDING"),
+                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                4 => std::borrow::Cow::Borrowed("PERMISSION_DENIED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LAST_BACKUP_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::LAST_BACKUP_STATE_UNSPECIFIED)
+                }
+                "FIRST_BACKUP_PENDING" => std::option::Option::Some(Self::FIRST_BACKUP_PENDING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "PERMISSION_DENIED" => std::option::Option::Some(Self::PERMISSION_DENIED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for LastBackupState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LastBackupState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LastBackupState {
         fn default() -> Self {
-            last_backup_state::LAST_BACKUP_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -4862,91 +5094,127 @@ pub mod backup {
 
     /// Holds the state of the backup resource.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State not set.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The backup is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// The backup has been created and is fully usable.
+        pub const ACTIVE: State = State::new(2);
+
+        /// The backup is being deleted.
+        pub const DELETING: State = State::new(3);
+
+        /// The backup is experiencing an issue and might be unusable.
+        pub const ERROR: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The backup is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The backup has been created and is fully usable.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The backup is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// The backup is experiencing an issue and might be unusable.
-        pub const ERROR: State = State::new("ERROR");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Type of the backup, scheduled or ondemand.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BackupType(std::borrow::Cow<'static, str>);
+    pub struct BackupType(i32);
 
     impl BackupType {
+        /// Backup type is unspecified.
+        pub const BACKUP_TYPE_UNSPECIFIED: BackupType = BackupType::new(0);
+
+        /// Scheduled backup.
+        pub const SCHEDULED: BackupType = BackupType::new(1);
+
+        /// On demand backup.
+        pub const ON_DEMAND: BackupType = BackupType::new(2);
+
         /// Creates a new BackupType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("BACKUP_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SCHEDULED"),
+                2 => std::borrow::Cow::Borrowed("ON_DEMAND"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "BACKUP_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::BACKUP_TYPE_UNSPECIFIED)
+                }
+                "SCHEDULED" => std::option::Option::Some(Self::SCHEDULED),
+                "ON_DEMAND" => std::option::Option::Some(Self::ON_DEMAND),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [BackupType](BackupType)
-    pub mod backup_type {
-        use super::BackupType;
-
-        /// Backup type is unspecified.
-        pub const BACKUP_TYPE_UNSPECIFIED: BackupType = BackupType::new("BACKUP_TYPE_UNSPECIFIED");
-
-        /// Scheduled backup.
-        pub const SCHEDULED: BackupType = BackupType::new("SCHEDULED");
-
-        /// On demand backup.
-        pub const ON_DEMAND: BackupType = BackupType::new("ON_DEMAND");
-    }
-
-    impl std::convert::From<std::string::String> for BackupType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for BackupType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for BackupType {
         fn default() -> Self {
-            backup_type::BACKUP_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -7279,57 +7547,82 @@ pub mod compute_instance_restore_properties {
 
     /// The private IPv6 google access type for the VMs.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct InstancePrivateIpv6GoogleAccess(std::borrow::Cow<'static, str>);
+    pub struct InstancePrivateIpv6GoogleAccess(i32);
 
     impl InstancePrivateIpv6GoogleAccess {
-        /// Creates a new InstancePrivateIpv6GoogleAccess instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [InstancePrivateIpv6GoogleAccess](InstancePrivateIpv6GoogleAccess)
-    pub mod instance_private_ipv_6_google_access {
-        use super::InstancePrivateIpv6GoogleAccess;
-
         /// Default value. This value is unused.
         pub const INSTANCE_PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED: InstancePrivateIpv6GoogleAccess =
-            InstancePrivateIpv6GoogleAccess::new("INSTANCE_PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED");
+            InstancePrivateIpv6GoogleAccess::new(0);
 
         /// Each network interface inherits PrivateIpv6GoogleAccess from its
         /// subnetwork.
         pub const INHERIT_FROM_SUBNETWORK: InstancePrivateIpv6GoogleAccess =
-            InstancePrivateIpv6GoogleAccess::new("INHERIT_FROM_SUBNETWORK");
+            InstancePrivateIpv6GoogleAccess::new(1);
 
         /// Outbound private IPv6 access from VMs in this subnet to Google services.
         /// If specified, the subnetwork who is attached to the instance's default
         /// network interface will be assigned an internal IPv6 prefix if it doesn't
         /// have before.
         pub const ENABLE_OUTBOUND_VM_ACCESS_TO_GOOGLE: InstancePrivateIpv6GoogleAccess =
-            InstancePrivateIpv6GoogleAccess::new("ENABLE_OUTBOUND_VM_ACCESS_TO_GOOGLE");
+            InstancePrivateIpv6GoogleAccess::new(2);
 
         /// Bidirectional private IPv6 access to/from Google services. If
         /// specified, the subnetwork who is attached to the instance's default
         /// network interface will be assigned an internal IPv6 prefix if it doesn't
         /// have before.
         pub const ENABLE_BIDIRECTIONAL_ACCESS_TO_GOOGLE: InstancePrivateIpv6GoogleAccess =
-            InstancePrivateIpv6GoogleAccess::new("ENABLE_BIDIRECTIONAL_ACCESS_TO_GOOGLE");
+            InstancePrivateIpv6GoogleAccess::new(3);
+
+        /// Creates a new InstancePrivateIpv6GoogleAccess instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("INSTANCE_PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INHERIT_FROM_SUBNETWORK"),
+                2 => std::borrow::Cow::Borrowed("ENABLE_OUTBOUND_VM_ACCESS_TO_GOOGLE"),
+                3 => std::borrow::Cow::Borrowed("ENABLE_BIDIRECTIONAL_ACCESS_TO_GOOGLE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "INSTANCE_PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::INSTANCE_PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED)
+                }
+                "INHERIT_FROM_SUBNETWORK" => {
+                    std::option::Option::Some(Self::INHERIT_FROM_SUBNETWORK)
+                }
+                "ENABLE_OUTBOUND_VM_ACCESS_TO_GOOGLE" => {
+                    std::option::Option::Some(Self::ENABLE_OUTBOUND_VM_ACCESS_TO_GOOGLE)
+                }
+                "ENABLE_BIDIRECTIONAL_ACCESS_TO_GOOGLE" => {
+                    std::option::Option::Some(Self::ENABLE_BIDIRECTIONAL_ACCESS_TO_GOOGLE)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for InstancePrivateIpv6GoogleAccess {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for InstancePrivateIpv6GoogleAccess {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for InstancePrivateIpv6GoogleAccess {
         fn default() -> Self {
-            instance_private_ipv_6_google_access::INSTANCE_PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8111,129 +8404,175 @@ pub mod network_interface {
 
     /// Stack type for this network interface.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StackType(std::borrow::Cow<'static, str>);
+    pub struct StackType(i32);
 
     impl StackType {
+        /// Default should be STACK_TYPE_UNSPECIFIED.
+        pub const STACK_TYPE_UNSPECIFIED: StackType = StackType::new(0);
+
+        /// The network interface will be assigned IPv4 address.
+        pub const IPV4_ONLY: StackType = StackType::new(1);
+
+        /// The network interface can have both IPv4 and IPv6 addresses.
+        pub const IPV4_IPV6: StackType = StackType::new(2);
+
         /// Creates a new StackType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STACK_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IPV4_ONLY"),
+                2 => std::borrow::Cow::Borrowed("IPV4_IPV6"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STACK_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::STACK_TYPE_UNSPECIFIED),
+                "IPV4_ONLY" => std::option::Option::Some(Self::IPV4_ONLY),
+                "IPV4_IPV6" => std::option::Option::Some(Self::IPV4_IPV6),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [StackType](StackType)
-    pub mod stack_type {
-        use super::StackType;
-
-        /// Default should be STACK_TYPE_UNSPECIFIED.
-        pub const STACK_TYPE_UNSPECIFIED: StackType = StackType::new("STACK_TYPE_UNSPECIFIED");
-
-        /// The network interface will be assigned IPv4 address.
-        pub const IPV4_ONLY: StackType = StackType::new("IPV4_ONLY");
-
-        /// The network interface can have both IPv4 and IPv6 addresses.
-        pub const IPV4_IPV6: StackType = StackType::new("IPV4_IPV6");
-    }
-
-    impl std::convert::From<std::string::String> for StackType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for StackType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for StackType {
         fn default() -> Self {
-            stack_type::STACK_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// IPv6 access type for this network interface.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Ipv6AccessType(std::borrow::Cow<'static, str>);
+    pub struct Ipv6AccessType(i32);
 
     impl Ipv6AccessType {
+        /// IPv6 access type not set. Means this network interface hasn't been
+        /// turned on IPv6 yet.
+        pub const UNSPECIFIED_IPV6_ACCESS_TYPE: Ipv6AccessType = Ipv6AccessType::new(0);
+
+        /// This network interface can have internal IPv6.
+        pub const INTERNAL: Ipv6AccessType = Ipv6AccessType::new(1);
+
+        /// This network interface can have external IPv6.
+        pub const EXTERNAL: Ipv6AccessType = Ipv6AccessType::new(2);
+
         /// Creates a new Ipv6AccessType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNSPECIFIED_IPV6_ACCESS_TYPE"),
+                1 => std::borrow::Cow::Borrowed("INTERNAL"),
+                2 => std::borrow::Cow::Borrowed("EXTERNAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNSPECIFIED_IPV6_ACCESS_TYPE" => {
+                    std::option::Option::Some(Self::UNSPECIFIED_IPV6_ACCESS_TYPE)
+                }
+                "INTERNAL" => std::option::Option::Some(Self::INTERNAL),
+                "EXTERNAL" => std::option::Option::Some(Self::EXTERNAL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Ipv6AccessType](Ipv6AccessType)
-    pub mod ipv_6_access_type {
-        use super::Ipv6AccessType;
-
-        /// IPv6 access type not set. Means this network interface hasn't been
-        /// turned on IPv6 yet.
-        pub const UNSPECIFIED_IPV6_ACCESS_TYPE: Ipv6AccessType =
-            Ipv6AccessType::new("UNSPECIFIED_IPV6_ACCESS_TYPE");
-
-        /// This network interface can have internal IPv6.
-        pub const INTERNAL: Ipv6AccessType = Ipv6AccessType::new("INTERNAL");
-
-        /// This network interface can have external IPv6.
-        pub const EXTERNAL: Ipv6AccessType = Ipv6AccessType::new("EXTERNAL");
-    }
-
-    impl std::convert::From<std::string::String> for Ipv6AccessType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Ipv6AccessType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Ipv6AccessType {
         fn default() -> Self {
-            ipv_6_access_type::UNSPECIFIED_IPV6_ACCESS_TYPE
+            Self::new(0)
         }
     }
 
     /// Nic type for this network interface.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NicType(std::borrow::Cow<'static, str>);
+    pub struct NicType(i32);
 
     impl NicType {
+        /// Default should be NIC_TYPE_UNSPECIFIED.
+        pub const NIC_TYPE_UNSPECIFIED: NicType = NicType::new(0);
+
+        /// VIRTIO
+        pub const VIRTIO_NET: NicType = NicType::new(1);
+
+        /// GVNIC
+        pub const GVNIC: NicType = NicType::new(2);
+
         /// Creates a new NicType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("NIC_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("VIRTIO_NET"),
+                2 => std::borrow::Cow::Borrowed("GVNIC"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "NIC_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::NIC_TYPE_UNSPECIFIED),
+                "VIRTIO_NET" => std::option::Option::Some(Self::VIRTIO_NET),
+                "GVNIC" => std::option::Option::Some(Self::GVNIC),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [NicType](NicType)
-    pub mod nic_type {
-        use super::NicType;
-
-        /// Default should be NIC_TYPE_UNSPECIFIED.
-        pub const NIC_TYPE_UNSPECIFIED: NicType = NicType::new("NIC_TYPE_UNSPECIFIED");
-
-        /// VIRTIO
-        pub const VIRTIO_NET: NicType = NicType::new("VIRTIO_NET");
-
-        /// GVNIC
-        pub const GVNIC: NicType = NicType::new("GVNIC");
-    }
-
-    impl std::convert::From<std::string::String> for NicType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for NicType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for NicType {
         fn default() -> Self {
-            nic_type::NIC_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8280,43 +8619,58 @@ pub mod network_performance_config {
 
     /// Network performance tier.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Tier(std::borrow::Cow<'static, str>);
+    pub struct Tier(i32);
 
     impl Tier {
+        /// This value is unused.
+        pub const TIER_UNSPECIFIED: Tier = Tier::new(0);
+
+        /// Default network performance config.
+        pub const DEFAULT: Tier = Tier::new(1);
+
+        /// Tier 1 network performance config.
+        pub const TIER_1: Tier = Tier::new(2);
+
         /// Creates a new Tier instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TIER_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DEFAULT"),
+                2 => std::borrow::Cow::Borrowed("TIER_1"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TIER_UNSPECIFIED" => std::option::Option::Some(Self::TIER_UNSPECIFIED),
+                "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
+                "TIER_1" => std::option::Option::Some(Self::TIER_1),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Tier](Tier)
-    pub mod tier {
-        use super::Tier;
-
-        /// This value is unused.
-        pub const TIER_UNSPECIFIED: Tier = Tier::new("TIER_UNSPECIFIED");
-
-        /// Default network performance config.
-        pub const DEFAULT: Tier = Tier::new("DEFAULT");
-
-        /// Tier 1 network performance config.
-        pub const TIER_1: Tier = Tier::new("TIER_1");
-    }
-
-    impl std::convert::From<std::string::String> for Tier {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Tier {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Tier {
         fn default() -> Self {
-            tier::TIER_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8464,88 +8818,121 @@ pub mod access_config {
 
     /// The type of configuration.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AccessType(std::borrow::Cow<'static, str>);
+    pub struct AccessType(i32);
 
     impl AccessType {
+        /// Default value. This value is unused.
+        pub const ACCESS_TYPE_UNSPECIFIED: AccessType = AccessType::new(0);
+
+        /// ONE_TO_ONE_NAT
+        pub const ONE_TO_ONE_NAT: AccessType = AccessType::new(1);
+
+        /// Direct IPv6 access.
+        pub const DIRECT_IPV6: AccessType = AccessType::new(2);
+
         /// Creates a new AccessType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ACCESS_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ONE_TO_ONE_NAT"),
+                2 => std::borrow::Cow::Borrowed("DIRECT_IPV6"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ACCESS_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ACCESS_TYPE_UNSPECIFIED)
+                }
+                "ONE_TO_ONE_NAT" => std::option::Option::Some(Self::ONE_TO_ONE_NAT),
+                "DIRECT_IPV6" => std::option::Option::Some(Self::DIRECT_IPV6),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AccessType](AccessType)
-    pub mod access_type {
-        use super::AccessType;
-
-        /// Default value. This value is unused.
-        pub const ACCESS_TYPE_UNSPECIFIED: AccessType = AccessType::new("ACCESS_TYPE_UNSPECIFIED");
-
-        /// ONE_TO_ONE_NAT
-        pub const ONE_TO_ONE_NAT: AccessType = AccessType::new("ONE_TO_ONE_NAT");
-
-        /// Direct IPv6 access.
-        pub const DIRECT_IPV6: AccessType = AccessType::new("DIRECT_IPV6");
-    }
-
-    impl std::convert::From<std::string::String> for AccessType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AccessType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AccessType {
         fn default() -> Self {
-            access_type::ACCESS_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Network tier property used by addresses, instances and forwarding rules.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NetworkTier(std::borrow::Cow<'static, str>);
+    pub struct NetworkTier(i32);
 
     impl NetworkTier {
-        /// Creates a new NetworkTier instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [NetworkTier](NetworkTier)
-    pub mod network_tier {
-        use super::NetworkTier;
-
         /// Default value. This value is unused.
-        pub const NETWORK_TIER_UNSPECIFIED: NetworkTier =
-            NetworkTier::new("NETWORK_TIER_UNSPECIFIED");
+        pub const NETWORK_TIER_UNSPECIFIED: NetworkTier = NetworkTier::new(0);
 
         /// High quality, Google-grade network tier, support for all networking
         /// products.
-        pub const PREMIUM: NetworkTier = NetworkTier::new("PREMIUM");
+        pub const PREMIUM: NetworkTier = NetworkTier::new(1);
 
         /// Public internet quality, only limited support for other networking
         /// products.
-        pub const STANDARD: NetworkTier = NetworkTier::new("STANDARD");
+        pub const STANDARD: NetworkTier = NetworkTier::new(2);
+
+        /// Creates a new NetworkTier instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("NETWORK_TIER_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PREMIUM"),
+                2 => std::borrow::Cow::Borrowed("STANDARD"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "NETWORK_TIER_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::NETWORK_TIER_UNSPECIFIED)
+                }
+                "PREMIUM" => std::option::Option::Some(Self::PREMIUM),
+                "STANDARD" => std::option::Option::Some(Self::STANDARD),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for NetworkTier {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for NetworkTier {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for NetworkTier {
         fn default() -> Self {
-            network_tier::NETWORK_TIER_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8704,47 +9091,64 @@ pub mod allocation_affinity {
 
     /// Indicates whether to consume from a reservation or not.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// Default value. This value is unused.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// Do not consume from any allocated capacity.
-        pub const NO_RESERVATION: Type = Type::new("NO_RESERVATION");
+        pub const NO_RESERVATION: Type = Type::new(1);
 
         /// Consume any allocation available.
-        pub const ANY_RESERVATION: Type = Type::new("ANY_RESERVATION");
+        pub const ANY_RESERVATION: Type = Type::new(2);
 
         /// Must consume from a specific reservation. Must specify key value fields
         /// for specifying the reservations.
-        pub const SPECIFIC_RESERVATION: Type = Type::new("SPECIFIC_RESERVATION");
+        pub const SPECIFIC_RESERVATION: Type = Type::new(3);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NO_RESERVATION"),
+                2 => std::borrow::Cow::Borrowed("ANY_RESERVATION"),
+                3 => std::borrow::Cow::Borrowed("SPECIFIC_RESERVATION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "NO_RESERVATION" => std::option::Option::Some(Self::NO_RESERVATION),
+                "ANY_RESERVATION" => std::option::Option::Some(Self::ANY_RESERVATION),
+                "SPECIFIC_RESERVATION" => std::option::Option::Some(Self::SPECIFIC_RESERVATION),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8968,175 +9372,239 @@ pub mod scheduling {
 
         /// Defines the type of node selections.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Operator(std::borrow::Cow<'static, str>);
+        pub struct Operator(i32);
 
         impl Operator {
+            /// Default value. This value is unused.
+            pub const OPERATOR_UNSPECIFIED: Operator = Operator::new(0);
+
+            /// Requires Compute Engine to seek for matched nodes.
+            pub const IN: Operator = Operator::new(1);
+
+            /// Requires Compute Engine to avoid certain nodes.
+            pub const NOT_IN: Operator = Operator::new(2);
+
             /// Creates a new Operator instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("OPERATOR_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("IN"),
+                    2 => std::borrow::Cow::Borrowed("NOT_IN"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "OPERATOR_UNSPECIFIED" => std::option::Option::Some(Self::OPERATOR_UNSPECIFIED),
+                    "IN" => std::option::Option::Some(Self::IN),
+                    "NOT_IN" => std::option::Option::Some(Self::NOT_IN),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Operator](Operator)
-        pub mod operator {
-            use super::Operator;
-
-            /// Default value. This value is unused.
-            pub const OPERATOR_UNSPECIFIED: Operator = Operator::new("OPERATOR_UNSPECIFIED");
-
-            /// Requires Compute Engine to seek for matched nodes.
-            pub const IN: Operator = Operator::new("IN");
-
-            /// Requires Compute Engine to avoid certain nodes.
-            pub const NOT_IN: Operator = Operator::new("NOT_IN");
-        }
-
-        impl std::convert::From<std::string::String> for Operator {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Operator {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Operator {
             fn default() -> Self {
-                operator::OPERATOR_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// Defines the maintenance behavior for this instance=
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OnHostMaintenance(std::borrow::Cow<'static, str>);
+    pub struct OnHostMaintenance(i32);
 
     impl OnHostMaintenance {
-        /// Creates a new OnHostMaintenance instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [OnHostMaintenance](OnHostMaintenance)
-    pub mod on_host_maintenance {
-        use super::OnHostMaintenance;
-
         /// Default value. This value is unused.
-        pub const ON_HOST_MAINTENANCE_UNSPECIFIED: OnHostMaintenance =
-            OnHostMaintenance::new("ON_HOST_MAINTENANCE_UNSPECIFIED");
+        pub const ON_HOST_MAINTENANCE_UNSPECIFIED: OnHostMaintenance = OnHostMaintenance::new(0);
 
         /// Tells Compute Engine to terminate and (optionally) restart the instance
         /// away from the maintenance activity.
-        pub const TERMINATE: OnHostMaintenance = OnHostMaintenance::new("TERMINATE");
+        pub const TERMINATE: OnHostMaintenance = OnHostMaintenance::new(1);
 
         /// Default, Allows Compute Engine to automatically migrate instances
         /// out of the way of maintenance events.
-        pub const MIGRATE: OnHostMaintenance = OnHostMaintenance::new("MIGRATE");
+        pub const MIGRATE: OnHostMaintenance = OnHostMaintenance::new(1000);
+
+        /// Creates a new OnHostMaintenance instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ON_HOST_MAINTENANCE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TERMINATE"),
+                1000 => std::borrow::Cow::Borrowed("MIGRATE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ON_HOST_MAINTENANCE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ON_HOST_MAINTENANCE_UNSPECIFIED)
+                }
+                "TERMINATE" => std::option::Option::Some(Self::TERMINATE),
+                "MIGRATE" => std::option::Option::Some(Self::MIGRATE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for OnHostMaintenance {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for OnHostMaintenance {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for OnHostMaintenance {
         fn default() -> Self {
-            on_host_maintenance::ON_HOST_MAINTENANCE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Defines the provisioning model for an instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ProvisioningModel(std::borrow::Cow<'static, str>);
+    pub struct ProvisioningModel(i32);
 
     impl ProvisioningModel {
+        /// Default value. This value is not used.
+        pub const PROVISIONING_MODEL_UNSPECIFIED: ProvisioningModel = ProvisioningModel::new(0);
+
+        /// Standard provisioning with user controlled runtime, no discounts.
+        pub const STANDARD: ProvisioningModel = ProvisioningModel::new(1);
+
+        /// Heavily discounted, no guaranteed runtime.
+        pub const SPOT: ProvisioningModel = ProvisioningModel::new(2);
+
         /// Creates a new ProvisioningModel instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PROVISIONING_MODEL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STANDARD"),
+                2 => std::borrow::Cow::Borrowed("SPOT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PROVISIONING_MODEL_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PROVISIONING_MODEL_UNSPECIFIED)
+                }
+                "STANDARD" => std::option::Option::Some(Self::STANDARD),
+                "SPOT" => std::option::Option::Some(Self::SPOT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ProvisioningModel](ProvisioningModel)
-    pub mod provisioning_model {
-        use super::ProvisioningModel;
-
-        /// Default value. This value is not used.
-        pub const PROVISIONING_MODEL_UNSPECIFIED: ProvisioningModel =
-            ProvisioningModel::new("PROVISIONING_MODEL_UNSPECIFIED");
-
-        /// Standard provisioning with user controlled runtime, no discounts.
-        pub const STANDARD: ProvisioningModel = ProvisioningModel::new("STANDARD");
-
-        /// Heavily discounted, no guaranteed runtime.
-        pub const SPOT: ProvisioningModel = ProvisioningModel::new("SPOT");
-    }
-
-    impl std::convert::From<std::string::String> for ProvisioningModel {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ProvisioningModel {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ProvisioningModel {
         fn default() -> Self {
-            provisioning_model::PROVISIONING_MODEL_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Defines the supported termination actions for an instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct InstanceTerminationAction(std::borrow::Cow<'static, str>);
+    pub struct InstanceTerminationAction(i32);
 
     impl InstanceTerminationAction {
+        /// Default value. This value is unused.
+        pub const INSTANCE_TERMINATION_ACTION_UNSPECIFIED: InstanceTerminationAction =
+            InstanceTerminationAction::new(0);
+
+        /// Delete the VM.
+        pub const DELETE: InstanceTerminationAction = InstanceTerminationAction::new(1);
+
+        /// Stop the VM without storing in-memory content. default action.
+        pub const STOP: InstanceTerminationAction = InstanceTerminationAction::new(2);
+
         /// Creates a new InstanceTerminationAction instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("INSTANCE_TERMINATION_ACTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DELETE"),
+                2 => std::borrow::Cow::Borrowed("STOP"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "INSTANCE_TERMINATION_ACTION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::INSTANCE_TERMINATION_ACTION_UNSPECIFIED)
+                }
+                "DELETE" => std::option::Option::Some(Self::DELETE),
+                "STOP" => std::option::Option::Some(Self::STOP),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [InstanceTerminationAction](InstanceTerminationAction)
-    pub mod instance_termination_action {
-        use super::InstanceTerminationAction;
-
-        /// Default value. This value is unused.
-        pub const INSTANCE_TERMINATION_ACTION_UNSPECIFIED: InstanceTerminationAction =
-            InstanceTerminationAction::new("INSTANCE_TERMINATION_ACTION_UNSPECIFIED");
-
-        /// Delete the VM.
-        pub const DELETE: InstanceTerminationAction = InstanceTerminationAction::new("DELETE");
-
-        /// Stop the VM without storing in-memory content. default action.
-        pub const STOP: InstanceTerminationAction = InstanceTerminationAction::new("STOP");
-    }
-
-    impl std::convert::From<std::string::String> for InstanceTerminationAction {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for InstanceTerminationAction {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for InstanceTerminationAction {
         fn default() -> Self {
-            instance_termination_action::INSTANCE_TERMINATION_ACTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -9587,182 +10055,248 @@ pub mod attached_disk {
 
     /// List of the Disk Types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DiskType(std::borrow::Cow<'static, str>);
+    pub struct DiskType(i32);
 
     impl DiskType {
+        /// Default value, which is unused.
+        pub const DISK_TYPE_UNSPECIFIED: DiskType = DiskType::new(0);
+
+        /// A scratch disk type.
+        pub const SCRATCH: DiskType = DiskType::new(1);
+
+        /// A persistent disk type.
+        pub const PERSISTENT: DiskType = DiskType::new(2);
+
         /// Creates a new DiskType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DISK_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SCRATCH"),
+                2 => std::borrow::Cow::Borrowed("PERSISTENT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DISK_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::DISK_TYPE_UNSPECIFIED),
+                "SCRATCH" => std::option::Option::Some(Self::SCRATCH),
+                "PERSISTENT" => std::option::Option::Some(Self::PERSISTENT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DiskType](DiskType)
-    pub mod disk_type {
-        use super::DiskType;
-
-        /// Default value, which is unused.
-        pub const DISK_TYPE_UNSPECIFIED: DiskType = DiskType::new("DISK_TYPE_UNSPECIFIED");
-
-        /// A scratch disk type.
-        pub const SCRATCH: DiskType = DiskType::new("SCRATCH");
-
-        /// A persistent disk type.
-        pub const PERSISTENT: DiskType = DiskType::new("PERSISTENT");
-    }
-
-    impl std::convert::From<std::string::String> for DiskType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DiskType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DiskType {
         fn default() -> Self {
-            disk_type::DISK_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// List of the Disk Modes.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DiskMode(std::borrow::Cow<'static, str>);
+    pub struct DiskMode(i32);
 
     impl DiskMode {
-        /// Creates a new DiskMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DiskMode](DiskMode)
-    pub mod disk_mode {
-        use super::DiskMode;
-
         /// Default value, which is unused.
-        pub const DISK_MODE_UNSPECIFIED: DiskMode = DiskMode::new("DISK_MODE_UNSPECIFIED");
+        pub const DISK_MODE_UNSPECIFIED: DiskMode = DiskMode::new(0);
 
         /// Attaches this disk in read-write mode. Only one
         /// virtual machine at a time can be attached to a disk in read-write mode.
-        pub const READ_WRITE: DiskMode = DiskMode::new("READ_WRITE");
+        pub const READ_WRITE: DiskMode = DiskMode::new(1);
 
         /// Attaches this disk in read-only mode. Multiple virtual machines can use
         /// a disk in read-only mode at a time.
-        pub const READ_ONLY: DiskMode = DiskMode::new("READ_ONLY");
+        pub const READ_ONLY: DiskMode = DiskMode::new(2);
 
         /// The disk is locked for administrative reasons. Nobody else
         /// can use the disk. This mode is used (for example) when taking
         /// a snapshot of a disk to prevent mounting the disk while it is
         /// being snapshotted.
-        pub const LOCKED: DiskMode = DiskMode::new("LOCKED");
+        pub const LOCKED: DiskMode = DiskMode::new(3);
+
+        /// Creates a new DiskMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DISK_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("READ_WRITE"),
+                2 => std::borrow::Cow::Borrowed("READ_ONLY"),
+                3 => std::borrow::Cow::Borrowed("LOCKED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DISK_MODE_UNSPECIFIED" => std::option::Option::Some(Self::DISK_MODE_UNSPECIFIED),
+                "READ_WRITE" => std::option::Option::Some(Self::READ_WRITE),
+                "READ_ONLY" => std::option::Option::Some(Self::READ_ONLY),
+                "LOCKED" => std::option::Option::Some(Self::LOCKED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DiskMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DiskMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DiskMode {
         fn default() -> Self {
-            disk_mode::DISK_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// List of the Disk Interfaces.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DiskInterface(std::borrow::Cow<'static, str>);
+    pub struct DiskInterface(i32);
 
     impl DiskInterface {
+        /// Default value, which is unused.
+        pub const DISK_INTERFACE_UNSPECIFIED: DiskInterface = DiskInterface::new(0);
+
+        /// SCSI Disk Interface.
+        pub const SCSI: DiskInterface = DiskInterface::new(1);
+
+        /// NVME Disk Interface.
+        pub const NVME: DiskInterface = DiskInterface::new(2);
+
+        /// NVDIMM Disk Interface.
+        pub const NVDIMM: DiskInterface = DiskInterface::new(3);
+
+        /// ISCSI Disk Interface.
+        pub const ISCSI: DiskInterface = DiskInterface::new(4);
+
         /// Creates a new DiskInterface instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DISK_INTERFACE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SCSI"),
+                2 => std::borrow::Cow::Borrowed("NVME"),
+                3 => std::borrow::Cow::Borrowed("NVDIMM"),
+                4 => std::borrow::Cow::Borrowed("ISCSI"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DISK_INTERFACE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DISK_INTERFACE_UNSPECIFIED)
+                }
+                "SCSI" => std::option::Option::Some(Self::SCSI),
+                "NVME" => std::option::Option::Some(Self::NVME),
+                "NVDIMM" => std::option::Option::Some(Self::NVDIMM),
+                "ISCSI" => std::option::Option::Some(Self::ISCSI),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DiskInterface](DiskInterface)
-    pub mod disk_interface {
-        use super::DiskInterface;
-
-        /// Default value, which is unused.
-        pub const DISK_INTERFACE_UNSPECIFIED: DiskInterface =
-            DiskInterface::new("DISK_INTERFACE_UNSPECIFIED");
-
-        /// SCSI Disk Interface.
-        pub const SCSI: DiskInterface = DiskInterface::new("SCSI");
-
-        /// NVME Disk Interface.
-        pub const NVME: DiskInterface = DiskInterface::new("NVME");
-
-        /// NVDIMM Disk Interface.
-        pub const NVDIMM: DiskInterface = DiskInterface::new("NVDIMM");
-
-        /// ISCSI Disk Interface.
-        pub const ISCSI: DiskInterface = DiskInterface::new("ISCSI");
-    }
-
-    impl std::convert::From<std::string::String> for DiskInterface {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DiskInterface {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DiskInterface {
         fn default() -> Self {
-            disk_interface::DISK_INTERFACE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// List of the states of the Disk.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DiskSavedState(std::borrow::Cow<'static, str>);
+    pub struct DiskSavedState(i32);
 
     impl DiskSavedState {
+        /// Default Disk state has not been preserved.
+        pub const DISK_SAVED_STATE_UNSPECIFIED: DiskSavedState = DiskSavedState::new(0);
+
+        /// Disk state has been preserved.
+        pub const PRESERVED: DiskSavedState = DiskSavedState::new(1);
+
         /// Creates a new DiskSavedState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DISK_SAVED_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PRESERVED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DISK_SAVED_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DISK_SAVED_STATE_UNSPECIFIED)
+                }
+                "PRESERVED" => std::option::Option::Some(Self::PRESERVED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DiskSavedState](DiskSavedState)
-    pub mod disk_saved_state {
-        use super::DiskSavedState;
-
-        /// Default Disk state has not been preserved.
-        pub const DISK_SAVED_STATE_UNSPECIFIED: DiskSavedState =
-            DiskSavedState::new("DISK_SAVED_STATE_UNSPECIFIED");
-
-        /// Disk state has been preserved.
-        pub const PRESERVED: DiskSavedState = DiskSavedState::new("PRESERVED");
-    }
-
-    impl std::convert::From<std::string::String> for DiskSavedState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DiskSavedState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DiskSavedState {
         fn default() -> Self {
-            disk_saved_state::DISK_SAVED_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -9809,217 +10343,304 @@ pub mod guest_os_feature {
 
     /// List of the Feature Types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FeatureType(std::borrow::Cow<'static, str>);
+    pub struct FeatureType(i32);
 
     impl FeatureType {
+        /// Default value, which is unused.
+        pub const FEATURE_TYPE_UNSPECIFIED: FeatureType = FeatureType::new(0);
+
+        /// VIRTIO_SCSI_MULTIQUEUE feature type.
+        pub const VIRTIO_SCSI_MULTIQUEUE: FeatureType = FeatureType::new(1);
+
+        /// WINDOWS feature type.
+        pub const WINDOWS: FeatureType = FeatureType::new(2);
+
+        /// MULTI_IP_SUBNET feature type.
+        pub const MULTI_IP_SUBNET: FeatureType = FeatureType::new(3);
+
+        /// UEFI_COMPATIBLE feature type.
+        pub const UEFI_COMPATIBLE: FeatureType = FeatureType::new(4);
+
+        /// SECURE_BOOT feature type.
+        pub const SECURE_BOOT: FeatureType = FeatureType::new(5);
+
+        /// GVNIC feature type.
+        pub const GVNIC: FeatureType = FeatureType::new(6);
+
+        /// SEV_CAPABLE feature type.
+        pub const SEV_CAPABLE: FeatureType = FeatureType::new(7);
+
+        /// BARE_METAL_LINUX_COMPATIBLE feature type.
+        pub const BARE_METAL_LINUX_COMPATIBLE: FeatureType = FeatureType::new(8);
+
+        /// SUSPEND_RESUME_COMPATIBLE feature type.
+        pub const SUSPEND_RESUME_COMPATIBLE: FeatureType = FeatureType::new(9);
+
+        /// SEV_LIVE_MIGRATABLE feature type.
+        pub const SEV_LIVE_MIGRATABLE: FeatureType = FeatureType::new(10);
+
+        /// SEV_SNP_CAPABLE feature type.
+        pub const SEV_SNP_CAPABLE: FeatureType = FeatureType::new(11);
+
+        /// TDX_CAPABLE feature type.
+        pub const TDX_CAPABLE: FeatureType = FeatureType::new(12);
+
+        /// IDPF feature type.
+        pub const IDPF: FeatureType = FeatureType::new(13);
+
+        /// SEV_LIVE_MIGRATABLE_V2 feature type.
+        pub const SEV_LIVE_MIGRATABLE_V2: FeatureType = FeatureType::new(14);
+
         /// Creates a new FeatureType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FEATURE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("VIRTIO_SCSI_MULTIQUEUE"),
+                2 => std::borrow::Cow::Borrowed("WINDOWS"),
+                3 => std::borrow::Cow::Borrowed("MULTI_IP_SUBNET"),
+                4 => std::borrow::Cow::Borrowed("UEFI_COMPATIBLE"),
+                5 => std::borrow::Cow::Borrowed("SECURE_BOOT"),
+                6 => std::borrow::Cow::Borrowed("GVNIC"),
+                7 => std::borrow::Cow::Borrowed("SEV_CAPABLE"),
+                8 => std::borrow::Cow::Borrowed("BARE_METAL_LINUX_COMPATIBLE"),
+                9 => std::borrow::Cow::Borrowed("SUSPEND_RESUME_COMPATIBLE"),
+                10 => std::borrow::Cow::Borrowed("SEV_LIVE_MIGRATABLE"),
+                11 => std::borrow::Cow::Borrowed("SEV_SNP_CAPABLE"),
+                12 => std::borrow::Cow::Borrowed("TDX_CAPABLE"),
+                13 => std::borrow::Cow::Borrowed("IDPF"),
+                14 => std::borrow::Cow::Borrowed("SEV_LIVE_MIGRATABLE_V2"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FEATURE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::FEATURE_TYPE_UNSPECIFIED)
+                }
+                "VIRTIO_SCSI_MULTIQUEUE" => std::option::Option::Some(Self::VIRTIO_SCSI_MULTIQUEUE),
+                "WINDOWS" => std::option::Option::Some(Self::WINDOWS),
+                "MULTI_IP_SUBNET" => std::option::Option::Some(Self::MULTI_IP_SUBNET),
+                "UEFI_COMPATIBLE" => std::option::Option::Some(Self::UEFI_COMPATIBLE),
+                "SECURE_BOOT" => std::option::Option::Some(Self::SECURE_BOOT),
+                "GVNIC" => std::option::Option::Some(Self::GVNIC),
+                "SEV_CAPABLE" => std::option::Option::Some(Self::SEV_CAPABLE),
+                "BARE_METAL_LINUX_COMPATIBLE" => {
+                    std::option::Option::Some(Self::BARE_METAL_LINUX_COMPATIBLE)
+                }
+                "SUSPEND_RESUME_COMPATIBLE" => {
+                    std::option::Option::Some(Self::SUSPEND_RESUME_COMPATIBLE)
+                }
+                "SEV_LIVE_MIGRATABLE" => std::option::Option::Some(Self::SEV_LIVE_MIGRATABLE),
+                "SEV_SNP_CAPABLE" => std::option::Option::Some(Self::SEV_SNP_CAPABLE),
+                "TDX_CAPABLE" => std::option::Option::Some(Self::TDX_CAPABLE),
+                "IDPF" => std::option::Option::Some(Self::IDPF),
+                "SEV_LIVE_MIGRATABLE_V2" => std::option::Option::Some(Self::SEV_LIVE_MIGRATABLE_V2),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [FeatureType](FeatureType)
-    pub mod feature_type {
-        use super::FeatureType;
-
-        /// Default value, which is unused.
-        pub const FEATURE_TYPE_UNSPECIFIED: FeatureType =
-            FeatureType::new("FEATURE_TYPE_UNSPECIFIED");
-
-        /// VIRTIO_SCSI_MULTIQUEUE feature type.
-        pub const VIRTIO_SCSI_MULTIQUEUE: FeatureType = FeatureType::new("VIRTIO_SCSI_MULTIQUEUE");
-
-        /// WINDOWS feature type.
-        pub const WINDOWS: FeatureType = FeatureType::new("WINDOWS");
-
-        /// MULTI_IP_SUBNET feature type.
-        pub const MULTI_IP_SUBNET: FeatureType = FeatureType::new("MULTI_IP_SUBNET");
-
-        /// UEFI_COMPATIBLE feature type.
-        pub const UEFI_COMPATIBLE: FeatureType = FeatureType::new("UEFI_COMPATIBLE");
-
-        /// SECURE_BOOT feature type.
-        pub const SECURE_BOOT: FeatureType = FeatureType::new("SECURE_BOOT");
-
-        /// GVNIC feature type.
-        pub const GVNIC: FeatureType = FeatureType::new("GVNIC");
-
-        /// SEV_CAPABLE feature type.
-        pub const SEV_CAPABLE: FeatureType = FeatureType::new("SEV_CAPABLE");
-
-        /// BARE_METAL_LINUX_COMPATIBLE feature type.
-        pub const BARE_METAL_LINUX_COMPATIBLE: FeatureType =
-            FeatureType::new("BARE_METAL_LINUX_COMPATIBLE");
-
-        /// SUSPEND_RESUME_COMPATIBLE feature type.
-        pub const SUSPEND_RESUME_COMPATIBLE: FeatureType =
-            FeatureType::new("SUSPEND_RESUME_COMPATIBLE");
-
-        /// SEV_LIVE_MIGRATABLE feature type.
-        pub const SEV_LIVE_MIGRATABLE: FeatureType = FeatureType::new("SEV_LIVE_MIGRATABLE");
-
-        /// SEV_SNP_CAPABLE feature type.
-        pub const SEV_SNP_CAPABLE: FeatureType = FeatureType::new("SEV_SNP_CAPABLE");
-
-        /// TDX_CAPABLE feature type.
-        pub const TDX_CAPABLE: FeatureType = FeatureType::new("TDX_CAPABLE");
-
-        /// IDPF feature type.
-        pub const IDPF: FeatureType = FeatureType::new("IDPF");
-
-        /// SEV_LIVE_MIGRATABLE_V2 feature type.
-        pub const SEV_LIVE_MIGRATABLE_V2: FeatureType = FeatureType::new("SEV_LIVE_MIGRATABLE_V2");
-    }
-
-    impl std::convert::From<std::string::String> for FeatureType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for FeatureType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for FeatureType {
         fn default() -> Self {
-            feature_type::FEATURE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
 
 /// Backup configuration state. Is the resource configured for backup?
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct BackupConfigState(std::borrow::Cow<'static, str>);
+pub struct BackupConfigState(i32);
 
 impl BackupConfigState {
-    /// Creates a new BackupConfigState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [BackupConfigState](BackupConfigState)
-pub mod backup_config_state {
-    use super::BackupConfigState;
-
     /// The possible states of backup configuration.
     /// Status not set.
-    pub const BACKUP_CONFIG_STATE_UNSPECIFIED: BackupConfigState =
-        BackupConfigState::new("BACKUP_CONFIG_STATE_UNSPECIFIED");
+    pub const BACKUP_CONFIG_STATE_UNSPECIFIED: BackupConfigState = BackupConfigState::new(0);
 
     /// The data source is actively protected (i.e. there is a
     /// BackupPlanAssociation or Appliance SLA pointing to it)
-    pub const ACTIVE: BackupConfigState = BackupConfigState::new("ACTIVE");
+    pub const ACTIVE: BackupConfigState = BackupConfigState::new(1);
 
     /// The data source is no longer protected (but may have backups under it)
-    pub const PASSIVE: BackupConfigState = BackupConfigState::new("PASSIVE");
+    pub const PASSIVE: BackupConfigState = BackupConfigState::new(2);
+
+    /// Creates a new BackupConfigState instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("BACKUP_CONFIG_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ACTIVE"),
+            2 => std::borrow::Cow::Borrowed("PASSIVE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "BACKUP_CONFIG_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::BACKUP_CONFIG_STATE_UNSPECIFIED)
+            }
+            "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+            "PASSIVE" => std::option::Option::Some(Self::PASSIVE),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for BackupConfigState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for BackupConfigState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for BackupConfigState {
     fn default() -> Self {
-        backup_config_state::BACKUP_CONFIG_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// BackupView contains enum options for Partial and Full view.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct BackupView(std::borrow::Cow<'static, str>);
+pub struct BackupView(i32);
 
 impl BackupView {
-    /// Creates a new BackupView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [BackupView](BackupView)
-pub mod backup_view {
-    use super::BackupView;
-
     /// If the value is not set, the default 'FULL' view is used.
-    pub const BACKUP_VIEW_UNSPECIFIED: BackupView = BackupView::new("BACKUP_VIEW_UNSPECIFIED");
+    pub const BACKUP_VIEW_UNSPECIFIED: BackupView = BackupView::new(0);
 
     /// Includes basic data about the Backup, but not the full contents.
-    pub const BACKUP_VIEW_BASIC: BackupView = BackupView::new("BACKUP_VIEW_BASIC");
+    pub const BACKUP_VIEW_BASIC: BackupView = BackupView::new(1);
 
     /// Includes all data about the Backup.
     /// This is the default value (for both ListBackups and GetBackup).
-    pub const BACKUP_VIEW_FULL: BackupView = BackupView::new("BACKUP_VIEW_FULL");
+    pub const BACKUP_VIEW_FULL: BackupView = BackupView::new(2);
+
+    /// Creates a new BackupView instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("BACKUP_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("BACKUP_VIEW_BASIC"),
+            2 => std::borrow::Cow::Borrowed("BACKUP_VIEW_FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "BACKUP_VIEW_UNSPECIFIED" => std::option::Option::Some(Self::BACKUP_VIEW_UNSPECIFIED),
+            "BACKUP_VIEW_BASIC" => std::option::Option::Some(Self::BACKUP_VIEW_BASIC),
+            "BACKUP_VIEW_FULL" => std::option::Option::Some(Self::BACKUP_VIEW_FULL),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for BackupView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for BackupView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for BackupView {
     fn default() -> Self {
-        backup_view::BACKUP_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// BackupVaultView contains enum options for Partial and Full view.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct BackupVaultView(std::borrow::Cow<'static, str>);
+pub struct BackupVaultView(i32);
 
 impl BackupVaultView {
-    /// Creates a new BackupVaultView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [BackupVaultView](BackupVaultView)
-pub mod backup_vault_view {
-    use super::BackupVaultView;
-
     /// If the value is not set, the default 'FULL' view is used.
-    pub const BACKUP_VAULT_VIEW_UNSPECIFIED: BackupVaultView =
-        BackupVaultView::new("BACKUP_VAULT_VIEW_UNSPECIFIED");
+    pub const BACKUP_VAULT_VIEW_UNSPECIFIED: BackupVaultView = BackupVaultView::new(0);
 
     /// Includes basic data about the Backup Vault, but not the full contents.
-    pub const BACKUP_VAULT_VIEW_BASIC: BackupVaultView =
-        BackupVaultView::new("BACKUP_VAULT_VIEW_BASIC");
+    pub const BACKUP_VAULT_VIEW_BASIC: BackupVaultView = BackupVaultView::new(1);
 
     /// Includes all data about the Backup Vault.
     /// This is the default value (for both ListBackupVaults and GetBackupVault).
-    pub const BACKUP_VAULT_VIEW_FULL: BackupVaultView =
-        BackupVaultView::new("BACKUP_VAULT_VIEW_FULL");
+    pub const BACKUP_VAULT_VIEW_FULL: BackupVaultView = BackupVaultView::new(2);
+
+    /// Creates a new BackupVaultView instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("BACKUP_VAULT_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("BACKUP_VAULT_VIEW_BASIC"),
+            2 => std::borrow::Cow::Borrowed("BACKUP_VAULT_VIEW_FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "BACKUP_VAULT_VIEW_UNSPECIFIED" => {
+                std::option::Option::Some(Self::BACKUP_VAULT_VIEW_UNSPECIFIED)
+            }
+            "BACKUP_VAULT_VIEW_BASIC" => std::option::Option::Some(Self::BACKUP_VAULT_VIEW_BASIC),
+            "BACKUP_VAULT_VIEW_FULL" => std::option::Option::Some(Self::BACKUP_VAULT_VIEW_FULL),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for BackupVaultView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for BackupVaultView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for BackupVaultView {
     fn default() -> Self {
-        backup_vault_view::BACKUP_VAULT_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -10027,43 +10648,60 @@ impl std::default::Default for BackupVaultView {
 /// revocation. It is currently used in instance, instance properties and GMI
 /// protos
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct KeyRevocationActionType(std::borrow::Cow<'static, str>);
+pub struct KeyRevocationActionType(i32);
 
 impl KeyRevocationActionType {
+    /// Default value. This value is unused.
+    pub const KEY_REVOCATION_ACTION_TYPE_UNSPECIFIED: KeyRevocationActionType =
+        KeyRevocationActionType::new(0);
+
+    /// Indicates user chose no operation.
+    pub const NONE: KeyRevocationActionType = KeyRevocationActionType::new(1);
+
+    /// Indicates user chose to opt for VM shutdown on key revocation.
+    pub const STOP: KeyRevocationActionType = KeyRevocationActionType::new(2);
+
     /// Creates a new KeyRevocationActionType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("KEY_REVOCATION_ACTION_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("NONE"),
+            2 => std::borrow::Cow::Borrowed("STOP"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "KEY_REVOCATION_ACTION_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::KEY_REVOCATION_ACTION_TYPE_UNSPECIFIED)
+            }
+            "NONE" => std::option::Option::Some(Self::NONE),
+            "STOP" => std::option::Option::Some(Self::STOP),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [KeyRevocationActionType](KeyRevocationActionType)
-pub mod key_revocation_action_type {
-    use super::KeyRevocationActionType;
-
-    /// Default value. This value is unused.
-    pub const KEY_REVOCATION_ACTION_TYPE_UNSPECIFIED: KeyRevocationActionType =
-        KeyRevocationActionType::new("KEY_REVOCATION_ACTION_TYPE_UNSPECIFIED");
-
-    /// Indicates user chose no operation.
-    pub const NONE: KeyRevocationActionType = KeyRevocationActionType::new("NONE");
-
-    /// Indicates user chose to opt for VM shutdown on key revocation.
-    pub const STOP: KeyRevocationActionType = KeyRevocationActionType::new("STOP");
-}
-
-impl std::convert::From<std::string::String> for KeyRevocationActionType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for KeyRevocationActionType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for KeyRevocationActionType {
     fn default() -> Self {
-        key_revocation_action_type::KEY_REVOCATION_ACTION_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/backupdr/v1/src/transport.rs
+++ b/src/generated/cloud/backupdr/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::BackupDR for BackupDR {
                 reqwest::Method::GET,
                 format!("/v1/{}/managementServers", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -81,7 +81,7 @@ impl crate::stubs::BackupDR for BackupDR {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -103,7 +103,7 @@ impl crate::stubs::BackupDR for BackupDR {
                 reqwest::Method::POST,
                 format!("/v1/{}/managementServers", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -124,7 +124,7 @@ impl crate::stubs::BackupDR for BackupDR {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -147,7 +147,7 @@ impl crate::stubs::BackupDR for BackupDR {
                 reqwest::Method::POST,
                 format!("/v1/{}/backupVaults", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -172,7 +172,7 @@ impl crate::stubs::BackupDR for BackupDR {
                 reqwest::Method::GET,
                 format!("/v1/{}/backupVaults", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -199,7 +199,7 @@ impl crate::stubs::BackupDR for BackupDR {
                 reqwest::Method::GET,
                 format!("/v1/{}/backupVaults:fetchUsable", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -222,7 +222,7 @@ impl crate::stubs::BackupDR for BackupDR {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -251,7 +251,7 @@ impl crate::stubs::BackupDR for BackupDR {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -283,7 +283,7 @@ impl crate::stubs::BackupDR for BackupDR {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -314,7 +314,7 @@ impl crate::stubs::BackupDR for BackupDR {
                 reqwest::Method::GET,
                 format!("/v1/{}/dataSources", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -337,7 +337,7 @@ impl crate::stubs::BackupDR for BackupDR {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -365,7 +365,7 @@ impl crate::stubs::BackupDR for BackupDR {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -396,7 +396,7 @@ impl crate::stubs::BackupDR for BackupDR {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/backups", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -420,7 +420,7 @@ impl crate::stubs::BackupDR for BackupDR {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -449,7 +449,7 @@ impl crate::stubs::BackupDR for BackupDR {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -477,7 +477,7 @@ impl crate::stubs::BackupDR for BackupDR {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -497,7 +497,7 @@ impl crate::stubs::BackupDR for BackupDR {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:restore", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -517,7 +517,7 @@ impl crate::stubs::BackupDR for BackupDR {
                 reqwest::Method::POST,
                 format!("/v1/{}/backupPlans", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -538,7 +538,7 @@ impl crate::stubs::BackupDR for BackupDR {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -560,7 +560,7 @@ impl crate::stubs::BackupDR for BackupDR {
                 reqwest::Method::GET,
                 format!("/v1/{}/backupPlans", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -583,7 +583,7 @@ impl crate::stubs::BackupDR for BackupDR {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -606,7 +606,7 @@ impl crate::stubs::BackupDR for BackupDR {
                 reqwest::Method::POST,
                 format!("/v1/{}/backupPlanAssociations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -628,7 +628,7 @@ impl crate::stubs::BackupDR for BackupDR {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -650,7 +650,7 @@ impl crate::stubs::BackupDR for BackupDR {
                 reqwest::Method::GET,
                 format!("/v1/{}/backupPlanAssociations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -672,7 +672,7 @@ impl crate::stubs::BackupDR for BackupDR {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -695,7 +695,7 @@ impl crate::stubs::BackupDR for BackupDR {
                 reqwest::Method::POST,
                 format!("/v1/{}:triggerBackup", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -715,7 +715,7 @@ impl crate::stubs::BackupDR for BackupDR {
                 reqwest::Method::POST,
                 format!("/v1/{}:initialize", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -732,7 +732,7 @@ impl crate::stubs::BackupDR for BackupDR {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -754,7 +754,7 @@ impl crate::stubs::BackupDR for BackupDR {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -776,7 +776,7 @@ impl crate::stubs::BackupDR for BackupDR {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -796,7 +796,7 @@ impl crate::stubs::BackupDR for BackupDR {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -828,7 +828,7 @@ impl crate::stubs::BackupDR for BackupDR {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -845,7 +845,7 @@ impl crate::stubs::BackupDR for BackupDR {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -867,7 +867,7 @@ impl crate::stubs::BackupDR for BackupDR {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -886,7 +886,7 @@ impl crate::stubs::BackupDR for BackupDR {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -905,7 +905,7 @@ impl crate::stubs::BackupDR for BackupDR {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/baremetalsolution/v2/src/model.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/model.rs
@@ -427,58 +427,83 @@ pub mod instance {
 
     /// The possible states for this server.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The server is in an unknown state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The server is being provisioned.
+        pub const PROVISIONING: State = State::new(1);
+
+        /// The server is running.
+        pub const RUNNING: State = State::new(2);
+
+        /// The server has been deleted.
+        pub const DELETED: State = State::new(3);
+
+        /// The server is being updated.
+        pub const UPDATING: State = State::new(4);
+
+        /// The server is starting.
+        pub const STARTING: State = State::new(5);
+
+        /// The server is stopping.
+        pub const STOPPING: State = State::new(6);
+
+        /// The server is shutdown.
+        pub const SHUTDOWN: State = State::new(7);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("DELETED"),
+                4 => std::borrow::Cow::Borrowed("UPDATING"),
+                5 => std::borrow::Cow::Borrowed("STARTING"),
+                6 => std::borrow::Cow::Borrowed("STOPPING"),
+                7 => std::borrow::Cow::Borrowed("SHUTDOWN"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "DELETED" => std::option::Option::Some(Self::DELETED),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "STARTING" => std::option::Option::Some(Self::STARTING),
+                "STOPPING" => std::option::Option::Some(Self::STOPPING),
+                "SHUTDOWN" => std::option::Option::Some(Self::SHUTDOWN),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The server is in an unknown state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The server is being provisioned.
-        pub const PROVISIONING: State = State::new("PROVISIONING");
-
-        /// The server is running.
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// The server has been deleted.
-        pub const DELETED: State = State::new("DELETED");
-
-        /// The server is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// The server is starting.
-        pub const STARTING: State = State::new("STARTING");
-
-        /// The server is stopping.
-        pub const STOPPING: State = State::new("STOPPING");
-
-        /// The server is shutdown.
-        pub const SHUTDOWN: State = State::new("SHUTDOWN");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1138,44 +1163,60 @@ pub mod server_network_template {
 
         /// Interface type.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct InterfaceType(std::borrow::Cow<'static, str>);
+        pub struct InterfaceType(i32);
 
         impl InterfaceType {
+            /// Unspecified value.
+            pub const INTERFACE_TYPE_UNSPECIFIED: InterfaceType = InterfaceType::new(0);
+
+            /// Bond interface type.
+            pub const BOND: InterfaceType = InterfaceType::new(1);
+
+            /// NIC interface type.
+            pub const NIC: InterfaceType = InterfaceType::new(2);
+
             /// Creates a new InterfaceType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("INTERFACE_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("BOND"),
+                    2 => std::borrow::Cow::Borrowed("NIC"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "INTERFACE_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::INTERFACE_TYPE_UNSPECIFIED)
+                    }
+                    "BOND" => std::option::Option::Some(Self::BOND),
+                    "NIC" => std::option::Option::Some(Self::NIC),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [InterfaceType](InterfaceType)
-        pub mod interface_type {
-            use super::InterfaceType;
-
-            /// Unspecified value.
-            pub const INTERFACE_TYPE_UNSPECIFIED: InterfaceType =
-                InterfaceType::new("INTERFACE_TYPE_UNSPECIFIED");
-
-            /// Bond interface type.
-            pub const BOND: InterfaceType = InterfaceType::new("BOND");
-
-            /// NIC interface type.
-            pub const NIC: InterfaceType = InterfaceType::new("NIC");
-        }
-
-        impl std::convert::From<std::string::String> for InterfaceType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for InterfaceType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for InterfaceType {
             fn default() -> Self {
-                interface_type::INTERFACE_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -1338,135 +1379,186 @@ pub mod lun {
 
     /// The possible states for the LUN.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The LUN is in an unknown state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The LUN is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// The LUN is being updated.
+        pub const UPDATING: State = State::new(2);
+
+        /// The LUN is ready for use.
+        pub const READY: State = State::new(3);
+
+        /// The LUN has been requested to be deleted.
+        pub const DELETING: State = State::new(4);
+
+        /// The LUN is in cool off state. It will be deleted after `expire_time`.
+        pub const COOL_OFF: State = State::new(5);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("UPDATING"),
+                3 => std::borrow::Cow::Borrowed("READY"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("COOL_OFF"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "COOL_OFF" => std::option::Option::Some(Self::COOL_OFF),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The LUN is in an unknown state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The LUN is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The LUN is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// The LUN is ready for use.
-        pub const READY: State = State::new("READY");
-
-        /// The LUN has been requested to be deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// The LUN is in cool off state. It will be deleted after `expire_time`.
-        pub const COOL_OFF: State = State::new("COOL_OFF");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Display the operating systems present for the LUN multiprotocol type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MultiprotocolType(std::borrow::Cow<'static, str>);
+    pub struct MultiprotocolType(i32);
 
     impl MultiprotocolType {
+        /// Server has no OS specified.
+        pub const MULTIPROTOCOL_TYPE_UNSPECIFIED: MultiprotocolType = MultiprotocolType::new(0);
+
+        /// Server with Linux OS.
+        pub const LINUX: MultiprotocolType = MultiprotocolType::new(1);
+
         /// Creates a new MultiprotocolType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MULTIPROTOCOL_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LINUX"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MULTIPROTOCOL_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MULTIPROTOCOL_TYPE_UNSPECIFIED)
+                }
+                "LINUX" => std::option::Option::Some(Self::LINUX),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [MultiprotocolType](MultiprotocolType)
-    pub mod multiprotocol_type {
-        use super::MultiprotocolType;
-
-        /// Server has no OS specified.
-        pub const MULTIPROTOCOL_TYPE_UNSPECIFIED: MultiprotocolType =
-            MultiprotocolType::new("MULTIPROTOCOL_TYPE_UNSPECIFIED");
-
-        /// Server with Linux OS.
-        pub const LINUX: MultiprotocolType = MultiprotocolType::new("LINUX");
-    }
-
-    impl std::convert::From<std::string::String> for MultiprotocolType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MultiprotocolType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MultiprotocolType {
         fn default() -> Self {
-            multiprotocol_type::MULTIPROTOCOL_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The storage types for a LUN.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StorageType(std::borrow::Cow<'static, str>);
+    pub struct StorageType(i32);
 
     impl StorageType {
+        /// The storage type for this LUN is unknown.
+        pub const STORAGE_TYPE_UNSPECIFIED: StorageType = StorageType::new(0);
+
+        /// This storage type for this LUN is SSD.
+        pub const SSD: StorageType = StorageType::new(1);
+
+        /// This storage type for this LUN is HDD.
+        pub const HDD: StorageType = StorageType::new(2);
+
         /// Creates a new StorageType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STORAGE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SSD"),
+                2 => std::borrow::Cow::Borrowed("HDD"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STORAGE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::STORAGE_TYPE_UNSPECIFIED)
+                }
+                "SSD" => std::option::Option::Some(Self::SSD),
+                "HDD" => std::option::Option::Some(Self::HDD),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [StorageType](StorageType)
-    pub mod storage_type {
-        use super::StorageType;
-
-        /// The storage type for this LUN is unknown.
-        pub const STORAGE_TYPE_UNSPECIFIED: StorageType =
-            StorageType::new("STORAGE_TYPE_UNSPECIFIED");
-
-        /// This storage type for this LUN is SSD.
-        pub const SSD: StorageType = StorageType::new("SSD");
-
-        /// This storage type for this LUN is HDD.
-        pub const HDD: StorageType = StorageType::new("HDD");
-    }
-
-    impl std::convert::From<std::string::String> for StorageType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for StorageType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for StorageType {
         fn default() -> Self {
-            storage_type::STORAGE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1864,91 +1956,125 @@ pub mod network {
 
     /// Network type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Unspecified value.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// Client network, a network peered to a Google Cloud VPC.
+        pub const CLIENT: Type = Type::new(1);
+
+        /// Private network, a network local to the Bare Metal Solution environment.
+        pub const PRIVATE: Type = Type::new(2);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CLIENT"),
+                2 => std::borrow::Cow::Borrowed("PRIVATE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "CLIENT" => std::option::Option::Some(Self::CLIENT),
+                "PRIVATE" => std::option::Option::Some(Self::PRIVATE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Unspecified value.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// Client network, a network peered to a Google Cloud VPC.
-        pub const CLIENT: Type = Type::new("CLIENT");
-
-        /// Private network, a network local to the Bare Metal Solution environment.
-        pub const PRIVATE: Type = Type::new("PRIVATE");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The possible states for this Network.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The Network is in an unknown state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The Network is provisioning.
+        pub const PROVISIONING: State = State::new(1);
+
+        /// The Network has been provisioned.
+        pub const PROVISIONED: State = State::new(2);
+
+        /// The Network is being deprovisioned.
+        pub const DEPROVISIONING: State = State::new(3);
+
+        /// The Network is being updated.
+        pub const UPDATING: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
+                2 => std::borrow::Cow::Borrowed("PROVISIONED"),
+                3 => std::borrow::Cow::Borrowed("DEPROVISIONING"),
+                4 => std::borrow::Cow::Borrowed("UPDATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
+                "PROVISIONED" => std::option::Option::Some(Self::PROVISIONED),
+                "DEPROVISIONING" => std::option::Option::Some(Self::DEPROVISIONING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The Network is in an unknown state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The Network is provisioning.
-        pub const PROVISIONING: State = State::new("PROVISIONING");
-
-        /// The Network has been provisioned.
-        pub const PROVISIONED: State = State::new("PROVISIONED");
-
-        /// The Network is being deprovisioned.
-        pub const DEPROVISIONING: State = State::new("DEPROVISIONING");
-
-        /// The Network is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2211,43 +2337,58 @@ pub mod vrf {
 
     /// The possible states for this VRF.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The unspecified state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The vrf is provisioning.
+        pub const PROVISIONING: State = State::new(1);
+
+        /// The vrf is provisioned.
+        pub const PROVISIONED: State = State::new(2);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
+                2 => std::borrow::Cow::Borrowed("PROVISIONED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
+                "PROVISIONED" => std::option::Option::Some(Self::PROVISIONED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The vrf is provisioning.
-        pub const PROVISIONING: State = State::new("PROVISIONING");
-
-        /// The vrf is provisioned.
-        pub const PROVISIONED: State = State::new("PROVISIONED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3051,135 +3192,186 @@ pub mod nfs_share {
 
     /// The possible states for this NFS share.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The share is in an unknown state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The share has been provisioned.
+        pub const PROVISIONED: State = State::new(1);
+
+        /// The NFS Share is being created.
+        pub const CREATING: State = State::new(2);
+
+        /// The NFS Share is being updated.
+        pub const UPDATING: State = State::new(3);
+
+        /// The NFS Share has been requested to be deleted.
+        pub const DELETING: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROVISIONED"),
+                2 => std::borrow::Cow::Borrowed("CREATING"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PROVISIONED" => std::option::Option::Some(Self::PROVISIONED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The share is in an unknown state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The share has been provisioned.
-        pub const PROVISIONED: State = State::new("PROVISIONED");
-
-        /// The NFS Share is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The NFS Share is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// The NFS Share has been requested to be deleted.
-        pub const DELETING: State = State::new("DELETING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The possible mount permissions.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MountPermissions(std::borrow::Cow<'static, str>);
+    pub struct MountPermissions(i32);
 
     impl MountPermissions {
+        /// Permissions were not specified.
+        pub const MOUNT_PERMISSIONS_UNSPECIFIED: MountPermissions = MountPermissions::new(0);
+
+        /// NFS share can be mount with read-only permissions.
+        pub const READ: MountPermissions = MountPermissions::new(1);
+
+        /// NFS share can be mount with read-write permissions.
+        pub const READ_WRITE: MountPermissions = MountPermissions::new(2);
+
         /// Creates a new MountPermissions instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MOUNT_PERMISSIONS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("READ"),
+                2 => std::borrow::Cow::Borrowed("READ_WRITE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MOUNT_PERMISSIONS_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MOUNT_PERMISSIONS_UNSPECIFIED)
+                }
+                "READ" => std::option::Option::Some(Self::READ),
+                "READ_WRITE" => std::option::Option::Some(Self::READ_WRITE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [MountPermissions](MountPermissions)
-    pub mod mount_permissions {
-        use super::MountPermissions;
-
-        /// Permissions were not specified.
-        pub const MOUNT_PERMISSIONS_UNSPECIFIED: MountPermissions =
-            MountPermissions::new("MOUNT_PERMISSIONS_UNSPECIFIED");
-
-        /// NFS share can be mount with read-only permissions.
-        pub const READ: MountPermissions = MountPermissions::new("READ");
-
-        /// NFS share can be mount with read-write permissions.
-        pub const READ_WRITE: MountPermissions = MountPermissions::new("READ_WRITE");
-    }
-
-    impl std::convert::From<std::string::String> for MountPermissions {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MountPermissions {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MountPermissions {
         fn default() -> Self {
-            mount_permissions::MOUNT_PERMISSIONS_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The storage type for a volume.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StorageType(std::borrow::Cow<'static, str>);
+    pub struct StorageType(i32);
 
     impl StorageType {
+        /// The storage type for this volume is unknown.
+        pub const STORAGE_TYPE_UNSPECIFIED: StorageType = StorageType::new(0);
+
+        /// The storage type for this volume is SSD.
+        pub const SSD: StorageType = StorageType::new(1);
+
+        /// This storage type for this volume is HDD.
+        pub const HDD: StorageType = StorageType::new(2);
+
         /// Creates a new StorageType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STORAGE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SSD"),
+                2 => std::borrow::Cow::Borrowed("HDD"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STORAGE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::STORAGE_TYPE_UNSPECIFIED)
+                }
+                "SSD" => std::option::Option::Some(Self::SSD),
+                "HDD" => std::option::Option::Some(Self::HDD),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [StorageType](StorageType)
-    pub mod storage_type {
-        use super::StorageType;
-
-        /// The storage type for this volume is unknown.
-        pub const STORAGE_TYPE_UNSPECIFIED: StorageType =
-            StorageType::new("STORAGE_TYPE_UNSPECIFIED");
-
-        /// The storage type for this volume is SSD.
-        pub const SSD: StorageType = StorageType::new("SSD");
-
-        /// This storage type for this volume is HDD.
-        pub const HDD: StorageType = StorageType::new("HDD");
-    }
-
-    impl std::convert::From<std::string::String> for StorageType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for StorageType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for StorageType {
         fn default() -> Self {
-            storage_type::STORAGE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3891,61 +4083,86 @@ pub mod provisioning_config {
 
     /// The possible states for this ProvisioningConfig.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// State wasn't specified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// ProvisioningConfig is a draft and can be freely modified.
-        pub const DRAFT: State = State::new("DRAFT");
+        pub const DRAFT: State = State::new(1);
 
         /// ProvisioningConfig was already submitted and cannot be modified.
-        pub const SUBMITTED: State = State::new("SUBMITTED");
+        pub const SUBMITTED: State = State::new(2);
 
         /// ProvisioningConfig was in the provisioning state.  Initially this state
         /// comes from the work order table in big query when SNOW is used.  Later
         /// this field can be set by the work order API.
-        pub const PROVISIONING: State = State::new("PROVISIONING");
+        pub const PROVISIONING: State = State::new(3);
 
         /// ProvisioningConfig was provisioned, meaning the resources exist.
-        pub const PROVISIONED: State = State::new("PROVISIONED");
+        pub const PROVISIONED: State = State::new(4);
 
         /// ProvisioningConfig was validated.  A validation tool will be run to
         /// set this state.
-        pub const VALIDATED: State = State::new("VALIDATED");
+        pub const VALIDATED: State = State::new(5);
 
         /// ProvisioningConfig was canceled.
-        pub const CANCELLED: State = State::new("CANCELLED");
+        pub const CANCELLED: State = State::new(6);
 
         /// The request is submitted for provisioning, with error return.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(7);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DRAFT"),
+                2 => std::borrow::Cow::Borrowed("SUBMITTED"),
+                3 => std::borrow::Cow::Borrowed("PROVISIONING"),
+                4 => std::borrow::Cow::Borrowed("PROVISIONED"),
+                5 => std::borrow::Cow::Borrowed("VALIDATED"),
+                6 => std::borrow::Cow::Borrowed("CANCELLED"),
+                7 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "DRAFT" => std::option::Option::Some(Self::DRAFT),
+                "SUBMITTED" => std::option::Option::Some(Self::SUBMITTED),
+                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
+                "PROVISIONED" => std::option::Option::Some(Self::PROVISIONED),
+                "VALIDATED" => std::option::Option::Some(Self::VALIDATED),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4254,46 +4471,63 @@ pub mod provisioning_quota {
 
     /// The available asset types for intake.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AssetType(std::borrow::Cow<'static, str>);
+    pub struct AssetType(i32);
 
     impl AssetType {
+        /// The unspecified type.
+        pub const ASSET_TYPE_UNSPECIFIED: AssetType = AssetType::new(0);
+
+        /// The server asset type.
+        pub const ASSET_TYPE_SERVER: AssetType = AssetType::new(1);
+
+        /// The storage asset type.
+        pub const ASSET_TYPE_STORAGE: AssetType = AssetType::new(2);
+
+        /// The network asset type.
+        pub const ASSET_TYPE_NETWORK: AssetType = AssetType::new(3);
+
         /// Creates a new AssetType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ASSET_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ASSET_TYPE_SERVER"),
+                2 => std::borrow::Cow::Borrowed("ASSET_TYPE_STORAGE"),
+                3 => std::borrow::Cow::Borrowed("ASSET_TYPE_NETWORK"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ASSET_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::ASSET_TYPE_UNSPECIFIED),
+                "ASSET_TYPE_SERVER" => std::option::Option::Some(Self::ASSET_TYPE_SERVER),
+                "ASSET_TYPE_STORAGE" => std::option::Option::Some(Self::ASSET_TYPE_STORAGE),
+                "ASSET_TYPE_NETWORK" => std::option::Option::Some(Self::ASSET_TYPE_NETWORK),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AssetType](AssetType)
-    pub mod asset_type {
-        use super::AssetType;
-
-        /// The unspecified type.
-        pub const ASSET_TYPE_UNSPECIFIED: AssetType = AssetType::new("ASSET_TYPE_UNSPECIFIED");
-
-        /// The server asset type.
-        pub const ASSET_TYPE_SERVER: AssetType = AssetType::new("ASSET_TYPE_SERVER");
-
-        /// The storage asset type.
-        pub const ASSET_TYPE_STORAGE: AssetType = AssetType::new("ASSET_TYPE_STORAGE");
-
-        /// The network asset type.
-        pub const ASSET_TYPE_NETWORK: AssetType = AssetType::new("ASSET_TYPE_NETWORK");
-    }
-
-    impl std::convert::From<std::string::String> for AssetType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AssetType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AssetType {
         fn default() -> Self {
-            asset_type::ASSET_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -4672,45 +4906,61 @@ pub mod instance_config {
 
     /// The network configuration of the instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NetworkConfig(std::borrow::Cow<'static, str>);
+    pub struct NetworkConfig(i32);
 
     impl NetworkConfig {
-        /// Creates a new NetworkConfig instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [NetworkConfig](NetworkConfig)
-    pub mod network_config {
-        use super::NetworkConfig;
-
         /// The unspecified network configuration.
-        pub const NETWORKCONFIG_UNSPECIFIED: NetworkConfig =
-            NetworkConfig::new("NETWORKCONFIG_UNSPECIFIED");
+        pub const NETWORKCONFIG_UNSPECIFIED: NetworkConfig = NetworkConfig::new(0);
 
         /// Instance part of single client network and single private network.
-        pub const SINGLE_VLAN: NetworkConfig = NetworkConfig::new("SINGLE_VLAN");
+        pub const SINGLE_VLAN: NetworkConfig = NetworkConfig::new(1);
 
         /// Instance part of multiple (or single) client networks and private
         /// networks.
-        pub const MULTI_VLAN: NetworkConfig = NetworkConfig::new("MULTI_VLAN");
+        pub const MULTI_VLAN: NetworkConfig = NetworkConfig::new(2);
+
+        /// Creates a new NetworkConfig instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("NETWORKCONFIG_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SINGLE_VLAN"),
+                2 => std::borrow::Cow::Borrowed("MULTI_VLAN"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "NETWORKCONFIG_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::NETWORKCONFIG_UNSPECIFIED)
+                }
+                "SINGLE_VLAN" => std::option::Option::Some(Self::SINGLE_VLAN),
+                "MULTI_VLAN" => std::option::Option::Some(Self::MULTI_VLAN),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for NetworkConfig {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for NetworkConfig {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for NetworkConfig {
         fn default() -> Self {
-            network_config::NETWORKCONFIG_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5067,44 +5317,60 @@ pub mod volume_config {
 
         /// Permissions that can granted for an export.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Permissions(std::borrow::Cow<'static, str>);
+        pub struct Permissions(i32);
 
         impl Permissions {
+            /// Unspecified value.
+            pub const PERMISSIONS_UNSPECIFIED: Permissions = Permissions::new(0);
+
+            /// Read-only permission.
+            pub const READ_ONLY: Permissions = Permissions::new(1);
+
+            /// Read-write permission.
+            pub const READ_WRITE: Permissions = Permissions::new(2);
+
             /// Creates a new Permissions instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("PERMISSIONS_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("READ_ONLY"),
+                    2 => std::borrow::Cow::Borrowed("READ_WRITE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "PERMISSIONS_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::PERMISSIONS_UNSPECIFIED)
+                    }
+                    "READ_ONLY" => std::option::Option::Some(Self::READ_ONLY),
+                    "READ_WRITE" => std::option::Option::Some(Self::READ_WRITE),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Permissions](Permissions)
-        pub mod permissions {
-            use super::Permissions;
-
-            /// Unspecified value.
-            pub const PERMISSIONS_UNSPECIFIED: Permissions =
-                Permissions::new("PERMISSIONS_UNSPECIFIED");
-
-            /// Read-only permission.
-            pub const READ_ONLY: Permissions = Permissions::new("READ_ONLY");
-
-            /// Read-write permission.
-            pub const READ_WRITE: Permissions = Permissions::new("READ_WRITE");
-        }
-
-        impl std::convert::From<std::string::String> for Permissions {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Permissions {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Permissions {
             fn default() -> Self {
-                permissions::PERMISSIONS_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -5123,85 +5389,115 @@ pub mod volume_config {
 
     /// The types of Volumes.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// The unspecified type.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// This Volume is on flash.
+        pub const FLASH: Type = Type::new(1);
+
+        /// This Volume is on disk.
+        pub const DISK: Type = Type::new(2);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FLASH"),
+                2 => std::borrow::Cow::Borrowed("DISK"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "FLASH" => std::option::Option::Some(Self::FLASH),
+                "DISK" => std::option::Option::Some(Self::DISK),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// The unspecified type.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// This Volume is on flash.
-        pub const FLASH: Type = Type::new("FLASH");
-
-        /// This Volume is on disk.
-        pub const DISK: Type = Type::new("DISK");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The protocol used to access the volume.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Protocol(std::borrow::Cow<'static, str>);
+    pub struct Protocol(i32);
 
     impl Protocol {
+        /// Unspecified value.
+        pub const PROTOCOL_UNSPECIFIED: Protocol = Protocol::new(0);
+
+        /// Fibre channel.
+        pub const PROTOCOL_FC: Protocol = Protocol::new(1);
+
+        /// Network file system.
+        pub const PROTOCOL_NFS: Protocol = Protocol::new(2);
+
         /// Creates a new Protocol instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PROTOCOL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROTOCOL_FC"),
+                2 => std::borrow::Cow::Borrowed("PROTOCOL_NFS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PROTOCOL_UNSPECIFIED" => std::option::Option::Some(Self::PROTOCOL_UNSPECIFIED),
+                "PROTOCOL_FC" => std::option::Option::Some(Self::PROTOCOL_FC),
+                "PROTOCOL_NFS" => std::option::Option::Some(Self::PROTOCOL_NFS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Protocol](Protocol)
-    pub mod protocol {
-        use super::Protocol;
-
-        /// Unspecified value.
-        pub const PROTOCOL_UNSPECIFIED: Protocol = Protocol::new("PROTOCOL_UNSPECIFIED");
-
-        /// Fibre channel.
-        pub const PROTOCOL_FC: Protocol = Protocol::new("PROTOCOL_FC");
-
-        /// Network file system.
-        pub const PROTOCOL_NFS: Protocol = Protocol::new("PROTOCOL_NFS");
-    }
-
-    impl std::convert::From<std::string::String> for Protocol {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Protocol {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Protocol {
         fn default() -> Self {
-            protocol::PROTOCOL_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5395,140 +5691,194 @@ pub mod network_config {
 
     /// Network type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Unspecified value.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// Client network, that is a network peered to a GCP VPC.
+        pub const CLIENT: Type = Type::new(1);
+
+        /// Private network, that is a network local to the BMS POD.
+        pub const PRIVATE: Type = Type::new(2);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CLIENT"),
+                2 => std::borrow::Cow::Borrowed("PRIVATE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "CLIENT" => std::option::Option::Some(Self::CLIENT),
+                "PRIVATE" => std::option::Option::Some(Self::PRIVATE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Unspecified value.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// Client network, that is a network peered to a GCP VPC.
-        pub const CLIENT: Type = Type::new("CLIENT");
-
-        /// Private network, that is a network local to the BMS POD.
-        pub const PRIVATE: Type = Type::new("PRIVATE");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Interconnect bandwidth.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Bandwidth(std::borrow::Cow<'static, str>);
+    pub struct Bandwidth(i32);
 
     impl Bandwidth {
+        /// Unspecified value.
+        pub const BANDWIDTH_UNSPECIFIED: Bandwidth = Bandwidth::new(0);
+
+        /// 1 Gbps.
+        pub const BW_1_GBPS: Bandwidth = Bandwidth::new(1);
+
+        /// 2 Gbps.
+        pub const BW_2_GBPS: Bandwidth = Bandwidth::new(2);
+
+        /// 5 Gbps.
+        pub const BW_5_GBPS: Bandwidth = Bandwidth::new(3);
+
+        /// 10 Gbps.
+        pub const BW_10_GBPS: Bandwidth = Bandwidth::new(4);
+
         /// Creates a new Bandwidth instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("BANDWIDTH_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BW_1_GBPS"),
+                2 => std::borrow::Cow::Borrowed("BW_2_GBPS"),
+                3 => std::borrow::Cow::Borrowed("BW_5_GBPS"),
+                4 => std::borrow::Cow::Borrowed("BW_10_GBPS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "BANDWIDTH_UNSPECIFIED" => std::option::Option::Some(Self::BANDWIDTH_UNSPECIFIED),
+                "BW_1_GBPS" => std::option::Option::Some(Self::BW_1_GBPS),
+                "BW_2_GBPS" => std::option::Option::Some(Self::BW_2_GBPS),
+                "BW_5_GBPS" => std::option::Option::Some(Self::BW_5_GBPS),
+                "BW_10_GBPS" => std::option::Option::Some(Self::BW_10_GBPS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Bandwidth](Bandwidth)
-    pub mod bandwidth {
-        use super::Bandwidth;
-
-        /// Unspecified value.
-        pub const BANDWIDTH_UNSPECIFIED: Bandwidth = Bandwidth::new("BANDWIDTH_UNSPECIFIED");
-
-        /// 1 Gbps.
-        pub const BW_1_GBPS: Bandwidth = Bandwidth::new("BW_1_GBPS");
-
-        /// 2 Gbps.
-        pub const BW_2_GBPS: Bandwidth = Bandwidth::new("BW_2_GBPS");
-
-        /// 5 Gbps.
-        pub const BW_5_GBPS: Bandwidth = Bandwidth::new("BW_5_GBPS");
-
-        /// 10 Gbps.
-        pub const BW_10_GBPS: Bandwidth = Bandwidth::new("BW_10_GBPS");
-    }
-
-    impl std::convert::From<std::string::String> for Bandwidth {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Bandwidth {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Bandwidth {
         fn default() -> Self {
-            bandwidth::BANDWIDTH_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Service network block.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ServiceCidr(std::borrow::Cow<'static, str>);
+    pub struct ServiceCidr(i32);
 
     impl ServiceCidr {
+        /// Unspecified value.
+        pub const SERVICE_CIDR_UNSPECIFIED: ServiceCidr = ServiceCidr::new(0);
+
+        /// Services are disabled for the given network.
+        pub const DISABLED: ServiceCidr = ServiceCidr::new(1);
+
+        /// Use the highest /26 block of the network to host services.
+        pub const HIGH_26: ServiceCidr = ServiceCidr::new(2);
+
+        /// Use the highest /27 block of the network to host services.
+        pub const HIGH_27: ServiceCidr = ServiceCidr::new(3);
+
+        /// Use the highest /28 block of the network to host services.
+        pub const HIGH_28: ServiceCidr = ServiceCidr::new(4);
+
         /// Creates a new ServiceCidr instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SERVICE_CIDR_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DISABLED"),
+                2 => std::borrow::Cow::Borrowed("HIGH_26"),
+                3 => std::borrow::Cow::Borrowed("HIGH_27"),
+                4 => std::borrow::Cow::Borrowed("HIGH_28"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SERVICE_CIDR_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SERVICE_CIDR_UNSPECIFIED)
+                }
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "HIGH_26" => std::option::Option::Some(Self::HIGH_26),
+                "HIGH_27" => std::option::Option::Some(Self::HIGH_27),
+                "HIGH_28" => std::option::Option::Some(Self::HIGH_28),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ServiceCidr](ServiceCidr)
-    pub mod service_cidr {
-        use super::ServiceCidr;
-
-        /// Unspecified value.
-        pub const SERVICE_CIDR_UNSPECIFIED: ServiceCidr =
-            ServiceCidr::new("SERVICE_CIDR_UNSPECIFIED");
-
-        /// Services are disabled for the given network.
-        pub const DISABLED: ServiceCidr = ServiceCidr::new("DISABLED");
-
-        /// Use the highest /26 block of the network to host services.
-        pub const HIGH_26: ServiceCidr = ServiceCidr::new("HIGH_26");
-
-        /// Use the highest /27 block of the network to host services.
-        pub const HIGH_27: ServiceCidr = ServiceCidr::new("HIGH_27");
-
-        /// Use the highest /28 block of the network to host services.
-        pub const HIGH_28: ServiceCidr = ServiceCidr::new("HIGH_28");
-    }
-
-    impl std::convert::From<std::string::String> for ServiceCidr {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ServiceCidr {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ServiceCidr {
         fn default() -> Self {
-            service_cidr::SERVICE_CIDR_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6357,233 +6707,317 @@ pub mod volume {
 
     /// The storage type for a volume.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StorageType(std::borrow::Cow<'static, str>);
+    pub struct StorageType(i32);
 
     impl StorageType {
+        /// The storage type for this volume is unknown.
+        pub const STORAGE_TYPE_UNSPECIFIED: StorageType = StorageType::new(0);
+
+        /// The storage type for this volume is SSD.
+        pub const SSD: StorageType = StorageType::new(1);
+
+        /// This storage type for this volume is HDD.
+        pub const HDD: StorageType = StorageType::new(2);
+
         /// Creates a new StorageType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STORAGE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SSD"),
+                2 => std::borrow::Cow::Borrowed("HDD"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STORAGE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::STORAGE_TYPE_UNSPECIFIED)
+                }
+                "SSD" => std::option::Option::Some(Self::SSD),
+                "HDD" => std::option::Option::Some(Self::HDD),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [StorageType](StorageType)
-    pub mod storage_type {
-        use super::StorageType;
-
-        /// The storage type for this volume is unknown.
-        pub const STORAGE_TYPE_UNSPECIFIED: StorageType =
-            StorageType::new("STORAGE_TYPE_UNSPECIFIED");
-
-        /// The storage type for this volume is SSD.
-        pub const SSD: StorageType = StorageType::new("SSD");
-
-        /// This storage type for this volume is HDD.
-        pub const HDD: StorageType = StorageType::new("HDD");
-    }
-
-    impl std::convert::From<std::string::String> for StorageType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for StorageType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for StorageType {
         fn default() -> Self {
-            storage_type::STORAGE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The possible states for a storage volume.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The storage volume is in an unknown state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The storage volume is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The storage volume is ready for use.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(2);
 
         /// The storage volume has been requested to be deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(3);
 
         /// The storage volume is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(4);
 
         /// The storage volume is in cool off state. It will be deleted after
         /// `expire_time`.
-        pub const COOL_OFF: State = State::new("COOL_OFF");
+        pub const COOL_OFF: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("UPDATING"),
+                5 => std::borrow::Cow::Borrowed("COOL_OFF"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "COOL_OFF" => std::option::Option::Some(Self::COOL_OFF),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The kinds of auto delete behavior to use when snapshot reserved space is
     /// full.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SnapshotAutoDeleteBehavior(std::borrow::Cow<'static, str>);
+    pub struct SnapshotAutoDeleteBehavior(i32);
 
     impl SnapshotAutoDeleteBehavior {
-        /// Creates a new SnapshotAutoDeleteBehavior instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [SnapshotAutoDeleteBehavior](SnapshotAutoDeleteBehavior)
-    pub mod snapshot_auto_delete_behavior {
-        use super::SnapshotAutoDeleteBehavior;
-
         /// The unspecified behavior.
         pub const SNAPSHOT_AUTO_DELETE_BEHAVIOR_UNSPECIFIED: SnapshotAutoDeleteBehavior =
-            SnapshotAutoDeleteBehavior::new("SNAPSHOT_AUTO_DELETE_BEHAVIOR_UNSPECIFIED");
+            SnapshotAutoDeleteBehavior::new(0);
 
         /// Don't delete any snapshots. This disables new snapshot creation, as
         /// long as the snapshot reserved space is full.
-        pub const DISABLED: SnapshotAutoDeleteBehavior =
-            SnapshotAutoDeleteBehavior::new("DISABLED");
+        pub const DISABLED: SnapshotAutoDeleteBehavior = SnapshotAutoDeleteBehavior::new(1);
 
         /// Delete the oldest snapshots first.
-        pub const OLDEST_FIRST: SnapshotAutoDeleteBehavior =
-            SnapshotAutoDeleteBehavior::new("OLDEST_FIRST");
+        pub const OLDEST_FIRST: SnapshotAutoDeleteBehavior = SnapshotAutoDeleteBehavior::new(2);
 
         /// Delete the newest snapshots first.
-        pub const NEWEST_FIRST: SnapshotAutoDeleteBehavior =
-            SnapshotAutoDeleteBehavior::new("NEWEST_FIRST");
+        pub const NEWEST_FIRST: SnapshotAutoDeleteBehavior = SnapshotAutoDeleteBehavior::new(3);
+
+        /// Creates a new SnapshotAutoDeleteBehavior instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SNAPSHOT_AUTO_DELETE_BEHAVIOR_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DISABLED"),
+                2 => std::borrow::Cow::Borrowed("OLDEST_FIRST"),
+                3 => std::borrow::Cow::Borrowed("NEWEST_FIRST"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SNAPSHOT_AUTO_DELETE_BEHAVIOR_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SNAPSHOT_AUTO_DELETE_BEHAVIOR_UNSPECIFIED)
+                }
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "OLDEST_FIRST" => std::option::Option::Some(Self::OLDEST_FIRST),
+                "NEWEST_FIRST" => std::option::Option::Some(Self::NEWEST_FIRST),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for SnapshotAutoDeleteBehavior {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SnapshotAutoDeleteBehavior {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SnapshotAutoDeleteBehavior {
         fn default() -> Self {
-            snapshot_auto_delete_behavior::SNAPSHOT_AUTO_DELETE_BEHAVIOR_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Storage protocol.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Protocol(std::borrow::Cow<'static, str>);
+    pub struct Protocol(i32);
 
     impl Protocol {
-        /// Creates a new Protocol instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Protocol](Protocol)
-    pub mod protocol {
-        use super::Protocol;
-
         /// Value is not specified.
-        pub const PROTOCOL_UNSPECIFIED: Protocol = Protocol::new("PROTOCOL_UNSPECIFIED");
+        pub const PROTOCOL_UNSPECIFIED: Protocol = Protocol::new(0);
 
         /// Fibre Channel protocol.
-        pub const FIBRE_CHANNEL: Protocol = Protocol::new("FIBRE_CHANNEL");
+        pub const FIBRE_CHANNEL: Protocol = Protocol::new(1);
 
         /// NFS protocol means Volume is a NFS Share volume.
         /// Such volumes cannot be manipulated via Volumes API.
-        pub const NFS: Protocol = Protocol::new("NFS");
+        pub const NFS: Protocol = Protocol::new(2);
+
+        /// Creates a new Protocol instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PROTOCOL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FIBRE_CHANNEL"),
+                2 => std::borrow::Cow::Borrowed("NFS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PROTOCOL_UNSPECIFIED" => std::option::Option::Some(Self::PROTOCOL_UNSPECIFIED),
+                "FIBRE_CHANNEL" => std::option::Option::Some(Self::FIBRE_CHANNEL),
+                "NFS" => std::option::Option::Some(Self::NFS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Protocol {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Protocol {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Protocol {
         fn default() -> Self {
-            protocol::PROTOCOL_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The possible values for a workload profile.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct WorkloadProfile(std::borrow::Cow<'static, str>);
+    pub struct WorkloadProfile(i32);
 
     impl WorkloadProfile {
+        /// The workload profile is in an unknown state.
+        pub const WORKLOAD_PROFILE_UNSPECIFIED: WorkloadProfile = WorkloadProfile::new(0);
+
+        /// The workload profile is generic.
+        pub const GENERIC: WorkloadProfile = WorkloadProfile::new(1);
+
+        /// The workload profile is hana.
+        pub const HANA: WorkloadProfile = WorkloadProfile::new(2);
+
         /// Creates a new WorkloadProfile instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("WORKLOAD_PROFILE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GENERIC"),
+                2 => std::borrow::Cow::Borrowed("HANA"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "WORKLOAD_PROFILE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::WORKLOAD_PROFILE_UNSPECIFIED)
+                }
+                "GENERIC" => std::option::Option::Some(Self::GENERIC),
+                "HANA" => std::option::Option::Some(Self::HANA),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [WorkloadProfile](WorkloadProfile)
-    pub mod workload_profile {
-        use super::WorkloadProfile;
-
-        /// The workload profile is in an unknown state.
-        pub const WORKLOAD_PROFILE_UNSPECIFIED: WorkloadProfile =
-            WorkloadProfile::new("WORKLOAD_PROFILE_UNSPECIFIED");
-
-        /// The workload profile is generic.
-        pub const GENERIC: WorkloadProfile = WorkloadProfile::new("GENERIC");
-
-        /// The workload profile is hana.
-        pub const HANA: WorkloadProfile = WorkloadProfile::new("HANA");
-    }
-
-    impl std::convert::From<std::string::String> for WorkloadProfile {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for WorkloadProfile {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for WorkloadProfile {
         fn default() -> Self {
-            workload_profile::WORKLOAD_PROFILE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6999,44 +7433,60 @@ pub mod volume_snapshot {
 
     /// Represents the type of a snapshot.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SnapshotType(std::borrow::Cow<'static, str>);
+    pub struct SnapshotType(i32);
 
     impl SnapshotType {
+        /// Type is not specified.
+        pub const SNAPSHOT_TYPE_UNSPECIFIED: SnapshotType = SnapshotType::new(0);
+
+        /// Snapshot was taken manually by user.
+        pub const AD_HOC: SnapshotType = SnapshotType::new(1);
+
+        /// Snapshot was taken automatically as a part of a snapshot schedule.
+        pub const SCHEDULED: SnapshotType = SnapshotType::new(2);
+
         /// Creates a new SnapshotType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SNAPSHOT_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AD_HOC"),
+                2 => std::borrow::Cow::Borrowed("SCHEDULED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SNAPSHOT_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SNAPSHOT_TYPE_UNSPECIFIED)
+                }
+                "AD_HOC" => std::option::Option::Some(Self::AD_HOC),
+                "SCHEDULED" => std::option::Option::Some(Self::SCHEDULED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SnapshotType](SnapshotType)
-    pub mod snapshot_type {
-        use super::SnapshotType;
-
-        /// Type is not specified.
-        pub const SNAPSHOT_TYPE_UNSPECIFIED: SnapshotType =
-            SnapshotType::new("SNAPSHOT_TYPE_UNSPECIFIED");
-
-        /// Snapshot was taken manually by user.
-        pub const AD_HOC: SnapshotType = SnapshotType::new("AD_HOC");
-
-        /// Snapshot was taken automatically as a part of a snapshot schedule.
-        pub const SCHEDULED: SnapshotType = SnapshotType::new("SCHEDULED");
-    }
-
-    impl std::convert::From<std::string::String> for SnapshotType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SnapshotType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SnapshotType {
         fn default() -> Self {
-            snapshot_type::SNAPSHOT_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7296,94 +7746,131 @@ impl wkt::message::Message for RestoreVolumeSnapshotRequest {
 
 /// Performance tier of the Volume.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct VolumePerformanceTier(std::borrow::Cow<'static, str>);
+pub struct VolumePerformanceTier(i32);
 
 impl VolumePerformanceTier {
-    /// Creates a new VolumePerformanceTier instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [VolumePerformanceTier](VolumePerformanceTier)
-pub mod volume_performance_tier {
-    use super::VolumePerformanceTier;
-
     /// Value is not specified.
     pub const VOLUME_PERFORMANCE_TIER_UNSPECIFIED: VolumePerformanceTier =
-        VolumePerformanceTier::new("VOLUME_PERFORMANCE_TIER_UNSPECIFIED");
+        VolumePerformanceTier::new(0);
 
     /// Regular volumes, shared aggregates.
-    pub const VOLUME_PERFORMANCE_TIER_SHARED: VolumePerformanceTier =
-        VolumePerformanceTier::new("VOLUME_PERFORMANCE_TIER_SHARED");
+    pub const VOLUME_PERFORMANCE_TIER_SHARED: VolumePerformanceTier = VolumePerformanceTier::new(1);
 
     /// Assigned aggregates.
     pub const VOLUME_PERFORMANCE_TIER_ASSIGNED: VolumePerformanceTier =
-        VolumePerformanceTier::new("VOLUME_PERFORMANCE_TIER_ASSIGNED");
+        VolumePerformanceTier::new(2);
 
     /// High throughput aggregates.
-    pub const VOLUME_PERFORMANCE_TIER_HT: VolumePerformanceTier =
-        VolumePerformanceTier::new("VOLUME_PERFORMANCE_TIER_HT");
+    pub const VOLUME_PERFORMANCE_TIER_HT: VolumePerformanceTier = VolumePerformanceTier::new(3);
+
+    /// Creates a new VolumePerformanceTier instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("VOLUME_PERFORMANCE_TIER_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("VOLUME_PERFORMANCE_TIER_SHARED"),
+            2 => std::borrow::Cow::Borrowed("VOLUME_PERFORMANCE_TIER_ASSIGNED"),
+            3 => std::borrow::Cow::Borrowed("VOLUME_PERFORMANCE_TIER_HT"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "VOLUME_PERFORMANCE_TIER_UNSPECIFIED" => {
+                std::option::Option::Some(Self::VOLUME_PERFORMANCE_TIER_UNSPECIFIED)
+            }
+            "VOLUME_PERFORMANCE_TIER_SHARED" => {
+                std::option::Option::Some(Self::VOLUME_PERFORMANCE_TIER_SHARED)
+            }
+            "VOLUME_PERFORMANCE_TIER_ASSIGNED" => {
+                std::option::Option::Some(Self::VOLUME_PERFORMANCE_TIER_ASSIGNED)
+            }
+            "VOLUME_PERFORMANCE_TIER_HT" => {
+                std::option::Option::Some(Self::VOLUME_PERFORMANCE_TIER_HT)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for VolumePerformanceTier {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for VolumePerformanceTier {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for VolumePerformanceTier {
     fn default() -> Self {
-        volume_performance_tier::VOLUME_PERFORMANCE_TIER_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The possible values for a workload profile.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct WorkloadProfile(std::borrow::Cow<'static, str>);
+pub struct WorkloadProfile(i32);
 
 impl WorkloadProfile {
+    /// The workload profile is in an unknown state.
+    pub const WORKLOAD_PROFILE_UNSPECIFIED: WorkloadProfile = WorkloadProfile::new(0);
+
+    /// The workload profile is generic.
+    pub const WORKLOAD_PROFILE_GENERIC: WorkloadProfile = WorkloadProfile::new(1);
+
+    /// The workload profile is hana.
+    pub const WORKLOAD_PROFILE_HANA: WorkloadProfile = WorkloadProfile::new(2);
+
     /// Creates a new WorkloadProfile instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("WORKLOAD_PROFILE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("WORKLOAD_PROFILE_GENERIC"),
+            2 => std::borrow::Cow::Borrowed("WORKLOAD_PROFILE_HANA"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "WORKLOAD_PROFILE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::WORKLOAD_PROFILE_UNSPECIFIED)
+            }
+            "WORKLOAD_PROFILE_GENERIC" => std::option::Option::Some(Self::WORKLOAD_PROFILE_GENERIC),
+            "WORKLOAD_PROFILE_HANA" => std::option::Option::Some(Self::WORKLOAD_PROFILE_HANA),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [WorkloadProfile](WorkloadProfile)
-pub mod workload_profile {
-    use super::WorkloadProfile;
-
-    /// The workload profile is in an unknown state.
-    pub const WORKLOAD_PROFILE_UNSPECIFIED: WorkloadProfile =
-        WorkloadProfile::new("WORKLOAD_PROFILE_UNSPECIFIED");
-
-    /// The workload profile is generic.
-    pub const WORKLOAD_PROFILE_GENERIC: WorkloadProfile =
-        WorkloadProfile::new("WORKLOAD_PROFILE_GENERIC");
-
-    /// The workload profile is hana.
-    pub const WORKLOAD_PROFILE_HANA: WorkloadProfile =
-        WorkloadProfile::new("WORKLOAD_PROFILE_HANA");
-}
-
-impl std::convert::From<std::string::String> for WorkloadProfile {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for WorkloadProfile {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for WorkloadProfile {
     fn default() -> Self {
-        workload_profile::WORKLOAD_PROFILE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/baremetalsolution/v2/src/transport.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
                 reqwest::Method::GET,
                 format!("/v2/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -74,7 +74,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -102,7 +102,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -131,7 +131,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:rename", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -148,7 +148,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:reset", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -165,7 +165,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:start", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -182,7 +182,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:stop", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -202,7 +202,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
                 reqwest::Method::POST,
                 format!("/v2/{}:enableInteractiveSerialConsole", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -222,7 +222,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
                 reqwest::Method::POST,
                 format!("/v2/{}:disableInteractiveSerialConsole", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -242,7 +242,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
                 reqwest::Method::POST,
                 format!("/v2/{}:detachLun", req.instance),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -259,7 +259,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/sshKeys", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -280,7 +280,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}/sshKeys", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -300,7 +300,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -319,7 +319,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/volumes", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -341,7 +341,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -369,7 +369,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -396,7 +396,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:rename", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -413,7 +413,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:evict", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -430,7 +430,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:resize", req.volume))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -447,7 +447,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/networks", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -472,7 +472,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
                 reqwest::Method::GET,
                 format!("/v2/{}/networks:listNetworkUsage", req.location),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -491,7 +491,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -519,7 +519,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -551,7 +551,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
                 reqwest::Method::POST,
                 format!("/v2/{}/snapshots", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -573,7 +573,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
                 reqwest::Method::POST,
                 format!("/v2/{}:restoreVolumeSnapshot", req.volume_snapshot),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -590,7 +590,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -609,7 +609,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -631,7 +631,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
                 reqwest::Method::GET,
                 format!("/v2/{}/snapshots", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -652,7 +652,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -671,7 +671,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/luns", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -692,7 +692,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:evict", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -709,7 +709,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -731,7 +731,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
                 reqwest::Method::GET,
                 format!("/v2/{}/nfsShares", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -762,7 +762,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -794,7 +794,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
                 reqwest::Method::POST,
                 format!("/v2/{}/nfsShares", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -813,7 +813,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:rename", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -830,7 +830,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -852,7 +852,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
                 reqwest::Method::GET,
                 format!("/v2/{}/provisioningQuotas", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -876,7 +876,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
                 reqwest::Method::POST,
                 format!("/v2/{}/provisioningConfigs:submit", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -893,7 +893,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -915,7 +915,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
                 reqwest::Method::POST,
                 format!("/v2/{}/provisioningConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -944,7 +944,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -974,7 +974,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:rename", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -991,7 +991,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/osImages", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1012,7 +1012,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1034,7 +1034,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1053,7 +1053,7 @@ impl crate::stubs::BareMetalSolution for BareMetalSolution {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/model.rs
@@ -950,40 +950,53 @@ pub mod app_connection {
 
         /// Enum listing possible gateway hosting options.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(std::borrow::Cow<'static, str>);
+        pub struct Type(i32);
 
         impl Type {
+            /// Default value. This value is unused.
+            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+            /// Gateway hosted in a GCP regional managed instance group.
+            pub const GCP_REGIONAL_MIG: Type = Type::new(1);
+
             /// Creates a new Type instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("GCP_REGIONAL_MIG"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                    "GCP_REGIONAL_MIG" => std::option::Option::Some(Self::GCP_REGIONAL_MIG),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Type](Type)
-        pub mod r#type {
-            use super::Type;
-
-            /// Default value. This value is unused.
-            pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-            /// Gateway hosted in a GCP regional managed instance group.
-            pub const GCP_REGIONAL_MIG: Type = Type::new("GCP_REGIONAL_MIG");
-        }
-
-        impl std::convert::From<std::string::String> for Type {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                r#type::TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -991,93 +1004,127 @@ pub mod app_connection {
     /// Enum containing list of all possible network connectivity options
     /// supported by BeyondCorp AppConnection.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// Default value. This value is unused.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// TCP Proxy based BeyondCorp AppConnection. API will default to this if
         /// unset.
-        pub const TCP_PROXY: Type = Type::new("TCP_PROXY");
+        pub const TCP_PROXY: Type = Type::new(1);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TCP_PROXY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "TCP_PROXY" => std::option::Option::Some(Self::TCP_PROXY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Represents the different states of a AppConnection.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// AppConnection is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// AppConnection has been created.
-        pub const CREATED: State = State::new("CREATED");
+        pub const CREATED: State = State::new(2);
 
         /// AppConnection's configuration is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(3);
 
         /// AppConnection is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(4);
 
         /// AppConnection is down and may be restored in the future.
         /// This happens when CCFE sends ProjectState = OFF.
-        pub const DOWN: State = State::new("DOWN");
+        pub const DOWN: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("CREATED"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("DOWN"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "CREATED" => std::option::Option::Some(Self::CREATED),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "DOWN" => std::option::Option::Some(Self::DOWN),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::AppConnectionsService for AppConnectionsService {
                 reqwest::Method::GET,
                 format!("/v1/{}/appConnections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::AppConnectionsService for AppConnectionsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::AppConnectionsService for AppConnectionsService {
                 reqwest::Method::POST,
                 format!("/v1/{}/appConnections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -128,7 +128,7 @@ impl crate::stubs::AppConnectionsService for AppConnectionsService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -160,7 +160,7 @@ impl crate::stubs::AppConnectionsService for AppConnectionsService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -184,7 +184,7 @@ impl crate::stubs::AppConnectionsService for AppConnectionsService {
                 reqwest::Method::GET,
                 format!("/v1/{}/appConnections:resolve", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -206,7 +206,7 @@ impl crate::stubs::AppConnectionsService for AppConnectionsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -228,7 +228,7 @@ impl crate::stubs::AppConnectionsService for AppConnectionsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -250,7 +250,7 @@ impl crate::stubs::AppConnectionsService for AppConnectionsService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -270,7 +270,7 @@ impl crate::stubs::AppConnectionsService for AppConnectionsService {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -302,7 +302,7 @@ impl crate::stubs::AppConnectionsService for AppConnectionsService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -319,7 +319,7 @@ impl crate::stubs::AppConnectionsService for AppConnectionsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -341,7 +341,7 @@ impl crate::stubs::AppConnectionsService for AppConnectionsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -360,7 +360,7 @@ impl crate::stubs::AppConnectionsService for AppConnectionsService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -379,7 +379,7 @@ impl crate::stubs::AppConnectionsService for AppConnectionsService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/model.rs
@@ -1029,53 +1029,74 @@ pub mod app_connector {
 
     /// Represents the different states of a AppConnector.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// AppConnector is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// AppConnector has been created.
-        pub const CREATED: State = State::new("CREATED");
+        pub const CREATED: State = State::new(2);
 
         /// AppConnector's configuration is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(3);
 
         /// AppConnector is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(4);
 
         /// AppConnector is down and may be restored in the future.
         /// This happens when CCFE sends ProjectState = OFF.
-        pub const DOWN: State = State::new("DOWN");
+        pub const DOWN: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("CREATED"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("DOWN"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "CREATED" => std::option::Option::Some(Self::CREATED),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "DOWN" => std::option::Option::Some(Self::DOWN),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1273,49 +1294,69 @@ impl wkt::message::Message for ResourceInfo {
 
 /// HealthStatus represents the health status.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct HealthStatus(std::borrow::Cow<'static, str>);
+pub struct HealthStatus(i32);
 
 impl HealthStatus {
+    /// Health status is unknown: not initialized or failed to retrieve.
+    pub const HEALTH_STATUS_UNSPECIFIED: HealthStatus = HealthStatus::new(0);
+
+    /// The resource is healthy.
+    pub const HEALTHY: HealthStatus = HealthStatus::new(1);
+
+    /// The resource is unhealthy.
+    pub const UNHEALTHY: HealthStatus = HealthStatus::new(2);
+
+    /// The resource is unresponsive.
+    pub const UNRESPONSIVE: HealthStatus = HealthStatus::new(3);
+
+    /// Some sub-resources are UNHEALTHY.
+    pub const DEGRADED: HealthStatus = HealthStatus::new(4);
+
     /// Creates a new HealthStatus instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("HEALTH_STATUS_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("HEALTHY"),
+            2 => std::borrow::Cow::Borrowed("UNHEALTHY"),
+            3 => std::borrow::Cow::Borrowed("UNRESPONSIVE"),
+            4 => std::borrow::Cow::Borrowed("DEGRADED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "HEALTH_STATUS_UNSPECIFIED" => {
+                std::option::Option::Some(Self::HEALTH_STATUS_UNSPECIFIED)
+            }
+            "HEALTHY" => std::option::Option::Some(Self::HEALTHY),
+            "UNHEALTHY" => std::option::Option::Some(Self::UNHEALTHY),
+            "UNRESPONSIVE" => std::option::Option::Some(Self::UNRESPONSIVE),
+            "DEGRADED" => std::option::Option::Some(Self::DEGRADED),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [HealthStatus](HealthStatus)
-pub mod health_status {
-    use super::HealthStatus;
-
-    /// Health status is unknown: not initialized or failed to retrieve.
-    pub const HEALTH_STATUS_UNSPECIFIED: HealthStatus =
-        HealthStatus::new("HEALTH_STATUS_UNSPECIFIED");
-
-    /// The resource is healthy.
-    pub const HEALTHY: HealthStatus = HealthStatus::new("HEALTHY");
-
-    /// The resource is unhealthy.
-    pub const UNHEALTHY: HealthStatus = HealthStatus::new("UNHEALTHY");
-
-    /// The resource is unresponsive.
-    pub const UNRESPONSIVE: HealthStatus = HealthStatus::new("UNRESPONSIVE");
-
-    /// Some sub-resources are UNHEALTHY.
-    pub const DEGRADED: HealthStatus = HealthStatus::new("DEGRADED");
-}
-
-impl std::convert::From<std::string::String> for HealthStatus {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for HealthStatus {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for HealthStatus {
     fn default() -> Self {
-        health_status::HEALTH_STATUS_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::AppConnectorsService for AppConnectorsService {
                 reqwest::Method::GET,
                 format!("/v1/{}/appConnectors", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::AppConnectorsService for AppConnectorsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::AppConnectorsService for AppConnectorsService {
                 reqwest::Method::POST,
                 format!("/v1/{}/appConnectors", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -128,7 +128,7 @@ impl crate::stubs::AppConnectorsService for AppConnectorsService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -159,7 +159,7 @@ impl crate::stubs::AppConnectorsService for AppConnectorsService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -183,7 +183,7 @@ impl crate::stubs::AppConnectorsService for AppConnectorsService {
                 reqwest::Method::POST,
                 format!("/v1/{}:reportStatus", req.app_connector),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -200,7 +200,7 @@ impl crate::stubs::AppConnectorsService for AppConnectorsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -222,7 +222,7 @@ impl crate::stubs::AppConnectorsService for AppConnectorsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -244,7 +244,7 @@ impl crate::stubs::AppConnectorsService for AppConnectorsService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -264,7 +264,7 @@ impl crate::stubs::AppConnectorsService for AppConnectorsService {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -296,7 +296,7 @@ impl crate::stubs::AppConnectorsService for AppConnectorsService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -313,7 +313,7 @@ impl crate::stubs::AppConnectorsService for AppConnectorsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -335,7 +335,7 @@ impl crate::stubs::AppConnectorsService for AppConnectorsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -354,7 +354,7 @@ impl crate::stubs::AppConnectorsService for AppConnectorsService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -373,7 +373,7 @@ impl crate::stubs::AppConnectorsService for AppConnectorsService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/model.rs
@@ -570,132 +570,179 @@ pub mod app_gateway {
     /// Enum containing list of all possible network connectivity options
     /// supported by BeyondCorp AppGateway.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Default value. This value is unused.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// TCP Proxy based BeyondCorp Connection. API will default to this if unset.
+        pub const TCP_PROXY: Type = Type::new(1);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TCP_PROXY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "TCP_PROXY" => std::option::Option::Some(Self::TCP_PROXY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Default value. This value is unused.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// TCP Proxy based BeyondCorp Connection. API will default to this if unset.
-        pub const TCP_PROXY: Type = Type::new("TCP_PROXY");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Represents the different states of an AppGateway.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// AppGateway is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// AppGateway has been created.
-        pub const CREATED: State = State::new("CREATED");
+        pub const CREATED: State = State::new(2);
 
         /// AppGateway's configuration is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(3);
 
         /// AppGateway is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(4);
 
         /// AppGateway is down and may be restored in the future.
         /// This happens when CCFE sends ProjectState = OFF.
-        pub const DOWN: State = State::new("DOWN");
+        pub const DOWN: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("CREATED"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("DOWN"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "CREATED" => std::option::Option::Some(Self::CREATED),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "DOWN" => std::option::Option::Some(Self::DOWN),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Enum containing list of all possible host types supported by BeyondCorp
     /// Connection.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HostType(std::borrow::Cow<'static, str>);
+    pub struct HostType(i32);
 
     impl HostType {
+        /// Default value. This value is unused.
+        pub const HOST_TYPE_UNSPECIFIED: HostType = HostType::new(0);
+
+        /// AppGateway hosted in a GCP regional managed instance group.
+        pub const GCP_REGIONAL_MIG: HostType = HostType::new(1);
+
         /// Creates a new HostType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("HOST_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GCP_REGIONAL_MIG"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "HOST_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::HOST_TYPE_UNSPECIFIED),
+                "GCP_REGIONAL_MIG" => std::option::Option::Some(Self::GCP_REGIONAL_MIG),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [HostType](HostType)
-    pub mod host_type {
-        use super::HostType;
-
-        /// Default value. This value is unused.
-        pub const HOST_TYPE_UNSPECIFIED: HostType = HostType::new("HOST_TYPE_UNSPECIFIED");
-
-        /// AppGateway hosted in a GCP regional managed instance group.
-        pub const GCP_REGIONAL_MIG: HostType = HostType::new("GCP_REGIONAL_MIG");
-    }
-
-    impl std::convert::From<std::string::String> for HostType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for HostType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for HostType {
         fn default() -> Self {
-            host_type::HOST_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::AppGatewaysService for AppGatewaysService {
                 reqwest::Method::GET,
                 format!("/v1/{}/appGateways", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::AppGatewaysService for AppGatewaysService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::AppGatewaysService for AppGatewaysService {
                 reqwest::Method::POST,
                 format!("/v1/{}/appGateways", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -119,7 +119,7 @@ impl crate::stubs::AppGatewaysService for AppGatewaysService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -140,7 +140,7 @@ impl crate::stubs::AppGatewaysService for AppGatewaysService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -162,7 +162,7 @@ impl crate::stubs::AppGatewaysService for AppGatewaysService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -184,7 +184,7 @@ impl crate::stubs::AppGatewaysService for AppGatewaysService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -204,7 +204,7 @@ impl crate::stubs::AppGatewaysService for AppGatewaysService {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -236,7 +236,7 @@ impl crate::stubs::AppGatewaysService for AppGatewaysService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -253,7 +253,7 @@ impl crate::stubs::AppGatewaysService for AppGatewaysService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -275,7 +275,7 @@ impl crate::stubs::AppGatewaysService for AppGatewaysService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -294,7 +294,7 @@ impl crate::stubs::AppGatewaysService for AppGatewaysService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -313,7 +313,7 @@ impl crate::stubs::AppGatewaysService for AppGatewaysService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/model.rs
@@ -340,41 +340,56 @@ pub mod client_connector_service {
 
             /// The protocol used to connect to the server.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct TransportProtocol(std::borrow::Cow<'static, str>);
+            pub struct TransportProtocol(i32);
 
             impl TransportProtocol {
+                /// Default value. This value is unused.
+                pub const TRANSPORT_PROTOCOL_UNSPECIFIED: TransportProtocol =
+                    TransportProtocol::new(0);
+
+                /// TCP protocol.
+                pub const TCP: TransportProtocol = TransportProtocol::new(1);
+
                 /// Creates a new TransportProtocol instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
                 }
 
                 /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("TRANSPORT_PROTOCOL_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("TCP"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "TRANSPORT_PROTOCOL_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::TRANSPORT_PROTOCOL_UNSPECIFIED)
+                        }
+                        "TCP" => std::option::Option::Some(Self::TCP),
+                        _ => std::option::Option::None,
+                    }
                 }
             }
 
-            /// Useful constants to work with [TransportProtocol](TransportProtocol)
-            pub mod transport_protocol {
-                use super::TransportProtocol;
-
-                /// Default value. This value is unused.
-                pub const TRANSPORT_PROTOCOL_UNSPECIFIED: TransportProtocol =
-                    TransportProtocol::new("TRANSPORT_PROTOCOL_UNSPECIFIED");
-
-                /// TCP protocol.
-                pub const TCP: TransportProtocol = TransportProtocol::new("TCP");
-            }
-
-            impl std::convert::From<std::string::String> for TransportProtocol {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for TransportProtocol {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for TransportProtocol {
                 fn default() -> Self {
-                    transport_protocol::TRANSPORT_PROTOCOL_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -512,57 +527,80 @@ pub mod client_connector_service {
 
     /// Represents the different states of a ClientConnectorService.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// ClientConnectorService is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// ClientConnectorService is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(2);
 
         /// ClientConnectorService is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(3);
 
         /// ClientConnectorService is running.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(4);
 
         /// ClientConnectorService is down and may be restored in the future.
         /// This happens when CCFE sends ProjectState = OFF.
-        pub const DOWN: State = State::new("DOWN");
+        pub const DOWN: State = State::new(5);
 
         /// ClientConnectorService encountered an error and is in an indeterministic
         /// state.
-        pub const ERROR: State = State::new("ERROR");
+        pub const ERROR: State = State::new(6);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("UPDATING"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("RUNNING"),
+                5 => std::borrow::Cow::Borrowed("DOWN"),
+                6 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "DOWN" => std::option::Option::Some(Self::DOWN),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::ClientConnectorServicesService for ClientConnectorServicesSer
                 reqwest::Method::GET,
                 format!("/v1/{}/clientConnectorServices", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::ClientConnectorServicesService for ClientConnectorServicesSer
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::ClientConnectorServicesService for ClientConnectorServicesSer
                 reqwest::Method::POST,
                 format!("/v1/{}/clientConnectorServices", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -129,7 +129,7 @@ impl crate::stubs::ClientConnectorServicesService for ClientConnectorServicesSer
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -161,7 +161,7 @@ impl crate::stubs::ClientConnectorServicesService for ClientConnectorServicesSer
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -182,7 +182,7 @@ impl crate::stubs::ClientConnectorServicesService for ClientConnectorServicesSer
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -204,7 +204,7 @@ impl crate::stubs::ClientConnectorServicesService for ClientConnectorServicesSer
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -226,7 +226,7 @@ impl crate::stubs::ClientConnectorServicesService for ClientConnectorServicesSer
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -246,7 +246,7 @@ impl crate::stubs::ClientConnectorServicesService for ClientConnectorServicesSer
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -278,7 +278,7 @@ impl crate::stubs::ClientConnectorServicesService for ClientConnectorServicesSer
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -295,7 +295,7 @@ impl crate::stubs::ClientConnectorServicesService for ClientConnectorServicesSer
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -317,7 +317,7 @@ impl crate::stubs::ClientConnectorServicesService for ClientConnectorServicesSer
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -336,7 +336,7 @@ impl crate::stubs::ClientConnectorServicesService for ClientConnectorServicesSer
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -355,7 +355,7 @@ impl crate::stubs::ClientConnectorServicesService for ClientConnectorServicesSer
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/model.rs
@@ -132,56 +132,79 @@ pub mod client_gateway {
 
     /// Represents the different states of a gateway.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Gateway is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// Gateway is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(2);
 
         /// Gateway is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(3);
 
         /// Gateway is running.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(4);
 
         /// Gateway is down and may be restored in the future.
         /// This happens when CCFE sends ProjectState = OFF.
-        pub const DOWN: State = State::new("DOWN");
+        pub const DOWN: State = State::new(5);
 
         /// ClientGateway encountered an error and is in indeterministic state.
-        pub const ERROR: State = State::new("ERROR");
+        pub const ERROR: State = State::new(6);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("UPDATING"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("RUNNING"),
+                5 => std::borrow::Cow::Borrowed("DOWN"),
+                6 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "DOWN" => std::option::Option::Some(Self::DOWN),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::ClientGatewaysService for ClientGatewaysService {
                 reqwest::Method::GET,
                 format!("/v1/{}/clientGateways", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::ClientGatewaysService for ClientGatewaysService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::ClientGatewaysService for ClientGatewaysService {
                 reqwest::Method::POST,
                 format!("/v1/{}/clientGateways", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -119,7 +119,7 @@ impl crate::stubs::ClientGatewaysService for ClientGatewaysService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -140,7 +140,7 @@ impl crate::stubs::ClientGatewaysService for ClientGatewaysService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -162,7 +162,7 @@ impl crate::stubs::ClientGatewaysService for ClientGatewaysService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -184,7 +184,7 @@ impl crate::stubs::ClientGatewaysService for ClientGatewaysService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -204,7 +204,7 @@ impl crate::stubs::ClientGatewaysService for ClientGatewaysService {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -236,7 +236,7 @@ impl crate::stubs::ClientGatewaysService for ClientGatewaysService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -253,7 +253,7 @@ impl crate::stubs::ClientGatewaysService for ClientGatewaysService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -275,7 +275,7 @@ impl crate::stubs::ClientGatewaysService for ClientGatewaysService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -294,7 +294,7 @@ impl crate::stubs::ClientGatewaysService for ClientGatewaysService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -313,7 +313,7 @@ impl crate::stubs::ClientGatewaysService for ClientGatewaysService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/model.rs
@@ -1101,120 +1101,188 @@ pub mod listing {
 
     /// State of the listing.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Subscribable state. Users with dataexchange.listings.subscribe permission
         /// can subscribe to this listing.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(1);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Listing categories.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Category(std::borrow::Cow<'static, str>);
+    pub struct Category(i32);
 
     impl Category {
+        pub const CATEGORY_UNSPECIFIED: Category = Category::new(0);
+
+        pub const CATEGORY_OTHERS: Category = Category::new(1);
+
+        pub const CATEGORY_ADVERTISING_AND_MARKETING: Category = Category::new(2);
+
+        pub const CATEGORY_COMMERCE: Category = Category::new(3);
+
+        pub const CATEGORY_CLIMATE_AND_ENVIRONMENT: Category = Category::new(4);
+
+        pub const CATEGORY_DEMOGRAPHICS: Category = Category::new(5);
+
+        pub const CATEGORY_ECONOMICS: Category = Category::new(6);
+
+        pub const CATEGORY_EDUCATION: Category = Category::new(7);
+
+        pub const CATEGORY_ENERGY: Category = Category::new(8);
+
+        pub const CATEGORY_FINANCIAL: Category = Category::new(9);
+
+        pub const CATEGORY_GAMING: Category = Category::new(10);
+
+        pub const CATEGORY_GEOSPATIAL: Category = Category::new(11);
+
+        pub const CATEGORY_HEALTHCARE_AND_LIFE_SCIENCE: Category = Category::new(12);
+
+        pub const CATEGORY_MEDIA: Category = Category::new(13);
+
+        pub const CATEGORY_PUBLIC_SECTOR: Category = Category::new(14);
+
+        pub const CATEGORY_RETAIL: Category = Category::new(15);
+
+        pub const CATEGORY_SPORTS: Category = Category::new(16);
+
+        pub const CATEGORY_SCIENCE_AND_RESEARCH: Category = Category::new(17);
+
+        pub const CATEGORY_TRANSPORTATION_AND_LOGISTICS: Category = Category::new(18);
+
+        pub const CATEGORY_TRAVEL_AND_TOURISM: Category = Category::new(19);
+
         /// Creates a new Category instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CATEGORY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CATEGORY_OTHERS"),
+                2 => std::borrow::Cow::Borrowed("CATEGORY_ADVERTISING_AND_MARKETING"),
+                3 => std::borrow::Cow::Borrowed("CATEGORY_COMMERCE"),
+                4 => std::borrow::Cow::Borrowed("CATEGORY_CLIMATE_AND_ENVIRONMENT"),
+                5 => std::borrow::Cow::Borrowed("CATEGORY_DEMOGRAPHICS"),
+                6 => std::borrow::Cow::Borrowed("CATEGORY_ECONOMICS"),
+                7 => std::borrow::Cow::Borrowed("CATEGORY_EDUCATION"),
+                8 => std::borrow::Cow::Borrowed("CATEGORY_ENERGY"),
+                9 => std::borrow::Cow::Borrowed("CATEGORY_FINANCIAL"),
+                10 => std::borrow::Cow::Borrowed("CATEGORY_GAMING"),
+                11 => std::borrow::Cow::Borrowed("CATEGORY_GEOSPATIAL"),
+                12 => std::borrow::Cow::Borrowed("CATEGORY_HEALTHCARE_AND_LIFE_SCIENCE"),
+                13 => std::borrow::Cow::Borrowed("CATEGORY_MEDIA"),
+                14 => std::borrow::Cow::Borrowed("CATEGORY_PUBLIC_SECTOR"),
+                15 => std::borrow::Cow::Borrowed("CATEGORY_RETAIL"),
+                16 => std::borrow::Cow::Borrowed("CATEGORY_SPORTS"),
+                17 => std::borrow::Cow::Borrowed("CATEGORY_SCIENCE_AND_RESEARCH"),
+                18 => std::borrow::Cow::Borrowed("CATEGORY_TRANSPORTATION_AND_LOGISTICS"),
+                19 => std::borrow::Cow::Borrowed("CATEGORY_TRAVEL_AND_TOURISM"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CATEGORY_UNSPECIFIED" => std::option::Option::Some(Self::CATEGORY_UNSPECIFIED),
+                "CATEGORY_OTHERS" => std::option::Option::Some(Self::CATEGORY_OTHERS),
+                "CATEGORY_ADVERTISING_AND_MARKETING" => {
+                    std::option::Option::Some(Self::CATEGORY_ADVERTISING_AND_MARKETING)
+                }
+                "CATEGORY_COMMERCE" => std::option::Option::Some(Self::CATEGORY_COMMERCE),
+                "CATEGORY_CLIMATE_AND_ENVIRONMENT" => {
+                    std::option::Option::Some(Self::CATEGORY_CLIMATE_AND_ENVIRONMENT)
+                }
+                "CATEGORY_DEMOGRAPHICS" => std::option::Option::Some(Self::CATEGORY_DEMOGRAPHICS),
+                "CATEGORY_ECONOMICS" => std::option::Option::Some(Self::CATEGORY_ECONOMICS),
+                "CATEGORY_EDUCATION" => std::option::Option::Some(Self::CATEGORY_EDUCATION),
+                "CATEGORY_ENERGY" => std::option::Option::Some(Self::CATEGORY_ENERGY),
+                "CATEGORY_FINANCIAL" => std::option::Option::Some(Self::CATEGORY_FINANCIAL),
+                "CATEGORY_GAMING" => std::option::Option::Some(Self::CATEGORY_GAMING),
+                "CATEGORY_GEOSPATIAL" => std::option::Option::Some(Self::CATEGORY_GEOSPATIAL),
+                "CATEGORY_HEALTHCARE_AND_LIFE_SCIENCE" => {
+                    std::option::Option::Some(Self::CATEGORY_HEALTHCARE_AND_LIFE_SCIENCE)
+                }
+                "CATEGORY_MEDIA" => std::option::Option::Some(Self::CATEGORY_MEDIA),
+                "CATEGORY_PUBLIC_SECTOR" => std::option::Option::Some(Self::CATEGORY_PUBLIC_SECTOR),
+                "CATEGORY_RETAIL" => std::option::Option::Some(Self::CATEGORY_RETAIL),
+                "CATEGORY_SPORTS" => std::option::Option::Some(Self::CATEGORY_SPORTS),
+                "CATEGORY_SCIENCE_AND_RESEARCH" => {
+                    std::option::Option::Some(Self::CATEGORY_SCIENCE_AND_RESEARCH)
+                }
+                "CATEGORY_TRANSPORTATION_AND_LOGISTICS" => {
+                    std::option::Option::Some(Self::CATEGORY_TRANSPORTATION_AND_LOGISTICS)
+                }
+                "CATEGORY_TRAVEL_AND_TOURISM" => {
+                    std::option::Option::Some(Self::CATEGORY_TRAVEL_AND_TOURISM)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Category](Category)
-    pub mod category {
-        use super::Category;
-
-        pub const CATEGORY_UNSPECIFIED: Category = Category::new("CATEGORY_UNSPECIFIED");
-
-        pub const CATEGORY_OTHERS: Category = Category::new("CATEGORY_OTHERS");
-
-        pub const CATEGORY_ADVERTISING_AND_MARKETING: Category =
-            Category::new("CATEGORY_ADVERTISING_AND_MARKETING");
-
-        pub const CATEGORY_COMMERCE: Category = Category::new("CATEGORY_COMMERCE");
-
-        pub const CATEGORY_CLIMATE_AND_ENVIRONMENT: Category =
-            Category::new("CATEGORY_CLIMATE_AND_ENVIRONMENT");
-
-        pub const CATEGORY_DEMOGRAPHICS: Category = Category::new("CATEGORY_DEMOGRAPHICS");
-
-        pub const CATEGORY_ECONOMICS: Category = Category::new("CATEGORY_ECONOMICS");
-
-        pub const CATEGORY_EDUCATION: Category = Category::new("CATEGORY_EDUCATION");
-
-        pub const CATEGORY_ENERGY: Category = Category::new("CATEGORY_ENERGY");
-
-        pub const CATEGORY_FINANCIAL: Category = Category::new("CATEGORY_FINANCIAL");
-
-        pub const CATEGORY_GAMING: Category = Category::new("CATEGORY_GAMING");
-
-        pub const CATEGORY_GEOSPATIAL: Category = Category::new("CATEGORY_GEOSPATIAL");
-
-        pub const CATEGORY_HEALTHCARE_AND_LIFE_SCIENCE: Category =
-            Category::new("CATEGORY_HEALTHCARE_AND_LIFE_SCIENCE");
-
-        pub const CATEGORY_MEDIA: Category = Category::new("CATEGORY_MEDIA");
-
-        pub const CATEGORY_PUBLIC_SECTOR: Category = Category::new("CATEGORY_PUBLIC_SECTOR");
-
-        pub const CATEGORY_RETAIL: Category = Category::new("CATEGORY_RETAIL");
-
-        pub const CATEGORY_SPORTS: Category = Category::new("CATEGORY_SPORTS");
-
-        pub const CATEGORY_SCIENCE_AND_RESEARCH: Category =
-            Category::new("CATEGORY_SCIENCE_AND_RESEARCH");
-
-        pub const CATEGORY_TRANSPORTATION_AND_LOGISTICS: Category =
-            Category::new("CATEGORY_TRANSPORTATION_AND_LOGISTICS");
-
-        pub const CATEGORY_TRAVEL_AND_TOURISM: Category =
-            Category::new("CATEGORY_TRAVEL_AND_TOURISM");
-    }
-
-    impl std::convert::From<std::string::String> for Category {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Category {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Category {
         fn default() -> Self {
-            category::CATEGORY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1503,48 +1571,65 @@ pub mod subscription {
 
     /// State of the subscription.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// This subscription is active and the data is accessible.
-        pub const STATE_ACTIVE: State = State::new("STATE_ACTIVE");
+        pub const STATE_ACTIVE: State = State::new(1);
 
         /// The data referenced by this subscription is out of date and should be
         /// refreshed. This can happen when a data provider adds or removes datasets.
-        pub const STATE_STALE: State = State::new("STATE_STALE");
+        pub const STATE_STALE: State = State::new(2);
 
         /// This subscription has been cancelled or revoked and the data is no longer
         /// accessible.
-        pub const STATE_INACTIVE: State = State::new("STATE_INACTIVE");
+        pub const STATE_INACTIVE: State = State::new(3);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STATE_ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("STATE_STALE"),
+                3 => std::borrow::Cow::Borrowed("STATE_INACTIVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "STATE_ACTIVE" => std::option::Option::Some(Self::STATE_ACTIVE),
+                "STATE_STALE" => std::option::Option::Some(Self::STATE_STALE),
+                "STATE_INACTIVE" => std::option::Option::Some(Self::STATE_INACTIVE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -2974,45 +3059,61 @@ impl wkt::message::Message for OperationMetadata {
 /// this does not control the visibility of the exchange/listing which is
 /// defined by IAM permission.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DiscoveryType(std::borrow::Cow<'static, str>);
+pub struct DiscoveryType(i32);
 
 impl DiscoveryType {
-    /// Creates a new DiscoveryType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [DiscoveryType](DiscoveryType)
-pub mod discovery_type {
-    use super::DiscoveryType;
-
     /// Unspecified. Defaults to DISCOVERY_TYPE_PRIVATE.
-    pub const DISCOVERY_TYPE_UNSPECIFIED: DiscoveryType =
-        DiscoveryType::new("DISCOVERY_TYPE_UNSPECIFIED");
+    pub const DISCOVERY_TYPE_UNSPECIFIED: DiscoveryType = DiscoveryType::new(0);
 
     /// The Data exchange/listing can be discovered in the 'Private' results
     /// list.
-    pub const DISCOVERY_TYPE_PRIVATE: DiscoveryType = DiscoveryType::new("DISCOVERY_TYPE_PRIVATE");
+    pub const DISCOVERY_TYPE_PRIVATE: DiscoveryType = DiscoveryType::new(1);
 
     /// The Data exchange/listing can be discovered in the 'Public' results
     /// list.
-    pub const DISCOVERY_TYPE_PUBLIC: DiscoveryType = DiscoveryType::new("DISCOVERY_TYPE_PUBLIC");
+    pub const DISCOVERY_TYPE_PUBLIC: DiscoveryType = DiscoveryType::new(2);
+
+    /// Creates a new DiscoveryType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DISCOVERY_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("DISCOVERY_TYPE_PRIVATE"),
+            2 => std::borrow::Cow::Borrowed("DISCOVERY_TYPE_PUBLIC"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DISCOVERY_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::DISCOVERY_TYPE_UNSPECIFIED)
+            }
+            "DISCOVERY_TYPE_PRIVATE" => std::option::Option::Some(Self::DISCOVERY_TYPE_PRIVATE),
+            "DISCOVERY_TYPE_PUBLIC" => std::option::Option::Some(Self::DISCOVERY_TYPE_PUBLIC),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for DiscoveryType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DiscoveryType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DiscoveryType {
     fn default() -> Self {
-        discovery_type::DISCOVERY_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::AnalyticsHubService for AnalyticsHubService {
                 reqwest::Method::GET,
                 format!("/v1/{}/dataExchanges", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -76,7 +76,7 @@ impl crate::stubs::AnalyticsHubService for AnalyticsHubService {
                 reqwest::Method::GET,
                 format!("/v1/{}/dataExchanges", req.organization),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::AnalyticsHubService for AnalyticsHubService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -119,7 +119,7 @@ impl crate::stubs::AnalyticsHubService for AnalyticsHubService {
                 reqwest::Method::POST,
                 format!("/v1/{}/dataExchanges", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -148,7 +148,7 @@ impl crate::stubs::AnalyticsHubService for AnalyticsHubService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -177,7 +177,7 @@ impl crate::stubs::AnalyticsHubService for AnalyticsHubService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -196,7 +196,7 @@ impl crate::stubs::AnalyticsHubService for AnalyticsHubService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/listings", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -217,7 +217,7 @@ impl crate::stubs::AnalyticsHubService for AnalyticsHubService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -239,7 +239,7 @@ impl crate::stubs::AnalyticsHubService for AnalyticsHubService {
                 reqwest::Method::POST,
                 format!("/v1/{}/listings", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -268,7 +268,7 @@ impl crate::stubs::AnalyticsHubService for AnalyticsHubService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -297,7 +297,7 @@ impl crate::stubs::AnalyticsHubService for AnalyticsHubService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -316,7 +316,7 @@ impl crate::stubs::AnalyticsHubService for AnalyticsHubService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:subscribe", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -333,7 +333,7 @@ impl crate::stubs::AnalyticsHubService for AnalyticsHubService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:subscribe", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -350,7 +350,7 @@ impl crate::stubs::AnalyticsHubService for AnalyticsHubService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:refresh", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -367,7 +367,7 @@ impl crate::stubs::AnalyticsHubService for AnalyticsHubService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -389,7 +389,7 @@ impl crate::stubs::AnalyticsHubService for AnalyticsHubService {
                 reqwest::Method::GET,
                 format!("/v1/{}/subscriptions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -414,7 +414,7 @@ impl crate::stubs::AnalyticsHubService for AnalyticsHubService {
                 reqwest::Method::GET,
                 format!("/v1/{}:listSubscriptions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -439,7 +439,7 @@ impl crate::stubs::AnalyticsHubService for AnalyticsHubService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:revoke", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -456,7 +456,7 @@ impl crate::stubs::AnalyticsHubService for AnalyticsHubService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -478,7 +478,7 @@ impl crate::stubs::AnalyticsHubService for AnalyticsHubService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -498,7 +498,7 @@ impl crate::stubs::AnalyticsHubService for AnalyticsHubService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -518,7 +518,7 @@ impl crate::stubs::AnalyticsHubService for AnalyticsHubService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -535,7 +535,7 @@ impl crate::stubs::AnalyticsHubService for AnalyticsHubService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/bigquery/connection/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/model.rs
@@ -735,44 +735,60 @@ pub mod cloud_sql_properties {
 
     /// Supported Cloud SQL database types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DatabaseType(std::borrow::Cow<'static, str>);
+    pub struct DatabaseType(i32);
 
     impl DatabaseType {
+        /// Unspecified database type.
+        pub const DATABASE_TYPE_UNSPECIFIED: DatabaseType = DatabaseType::new(0);
+
+        /// Cloud SQL for PostgreSQL.
+        pub const POSTGRES: DatabaseType = DatabaseType::new(1);
+
+        /// Cloud SQL for MySQL.
+        pub const MYSQL: DatabaseType = DatabaseType::new(2);
+
         /// Creates a new DatabaseType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATABASE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("POSTGRES"),
+                2 => std::borrow::Cow::Borrowed("MYSQL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATABASE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DATABASE_TYPE_UNSPECIFIED)
+                }
+                "POSTGRES" => std::option::Option::Some(Self::POSTGRES),
+                "MYSQL" => std::option::Option::Some(Self::MYSQL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DatabaseType](DatabaseType)
-    pub mod database_type {
-        use super::DatabaseType;
-
-        /// Unspecified database type.
-        pub const DATABASE_TYPE_UNSPECIFIED: DatabaseType =
-            DatabaseType::new("DATABASE_TYPE_UNSPECIFIED");
-
-        /// Cloud SQL for PostgreSQL.
-        pub const POSTGRES: DatabaseType = DatabaseType::new("POSTGRES");
-
-        /// Cloud SQL for MySQL.
-        pub const MYSQL: DatabaseType = DatabaseType::new("MYSQL");
-    }
-
-    impl std::convert::From<std::string::String> for DatabaseType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DatabaseType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DatabaseType {
         fn default() -> Self {
-            database_type::DATABASE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/bigquery/connection/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::ConnectionService for ConnectionService {
                 reqwest::Method::POST,
                 format!("/v1/{}/connections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::ConnectionService for ConnectionService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -94,7 +94,7 @@ impl crate::stubs::ConnectionService for ConnectionService {
                 reqwest::Method::GET,
                 format!("/v1/{}/connections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -115,7 +115,7 @@ impl crate::stubs::ConnectionService for ConnectionService {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -144,7 +144,7 @@ impl crate::stubs::ConnectionService for ConnectionService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -166,7 +166,7 @@ impl crate::stubs::ConnectionService for ConnectionService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -186,7 +186,7 @@ impl crate::stubs::ConnectionService for ConnectionService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -206,7 +206,7 @@ impl crate::stubs::ConnectionService for ConnectionService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/model.rs
@@ -503,46 +503,63 @@ pub mod data_policy {
 
     /// A list of supported data policy types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataPolicyType(std::borrow::Cow<'static, str>);
+    pub struct DataPolicyType(i32);
 
     impl DataPolicyType {
-        /// Creates a new DataPolicyType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DataPolicyType](DataPolicyType)
-    pub mod data_policy_type {
-        use super::DataPolicyType;
-
         /// Default value for the data policy type. This should not be used.
-        pub const DATA_POLICY_TYPE_UNSPECIFIED: DataPolicyType =
-            DataPolicyType::new("DATA_POLICY_TYPE_UNSPECIFIED");
+        pub const DATA_POLICY_TYPE_UNSPECIFIED: DataPolicyType = DataPolicyType::new(0);
 
         /// Used to create a data policy for column-level security, without data
         /// masking.
-        pub const COLUMN_LEVEL_SECURITY_POLICY: DataPolicyType =
-            DataPolicyType::new("COLUMN_LEVEL_SECURITY_POLICY");
+        pub const COLUMN_LEVEL_SECURITY_POLICY: DataPolicyType = DataPolicyType::new(3);
 
         /// Used to create a data policy for data masking.
-        pub const DATA_MASKING_POLICY: DataPolicyType = DataPolicyType::new("DATA_MASKING_POLICY");
+        pub const DATA_MASKING_POLICY: DataPolicyType = DataPolicyType::new(2);
+
+        /// Creates a new DataPolicyType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATA_POLICY_TYPE_UNSPECIFIED"),
+                2 => std::borrow::Cow::Borrowed("DATA_MASKING_POLICY"),
+                3 => std::borrow::Cow::Borrowed("COLUMN_LEVEL_SECURITY_POLICY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATA_POLICY_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DATA_POLICY_TYPE_UNSPECIFIED)
+                }
+                "COLUMN_LEVEL_SECURITY_POLICY" => {
+                    std::option::Option::Some(Self::COLUMN_LEVEL_SECURITY_POLICY)
+                }
+                "DATA_MASKING_POLICY" => std::option::Option::Some(Self::DATA_MASKING_POLICY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DataPolicyType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DataPolicyType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DataPolicyType {
         fn default() -> Self {
-            data_policy_type::DATA_POLICY_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -668,34 +685,19 @@ pub mod data_masking_policy {
     /// The available masking rules. Learn more here:
     /// <https://cloud.google.com/bigquery/docs/column-data-masking-intro#masking_options>.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PredefinedExpression(std::borrow::Cow<'static, str>);
+    pub struct PredefinedExpression(i32);
 
     impl PredefinedExpression {
-        /// Creates a new PredefinedExpression instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PredefinedExpression](PredefinedExpression)
-    pub mod predefined_expression {
-        use super::PredefinedExpression;
-
         /// Default, unspecified predefined expression. No masking will take place
         /// since no expression is specified.
         pub const PREDEFINED_EXPRESSION_UNSPECIFIED: PredefinedExpression =
-            PredefinedExpression::new("PREDEFINED_EXPRESSION_UNSPECIFIED");
+            PredefinedExpression::new(0);
 
         /// Masking expression to replace data with SHA-256 hash.
-        pub const SHA256: PredefinedExpression = PredefinedExpression::new("SHA256");
+        pub const SHA256: PredefinedExpression = PredefinedExpression::new(3);
 
         /// Masking expression to replace data with NULLs.
-        pub const ALWAYS_NULL: PredefinedExpression = PredefinedExpression::new("ALWAYS_NULL");
+        pub const ALWAYS_NULL: PredefinedExpression = PredefinedExpression::new(5);
 
         /// Masking expression to replace data with their default masking values.
         /// The default masking values for each type listed as below:
@@ -715,8 +717,7 @@ pub mod data_masking_policy {
         /// * ARRAY: []
         /// * STRUCT: NOT_APPLICABLE
         /// * JSON: NULL
-        pub const DEFAULT_MASKING_VALUE: PredefinedExpression =
-            PredefinedExpression::new("DEFAULT_MASKING_VALUE");
+        pub const DEFAULT_MASKING_VALUE: PredefinedExpression = PredefinedExpression::new(7);
 
         /// Masking expression shows the last four characters of text.
         /// The masking behavior is as follows:
@@ -724,8 +725,7 @@ pub mod data_masking_policy {
         /// * If text length > 4 characters: Replace text with XXXXX, append last
         ///   four characters of original text.
         /// * If text length <= 4 characters: Apply SHA-256 hash.
-        pub const LAST_FOUR_CHARACTERS: PredefinedExpression =
-            PredefinedExpression::new("LAST_FOUR_CHARACTERS");
+        pub const LAST_FOUR_CHARACTERS: PredefinedExpression = PredefinedExpression::new(9);
 
         /// Masking expression shows the first four characters of text.
         /// The masking behavior is as follows:
@@ -733,8 +733,7 @@ pub mod data_masking_policy {
         /// * If text length > 4 characters: Replace text with XXXXX, prepend first
         ///   four characters of original text.
         /// * If text length <= 4 characters: Apply SHA-256 hash.
-        pub const FIRST_FOUR_CHARACTERS: PredefinedExpression =
-            PredefinedExpression::new("FIRST_FOUR_CHARACTERS");
+        pub const FIRST_FOUR_CHARACTERS: PredefinedExpression = PredefinedExpression::new(10);
 
         /// Masking expression for email addresses.
         /// The masking behavior is as follows:
@@ -745,7 +744,7 @@ pub mod data_masking_policy {
         ///
         /// For more information, see [Email
         /// mask](https://cloud.google.com/bigquery/docs/column-data-masking-intro#masking_options).
-        pub const EMAIL_MASK: PredefinedExpression = PredefinedExpression::new("EMAIL_MASK");
+        pub const EMAIL_MASK: PredefinedExpression = PredefinedExpression::new(12);
 
         /// Masking expression to only show the year of `Date`,
         /// `DateTime` and `TimeStamp`. For example, with the
@@ -760,19 +759,60 @@ pub mod data_masking_policy {
         /// For more information, see the <a
         /// href="https://cloud.google.com/bigquery/docs/reference/system-variables">System
         /// variables reference</a>.
-        pub const DATE_YEAR_MASK: PredefinedExpression =
-            PredefinedExpression::new("DATE_YEAR_MASK");
+        pub const DATE_YEAR_MASK: PredefinedExpression = PredefinedExpression::new(13);
+
+        /// Creates a new PredefinedExpression instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PREDEFINED_EXPRESSION_UNSPECIFIED"),
+                3 => std::borrow::Cow::Borrowed("SHA256"),
+                5 => std::borrow::Cow::Borrowed("ALWAYS_NULL"),
+                7 => std::borrow::Cow::Borrowed("DEFAULT_MASKING_VALUE"),
+                9 => std::borrow::Cow::Borrowed("LAST_FOUR_CHARACTERS"),
+                10 => std::borrow::Cow::Borrowed("FIRST_FOUR_CHARACTERS"),
+                12 => std::borrow::Cow::Borrowed("EMAIL_MASK"),
+                13 => std::borrow::Cow::Borrowed("DATE_YEAR_MASK"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PREDEFINED_EXPRESSION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PREDEFINED_EXPRESSION_UNSPECIFIED)
+                }
+                "SHA256" => std::option::Option::Some(Self::SHA256),
+                "ALWAYS_NULL" => std::option::Option::Some(Self::ALWAYS_NULL),
+                "DEFAULT_MASKING_VALUE" => std::option::Option::Some(Self::DEFAULT_MASKING_VALUE),
+                "LAST_FOUR_CHARACTERS" => std::option::Option::Some(Self::LAST_FOUR_CHARACTERS),
+                "FIRST_FOUR_CHARACTERS" => std::option::Option::Some(Self::FIRST_FOUR_CHARACTERS),
+                "EMAIL_MASK" => std::option::Option::Some(Self::EMAIL_MASK),
+                "DATE_YEAR_MASK" => std::option::Option::Some(Self::DATE_YEAR_MASK),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PredefinedExpression {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PredefinedExpression {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PredefinedExpression {
         fn default() -> Self {
-            predefined_expression::PREDEFINED_EXPRESSION_UNSPECIFIED
+            Self::new(0)
         }
     }
 

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::DataPolicyService for DataPolicyService {
                 reqwest::Method::POST,
                 format!("/v1/{}/dataPolicies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -80,7 +80,7 @@ impl crate::stubs::DataPolicyService for DataPolicyService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -109,7 +109,7 @@ impl crate::stubs::DataPolicyService for DataPolicyService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:rename", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -126,7 +126,7 @@ impl crate::stubs::DataPolicyService for DataPolicyService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -145,7 +145,7 @@ impl crate::stubs::DataPolicyService for DataPolicyService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -167,7 +167,7 @@ impl crate::stubs::DataPolicyService for DataPolicyService {
                 reqwest::Method::GET,
                 format!("/v1/{}/dataPolicies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -192,7 +192,7 @@ impl crate::stubs::DataPolicyService for DataPolicyService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -212,7 +212,7 @@ impl crate::stubs::DataPolicyService for DataPolicyService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -232,7 +232,7 @@ impl crate::stubs::DataPolicyService for DataPolicyService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/model.rs
@@ -242,59 +242,84 @@ pub mod data_source_parameter {
 
     /// Parameter type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// Type unspecified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// String parameter.
-        pub const STRING: Type = Type::new("STRING");
+        pub const STRING: Type = Type::new(1);
 
         /// Integer parameter (64-bits).
         /// Will be serialized to json as string.
-        pub const INTEGER: Type = Type::new("INTEGER");
+        pub const INTEGER: Type = Type::new(2);
 
         /// Double precision floating point parameter.
-        pub const DOUBLE: Type = Type::new("DOUBLE");
+        pub const DOUBLE: Type = Type::new(3);
 
         /// Boolean parameter.
-        pub const BOOLEAN: Type = Type::new("BOOLEAN");
+        pub const BOOLEAN: Type = Type::new(4);
 
         /// Deprecated. This field has no effect.
-        pub const RECORD: Type = Type::new("RECORD");
+        pub const RECORD: Type = Type::new(5);
 
         /// Page ID for a Google+ Page.
-        pub const PLUS_PAGE: Type = Type::new("PLUS_PAGE");
+        pub const PLUS_PAGE: Type = Type::new(6);
 
         /// List of strings parameter.
-        pub const LIST: Type = Type::new("LIST");
+        pub const LIST: Type = Type::new(7);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STRING"),
+                2 => std::borrow::Cow::Borrowed("INTEGER"),
+                3 => std::borrow::Cow::Borrowed("DOUBLE"),
+                4 => std::borrow::Cow::Borrowed("BOOLEAN"),
+                5 => std::borrow::Cow::Borrowed("RECORD"),
+                6 => std::borrow::Cow::Borrowed("PLUS_PAGE"),
+                7 => std::borrow::Cow::Borrowed("LIST"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "STRING" => std::option::Option::Some(Self::STRING),
+                "INTEGER" => std::option::Option::Some(Self::INTEGER),
+                "DOUBLE" => std::option::Option::Some(Self::DOUBLE),
+                "BOOLEAN" => std::option::Option::Some(Self::BOOLEAN),
+                "RECORD" => std::option::Option::Some(Self::RECORD),
+                "PLUS_PAGE" => std::option::Option::Some(Self::PLUS_PAGE),
+                "LIST" => std::option::Option::Some(Self::LIST),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -545,100 +570,132 @@ pub mod data_source {
 
     /// The type of authorization needed for this data source.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AuthorizationType(std::borrow::Cow<'static, str>);
+    pub struct AuthorizationType(i32);
 
     impl AuthorizationType {
-        /// Creates a new AuthorizationType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [AuthorizationType](AuthorizationType)
-    pub mod authorization_type {
-        use super::AuthorizationType;
-
         /// Type unspecified.
-        pub const AUTHORIZATION_TYPE_UNSPECIFIED: AuthorizationType =
-            AuthorizationType::new("AUTHORIZATION_TYPE_UNSPECIFIED");
+        pub const AUTHORIZATION_TYPE_UNSPECIFIED: AuthorizationType = AuthorizationType::new(0);
 
         /// Use OAuth 2 authorization codes that can be exchanged
         /// for a refresh token on the backend.
-        pub const AUTHORIZATION_CODE: AuthorizationType =
-            AuthorizationType::new("AUTHORIZATION_CODE");
+        pub const AUTHORIZATION_CODE: AuthorizationType = AuthorizationType::new(1);
 
         /// Return an authorization code for a given Google+ page that can then be
         /// exchanged for a refresh token on the backend.
-        pub const GOOGLE_PLUS_AUTHORIZATION_CODE: AuthorizationType =
-            AuthorizationType::new("GOOGLE_PLUS_AUTHORIZATION_CODE");
+        pub const GOOGLE_PLUS_AUTHORIZATION_CODE: AuthorizationType = AuthorizationType::new(2);
 
         /// Use First Party OAuth.
-        pub const FIRST_PARTY_OAUTH: AuthorizationType =
-            AuthorizationType::new("FIRST_PARTY_OAUTH");
+        pub const FIRST_PARTY_OAUTH: AuthorizationType = AuthorizationType::new(3);
+
+        /// Creates a new AuthorizationType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("AUTHORIZATION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AUTHORIZATION_CODE"),
+                2 => std::borrow::Cow::Borrowed("GOOGLE_PLUS_AUTHORIZATION_CODE"),
+                3 => std::borrow::Cow::Borrowed("FIRST_PARTY_OAUTH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "AUTHORIZATION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::AUTHORIZATION_TYPE_UNSPECIFIED)
+                }
+                "AUTHORIZATION_CODE" => std::option::Option::Some(Self::AUTHORIZATION_CODE),
+                "GOOGLE_PLUS_AUTHORIZATION_CODE" => {
+                    std::option::Option::Some(Self::GOOGLE_PLUS_AUTHORIZATION_CODE)
+                }
+                "FIRST_PARTY_OAUTH" => std::option::Option::Some(Self::FIRST_PARTY_OAUTH),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for AuthorizationType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AuthorizationType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AuthorizationType {
         fn default() -> Self {
-            authorization_type::AUTHORIZATION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Represents how the data source supports data auto refresh.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataRefreshType(std::borrow::Cow<'static, str>);
+    pub struct DataRefreshType(i32);
 
     impl DataRefreshType {
-        /// Creates a new DataRefreshType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DataRefreshType](DataRefreshType)
-    pub mod data_refresh_type {
-        use super::DataRefreshType;
-
         /// The data source won't support data auto refresh, which is default value.
-        pub const DATA_REFRESH_TYPE_UNSPECIFIED: DataRefreshType =
-            DataRefreshType::new("DATA_REFRESH_TYPE_UNSPECIFIED");
+        pub const DATA_REFRESH_TYPE_UNSPECIFIED: DataRefreshType = DataRefreshType::new(0);
 
         /// The data source supports data auto refresh, and runs will be scheduled
         /// for the past few days. Does not allow custom values to be set for each
         /// transfer config.
-        pub const SLIDING_WINDOW: DataRefreshType = DataRefreshType::new("SLIDING_WINDOW");
+        pub const SLIDING_WINDOW: DataRefreshType = DataRefreshType::new(1);
 
         /// The data source supports data auto refresh, and runs will be scheduled
         /// for the past few days. Allows custom values to be set for each transfer
         /// config.
-        pub const CUSTOM_SLIDING_WINDOW: DataRefreshType =
-            DataRefreshType::new("CUSTOM_SLIDING_WINDOW");
+        pub const CUSTOM_SLIDING_WINDOW: DataRefreshType = DataRefreshType::new(2);
+
+        /// Creates a new DataRefreshType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATA_REFRESH_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SLIDING_WINDOW"),
+                2 => std::borrow::Cow::Borrowed("CUSTOM_SLIDING_WINDOW"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATA_REFRESH_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DATA_REFRESH_TYPE_UNSPECIFIED)
+                }
+                "SLIDING_WINDOW" => std::option::Option::Some(Self::SLIDING_WINDOW),
+                "CUSTOM_SLIDING_WINDOW" => std::option::Option::Some(Self::CUSTOM_SLIDING_WINDOW),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DataRefreshType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DataRefreshType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DataRefreshType {
         fn default() -> Self {
-            data_refresh_type::DATA_REFRESH_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1388,40 +1445,55 @@ pub mod list_transfer_runs_request {
 
     /// Represents which runs should be pulled.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RunAttempt(std::borrow::Cow<'static, str>);
+    pub struct RunAttempt(i32);
 
     impl RunAttempt {
+        /// All runs should be returned.
+        pub const RUN_ATTEMPT_UNSPECIFIED: RunAttempt = RunAttempt::new(0);
+
+        /// Only latest run per day should be returned.
+        pub const LATEST: RunAttempt = RunAttempt::new(1);
+
         /// Creates a new RunAttempt instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RUN_ATTEMPT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LATEST"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RUN_ATTEMPT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RUN_ATTEMPT_UNSPECIFIED)
+                }
+                "LATEST" => std::option::Option::Some(Self::LATEST),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RunAttempt](RunAttempt)
-    pub mod run_attempt {
-        use super::RunAttempt;
-
-        /// All runs should be returned.
-        pub const RUN_ATTEMPT_UNSPECIFIED: RunAttempt = RunAttempt::new("RUN_ATTEMPT_UNSPECIFIED");
-
-        /// Only latest run per day should be returned.
-        pub const LATEST: RunAttempt = RunAttempt::new("LATEST");
-    }
-
-    impl std::convert::From<std::string::String> for RunAttempt {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RunAttempt {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RunAttempt {
         fn default() -> Self {
-            run_attempt::RUN_ATTEMPT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3208,144 +3280,200 @@ pub mod transfer_message {
 
     /// Represents data transfer user facing message severity.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MessageSeverity(std::borrow::Cow<'static, str>);
+    pub struct MessageSeverity(i32);
 
     impl MessageSeverity {
+        /// No severity specified.
+        pub const MESSAGE_SEVERITY_UNSPECIFIED: MessageSeverity = MessageSeverity::new(0);
+
+        /// Informational message.
+        pub const INFO: MessageSeverity = MessageSeverity::new(1);
+
+        /// Warning message.
+        pub const WARNING: MessageSeverity = MessageSeverity::new(2);
+
+        /// Error message.
+        pub const ERROR: MessageSeverity = MessageSeverity::new(3);
+
         /// Creates a new MessageSeverity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MESSAGE_SEVERITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INFO"),
+                2 => std::borrow::Cow::Borrowed("WARNING"),
+                3 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MESSAGE_SEVERITY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MESSAGE_SEVERITY_UNSPECIFIED)
+                }
+                "INFO" => std::option::Option::Some(Self::INFO),
+                "WARNING" => std::option::Option::Some(Self::WARNING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [MessageSeverity](MessageSeverity)
-    pub mod message_severity {
-        use super::MessageSeverity;
-
-        /// No severity specified.
-        pub const MESSAGE_SEVERITY_UNSPECIFIED: MessageSeverity =
-            MessageSeverity::new("MESSAGE_SEVERITY_UNSPECIFIED");
-
-        /// Informational message.
-        pub const INFO: MessageSeverity = MessageSeverity::new("INFO");
-
-        /// Warning message.
-        pub const WARNING: MessageSeverity = MessageSeverity::new("WARNING");
-
-        /// Error message.
-        pub const ERROR: MessageSeverity = MessageSeverity::new("ERROR");
-    }
-
-    impl std::convert::From<std::string::String> for MessageSeverity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MessageSeverity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MessageSeverity {
         fn default() -> Self {
-            message_severity::MESSAGE_SEVERITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
 
 /// DEPRECATED. Represents data transfer type.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TransferType(std::borrow::Cow<'static, str>);
+pub struct TransferType(i32);
 
 impl TransferType {
-    /// Creates a new TransferType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [TransferType](TransferType)
-pub mod transfer_type {
-    use super::TransferType;
-
     /// Invalid or Unknown transfer type placeholder.
-    pub const TRANSFER_TYPE_UNSPECIFIED: TransferType =
-        TransferType::new("TRANSFER_TYPE_UNSPECIFIED");
+    pub const TRANSFER_TYPE_UNSPECIFIED: TransferType = TransferType::new(0);
 
     /// Batch data transfer.
-    pub const BATCH: TransferType = TransferType::new("BATCH");
+    pub const BATCH: TransferType = TransferType::new(1);
 
     /// Streaming data transfer. Streaming data source currently doesn't
     /// support multiple transfer configs per project.
-    pub const STREAMING: TransferType = TransferType::new("STREAMING");
+    pub const STREAMING: TransferType = TransferType::new(2);
+
+    /// Creates a new TransferType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("TRANSFER_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("BATCH"),
+            2 => std::borrow::Cow::Borrowed("STREAMING"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "TRANSFER_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::TRANSFER_TYPE_UNSPECIFIED)
+            }
+            "BATCH" => std::option::Option::Some(Self::BATCH),
+            "STREAMING" => std::option::Option::Some(Self::STREAMING),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for TransferType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for TransferType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for TransferType {
     fn default() -> Self {
-        transfer_type::TRANSFER_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Represents data transfer run state.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TransferState(std::borrow::Cow<'static, str>);
+pub struct TransferState(i32);
 
 impl TransferState {
-    /// Creates a new TransferState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [TransferState](TransferState)
-pub mod transfer_state {
-    use super::TransferState;
-
     /// State placeholder (0).
-    pub const TRANSFER_STATE_UNSPECIFIED: TransferState =
-        TransferState::new("TRANSFER_STATE_UNSPECIFIED");
+    pub const TRANSFER_STATE_UNSPECIFIED: TransferState = TransferState::new(0);
 
     /// Data transfer is scheduled and is waiting to be picked up by
     /// data transfer backend (2).
-    pub const PENDING: TransferState = TransferState::new("PENDING");
+    pub const PENDING: TransferState = TransferState::new(2);
 
     /// Data transfer is in progress (3).
-    pub const RUNNING: TransferState = TransferState::new("RUNNING");
+    pub const RUNNING: TransferState = TransferState::new(3);
 
     /// Data transfer completed successfully (4).
-    pub const SUCCEEDED: TransferState = TransferState::new("SUCCEEDED");
+    pub const SUCCEEDED: TransferState = TransferState::new(4);
 
     /// Data transfer failed (5).
-    pub const FAILED: TransferState = TransferState::new("FAILED");
+    pub const FAILED: TransferState = TransferState::new(5);
 
     /// Data transfer is cancelled (6).
-    pub const CANCELLED: TransferState = TransferState::new("CANCELLED");
+    pub const CANCELLED: TransferState = TransferState::new(6);
+
+    /// Creates a new TransferState instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("TRANSFER_STATE_UNSPECIFIED"),
+            2 => std::borrow::Cow::Borrowed("PENDING"),
+            3 => std::borrow::Cow::Borrowed("RUNNING"),
+            4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+            5 => std::borrow::Cow::Borrowed("FAILED"),
+            6 => std::borrow::Cow::Borrowed("CANCELLED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "TRANSFER_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::TRANSFER_STATE_UNSPECIFIED)
+            }
+            "PENDING" => std::option::Option::Some(Self::PENDING),
+            "RUNNING" => std::option::Option::Some(Self::RUNNING),
+            "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+            "FAILED" => std::option::Option::Some(Self::FAILED),
+            "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for TransferState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for TransferState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for TransferState {
     fn default() -> Self {
-        transfer_state::TRANSFER_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::DataTransferService for DataTransferService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -71,7 +71,7 @@ impl crate::stubs::DataTransferService for DataTransferService {
                 reqwest::Method::GET,
                 format!("/v1/{}/dataSources", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -95,7 +95,7 @@ impl crate::stubs::DataTransferService for DataTransferService {
                 reqwest::Method::POST,
                 format!("/v1/{}/transferConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -126,7 +126,7 @@ impl crate::stubs::DataTransferService for DataTransferService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -158,7 +158,7 @@ impl crate::stubs::DataTransferService for DataTransferService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -177,7 +177,7 @@ impl crate::stubs::DataTransferService for DataTransferService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -199,7 +199,7 @@ impl crate::stubs::DataTransferService for DataTransferService {
                 reqwest::Method::GET,
                 format!("/v1/{}/transferConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -227,7 +227,7 @@ impl crate::stubs::DataTransferService for DataTransferService {
                 reqwest::Method::POST,
                 format!("/v1/{}:scheduleRuns", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -247,7 +247,7 @@ impl crate::stubs::DataTransferService for DataTransferService {
                 reqwest::Method::POST,
                 format!("/v1/{}:startManualRuns", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -264,7 +264,7 @@ impl crate::stubs::DataTransferService for DataTransferService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -283,7 +283,7 @@ impl crate::stubs::DataTransferService for DataTransferService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -302,7 +302,7 @@ impl crate::stubs::DataTransferService for DataTransferService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/runs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -330,7 +330,7 @@ impl crate::stubs::DataTransferService for DataTransferService {
                 reqwest::Method::GET,
                 format!("/v1/{}/transferLogs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -357,7 +357,7 @@ impl crate::stubs::DataTransferService for DataTransferService {
                 reqwest::Method::POST,
                 format!("/v1/{}:checkValidCreds", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -377,7 +377,7 @@ impl crate::stubs::DataTransferService for DataTransferService {
                 reqwest::Method::POST,
                 format!("/v1/{}:enrollDataSources", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -397,7 +397,7 @@ impl crate::stubs::DataTransferService for DataTransferService {
                 reqwest::Method::POST,
                 format!("/v1/{}:unenrollDataSources", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -414,7 +414,7 @@ impl crate::stubs::DataTransferService for DataTransferService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -436,7 +436,7 @@ impl crate::stubs::DataTransferService for DataTransferService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/bigquery/migration/v2/src/model.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/model.rs
@@ -138,53 +138,72 @@ pub mod migration_workflow {
 
     /// Possible migration workflow states.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Workflow state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Workflow is in draft status, i.e. tasks are not yet eligible for
         /// execution.
-        pub const DRAFT: State = State::new("DRAFT");
+        pub const DRAFT: State = State::new(1);
 
         /// Workflow is running (i.e. tasks are eligible for execution).
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(2);
 
         /// Workflow is paused. Tasks currently in progress may continue, but no
         /// further tasks will be scheduled.
-        pub const PAUSED: State = State::new("PAUSED");
+        pub const PAUSED: State = State::new(3);
 
         /// Workflow is complete. There should not be any task in a non-terminal
         /// state, but if they are (e.g. forced termination), they will not be
         /// scheduled.
-        pub const COMPLETED: State = State::new("COMPLETED");
+        pub const COMPLETED: State = State::new(4);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DRAFT"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("PAUSED"),
+                4 => std::borrow::Cow::Borrowed("COMPLETED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "DRAFT" => std::option::Option::Some(Self::DRAFT),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "PAUSED" => std::option::Option::Some(Self::PAUSED),
+                "COMPLETED" => std::option::Option::Some(Self::COMPLETED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -454,56 +473,79 @@ pub mod migration_task {
 
     /// Possible states of a migration task.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The task is waiting for orchestration.
-        pub const PENDING: State = State::new("PENDING");
+        pub const PENDING: State = State::new(1);
 
         /// The task is assigned to an orchestrator.
-        pub const ORCHESTRATING: State = State::new("ORCHESTRATING");
+        pub const ORCHESTRATING: State = State::new(2);
 
         /// The task is running, i.e. its subtasks are ready for execution.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(3);
 
         /// Tha task is paused. Assigned subtasks can continue, but no new subtasks
         /// will be scheduled.
-        pub const PAUSED: State = State::new("PAUSED");
+        pub const PAUSED: State = State::new(4);
 
         /// The task finished successfully.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
+        pub const SUCCEEDED: State = State::new(5);
 
         /// The task finished unsuccessfully.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(6);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("ORCHESTRATING"),
+                3 => std::borrow::Cow::Borrowed("RUNNING"),
+                4 => std::borrow::Cow::Borrowed("PAUSED"),
+                5 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                6 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "ORCHESTRATING" => std::option::Option::Some(Self::ORCHESTRATING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "PAUSED" => std::option::Option::Some(Self::PAUSED),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -682,57 +724,80 @@ pub mod migration_subtask {
 
     /// Possible states of a migration subtask.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The subtask is ready, i.e. it is ready for execution.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(1);
 
         /// The subtask is running, i.e. it is assigned to a worker for execution.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(2);
 
         /// The subtask finished successfully.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
+        pub const SUCCEEDED: State = State::new(3);
 
         /// The subtask finished unsuccessfully.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(4);
 
         /// The subtask is paused, i.e., it will not be scheduled. If it was already
         /// assigned,it might still finish but no new lease renewals will be granted.
-        pub const PAUSED: State = State::new("PAUSED");
+        pub const PAUSED: State = State::new(5);
 
         /// The subtask is pending a dependency. It will be scheduled once its
         /// dependencies are done.
-        pub const PENDING_DEPENDENCY: State = State::new("PENDING_DEPENDENCY");
+        pub const PENDING_DEPENDENCY: State = State::new(6);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                5 => std::borrow::Cow::Borrowed("PAUSED"),
+                6 => std::borrow::Cow::Borrowed("PENDING_DEPENDENCY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "PAUSED" => std::option::Option::Some(Self::PAUSED),
+                "PENDING_DEPENDENCY" => std::option::Option::Some(Self::PENDING_DEPENDENCY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2770,43 +2835,58 @@ pub mod teradata_dialect {
 
     /// The sub-dialect options for Teradata.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(std::borrow::Cow<'static, str>);
+    pub struct Mode(i32);
 
     impl Mode {
+        /// Unspecified mode.
+        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
+
+        /// Teradata SQL mode.
+        pub const SQL: Mode = Mode::new(1);
+
+        /// BTEQ mode (which includes SQL).
+        pub const BTEQ: Mode = Mode::new(2);
+
         /// Creates a new Mode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SQL"),
+                2 => std::borrow::Cow::Borrowed("BTEQ"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
+                "SQL" => std::option::Option::Some(Self::SQL),
+                "BTEQ" => std::option::Option::Some(Self::BTEQ),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Mode](Mode)
-    pub mod mode {
-        use super::Mode;
-
-        /// Unspecified mode.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new("MODE_UNSPECIFIED");
-
-        /// Teradata SQL mode.
-        pub const SQL: Mode = Mode::new("SQL");
-
-        /// BTEQ mode (which includes SQL).
-        pub const BTEQ: Mode = Mode::new("BTEQ");
-    }
-
-    impl std::convert::From<std::string::String> for Mode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            mode::MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3224,58 +3304,83 @@ pub mod name_mapping_key {
 
     /// The type of the object that is being mapped.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Unspecified name mapping type.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// The object being mapped is a database.
+        pub const DATABASE: Type = Type::new(1);
+
+        /// The object being mapped is a schema.
+        pub const SCHEMA: Type = Type::new(2);
+
+        /// The object being mapped is a relation.
+        pub const RELATION: Type = Type::new(3);
+
+        /// The object being mapped is an attribute.
+        pub const ATTRIBUTE: Type = Type::new(4);
+
+        /// The object being mapped is a relation alias.
+        pub const RELATION_ALIAS: Type = Type::new(5);
+
+        /// The object being mapped is a an attribute alias.
+        pub const ATTRIBUTE_ALIAS: Type = Type::new(6);
+
+        /// The object being mapped is a function.
+        pub const FUNCTION: Type = Type::new(7);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DATABASE"),
+                2 => std::borrow::Cow::Borrowed("SCHEMA"),
+                3 => std::borrow::Cow::Borrowed("RELATION"),
+                4 => std::borrow::Cow::Borrowed("ATTRIBUTE"),
+                5 => std::borrow::Cow::Borrowed("RELATION_ALIAS"),
+                6 => std::borrow::Cow::Borrowed("ATTRIBUTE_ALIAS"),
+                7 => std::borrow::Cow::Borrowed("FUNCTION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "DATABASE" => std::option::Option::Some(Self::DATABASE),
+                "SCHEMA" => std::option::Option::Some(Self::SCHEMA),
+                "RELATION" => std::option::Option::Some(Self::RELATION),
+                "ATTRIBUTE" => std::option::Option::Some(Self::ATTRIBUTE),
+                "RELATION_ALIAS" => std::option::Option::Some(Self::RELATION_ALIAS),
+                "ATTRIBUTE_ALIAS" => std::option::Option::Some(Self::ATTRIBUTE_ALIAS),
+                "FUNCTION" => std::option::Option::Some(Self::FUNCTION),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Unspecified name mapping type.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// The object being mapped is a database.
-        pub const DATABASE: Type = Type::new("DATABASE");
-
-        /// The object being mapped is a schema.
-        pub const SCHEMA: Type = Type::new("SCHEMA");
-
-        /// The object being mapped is a relation.
-        pub const RELATION: Type = Type::new("RELATION");
-
-        /// The object being mapped is an attribute.
-        pub const ATTRIBUTE: Type = Type::new("ATTRIBUTE");
-
-        /// The object being mapped is a relation alias.
-        pub const RELATION_ALIAS: Type = Type::new("RELATION_ALIAS");
-
-        /// The object being mapped is a an attribute alias.
-        pub const ATTRIBUTE_ALIAS: Type = Type::new("ATTRIBUTE_ALIAS");
-
-        /// The object being mapped is a function.
-        pub const FUNCTION: Type = Type::new("FUNCTION");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3941,47 +4046,64 @@ pub mod translation_report_record {
 
     /// The severity type of the record.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(std::borrow::Cow<'static, str>);
+    pub struct Severity(i32);
 
     impl Severity {
-        /// Creates a new Severity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Severity](Severity)
-    pub mod severity {
-        use super::Severity;
-
         /// SeverityType not specified.
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new("SEVERITY_UNSPECIFIED");
+        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
 
         /// INFO type.
-        pub const INFO: Severity = Severity::new("INFO");
+        pub const INFO: Severity = Severity::new(1);
 
         /// WARNING type. The translated query may still provide useful information
         /// if all the report records are WARNING.
-        pub const WARNING: Severity = Severity::new("WARNING");
+        pub const WARNING: Severity = Severity::new(2);
 
         /// ERROR type. Translation failed.
-        pub const ERROR: Severity = Severity::new("ERROR");
+        pub const ERROR: Severity = Severity::new(3);
+
+        /// Creates a new Severity instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INFO"),
+                2 => std::borrow::Cow::Borrowed("WARNING"),
+                3 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
+                "INFO" => std::option::Option::Some(Self::INFO),
+                "WARNING" => std::option::Option::Some(Self::WARNING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Severity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            severity::SEVERITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/bigquery/migration/v2/src/transport.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::MigrationService for MigrationService {
                 reqwest::Method::POST,
                 format!("/v2/{}/workflows", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -71,7 +71,7 @@ impl crate::stubs::MigrationService for MigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -103,7 +103,7 @@ impl crate::stubs::MigrationService for MigrationService {
                 reqwest::Method::GET,
                 format!("/v2/{}/workflows", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -134,7 +134,7 @@ impl crate::stubs::MigrationService for MigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -153,7 +153,7 @@ impl crate::stubs::MigrationService for MigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:start", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -170,7 +170,7 @@ impl crate::stubs::MigrationService for MigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -199,7 +199,7 @@ impl crate::stubs::MigrationService for MigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/subtasks", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/bigquery/reservation/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/model.rs
@@ -547,66 +547,50 @@ pub mod capacity_commitment {
     /// Commitment plan defines the current committed period. Capacity commitment
     /// cannot be deleted during it's committed period.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CommitmentPlan(std::borrow::Cow<'static, str>);
+    pub struct CommitmentPlan(i32);
 
     impl CommitmentPlan {
-        /// Creates a new CommitmentPlan instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CommitmentPlan](CommitmentPlan)
-    pub mod commitment_plan {
-        use super::CommitmentPlan;
-
         /// Invalid plan value. Requests with this value will be rejected with
         /// error code `google.rpc.Code.INVALID_ARGUMENT`.
-        pub const COMMITMENT_PLAN_UNSPECIFIED: CommitmentPlan =
-            CommitmentPlan::new("COMMITMENT_PLAN_UNSPECIFIED");
+        pub const COMMITMENT_PLAN_UNSPECIFIED: CommitmentPlan = CommitmentPlan::new(0);
 
         /// Flex commitments have committed period of 1 minute after becoming ACTIVE.
         /// After that, they are not in a committed period anymore and can be removed
         /// any time.
-        pub const FLEX: CommitmentPlan = CommitmentPlan::new("FLEX");
+        pub const FLEX: CommitmentPlan = CommitmentPlan::new(3);
 
         /// Same as FLEX, should only be used if flat-rate commitments are still
         /// available.
-        pub const FLEX_FLAT_RATE: CommitmentPlan = CommitmentPlan::new("FLEX_FLAT_RATE");
+        pub const FLEX_FLAT_RATE: CommitmentPlan = CommitmentPlan::new(7);
 
         /// Trial commitments have a committed period of 182 days after becoming
         /// ACTIVE. After that, they are converted to a new commitment based on the
         /// `renewal_plan`. Default `renewal_plan` for Trial commitment is Flex so
         /// that it can be deleted right after committed period ends.
-        pub const TRIAL: CommitmentPlan = CommitmentPlan::new("TRIAL");
+        pub const TRIAL: CommitmentPlan = CommitmentPlan::new(5);
 
         /// Monthly commitments have a committed period of 30 days after becoming
         /// ACTIVE. After that, they are not in a committed period anymore and can be
         /// removed any time.
-        pub const MONTHLY: CommitmentPlan = CommitmentPlan::new("MONTHLY");
+        pub const MONTHLY: CommitmentPlan = CommitmentPlan::new(2);
 
         /// Same as MONTHLY, should only be used if flat-rate commitments are still
         /// available.
-        pub const MONTHLY_FLAT_RATE: CommitmentPlan = CommitmentPlan::new("MONTHLY_FLAT_RATE");
+        pub const MONTHLY_FLAT_RATE: CommitmentPlan = CommitmentPlan::new(8);
 
         /// Annual commitments have a committed period of 365 days after becoming
         /// ACTIVE. After that they are converted to a new commitment based on the
         /// renewal_plan.
-        pub const ANNUAL: CommitmentPlan = CommitmentPlan::new("ANNUAL");
+        pub const ANNUAL: CommitmentPlan = CommitmentPlan::new(4);
 
         /// Same as ANNUAL, should only be used if flat-rate commitments are still
         /// available.
-        pub const ANNUAL_FLAT_RATE: CommitmentPlan = CommitmentPlan::new("ANNUAL_FLAT_RATE");
+        pub const ANNUAL_FLAT_RATE: CommitmentPlan = CommitmentPlan::new(9);
 
         /// 3-year commitments have a committed period of 1095(3 * 365) days after
         /// becoming ACTIVE. After that they are converted to a new commitment based
         /// on the renewal_plan.
-        pub const THREE_YEAR: CommitmentPlan = CommitmentPlan::new("THREE_YEAR");
+        pub const THREE_YEAR: CommitmentPlan = CommitmentPlan::new(10);
 
         /// Should only be used for `renewal_plan` and is only meaningful if
         /// edition is specified to values other than EDITION_UNSPECIFIED. Otherwise
@@ -614,66 +598,129 @@ pub mod capacity_commitment {
         /// be rejected with error code `google.rpc.Code.INVALID_ARGUMENT`. If the
         /// renewal_plan is NONE, capacity commitment will be removed at the end of
         /// its commitment period.
-        pub const NONE: CommitmentPlan = CommitmentPlan::new("NONE");
+        pub const NONE: CommitmentPlan = CommitmentPlan::new(6);
+
+        /// Creates a new CommitmentPlan instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COMMITMENT_PLAN_UNSPECIFIED"),
+                2 => std::borrow::Cow::Borrowed("MONTHLY"),
+                3 => std::borrow::Cow::Borrowed("FLEX"),
+                4 => std::borrow::Cow::Borrowed("ANNUAL"),
+                5 => std::borrow::Cow::Borrowed("TRIAL"),
+                6 => std::borrow::Cow::Borrowed("NONE"),
+                7 => std::borrow::Cow::Borrowed("FLEX_FLAT_RATE"),
+                8 => std::borrow::Cow::Borrowed("MONTHLY_FLAT_RATE"),
+                9 => std::borrow::Cow::Borrowed("ANNUAL_FLAT_RATE"),
+                10 => std::borrow::Cow::Borrowed("THREE_YEAR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COMMITMENT_PLAN_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::COMMITMENT_PLAN_UNSPECIFIED)
+                }
+                "FLEX" => std::option::Option::Some(Self::FLEX),
+                "FLEX_FLAT_RATE" => std::option::Option::Some(Self::FLEX_FLAT_RATE),
+                "TRIAL" => std::option::Option::Some(Self::TRIAL),
+                "MONTHLY" => std::option::Option::Some(Self::MONTHLY),
+                "MONTHLY_FLAT_RATE" => std::option::Option::Some(Self::MONTHLY_FLAT_RATE),
+                "ANNUAL" => std::option::Option::Some(Self::ANNUAL),
+                "ANNUAL_FLAT_RATE" => std::option::Option::Some(Self::ANNUAL_FLAT_RATE),
+                "THREE_YEAR" => std::option::Option::Some(Self::THREE_YEAR),
+                "NONE" => std::option::Option::Some(Self::NONE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CommitmentPlan {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CommitmentPlan {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CommitmentPlan {
         fn default() -> Self {
-            commitment_plan::COMMITMENT_PLAN_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Capacity commitment can either become ACTIVE right away or transition
     /// from PENDING to ACTIVE or FAILED.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Invalid state value.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Capacity commitment is pending provisioning. Pending capacity commitment
         /// does not contribute to the project's slot_capacity.
-        pub const PENDING: State = State::new("PENDING");
+        pub const PENDING: State = State::new(1);
 
         /// Once slots are provisioned, capacity commitment becomes active.
         /// slot_count is added to the project's slot_capacity.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(2);
 
         /// Capacity commitment is failed to be activated by the backend.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(3);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1553,55 +1600,76 @@ pub mod assignment {
 
     /// Types of job, which could be specified when using the reservation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct JobType(std::borrow::Cow<'static, str>);
+    pub struct JobType(i32);
 
     impl JobType {
-        /// Creates a new JobType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [JobType](JobType)
-    pub mod job_type {
-        use super::JobType;
-
         /// Invalid type. Requests with this value will be rejected with
         /// error code `google.rpc.Code.INVALID_ARGUMENT`.
-        pub const JOB_TYPE_UNSPECIFIED: JobType = JobType::new("JOB_TYPE_UNSPECIFIED");
+        pub const JOB_TYPE_UNSPECIFIED: JobType = JobType::new(0);
 
         /// Pipeline (load/export) jobs from the project will use the reservation.
-        pub const PIPELINE: JobType = JobType::new("PIPELINE");
+        pub const PIPELINE: JobType = JobType::new(1);
 
         /// Query jobs from the project will use the reservation.
-        pub const QUERY: JobType = JobType::new("QUERY");
+        pub const QUERY: JobType = JobType::new(2);
 
         /// BigQuery ML jobs that use services external to BigQuery for model
         /// training. These jobs will not utilize idle slots from other reservations.
-        pub const ML_EXTERNAL: JobType = JobType::new("ML_EXTERNAL");
+        pub const ML_EXTERNAL: JobType = JobType::new(3);
 
         /// Background jobs that BigQuery runs for the customers in the background.
-        pub const BACKGROUND: JobType = JobType::new("BACKGROUND");
+        pub const BACKGROUND: JobType = JobType::new(4);
 
         /// Continuous SQL jobs will use this reservation. Reservations with
         /// continuous assignments cannot be mixed with non-continuous assignments.
-        pub const CONTINUOUS: JobType = JobType::new("CONTINUOUS");
+        pub const CONTINUOUS: JobType = JobType::new(6);
+
+        /// Creates a new JobType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("JOB_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PIPELINE"),
+                2 => std::borrow::Cow::Borrowed("QUERY"),
+                3 => std::borrow::Cow::Borrowed("ML_EXTERNAL"),
+                4 => std::borrow::Cow::Borrowed("BACKGROUND"),
+                6 => std::borrow::Cow::Borrowed("CONTINUOUS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "JOB_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::JOB_TYPE_UNSPECIFIED),
+                "PIPELINE" => std::option::Option::Some(Self::PIPELINE),
+                "QUERY" => std::option::Option::Some(Self::QUERY),
+                "ML_EXTERNAL" => std::option::Option::Some(Self::ML_EXTERNAL),
+                "BACKGROUND" => std::option::Option::Some(Self::BACKGROUND),
+                "CONTINUOUS" => std::option::Option::Some(Self::CONTINUOUS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for JobType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for JobType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for JobType {
         fn default() -> Self {
-            job_type::JOB_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1609,44 +1677,59 @@ pub mod assignment {
     /// present. It will become ACTIVE when some capacity commitment becomes
     /// active.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Invalid state value.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Queries from assignee will be executed as on-demand, if related
         /// assignment is pending.
-        pub const PENDING: State = State::new("PENDING");
+        pub const PENDING: State = State::new(1);
 
         /// Assignment is ready.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2443,45 +2526,62 @@ impl wkt::message::Message for UpdateBiReservationRequest {
 /// Different features and behaviors are provided to different editions
 /// Capacity commitments and reservations are linked to editions.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Edition(std::borrow::Cow<'static, str>);
+pub struct Edition(i32);
 
 impl Edition {
+    /// Default value, which will be treated as ENTERPRISE.
+    pub const EDITION_UNSPECIFIED: Edition = Edition::new(0);
+
+    /// Standard edition.
+    pub const STANDARD: Edition = Edition::new(1);
+
+    /// Enterprise edition.
+    pub const ENTERPRISE: Edition = Edition::new(2);
+
+    /// Enterprise Plus edition.
+    pub const ENTERPRISE_PLUS: Edition = Edition::new(3);
+
     /// Creates a new Edition instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("EDITION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("STANDARD"),
+            2 => std::borrow::Cow::Borrowed("ENTERPRISE"),
+            3 => std::borrow::Cow::Borrowed("ENTERPRISE_PLUS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "EDITION_UNSPECIFIED" => std::option::Option::Some(Self::EDITION_UNSPECIFIED),
+            "STANDARD" => std::option::Option::Some(Self::STANDARD),
+            "ENTERPRISE" => std::option::Option::Some(Self::ENTERPRISE),
+            "ENTERPRISE_PLUS" => std::option::Option::Some(Self::ENTERPRISE_PLUS),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [Edition](Edition)
-pub mod edition {
-    use super::Edition;
-
-    /// Default value, which will be treated as ENTERPRISE.
-    pub const EDITION_UNSPECIFIED: Edition = Edition::new("EDITION_UNSPECIFIED");
-
-    /// Standard edition.
-    pub const STANDARD: Edition = Edition::new("STANDARD");
-
-    /// Enterprise edition.
-    pub const ENTERPRISE: Edition = Edition::new("ENTERPRISE");
-
-    /// Enterprise Plus edition.
-    pub const ENTERPRISE_PLUS: Edition = Edition::new("ENTERPRISE_PLUS");
-}
-
-impl std::convert::From<std::string::String> for Edition {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Edition {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Edition {
     fn default() -> Self {
-        edition::EDITION_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/bigquery/reservation/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::ReservationService for ReservationService {
                 reqwest::Method::POST,
                 format!("/v1/{}/reservations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::ReservationService for ReservationService {
                 reqwest::Method::GET,
                 format!("/v1/{}/reservations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -96,7 +96,7 @@ impl crate::stubs::ReservationService for ReservationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -115,7 +115,7 @@ impl crate::stubs::ReservationService for ReservationService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -143,7 +143,7 @@ impl crate::stubs::ReservationService for ReservationService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -175,7 +175,7 @@ impl crate::stubs::ReservationService for ReservationService {
                 reqwest::Method::POST,
                 format!("/v1/{}:failoverReservation", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -195,7 +195,7 @@ impl crate::stubs::ReservationService for ReservationService {
                 reqwest::Method::POST,
                 format!("/v1/{}/capacityCommitments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -222,7 +222,7 @@ impl crate::stubs::ReservationService for ReservationService {
                 reqwest::Method::GET,
                 format!("/v1/{}/capacityCommitments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -243,7 +243,7 @@ impl crate::stubs::ReservationService for ReservationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -262,7 +262,7 @@ impl crate::stubs::ReservationService for ReservationService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -291,7 +291,7 @@ impl crate::stubs::ReservationService for ReservationService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -320,7 +320,7 @@ impl crate::stubs::ReservationService for ReservationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:split", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -340,7 +340,7 @@ impl crate::stubs::ReservationService for ReservationService {
                 reqwest::Method::POST,
                 format!("/v1/{}/capacityCommitments:merge", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -360,7 +360,7 @@ impl crate::stubs::ReservationService for ReservationService {
                 reqwest::Method::POST,
                 format!("/v1/{}/assignments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -383,7 +383,7 @@ impl crate::stubs::ReservationService for ReservationService {
                 reqwest::Method::GET,
                 format!("/v1/{}/assignments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -404,7 +404,7 @@ impl crate::stubs::ReservationService for ReservationService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -426,7 +426,7 @@ impl crate::stubs::ReservationService for ReservationService {
                 reqwest::Method::GET,
                 format!("/v1/{}:searchAssignments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -451,7 +451,7 @@ impl crate::stubs::ReservationService for ReservationService {
                 reqwest::Method::GET,
                 format!("/v1/{}:searchAllAssignments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -473,7 +473,7 @@ impl crate::stubs::ReservationService for ReservationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:move", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -499,7 +499,7 @@ impl crate::stubs::ReservationService for ReservationService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -528,7 +528,7 @@ impl crate::stubs::ReservationService for ReservationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -556,7 +556,7 @@ impl crate::stubs::ReservationService for ReservationService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/billing/v1/src/model.rs
+++ b/src/generated/cloud/billing/v1/src/model.rs
@@ -1308,41 +1308,57 @@ pub mod aggregation_info {
     /// Example: "ACCOUNT" aggregation level indicates that usage for tiered
     /// pricing is aggregated across all projects in a single account.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AggregationLevel(std::borrow::Cow<'static, str>);
+    pub struct AggregationLevel(i32);
 
     impl AggregationLevel {
+        pub const AGGREGATION_LEVEL_UNSPECIFIED: AggregationLevel = AggregationLevel::new(0);
+
+        pub const ACCOUNT: AggregationLevel = AggregationLevel::new(1);
+
+        pub const PROJECT: AggregationLevel = AggregationLevel::new(2);
+
         /// Creates a new AggregationLevel instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("AGGREGATION_LEVEL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACCOUNT"),
+                2 => std::borrow::Cow::Borrowed("PROJECT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "AGGREGATION_LEVEL_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::AGGREGATION_LEVEL_UNSPECIFIED)
+                }
+                "ACCOUNT" => std::option::Option::Some(Self::ACCOUNT),
+                "PROJECT" => std::option::Option::Some(Self::PROJECT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AggregationLevel](AggregationLevel)
-    pub mod aggregation_level {
-        use super::AggregationLevel;
-
-        pub const AGGREGATION_LEVEL_UNSPECIFIED: AggregationLevel =
-            AggregationLevel::new("AGGREGATION_LEVEL_UNSPECIFIED");
-
-        pub const ACCOUNT: AggregationLevel = AggregationLevel::new("ACCOUNT");
-
-        pub const PROJECT: AggregationLevel = AggregationLevel::new("PROJECT");
-    }
-
-    impl std::convert::From<std::string::String> for AggregationLevel {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AggregationLevel {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AggregationLevel {
         fn default() -> Self {
-            aggregation_level::AGGREGATION_LEVEL_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1350,41 +1366,58 @@ pub mod aggregation_info {
     /// Example: "MONTHLY" aggregation interval indicates that usage for tiered
     /// pricing is aggregated every month.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AggregationInterval(std::borrow::Cow<'static, str>);
+    pub struct AggregationInterval(i32);
 
     impl AggregationInterval {
+        pub const AGGREGATION_INTERVAL_UNSPECIFIED: AggregationInterval =
+            AggregationInterval::new(0);
+
+        pub const DAILY: AggregationInterval = AggregationInterval::new(1);
+
+        pub const MONTHLY: AggregationInterval = AggregationInterval::new(2);
+
         /// Creates a new AggregationInterval instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("AGGREGATION_INTERVAL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DAILY"),
+                2 => std::borrow::Cow::Borrowed("MONTHLY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "AGGREGATION_INTERVAL_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::AGGREGATION_INTERVAL_UNSPECIFIED)
+                }
+                "DAILY" => std::option::Option::Some(Self::DAILY),
+                "MONTHLY" => std::option::Option::Some(Self::MONTHLY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AggregationInterval](AggregationInterval)
-    pub mod aggregation_interval {
-        use super::AggregationInterval;
-
-        pub const AGGREGATION_INTERVAL_UNSPECIFIED: AggregationInterval =
-            AggregationInterval::new("AGGREGATION_INTERVAL_UNSPECIFIED");
-
-        pub const DAILY: AggregationInterval = AggregationInterval::new("DAILY");
-
-        pub const MONTHLY: AggregationInterval = AggregationInterval::new("MONTHLY");
-    }
-
-    impl std::convert::From<std::string::String> for AggregationInterval {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AggregationInterval {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AggregationInterval {
         fn default() -> Self {
-            aggregation_interval::AGGREGATION_INTERVAL_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1444,48 +1477,65 @@ pub mod geo_taxonomy {
 
     /// The type of Geo Taxonomy: GLOBAL, REGIONAL, or MULTI_REGIONAL.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// The type is not specified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// The sku is global in nature, e.g. a license sku. Global skus are
         /// available in all regions, and so have an empty region list.
-        pub const GLOBAL: Type = Type::new("GLOBAL");
+        pub const GLOBAL: Type = Type::new(1);
 
         /// The sku is available in a specific region, e.g. "us-west2".
-        pub const REGIONAL: Type = Type::new("REGIONAL");
+        pub const REGIONAL: Type = Type::new(2);
 
         /// The sku is associated with multiple regions, e.g. "us-west2" and
         /// "us-east1".
-        pub const MULTI_REGIONAL: Type = Type::new("MULTI_REGIONAL");
+        pub const MULTI_REGIONAL: Type = Type::new(3);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GLOBAL"),
+                2 => std::borrow::Cow::Borrowed("REGIONAL"),
+                3 => std::borrow::Cow::Borrowed("MULTI_REGIONAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "GLOBAL" => std::option::Option::Some(Self::GLOBAL),
+                "REGIONAL" => std::option::Option::Some(Self::REGIONAL),
+                "MULTI_REGIONAL" => std::option::Option::Some(Self::MULTI_REGIONAL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/billing/v1/src/transport.rs
+++ b/src/generated/cloud/billing/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::CloudBilling for CloudBilling {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -68,7 +68,7 @@ impl crate::stubs::CloudBilling for CloudBilling {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v1/billingAccounts".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -91,7 +91,7 @@ impl crate::stubs::CloudBilling for CloudBilling {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -120,7 +120,7 @@ impl crate::stubs::CloudBilling for CloudBilling {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, "/v1/billingAccounts".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -140,7 +140,7 @@ impl crate::stubs::CloudBilling for CloudBilling {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/projects", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -164,7 +164,7 @@ impl crate::stubs::CloudBilling for CloudBilling {
                 reqwest::Method::GET,
                 format!("/v1/{}/billingInfo", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -186,7 +186,7 @@ impl crate::stubs::CloudBilling for CloudBilling {
                 reqwest::Method::PUT,
                 format!("/v1/{}/billingInfo", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -208,7 +208,7 @@ impl crate::stubs::CloudBilling for CloudBilling {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -240,7 +240,7 @@ impl crate::stubs::CloudBilling for CloudBilling {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -260,7 +260,7 @@ impl crate::stubs::CloudBilling for CloudBilling {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -277,7 +277,7 @@ impl crate::stubs::CloudBilling for CloudBilling {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:move", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -317,7 +317,7 @@ impl crate::stubs::CloudCatalog for CloudCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v1/services".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -338,7 +338,7 @@ impl crate::stubs::CloudCatalog for CloudCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/skus", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/binaryauthorization/v1/src/model.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/model.rs
@@ -224,44 +224,61 @@ pub mod policy {
     use super::*;
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct GlobalPolicyEvaluationMode(std::borrow::Cow<'static, str>);
+    pub struct GlobalPolicyEvaluationMode(i32);
 
     impl GlobalPolicyEvaluationMode {
+        /// Not specified: DISABLE is assumed.
+        pub const GLOBAL_POLICY_EVALUATION_MODE_UNSPECIFIED: GlobalPolicyEvaluationMode =
+            GlobalPolicyEvaluationMode::new(0);
+
+        /// Enables system policy evaluation.
+        pub const ENABLE: GlobalPolicyEvaluationMode = GlobalPolicyEvaluationMode::new(1);
+
+        /// Disables system policy evaluation.
+        pub const DISABLE: GlobalPolicyEvaluationMode = GlobalPolicyEvaluationMode::new(2);
+
         /// Creates a new GlobalPolicyEvaluationMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("GLOBAL_POLICY_EVALUATION_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENABLE"),
+                2 => std::borrow::Cow::Borrowed("DISABLE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "GLOBAL_POLICY_EVALUATION_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::GLOBAL_POLICY_EVALUATION_MODE_UNSPECIFIED)
+                }
+                "ENABLE" => std::option::Option::Some(Self::ENABLE),
+                "DISABLE" => std::option::Option::Some(Self::DISABLE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [GlobalPolicyEvaluationMode](GlobalPolicyEvaluationMode)
-    pub mod global_policy_evaluation_mode {
-        use super::GlobalPolicyEvaluationMode;
-
-        /// Not specified: DISABLE is assumed.
-        pub const GLOBAL_POLICY_EVALUATION_MODE_UNSPECIFIED: GlobalPolicyEvaluationMode =
-            GlobalPolicyEvaluationMode::new("GLOBAL_POLICY_EVALUATION_MODE_UNSPECIFIED");
-
-        /// Enables system policy evaluation.
-        pub const ENABLE: GlobalPolicyEvaluationMode = GlobalPolicyEvaluationMode::new("ENABLE");
-
-        /// Disables system policy evaluation.
-        pub const DISABLE: GlobalPolicyEvaluationMode = GlobalPolicyEvaluationMode::new("DISABLE");
-    }
-
-    impl std::convert::From<std::string::String> for GlobalPolicyEvaluationMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for GlobalPolicyEvaluationMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for GlobalPolicyEvaluationMode {
         fn default() -> Self {
-            global_policy_evaluation_mode::GLOBAL_POLICY_EVALUATION_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -387,96 +404,130 @@ pub mod admission_rule {
     use super::*;
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EvaluationMode(std::borrow::Cow<'static, str>);
+    pub struct EvaluationMode(i32);
 
     impl EvaluationMode {
-        /// Creates a new EvaluationMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [EvaluationMode](EvaluationMode)
-    pub mod evaluation_mode {
-        use super::EvaluationMode;
-
         /// Do not use.
-        pub const EVALUATION_MODE_UNSPECIFIED: EvaluationMode =
-            EvaluationMode::new("EVALUATION_MODE_UNSPECIFIED");
+        pub const EVALUATION_MODE_UNSPECIFIED: EvaluationMode = EvaluationMode::new(0);
 
         /// This rule allows all all pod creations.
-        pub const ALWAYS_ALLOW: EvaluationMode = EvaluationMode::new("ALWAYS_ALLOW");
+        pub const ALWAYS_ALLOW: EvaluationMode = EvaluationMode::new(1);
 
         /// This rule allows a pod creation if all the attestors listed in
         /// 'require_attestations_by' have valid attestations for all of the
         /// images in the pod spec.
-        pub const REQUIRE_ATTESTATION: EvaluationMode = EvaluationMode::new("REQUIRE_ATTESTATION");
+        pub const REQUIRE_ATTESTATION: EvaluationMode = EvaluationMode::new(2);
 
         /// This rule denies all pod creations.
-        pub const ALWAYS_DENY: EvaluationMode = EvaluationMode::new("ALWAYS_DENY");
+        pub const ALWAYS_DENY: EvaluationMode = EvaluationMode::new(3);
+
+        /// Creates a new EvaluationMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EVALUATION_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALWAYS_ALLOW"),
+                2 => std::borrow::Cow::Borrowed("REQUIRE_ATTESTATION"),
+                3 => std::borrow::Cow::Borrowed("ALWAYS_DENY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EVALUATION_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::EVALUATION_MODE_UNSPECIFIED)
+                }
+                "ALWAYS_ALLOW" => std::option::Option::Some(Self::ALWAYS_ALLOW),
+                "REQUIRE_ATTESTATION" => std::option::Option::Some(Self::REQUIRE_ATTESTATION),
+                "ALWAYS_DENY" => std::option::Option::Some(Self::ALWAYS_DENY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for EvaluationMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EvaluationMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EvaluationMode {
         fn default() -> Self {
-            evaluation_mode::EVALUATION_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Defines the possible actions when a pod creation is denied by an admission
     /// rule.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EnforcementMode(std::borrow::Cow<'static, str>);
+    pub struct EnforcementMode(i32);
 
     impl EnforcementMode {
-        /// Creates a new EnforcementMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [EnforcementMode](EnforcementMode)
-    pub mod enforcement_mode {
-        use super::EnforcementMode;
-
         /// Do not use.
-        pub const ENFORCEMENT_MODE_UNSPECIFIED: EnforcementMode =
-            EnforcementMode::new("ENFORCEMENT_MODE_UNSPECIFIED");
+        pub const ENFORCEMENT_MODE_UNSPECIFIED: EnforcementMode = EnforcementMode::new(0);
 
         /// Enforce the admission rule by blocking the pod creation.
-        pub const ENFORCED_BLOCK_AND_AUDIT_LOG: EnforcementMode =
-            EnforcementMode::new("ENFORCED_BLOCK_AND_AUDIT_LOG");
+        pub const ENFORCED_BLOCK_AND_AUDIT_LOG: EnforcementMode = EnforcementMode::new(1);
 
         /// Dryrun mode: Audit logging only.  This will allow the pod creation as if
         /// the admission request had specified break-glass.
-        pub const DRYRUN_AUDIT_LOG_ONLY: EnforcementMode =
-            EnforcementMode::new("DRYRUN_AUDIT_LOG_ONLY");
+        pub const DRYRUN_AUDIT_LOG_ONLY: EnforcementMode = EnforcementMode::new(2);
+
+        /// Creates a new EnforcementMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ENFORCEMENT_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENFORCED_BLOCK_AND_AUDIT_LOG"),
+                2 => std::borrow::Cow::Borrowed("DRYRUN_AUDIT_LOG_ONLY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ENFORCEMENT_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ENFORCEMENT_MODE_UNSPECIFIED)
+                }
+                "ENFORCED_BLOCK_AND_AUDIT_LOG" => {
+                    std::option::Option::Some(Self::ENFORCED_BLOCK_AND_AUDIT_LOG)
+                }
+                "DRYRUN_AUDIT_LOG_ONLY" => std::option::Option::Some(Self::DRYRUN_AUDIT_LOG_ONLY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for EnforcementMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EnforcementMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EnforcementMode {
         fn default() -> Self {
-            enforcement_mode::ENFORCEMENT_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -745,94 +796,125 @@ pub mod pkix_public_key {
     /// See <https://cloud.google.com/kms/docs/algorithms>. In the future, BinAuthz
     /// might support additional public key types independently of Tink and/or KMS.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SignatureAlgorithm(std::borrow::Cow<'static, str>);
+    pub struct SignatureAlgorithm(i32);
 
     impl SignatureAlgorithm {
+        /// Not specified.
+        pub const SIGNATURE_ALGORITHM_UNSPECIFIED: SignatureAlgorithm = SignatureAlgorithm::new(0);
+
+        /// RSASSA-PSS 2048 bit key with a SHA256 digest.
+        pub const RSA_PSS_2048_SHA256: SignatureAlgorithm = SignatureAlgorithm::new(1);
+
+        /// RSASSA-PSS 3072 bit key with a SHA256 digest.
+        pub const RSA_PSS_3072_SHA256: SignatureAlgorithm = SignatureAlgorithm::new(2);
+
+        /// RSASSA-PSS 4096 bit key with a SHA256 digest.
+        pub const RSA_PSS_4096_SHA256: SignatureAlgorithm = SignatureAlgorithm::new(3);
+
+        /// RSASSA-PSS 4096 bit key with a SHA512 digest.
+        pub const RSA_PSS_4096_SHA512: SignatureAlgorithm = SignatureAlgorithm::new(4);
+
+        /// RSASSA-PKCS1-v1_5 with a 2048 bit key and a SHA256 digest.
+        pub const RSA_SIGN_PKCS1_2048_SHA256: SignatureAlgorithm = SignatureAlgorithm::new(5);
+
+        /// RSASSA-PKCS1-v1_5 with a 3072 bit key and a SHA256 digest.
+        pub const RSA_SIGN_PKCS1_3072_SHA256: SignatureAlgorithm = SignatureAlgorithm::new(6);
+
+        /// RSASSA-PKCS1-v1_5 with a 4096 bit key and a SHA256 digest.
+        pub const RSA_SIGN_PKCS1_4096_SHA256: SignatureAlgorithm = SignatureAlgorithm::new(7);
+
+        /// RSASSA-PKCS1-v1_5 with a 4096 bit key and a SHA512 digest.
+        pub const RSA_SIGN_PKCS1_4096_SHA512: SignatureAlgorithm = SignatureAlgorithm::new(8);
+
+        /// ECDSA on the NIST P-256 curve with a SHA256 digest.
+        pub const ECDSA_P256_SHA256: SignatureAlgorithm = SignatureAlgorithm::new(9);
+
+        /// ECDSA on the NIST P-256 curve with a SHA256 digest.
+        pub const EC_SIGN_P256_SHA256: SignatureAlgorithm = SignatureAlgorithm::new(9);
+
+        /// ECDSA on the NIST P-384 curve with a SHA384 digest.
+        pub const ECDSA_P384_SHA384: SignatureAlgorithm = SignatureAlgorithm::new(10);
+
+        /// ECDSA on the NIST P-384 curve with a SHA384 digest.
+        pub const EC_SIGN_P384_SHA384: SignatureAlgorithm = SignatureAlgorithm::new(10);
+
+        /// ECDSA on the NIST P-521 curve with a SHA512 digest.
+        pub const ECDSA_P521_SHA512: SignatureAlgorithm = SignatureAlgorithm::new(11);
+
+        /// ECDSA on the NIST P-521 curve with a SHA512 digest.
+        pub const EC_SIGN_P521_SHA512: SignatureAlgorithm = SignatureAlgorithm::new(11);
+
         /// Creates a new SignatureAlgorithm instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SIGNATURE_ALGORITHM_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RSA_PSS_2048_SHA256"),
+                2 => std::borrow::Cow::Borrowed("RSA_PSS_3072_SHA256"),
+                3 => std::borrow::Cow::Borrowed("RSA_PSS_4096_SHA256"),
+                4 => std::borrow::Cow::Borrowed("RSA_PSS_4096_SHA512"),
+                5 => std::borrow::Cow::Borrowed("RSA_SIGN_PKCS1_2048_SHA256"),
+                6 => std::borrow::Cow::Borrowed("RSA_SIGN_PKCS1_3072_SHA256"),
+                7 => std::borrow::Cow::Borrowed("RSA_SIGN_PKCS1_4096_SHA256"),
+                8 => std::borrow::Cow::Borrowed("RSA_SIGN_PKCS1_4096_SHA512"),
+                9 => std::borrow::Cow::Borrowed("ECDSA_P256_SHA256"),
+                10 => std::borrow::Cow::Borrowed("ECDSA_P384_SHA384"),
+                11 => std::borrow::Cow::Borrowed("ECDSA_P521_SHA512"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SIGNATURE_ALGORITHM_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SIGNATURE_ALGORITHM_UNSPECIFIED)
+                }
+                "RSA_PSS_2048_SHA256" => std::option::Option::Some(Self::RSA_PSS_2048_SHA256),
+                "RSA_PSS_3072_SHA256" => std::option::Option::Some(Self::RSA_PSS_3072_SHA256),
+                "RSA_PSS_4096_SHA256" => std::option::Option::Some(Self::RSA_PSS_4096_SHA256),
+                "RSA_PSS_4096_SHA512" => std::option::Option::Some(Self::RSA_PSS_4096_SHA512),
+                "RSA_SIGN_PKCS1_2048_SHA256" => {
+                    std::option::Option::Some(Self::RSA_SIGN_PKCS1_2048_SHA256)
+                }
+                "RSA_SIGN_PKCS1_3072_SHA256" => {
+                    std::option::Option::Some(Self::RSA_SIGN_PKCS1_3072_SHA256)
+                }
+                "RSA_SIGN_PKCS1_4096_SHA256" => {
+                    std::option::Option::Some(Self::RSA_SIGN_PKCS1_4096_SHA256)
+                }
+                "RSA_SIGN_PKCS1_4096_SHA512" => {
+                    std::option::Option::Some(Self::RSA_SIGN_PKCS1_4096_SHA512)
+                }
+                "ECDSA_P256_SHA256" => std::option::Option::Some(Self::ECDSA_P256_SHA256),
+                "EC_SIGN_P256_SHA256" => std::option::Option::Some(Self::EC_SIGN_P256_SHA256),
+                "ECDSA_P384_SHA384" => std::option::Option::Some(Self::ECDSA_P384_SHA384),
+                "EC_SIGN_P384_SHA384" => std::option::Option::Some(Self::EC_SIGN_P384_SHA384),
+                "ECDSA_P521_SHA512" => std::option::Option::Some(Self::ECDSA_P521_SHA512),
+                "EC_SIGN_P521_SHA512" => std::option::Option::Some(Self::EC_SIGN_P521_SHA512),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SignatureAlgorithm](SignatureAlgorithm)
-    pub mod signature_algorithm {
-        use super::SignatureAlgorithm;
-
-        /// Not specified.
-        pub const SIGNATURE_ALGORITHM_UNSPECIFIED: SignatureAlgorithm =
-            SignatureAlgorithm::new("SIGNATURE_ALGORITHM_UNSPECIFIED");
-
-        /// RSASSA-PSS 2048 bit key with a SHA256 digest.
-        pub const RSA_PSS_2048_SHA256: SignatureAlgorithm =
-            SignatureAlgorithm::new("RSA_PSS_2048_SHA256");
-
-        /// RSASSA-PSS 3072 bit key with a SHA256 digest.
-        pub const RSA_PSS_3072_SHA256: SignatureAlgorithm =
-            SignatureAlgorithm::new("RSA_PSS_3072_SHA256");
-
-        /// RSASSA-PSS 4096 bit key with a SHA256 digest.
-        pub const RSA_PSS_4096_SHA256: SignatureAlgorithm =
-            SignatureAlgorithm::new("RSA_PSS_4096_SHA256");
-
-        /// RSASSA-PSS 4096 bit key with a SHA512 digest.
-        pub const RSA_PSS_4096_SHA512: SignatureAlgorithm =
-            SignatureAlgorithm::new("RSA_PSS_4096_SHA512");
-
-        /// RSASSA-PKCS1-v1_5 with a 2048 bit key and a SHA256 digest.
-        pub const RSA_SIGN_PKCS1_2048_SHA256: SignatureAlgorithm =
-            SignatureAlgorithm::new("RSA_SIGN_PKCS1_2048_SHA256");
-
-        /// RSASSA-PKCS1-v1_5 with a 3072 bit key and a SHA256 digest.
-        pub const RSA_SIGN_PKCS1_3072_SHA256: SignatureAlgorithm =
-            SignatureAlgorithm::new("RSA_SIGN_PKCS1_3072_SHA256");
-
-        /// RSASSA-PKCS1-v1_5 with a 4096 bit key and a SHA256 digest.
-        pub const RSA_SIGN_PKCS1_4096_SHA256: SignatureAlgorithm =
-            SignatureAlgorithm::new("RSA_SIGN_PKCS1_4096_SHA256");
-
-        /// RSASSA-PKCS1-v1_5 with a 4096 bit key and a SHA512 digest.
-        pub const RSA_SIGN_PKCS1_4096_SHA512: SignatureAlgorithm =
-            SignatureAlgorithm::new("RSA_SIGN_PKCS1_4096_SHA512");
-
-        /// ECDSA on the NIST P-256 curve with a SHA256 digest.
-        pub const ECDSA_P256_SHA256: SignatureAlgorithm =
-            SignatureAlgorithm::new("ECDSA_P256_SHA256");
-
-        /// ECDSA on the NIST P-256 curve with a SHA256 digest.
-        pub const EC_SIGN_P256_SHA256: SignatureAlgorithm =
-            SignatureAlgorithm::new("EC_SIGN_P256_SHA256");
-
-        /// ECDSA on the NIST P-384 curve with a SHA384 digest.
-        pub const ECDSA_P384_SHA384: SignatureAlgorithm =
-            SignatureAlgorithm::new("ECDSA_P384_SHA384");
-
-        /// ECDSA on the NIST P-384 curve with a SHA384 digest.
-        pub const EC_SIGN_P384_SHA384: SignatureAlgorithm =
-            SignatureAlgorithm::new("EC_SIGN_P384_SHA384");
-
-        /// ECDSA on the NIST P-521 curve with a SHA512 digest.
-        pub const ECDSA_P521_SHA512: SignatureAlgorithm =
-            SignatureAlgorithm::new("ECDSA_P521_SHA512");
-
-        /// ECDSA on the NIST P-521 curve with a SHA512 digest.
-        pub const EC_SIGN_P521_SHA512: SignatureAlgorithm =
-            SignatureAlgorithm::new("EC_SIGN_P521_SHA512");
-    }
-
-    impl std::convert::From<std::string::String> for SignatureAlgorithm {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SignatureAlgorithm {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SignatureAlgorithm {
         fn default() -> Self {
-            signature_algorithm::SIGNATURE_ALGORITHM_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1501,43 +1583,60 @@ pub mod validate_attestation_occurrence_response {
 
     /// The enum returned in the "result" field.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Result(std::borrow::Cow<'static, str>);
+    pub struct Result(i32);
 
     impl Result {
+        /// Unspecified.
+        pub const RESULT_UNSPECIFIED: Result = Result::new(0);
+
+        /// The Attestation was able to verified by the Attestor.
+        pub const VERIFIED: Result = Result::new(1);
+
+        /// The Attestation was not able to verified by the Attestor.
+        pub const ATTESTATION_NOT_VERIFIABLE: Result = Result::new(2);
+
         /// Creates a new Result instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RESULT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("VERIFIED"),
+                2 => std::borrow::Cow::Borrowed("ATTESTATION_NOT_VERIFIABLE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RESULT_UNSPECIFIED" => std::option::Option::Some(Self::RESULT_UNSPECIFIED),
+                "VERIFIED" => std::option::Option::Some(Self::VERIFIED),
+                "ATTESTATION_NOT_VERIFIABLE" => {
+                    std::option::Option::Some(Self::ATTESTATION_NOT_VERIFIABLE)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Result](Result)
-    pub mod result {
-        use super::Result;
-
-        /// Unspecified.
-        pub const RESULT_UNSPECIFIED: Result = Result::new("RESULT_UNSPECIFIED");
-
-        /// The Attestation was able to verified by the Attestor.
-        pub const VERIFIED: Result = Result::new("VERIFIED");
-
-        /// The Attestation was not able to verified by the Attestor.
-        pub const ATTESTATION_NOT_VERIFIABLE: Result = Result::new("ATTESTATION_NOT_VERIFIABLE");
-    }
-
-    impl std::convert::From<std::string::String> for Result {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Result {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Result {
         fn default() -> Self {
-            result::RESULT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/binaryauthorization/v1/src/transport.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -77,7 +77,7 @@ impl crate::stubs::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
                 reqwest::Method::POST,
                 format!("/v1/{}/attestors", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -117,7 +117,7 @@ impl crate::stubs::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -145,7 +145,7 @@ impl crate::stubs::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -167,7 +167,7 @@ impl crate::stubs::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
                 reqwest::Method::GET,
                 format!("/v1/{}/attestors", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -188,7 +188,7 @@ impl crate::stubs::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -230,7 +230,7 @@ impl crate::stubs::SystemPolicyV1 for SystemPolicyV1 {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -275,7 +275,7 @@ impl crate::stubs::ValidationHelperV1 for ValidationHelperV1 {
                 reqwest::Method::POST,
                 format!("/v1/{}:validateAttestationOccurrence", req.attestor),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/certificatemanager/v1/src/model.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/model.rs
@@ -557,44 +557,60 @@ pub mod certificate_issuance_config {
 
     /// The type of keypair to generate.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct KeyAlgorithm(std::borrow::Cow<'static, str>);
+    pub struct KeyAlgorithm(i32);
 
     impl KeyAlgorithm {
+        /// Unspecified key algorithm.
+        pub const KEY_ALGORITHM_UNSPECIFIED: KeyAlgorithm = KeyAlgorithm::new(0);
+
+        /// Specifies RSA with a 2048-bit modulus.
+        pub const RSA_2048: KeyAlgorithm = KeyAlgorithm::new(1);
+
+        /// Specifies ECDSA with curve P256.
+        pub const ECDSA_P256: KeyAlgorithm = KeyAlgorithm::new(4);
+
         /// Creates a new KeyAlgorithm instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("KEY_ALGORITHM_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RSA_2048"),
+                4 => std::borrow::Cow::Borrowed("ECDSA_P256"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "KEY_ALGORITHM_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::KEY_ALGORITHM_UNSPECIFIED)
+                }
+                "RSA_2048" => std::option::Option::Some(Self::RSA_2048),
+                "ECDSA_P256" => std::option::Option::Some(Self::ECDSA_P256),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [KeyAlgorithm](KeyAlgorithm)
-    pub mod key_algorithm {
-        use super::KeyAlgorithm;
-
-        /// Unspecified key algorithm.
-        pub const KEY_ALGORITHM_UNSPECIFIED: KeyAlgorithm =
-            KeyAlgorithm::new("KEY_ALGORITHM_UNSPECIFIED");
-
-        /// Specifies RSA with a 2048-bit modulus.
-        pub const RSA_2048: KeyAlgorithm = KeyAlgorithm::new("RSA_2048");
-
-        /// Specifies ECDSA with curve P256.
-        pub const ECDSA_P256: KeyAlgorithm = KeyAlgorithm::new("ECDSA_P256");
-    }
-
-    impl std::convert::From<std::string::String> for KeyAlgorithm {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for KeyAlgorithm {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for KeyAlgorithm {
         fn default() -> Self {
-            key_algorithm::KEY_ALGORITHM_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2403,47 +2419,64 @@ pub mod certificate {
 
             /// Reason for provisioning failures.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct Reason(std::borrow::Cow<'static, str>);
+            pub struct Reason(i32);
 
             impl Reason {
-                /// Creates a new Reason instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [Reason](Reason)
-            pub mod reason {
-                use super::Reason;
-
                 /// Reason is unspecified.
-                pub const REASON_UNSPECIFIED: Reason = Reason::new("REASON_UNSPECIFIED");
+                pub const REASON_UNSPECIFIED: Reason = Reason::new(0);
 
                 /// Certificate provisioning failed due to an issue with one or more of
                 /// the domains on the certificate.
                 /// For details of which domains failed, consult the
                 /// `authorization_attempt_info` field.
-                pub const AUTHORIZATION_ISSUE: Reason = Reason::new("AUTHORIZATION_ISSUE");
+                pub const AUTHORIZATION_ISSUE: Reason = Reason::new(1);
 
                 /// Exceeded Certificate Authority quotas or internal rate limits of the
                 /// system. Provisioning may take longer to complete.
-                pub const RATE_LIMITED: Reason = Reason::new("RATE_LIMITED");
+                pub const RATE_LIMITED: Reason = Reason::new(2);
+
+                /// Creates a new Reason instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("REASON_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("AUTHORIZATION_ISSUE"),
+                        2 => std::borrow::Cow::Borrowed("RATE_LIMITED"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "REASON_UNSPECIFIED" => std::option::Option::Some(Self::REASON_UNSPECIFIED),
+                        "AUTHORIZATION_ISSUE" => {
+                            std::option::Option::Some(Self::AUTHORIZATION_ISSUE)
+                        }
+                        "RATE_LIMITED" => std::option::Option::Some(Self::RATE_LIMITED),
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for Reason {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for Reason {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for Reason {
                 fn default() -> Self {
-                    reason::REASON_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -2517,197 +2550,264 @@ pub mod certificate {
 
             /// State of the domain for managed certificate issuance.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct State(std::borrow::Cow<'static, str>);
+            pub struct State(i32);
 
             impl State {
-                /// Creates a new State instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [State](State)
-            pub mod state {
-                use super::State;
-
                 /// State is unspecified.
-                pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+                pub const STATE_UNSPECIFIED: State = State::new(0);
 
                 /// Certificate provisioning for this domain is under way. Google Cloud
                 /// will attempt to authorize the domain.
-                pub const AUTHORIZING: State = State::new("AUTHORIZING");
+                pub const AUTHORIZING: State = State::new(1);
 
                 /// A managed certificate can be provisioned, no issues for this domain.
-                pub const AUTHORIZED: State = State::new("AUTHORIZED");
+                pub const AUTHORIZED: State = State::new(6);
 
                 /// Attempt to authorize the domain failed. This prevents the Managed
                 /// Certificate from being issued.
                 /// See `failure_reason` and `details` fields for more information.
-                pub const FAILED: State = State::new("FAILED");
+                pub const FAILED: State = State::new(7);
+
+                /// Creates a new State instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("AUTHORIZING"),
+                        6 => std::borrow::Cow::Borrowed("AUTHORIZED"),
+                        7 => std::borrow::Cow::Borrowed("FAILED"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                        "AUTHORIZING" => std::option::Option::Some(Self::AUTHORIZING),
+                        "AUTHORIZED" => std::option::Option::Some(Self::AUTHORIZED),
+                        "FAILED" => std::option::Option::Some(Self::FAILED),
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for State {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for State {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for State {
                 fn default() -> Self {
-                    state::STATE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
 
             /// Reason for failure of the authorization attempt for the domain.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct FailureReason(std::borrow::Cow<'static, str>);
+            pub struct FailureReason(i32);
 
             impl FailureReason {
-                /// Creates a new FailureReason instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [FailureReason](FailureReason)
-            pub mod failure_reason {
-                use super::FailureReason;
-
                 /// FailureReason is unspecified.
-                pub const FAILURE_REASON_UNSPECIFIED: FailureReason =
-                    FailureReason::new("FAILURE_REASON_UNSPECIFIED");
+                pub const FAILURE_REASON_UNSPECIFIED: FailureReason = FailureReason::new(0);
 
                 /// There was a problem with the user's DNS or load balancer
                 /// configuration for this domain.
-                pub const CONFIG: FailureReason = FailureReason::new("CONFIG");
+                pub const CONFIG: FailureReason = FailureReason::new(1);
 
                 /// Certificate issuance forbidden by an explicit CAA record for the
                 /// domain or a failure to check CAA records for the domain.
-                pub const CAA: FailureReason = FailureReason::new("CAA");
+                pub const CAA: FailureReason = FailureReason::new(2);
 
                 /// Reached a CA or internal rate-limit for the domain,
                 /// e.g. for certificates per top-level private domain.
-                pub const RATE_LIMITED: FailureReason = FailureReason::new("RATE_LIMITED");
+                pub const RATE_LIMITED: FailureReason = FailureReason::new(3);
+
+                /// Creates a new FailureReason instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("FAILURE_REASON_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("CONFIG"),
+                        2 => std::borrow::Cow::Borrowed("CAA"),
+                        3 => std::borrow::Cow::Borrowed("RATE_LIMITED"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "FAILURE_REASON_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::FAILURE_REASON_UNSPECIFIED)
+                        }
+                        "CONFIG" => std::option::Option::Some(Self::CONFIG),
+                        "CAA" => std::option::Option::Some(Self::CAA),
+                        "RATE_LIMITED" => std::option::Option::Some(Self::RATE_LIMITED),
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for FailureReason {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for FailureReason {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for FailureReason {
                 fn default() -> Self {
-                    failure_reason::FAILURE_REASON_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
 
         /// State of the managed certificate resource.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(std::borrow::Cow<'static, str>);
+        pub struct State(i32);
 
         impl State {
-            /// Creates a new State instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [State](State)
-        pub mod state {
-            use super::State;
-
             /// State is unspecified.
-            pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+            pub const STATE_UNSPECIFIED: State = State::new(0);
 
             /// Certificate Manager attempts to provision or renew the certificate.
             /// If the process takes longer than expected, consult the
             /// `provisioning_issue` field.
-            pub const PROVISIONING: State = State::new("PROVISIONING");
+            pub const PROVISIONING: State = State::new(1);
 
             /// Multiple certificate provisioning attempts failed and Certificate
             /// Manager gave up. To try again, delete and create a new managed
             /// Certificate resource.
             /// For details see the `provisioning_issue` field.
-            pub const FAILED: State = State::new("FAILED");
+            pub const FAILED: State = State::new(2);
 
             /// The certificate management is working, and a certificate has been
             /// provisioned.
-            pub const ACTIVE: State = State::new("ACTIVE");
+            pub const ACTIVE: State = State::new(3);
+
+            /// Creates a new State instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("PROVISIONING"),
+                    2 => std::borrow::Cow::Borrowed("FAILED"),
+                    3 => std::borrow::Cow::Borrowed("ACTIVE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                    "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
+                    "FAILED" => std::option::Option::Some(Self::FAILED),
+                    "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for State {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                state::STATE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// Certificate scope.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Scope(std::borrow::Cow<'static, str>);
+    pub struct Scope(i32);
 
     impl Scope {
-        /// Creates a new Scope instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Scope](Scope)
-    pub mod scope {
-        use super::Scope;
-
         /// Certificates with default scope are served from core Google data centers.
         /// If unsure, choose this option.
-        pub const DEFAULT: Scope = Scope::new("DEFAULT");
+        pub const DEFAULT: Scope = Scope::new(0);
 
         /// Certificates with scope EDGE_CACHE are special-purposed certificates,
         /// served from Edge Points of Presence.
         /// See <https://cloud.google.com/vpc/docs/edge-locations>.
-        pub const EDGE_CACHE: Scope = Scope::new("EDGE_CACHE");
+        pub const EDGE_CACHE: Scope = Scope::new(1);
 
         /// Certificates with ALL_REGIONS scope are served from all Google Cloud
         /// regions. See <https://cloud.google.com/compute/docs/regions-zones>.
-        pub const ALL_REGIONS: Scope = Scope::new("ALL_REGIONS");
+        pub const ALL_REGIONS: Scope = Scope::new(2);
+
+        /// Creates a new Scope instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DEFAULT"),
+                1 => std::borrow::Cow::Borrowed("EDGE_CACHE"),
+                2 => std::borrow::Cow::Borrowed("ALL_REGIONS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
+                "EDGE_CACHE" => std::option::Option::Some(Self::EDGE_CACHE),
+                "ALL_REGIONS" => std::option::Option::Some(Self::ALL_REGIONS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Scope {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Scope {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Scope {
         fn default() -> Self {
-            scope::DEFAULT
+            Self::new(0)
         }
     }
 
@@ -3187,41 +3287,54 @@ pub mod certificate_map_entry {
     /// Defines predefined cases other than SNI-hostname match when this
     /// configuration should be applied.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Matcher(std::borrow::Cow<'static, str>);
+    pub struct Matcher(i32);
 
     impl Matcher {
-        /// Creates a new Matcher instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Matcher](Matcher)
-    pub mod matcher {
-        use super::Matcher;
-
         /// A matcher has't been recognized.
-        pub const MATCHER_UNSPECIFIED: Matcher = Matcher::new("MATCHER_UNSPECIFIED");
+        pub const MATCHER_UNSPECIFIED: Matcher = Matcher::new(0);
 
         /// A primary certificate that is served when SNI wasn't specified in the
         /// request or SNI couldn't be found in the map.
-        pub const PRIMARY: Matcher = Matcher::new("PRIMARY");
+        pub const PRIMARY: Matcher = Matcher::new(1);
+
+        /// Creates a new Matcher instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MATCHER_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PRIMARY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MATCHER_UNSPECIFIED" => std::option::Option::Some(Self::MATCHER_UNSPECIFIED),
+                "PRIMARY" => std::option::Option::Some(Self::PRIMARY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Matcher {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Matcher {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Matcher {
         fn default() -> Self {
-            matcher::MATCHER_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -3429,45 +3542,60 @@ pub mod dns_authorization {
 
     /// DnsAuthorization type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// Type is unspecified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// FIXED_RECORD DNS authorization uses DNS-01 validation method.
-        pub const FIXED_RECORD: Type = Type::new("FIXED_RECORD");
+        pub const FIXED_RECORD: Type = Type::new(1);
 
         /// PER_PROJECT_RECORD DNS authorization allows for independent management
         /// of Google-managed certificates with DNS authorization across multiple
         /// projects.
-        pub const PER_PROJECT_RECORD: Type = Type::new("PER_PROJECT_RECORD");
+        pub const PER_PROJECT_RECORD: Type = Type::new(2);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FIXED_RECORD"),
+                2 => std::borrow::Cow::Borrowed("PER_PROJECT_RECORD"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "FIXED_RECORD" => std::option::Option::Some(Self::FIXED_RECORD),
+                "PER_PROJECT_RECORD" => std::option::Option::Some(Self::PER_PROJECT_RECORD),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4130,43 +4258,59 @@ pub mod trust_config {
 
 /// Defines set of serving states associated with a resource.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ServingState(std::borrow::Cow<'static, str>);
+pub struct ServingState(i32);
 
 impl ServingState {
+    /// The status is undefined.
+    pub const SERVING_STATE_UNSPECIFIED: ServingState = ServingState::new(0);
+
+    /// The configuration is serving.
+    pub const ACTIVE: ServingState = ServingState::new(1);
+
+    /// Update is in progress. Some frontends may serve this configuration.
+    pub const PENDING: ServingState = ServingState::new(2);
+
     /// Creates a new ServingState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SERVING_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ACTIVE"),
+            2 => std::borrow::Cow::Borrowed("PENDING"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SERVING_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::SERVING_STATE_UNSPECIFIED)
+            }
+            "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+            "PENDING" => std::option::Option::Some(Self::PENDING),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [ServingState](ServingState)
-pub mod serving_state {
-    use super::ServingState;
-
-    /// The status is undefined.
-    pub const SERVING_STATE_UNSPECIFIED: ServingState =
-        ServingState::new("SERVING_STATE_UNSPECIFIED");
-
-    /// The configuration is serving.
-    pub const ACTIVE: ServingState = ServingState::new("ACTIVE");
-
-    /// Update is in progress. Some frontends may serve this configuration.
-    pub const PENDING: ServingState = ServingState::new("PENDING");
-}
-
-impl std::convert::From<std::string::String> for ServingState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ServingState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ServingState {
     fn default() -> Self {
-        serving_state::SERVING_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/certificatemanager/v1/src/transport.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/certificates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/certificates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -126,7 +126,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -155,7 +155,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -177,7 +177,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/certificateMaps", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -200,7 +200,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -222,7 +222,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/certificateMaps", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -251,7 +251,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -280,7 +280,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -302,7 +302,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/certificateMapEntries", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -325,7 +325,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -347,7 +347,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/certificateMapEntries", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -376,7 +376,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -405,7 +405,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -427,7 +427,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/dnsAuthorizations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -450,7 +450,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -472,7 +472,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/dnsAuthorizations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -501,7 +501,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -530,7 +530,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -552,7 +552,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/certificateIssuanceConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -575,7 +575,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -597,7 +597,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/certificateIssuanceConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -620,7 +620,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -642,7 +642,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/trustConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -665,7 +665,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -687,7 +687,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/trustConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -716,7 +716,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -745,7 +745,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -765,7 +765,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -787,7 +787,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -806,7 +806,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -828,7 +828,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -847,7 +847,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -866,7 +866,7 @@ impl crate::stubs::CertificateManager for CertificateManager {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/model.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/model.rs
@@ -300,26 +300,11 @@ pub mod access_reason {
 
     /// Type of access justification.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// Default value for proto, shouldn't be used.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// Customer made a request or raised an issue that required the principal to
         /// access customer data. `detail` is of the form ("#####" is the issue ID):
@@ -330,44 +315,91 @@ pub mod access_reason {
         /// - "E-PIN Reference: #####"
         /// - "Google-#####"
         /// - "T-#####"
-        pub const CUSTOMER_INITIATED_SUPPORT: Type = Type::new("CUSTOMER_INITIATED_SUPPORT");
+        pub const CUSTOMER_INITIATED_SUPPORT: Type = Type::new(1);
 
         /// The principal accessed customer data in order to diagnose or resolve a
         /// suspected issue in services. Often this access is used to confirm that
         /// customers are not affected by a suspected service issue or to remediate a
         /// reversible system issue.
-        pub const GOOGLE_INITIATED_SERVICE: Type = Type::new("GOOGLE_INITIATED_SERVICE");
+        pub const GOOGLE_INITIATED_SERVICE: Type = Type::new(2);
 
         /// Google initiated service for security, fraud, abuse, or compliance
         /// purposes.
-        pub const GOOGLE_INITIATED_REVIEW: Type = Type::new("GOOGLE_INITIATED_REVIEW");
+        pub const GOOGLE_INITIATED_REVIEW: Type = Type::new(3);
 
         /// The principal was compelled to access customer data in order to respond
         /// to a legal third party data request or process, including legal processes
         /// from customers themselves.
-        pub const THIRD_PARTY_DATA_REQUEST: Type = Type::new("THIRD_PARTY_DATA_REQUEST");
+        pub const THIRD_PARTY_DATA_REQUEST: Type = Type::new(4);
 
         /// The principal accessed customer data in order to diagnose or resolve a
         /// suspected issue in services or a known outage.
-        pub const GOOGLE_RESPONSE_TO_PRODUCTION_ALERT: Type =
-            Type::new("GOOGLE_RESPONSE_TO_PRODUCTION_ALERT");
+        pub const GOOGLE_RESPONSE_TO_PRODUCTION_ALERT: Type = Type::new(5);
 
         /// Similar to 'GOOGLE_INITIATED_SERVICE' or 'GOOGLE_INITIATED_REVIEW', but
         /// with universe agnostic naming. The principal accessed customer data in
         /// order to diagnose or resolve a suspected issue in services or a known
         /// outage, or for security, fraud, abuse, or compliance review purposes.
-        pub const CLOUD_INITIATED_ACCESS: Type = Type::new("CLOUD_INITIATED_ACCESS");
+        pub const CLOUD_INITIATED_ACCESS: Type = Type::new(6);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CUSTOMER_INITIATED_SUPPORT"),
+                2 => std::borrow::Cow::Borrowed("GOOGLE_INITIATED_SERVICE"),
+                3 => std::borrow::Cow::Borrowed("GOOGLE_INITIATED_REVIEW"),
+                4 => std::borrow::Cow::Borrowed("THIRD_PARTY_DATA_REQUEST"),
+                5 => std::borrow::Cow::Borrowed("GOOGLE_RESPONSE_TO_PRODUCTION_ALERT"),
+                6 => std::borrow::Cow::Borrowed("CLOUD_INITIATED_ACCESS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "CUSTOMER_INITIATED_SUPPORT" => {
+                    std::option::Option::Some(Self::CUSTOMER_INITIATED_SUPPORT)
+                }
+                "GOOGLE_INITIATED_SERVICE" => {
+                    std::option::Option::Some(Self::GOOGLE_INITIATED_SERVICE)
+                }
+                "GOOGLE_INITIATED_REVIEW" => {
+                    std::option::Option::Some(Self::GOOGLE_INITIATED_REVIEW)
+                }
+                "THIRD_PARTY_DATA_REQUEST" => {
+                    std::option::Option::Some(Self::THIRD_PARTY_DATA_REQUEST)
+                }
+                "GOOGLE_RESPONSE_TO_PRODUCTION_ALERT" => {
+                    std::option::Option::Some(Self::GOOGLE_RESPONSE_TO_PRODUCTION_ALERT)
+                }
+                "CLOUD_INITIATED_ACCESS" => std::option::Option::Some(Self::CLOUD_INITIATED_ACCESS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -601,62 +633,91 @@ pub mod workload {
 
     /// Supported Assured Workloads Partners.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Partner(std::borrow::Cow<'static, str>);
+    pub struct Partner(i32);
 
     impl Partner {
-        /// Creates a new Partner instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Partner](Partner)
-    pub mod partner {
-        use super::Partner;
-
         /// Unknown Partner.
-        pub const PARTNER_UNSPECIFIED: Partner = Partner::new("PARTNER_UNSPECIFIED");
+        pub const PARTNER_UNSPECIFIED: Partner = Partner::new(0);
 
         /// Enum representing S3NS (Thales) partner.
-        pub const PARTNER_LOCAL_CONTROLS_BY_S3NS: Partner =
-            Partner::new("PARTNER_LOCAL_CONTROLS_BY_S3NS");
+        pub const PARTNER_LOCAL_CONTROLS_BY_S3NS: Partner = Partner::new(1);
 
         /// Enum representing T_SYSTEM (TSI) partner.
-        pub const PARTNER_SOVEREIGN_CONTROLS_BY_T_SYSTEMS: Partner =
-            Partner::new("PARTNER_SOVEREIGN_CONTROLS_BY_T_SYSTEMS");
+        pub const PARTNER_SOVEREIGN_CONTROLS_BY_T_SYSTEMS: Partner = Partner::new(2);
 
         /// Enum representing SIA_MINSAIT (Indra) partner.
-        pub const PARTNER_SOVEREIGN_CONTROLS_BY_SIA_MINSAIT: Partner =
-            Partner::new("PARTNER_SOVEREIGN_CONTROLS_BY_SIA_MINSAIT");
+        pub const PARTNER_SOVEREIGN_CONTROLS_BY_SIA_MINSAIT: Partner = Partner::new(3);
 
         /// Enum representing PSN (TIM) partner.
-        pub const PARTNER_SOVEREIGN_CONTROLS_BY_PSN: Partner =
-            Partner::new("PARTNER_SOVEREIGN_CONTROLS_BY_PSN");
+        pub const PARTNER_SOVEREIGN_CONTROLS_BY_PSN: Partner = Partner::new(4);
 
         /// Enum representing CNTXT (Kingdom of Saudi Arabia) partner.
-        pub const PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT: Partner =
-            Partner::new("PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT");
+        pub const PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT: Partner = Partner::new(6);
 
         /// Enum representing CNXT (Kingdom of Saudi Arabia) partner offering without
         /// EKM provisioning.
-        pub const PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM: Partner =
-            Partner::new("PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM");
+        pub const PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM: Partner = Partner::new(7);
+
+        /// Creates a new Partner instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PARTNER_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PARTNER_LOCAL_CONTROLS_BY_S3NS"),
+                2 => std::borrow::Cow::Borrowed("PARTNER_SOVEREIGN_CONTROLS_BY_T_SYSTEMS"),
+                3 => std::borrow::Cow::Borrowed("PARTNER_SOVEREIGN_CONTROLS_BY_SIA_MINSAIT"),
+                4 => std::borrow::Cow::Borrowed("PARTNER_SOVEREIGN_CONTROLS_BY_PSN"),
+                6 => std::borrow::Cow::Borrowed("PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT"),
+                7 => std::borrow::Cow::Borrowed("PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PARTNER_UNSPECIFIED" => std::option::Option::Some(Self::PARTNER_UNSPECIFIED),
+                "PARTNER_LOCAL_CONTROLS_BY_S3NS" => {
+                    std::option::Option::Some(Self::PARTNER_LOCAL_CONTROLS_BY_S3NS)
+                }
+                "PARTNER_SOVEREIGN_CONTROLS_BY_T_SYSTEMS" => {
+                    std::option::Option::Some(Self::PARTNER_SOVEREIGN_CONTROLS_BY_T_SYSTEMS)
+                }
+                "PARTNER_SOVEREIGN_CONTROLS_BY_SIA_MINSAIT" => {
+                    std::option::Option::Some(Self::PARTNER_SOVEREIGN_CONTROLS_BY_SIA_MINSAIT)
+                }
+                "PARTNER_SOVEREIGN_CONTROLS_BY_PSN" => {
+                    std::option::Option::Some(Self::PARTNER_SOVEREIGN_CONTROLS_BY_PSN)
+                }
+                "PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT" => {
+                    std::option::Option::Some(Self::PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT)
+                }
+                "PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM" => {
+                    std::option::Option::Some(Self::PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Partner {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Partner {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Partner {
         fn default() -> Self {
-            partner::PARTNER_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -946,44 +1007,60 @@ pub mod workload_onboarding_step {
 
     /// Enum for possible onboarding steps.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Step(std::borrow::Cow<'static, str>);
+    pub struct Step(i32);
 
     impl Step {
+        /// Unspecified step.
+        pub const STEP_UNSPECIFIED: Step = Step::new(0);
+
+        /// EKM Provisioned step.
+        pub const EKM_PROVISIONED: Step = Step::new(1);
+
+        /// Signed Access Approval step.
+        pub const SIGNED_ACCESS_APPROVAL_CONFIGURED: Step = Step::new(2);
+
         /// Creates a new Step instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STEP_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("EKM_PROVISIONED"),
+                2 => std::borrow::Cow::Borrowed("SIGNED_ACCESS_APPROVAL_CONFIGURED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STEP_UNSPECIFIED" => std::option::Option::Some(Self::STEP_UNSPECIFIED),
+                "EKM_PROVISIONED" => std::option::Option::Some(Self::EKM_PROVISIONED),
+                "SIGNED_ACCESS_APPROVAL_CONFIGURED" => {
+                    std::option::Option::Some(Self::SIGNED_ACCESS_APPROVAL_CONFIGURED)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Step](Step)
-    pub mod step {
-        use super::Step;
-
-        /// Unspecified step.
-        pub const STEP_UNSPECIFIED: Step = Step::new("STEP_UNSPECIFIED");
-
-        /// EKM Provisioned step.
-        pub const EKM_PROVISIONED: Step = Step::new("EKM_PROVISIONED");
-
-        /// Signed Access Approval step.
-        pub const SIGNED_ACCESS_APPROVAL_CONFIGURED: Step =
-            Step::new("SIGNED_ACCESS_APPROVAL_CONFIGURED");
-    }
-
-    impl std::convert::From<std::string::String> for Step {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Step {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Step {
         fn default() -> Self {
-            step::STEP_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1336,43 +1413,58 @@ pub mod customer_onboarding_step {
 
     /// Enum for possible onboarding steps
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Step(std::borrow::Cow<'static, str>);
+    pub struct Step(i32);
 
     impl Step {
+        /// Unspecified step
+        pub const STEP_UNSPECIFIED: Step = Step::new(0);
+
+        /// KAJ Enrollment
+        pub const KAJ_ENROLLMENT: Step = Step::new(1);
+
+        /// Customer Environment
+        pub const CUSTOMER_ENVIRONMENT: Step = Step::new(2);
+
         /// Creates a new Step instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STEP_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("KAJ_ENROLLMENT"),
+                2 => std::borrow::Cow::Borrowed("CUSTOMER_ENVIRONMENT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STEP_UNSPECIFIED" => std::option::Option::Some(Self::STEP_UNSPECIFIED),
+                "KAJ_ENROLLMENT" => std::option::Option::Some(Self::KAJ_ENROLLMENT),
+                "CUSTOMER_ENVIRONMENT" => std::option::Option::Some(Self::CUSTOMER_ENVIRONMENT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Step](Step)
-    pub mod step {
-        use super::Step;
-
-        /// Unspecified step
-        pub const STEP_UNSPECIFIED: Step = Step::new("STEP_UNSPECIFIED");
-
-        /// KAJ Enrollment
-        pub const KAJ_ENROLLMENT: Step = Step::new("KAJ_ENROLLMENT");
-
-        /// Customer Environment
-        pub const CUSTOMER_ENVIRONMENT: Step = Step::new("CUSTOMER_ENVIRONMENT");
-    }
-
-    impl std::convert::From<std::string::String> for Step {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Step {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Step {
         fn default() -> Self {
-            step::STEP_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1564,50 +1656,70 @@ pub mod ekm_connection {
 
     /// The EKM connection state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConnectionState(std::borrow::Cow<'static, str>);
+    pub struct ConnectionState(i32);
 
     impl ConnectionState {
+        /// Unspecified EKM connection state
+        pub const CONNECTION_STATE_UNSPECIFIED: ConnectionState = ConnectionState::new(0);
+
+        /// Available EKM connection state
+        pub const AVAILABLE: ConnectionState = ConnectionState::new(1);
+
+        /// Not available EKM connection state
+        pub const NOT_AVAILABLE: ConnectionState = ConnectionState::new(2);
+
+        /// Error EKM connection state
+        pub const ERROR: ConnectionState = ConnectionState::new(3);
+
+        /// Permission denied EKM connection state
+        pub const PERMISSION_DENIED: ConnectionState = ConnectionState::new(4);
+
         /// Creates a new ConnectionState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CONNECTION_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AVAILABLE"),
+                2 => std::borrow::Cow::Borrowed("NOT_AVAILABLE"),
+                3 => std::borrow::Cow::Borrowed("ERROR"),
+                4 => std::borrow::Cow::Borrowed("PERMISSION_DENIED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CONNECTION_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CONNECTION_STATE_UNSPECIFIED)
+                }
+                "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
+                "NOT_AVAILABLE" => std::option::Option::Some(Self::NOT_AVAILABLE),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "PERMISSION_DENIED" => std::option::Option::Some(Self::PERMISSION_DENIED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ConnectionState](ConnectionState)
-    pub mod connection_state {
-        use super::ConnectionState;
-
-        /// Unspecified EKM connection state
-        pub const CONNECTION_STATE_UNSPECIFIED: ConnectionState =
-            ConnectionState::new("CONNECTION_STATE_UNSPECIFIED");
-
-        /// Available EKM connection state
-        pub const AVAILABLE: ConnectionState = ConnectionState::new("AVAILABLE");
-
-        /// Not available EKM connection state
-        pub const NOT_AVAILABLE: ConnectionState = ConnectionState::new("NOT_AVAILABLE");
-
-        /// Error EKM connection state
-        pub const ERROR: ConnectionState = ConnectionState::new("ERROR");
-
-        /// Permission denied EKM connection state
-        pub const PERMISSION_DENIED: ConnectionState = ConnectionState::new("PERMISSION_DENIED");
-    }
-
-    impl std::convert::From<std::string::String> for ConnectionState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ConnectionState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ConnectionState {
         fn default() -> Self {
-            connection_state::CONNECTION_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1663,57 +1775,83 @@ pub mod partner_permissions {
     use super::*;
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Permission(std::borrow::Cow<'static, str>);
+    pub struct Permission(i32);
 
     impl Permission {
+        /// Unspecified partner permission
+        pub const PERMISSION_UNSPECIFIED: Permission = Permission::new(0);
+
+        /// Permission for Access Transparency and emergency logs
+        pub const ACCESS_TRANSPARENCY_AND_EMERGENCY_ACCESS_LOGS: Permission = Permission::new(1);
+
+        /// Permission for Assured Workloads monitoring violations
+        pub const ASSURED_WORKLOADS_MONITORING: Permission = Permission::new(2);
+
+        /// Permission for Access Approval requests
+        pub const ACCESS_APPROVAL_REQUESTS: Permission = Permission::new(3);
+
+        /// Permission for External Key Manager connection status
+        pub const ASSURED_WORKLOADS_EKM_CONNECTION_STATUS: Permission = Permission::new(4);
+
+        /// Permission for support case details for Access Transparency log entries
+        pub const ACCESS_TRANSPARENCY_LOGS_SUPPORT_CASE_VIEWER: Permission = Permission::new(5);
+
         /// Creates a new Permission instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PERMISSION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACCESS_TRANSPARENCY_AND_EMERGENCY_ACCESS_LOGS"),
+                2 => std::borrow::Cow::Borrowed("ASSURED_WORKLOADS_MONITORING"),
+                3 => std::borrow::Cow::Borrowed("ACCESS_APPROVAL_REQUESTS"),
+                4 => std::borrow::Cow::Borrowed("ASSURED_WORKLOADS_EKM_CONNECTION_STATUS"),
+                5 => std::borrow::Cow::Borrowed("ACCESS_TRANSPARENCY_LOGS_SUPPORT_CASE_VIEWER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PERMISSION_UNSPECIFIED" => std::option::Option::Some(Self::PERMISSION_UNSPECIFIED),
+                "ACCESS_TRANSPARENCY_AND_EMERGENCY_ACCESS_LOGS" => {
+                    std::option::Option::Some(Self::ACCESS_TRANSPARENCY_AND_EMERGENCY_ACCESS_LOGS)
+                }
+                "ASSURED_WORKLOADS_MONITORING" => {
+                    std::option::Option::Some(Self::ASSURED_WORKLOADS_MONITORING)
+                }
+                "ACCESS_APPROVAL_REQUESTS" => {
+                    std::option::Option::Some(Self::ACCESS_APPROVAL_REQUESTS)
+                }
+                "ASSURED_WORKLOADS_EKM_CONNECTION_STATUS" => {
+                    std::option::Option::Some(Self::ASSURED_WORKLOADS_EKM_CONNECTION_STATUS)
+                }
+                "ACCESS_TRANSPARENCY_LOGS_SUPPORT_CASE_VIEWER" => {
+                    std::option::Option::Some(Self::ACCESS_TRANSPARENCY_LOGS_SUPPORT_CASE_VIEWER)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Permission](Permission)
-    pub mod permission {
-        use super::Permission;
-
-        /// Unspecified partner permission
-        pub const PERMISSION_UNSPECIFIED: Permission = Permission::new("PERMISSION_UNSPECIFIED");
-
-        /// Permission for Access Transparency and emergency logs
-        pub const ACCESS_TRANSPARENCY_AND_EMERGENCY_ACCESS_LOGS: Permission =
-            Permission::new("ACCESS_TRANSPARENCY_AND_EMERGENCY_ACCESS_LOGS");
-
-        /// Permission for Assured Workloads monitoring violations
-        pub const ASSURED_WORKLOADS_MONITORING: Permission =
-            Permission::new("ASSURED_WORKLOADS_MONITORING");
-
-        /// Permission for Access Approval requests
-        pub const ACCESS_APPROVAL_REQUESTS: Permission =
-            Permission::new("ACCESS_APPROVAL_REQUESTS");
-
-        /// Permission for External Key Manager connection status
-        pub const ASSURED_WORKLOADS_EKM_CONNECTION_STATUS: Permission =
-            Permission::new("ASSURED_WORKLOADS_EKM_CONNECTION_STATUS");
-
-        /// Permission for support case details for Access Transparency log entries
-        pub const ACCESS_TRANSPARENCY_LOGS_SUPPORT_CASE_VIEWER: Permission =
-            Permission::new("ACCESS_TRANSPARENCY_LOGS_SUPPORT_CASE_VIEWER");
-    }
-
-    impl std::convert::From<std::string::String> for Permission {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Permission {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Permission {
         fn default() -> Self {
-            permission::PERMISSION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1993,50 +2131,70 @@ pub mod ekm_metadata {
     /// [Google Cloud EKM partners
     /// docs](https://cloud.google.com/kms/docs/ekm#supported_partners).
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EkmSolution(std::borrow::Cow<'static, str>);
+    pub struct EkmSolution(i32);
 
     impl EkmSolution {
+        /// Unspecified EKM solution
+        pub const EKM_SOLUTION_UNSPECIFIED: EkmSolution = EkmSolution::new(0);
+
+        /// EKM Partner Fortanix
+        pub const FORTANIX: EkmSolution = EkmSolution::new(1);
+
+        /// EKM Partner FutureX
+        pub const FUTUREX: EkmSolution = EkmSolution::new(2);
+
+        /// EKM Partner Thales
+        pub const THALES: EkmSolution = EkmSolution::new(3);
+
+        /// EKM Partner Virtu
+        pub const VIRTRU: EkmSolution = EkmSolution::new(4);
+
         /// Creates a new EkmSolution instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EKM_SOLUTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FORTANIX"),
+                2 => std::borrow::Cow::Borrowed("FUTUREX"),
+                3 => std::borrow::Cow::Borrowed("THALES"),
+                4 => std::borrow::Cow::Borrowed("VIRTRU"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EKM_SOLUTION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::EKM_SOLUTION_UNSPECIFIED)
+                }
+                "FORTANIX" => std::option::Option::Some(Self::FORTANIX),
+                "FUTUREX" => std::option::Option::Some(Self::FUTUREX),
+                "THALES" => std::option::Option::Some(Self::THALES),
+                "VIRTRU" => std::option::Option::Some(Self::VIRTRU),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [EkmSolution](EkmSolution)
-    pub mod ekm_solution {
-        use super::EkmSolution;
-
-        /// Unspecified EKM solution
-        pub const EKM_SOLUTION_UNSPECIFIED: EkmSolution =
-            EkmSolution::new("EKM_SOLUTION_UNSPECIFIED");
-
-        /// EKM Partner Fortanix
-        pub const FORTANIX: EkmSolution = EkmSolution::new("FORTANIX");
-
-        /// EKM Partner FutureX
-        pub const FUTUREX: EkmSolution = EkmSolution::new("FUTUREX");
-
-        /// EKM Partner Thales
-        pub const THALES: EkmSolution = EkmSolution::new("THALES");
-
-        /// EKM Partner Virtu
-        pub const VIRTRU: EkmSolution = EkmSolution::new("VIRTRU");
-    }
-
-    impl std::convert::From<std::string::String> for EkmSolution {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EkmSolution {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EkmSolution {
         fn default() -> Self {
-            ekm_solution::EKM_SOLUTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2462,108 +2620,148 @@ pub mod violation {
         /// policy requires different remediation instructions compared to violation
         /// caused due to changes in allowed values of list org policy.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct RemediationType(std::borrow::Cow<'static, str>);
+        pub struct RemediationType(i32);
 
         impl RemediationType {
-            /// Creates a new RemediationType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [RemediationType](RemediationType)
-        pub mod remediation_type {
-            use super::RemediationType;
-
             /// Unspecified remediation type
-            pub const REMEDIATION_TYPE_UNSPECIFIED: RemediationType =
-                RemediationType::new("REMEDIATION_TYPE_UNSPECIFIED");
+            pub const REMEDIATION_TYPE_UNSPECIFIED: RemediationType = RemediationType::new(0);
 
             /// Remediation type for boolean org policy
             pub const REMEDIATION_BOOLEAN_ORG_POLICY_VIOLATION: RemediationType =
-                RemediationType::new("REMEDIATION_BOOLEAN_ORG_POLICY_VIOLATION");
+                RemediationType::new(1);
 
             /// Remediation type for list org policy which have allowed values in the
             /// monitoring rule
             pub const REMEDIATION_LIST_ALLOWED_VALUES_ORG_POLICY_VIOLATION: RemediationType =
-                RemediationType::new("REMEDIATION_LIST_ALLOWED_VALUES_ORG_POLICY_VIOLATION");
+                RemediationType::new(2);
 
             /// Remediation type for list org policy which have denied values in the
             /// monitoring rule
             pub const REMEDIATION_LIST_DENIED_VALUES_ORG_POLICY_VIOLATION: RemediationType =
-                RemediationType::new("REMEDIATION_LIST_DENIED_VALUES_ORG_POLICY_VIOLATION");
+                RemediationType::new(3);
 
             /// Remediation type for gcp.restrictCmekCryptoKeyProjects
             pub const REMEDIATION_RESTRICT_CMEK_CRYPTO_KEY_PROJECTS_ORG_POLICY_VIOLATION:
-                RemediationType = RemediationType::new(
-                "REMEDIATION_RESTRICT_CMEK_CRYPTO_KEY_PROJECTS_ORG_POLICY_VIOLATION",
-            );
+                RemediationType = RemediationType::new(4);
 
             /// Remediation type for resource violation.
-            pub const REMEDIATION_RESOURCE_VIOLATION: RemediationType =
-                RemediationType::new("REMEDIATION_RESOURCE_VIOLATION");
+            pub const REMEDIATION_RESOURCE_VIOLATION: RemediationType = RemediationType::new(5);
+
+            /// Creates a new RemediationType instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("REMEDIATION_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("REMEDIATION_BOOLEAN_ORG_POLICY_VIOLATION"),
+                    2 => std::borrow::Cow::Borrowed(
+                        "REMEDIATION_LIST_ALLOWED_VALUES_ORG_POLICY_VIOLATION",
+                    ),
+                    3 => std::borrow::Cow::Borrowed(
+                        "REMEDIATION_LIST_DENIED_VALUES_ORG_POLICY_VIOLATION",
+                    ),
+                    4 => std::borrow::Cow::Borrowed(
+                        "REMEDIATION_RESTRICT_CMEK_CRYPTO_KEY_PROJECTS_ORG_POLICY_VIOLATION",
+                    ),
+                    5 => std::borrow::Cow::Borrowed("REMEDIATION_RESOURCE_VIOLATION"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "REMEDIATION_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::REMEDIATION_TYPE_UNSPECIFIED),
+                    "REMEDIATION_BOOLEAN_ORG_POLICY_VIOLATION" => std::option::Option::Some(Self::REMEDIATION_BOOLEAN_ORG_POLICY_VIOLATION),
+                    "REMEDIATION_LIST_ALLOWED_VALUES_ORG_POLICY_VIOLATION" => std::option::Option::Some(Self::REMEDIATION_LIST_ALLOWED_VALUES_ORG_POLICY_VIOLATION),
+                    "REMEDIATION_LIST_DENIED_VALUES_ORG_POLICY_VIOLATION" => std::option::Option::Some(Self::REMEDIATION_LIST_DENIED_VALUES_ORG_POLICY_VIOLATION),
+                    "REMEDIATION_RESTRICT_CMEK_CRYPTO_KEY_PROJECTS_ORG_POLICY_VIOLATION" => std::option::Option::Some(Self::REMEDIATION_RESTRICT_CMEK_CRYPTO_KEY_PROJECTS_ORG_POLICY_VIOLATION),
+                    "REMEDIATION_RESOURCE_VIOLATION" => std::option::Option::Some(Self::REMEDIATION_RESOURCE_VIOLATION),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for RemediationType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for RemediationType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for RemediationType {
             fn default() -> Self {
-                remediation_type::REMEDIATION_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// Violation State Values
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Violation is resolved.
+        pub const RESOLVED: State = State::new(1);
+
+        /// Violation is Unresolved
+        pub const UNRESOLVED: State = State::new(2);
+
+        /// Violation is Exception
+        pub const EXCEPTION: State = State::new(3);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RESOLVED"),
+                2 => std::borrow::Cow::Borrowed("UNRESOLVED"),
+                3 => std::borrow::Cow::Borrowed("EXCEPTION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "RESOLVED" => std::option::Option::Some(Self::RESOLVED),
+                "UNRESOLVED" => std::option::Option::Some(Self::UNRESOLVED),
+                "EXCEPTION" => std::option::Option::Some(Self::EXCEPTION),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Violation is resolved.
-        pub const RESOLVED: State = State::new("RESOLVED");
-
-        /// Violation is Unresolved
-        pub const UNRESOLVED: State = State::new("UNRESOLVED");
-
-        /// Violation is Exception
-        pub const EXCEPTION: State = State::new("EXCEPTION");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2761,49 +2959,69 @@ impl wkt::message::Message for GetViolationRequest {
 
 /// Enum for possible completion states.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct CompletionState(std::borrow::Cow<'static, str>);
+pub struct CompletionState(i32);
 
 impl CompletionState {
+    /// Unspecified completion state.
+    pub const COMPLETION_STATE_UNSPECIFIED: CompletionState = CompletionState::new(0);
+
+    /// Task started (has start date) but not yet completed.
+    pub const PENDING: CompletionState = CompletionState::new(1);
+
+    /// Succeeded state.
+    pub const SUCCEEDED: CompletionState = CompletionState::new(2);
+
+    /// Failed state.
+    pub const FAILED: CompletionState = CompletionState::new(3);
+
+    /// Not applicable state.
+    pub const NOT_APPLICABLE: CompletionState = CompletionState::new(4);
+
     /// Creates a new CompletionState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("COMPLETION_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PENDING"),
+            2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+            3 => std::borrow::Cow::Borrowed("FAILED"),
+            4 => std::borrow::Cow::Borrowed("NOT_APPLICABLE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "COMPLETION_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::COMPLETION_STATE_UNSPECIFIED)
+            }
+            "PENDING" => std::option::Option::Some(Self::PENDING),
+            "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+            "FAILED" => std::option::Option::Some(Self::FAILED),
+            "NOT_APPLICABLE" => std::option::Option::Some(Self::NOT_APPLICABLE),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [CompletionState](CompletionState)
-pub mod completion_state {
-    use super::CompletionState;
-
-    /// Unspecified completion state.
-    pub const COMPLETION_STATE_UNSPECIFIED: CompletionState =
-        CompletionState::new("COMPLETION_STATE_UNSPECIFIED");
-
-    /// Task started (has start date) but not yet completed.
-    pub const PENDING: CompletionState = CompletionState::new("PENDING");
-
-    /// Succeeded state.
-    pub const SUCCEEDED: CompletionState = CompletionState::new("SUCCEEDED");
-
-    /// Failed state.
-    pub const FAILED: CompletionState = CompletionState::new("FAILED");
-
-    /// Not applicable state.
-    pub const NOT_APPLICABLE: CompletionState = CompletionState::new("NOT_APPLICABLE");
-}
-
-impl std::convert::From<std::string::String> for CompletionState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for CompletionState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for CompletionState {
     fn default() -> Self {
-        completion_state::COMPLETION_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/transport.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::CloudControlsPartnerCore for CloudControlsPartnerCore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -71,7 +71,7 @@ impl crate::stubs::CloudControlsPartnerCore for CloudControlsPartnerCore {
                 reqwest::Method::GET,
                 format!("/v1/{}/workloads", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -94,7 +94,7 @@ impl crate::stubs::CloudControlsPartnerCore for CloudControlsPartnerCore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -116,7 +116,7 @@ impl crate::stubs::CloudControlsPartnerCore for CloudControlsPartnerCore {
                 reqwest::Method::GET,
                 format!("/v1/{}/customers", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -139,7 +139,7 @@ impl crate::stubs::CloudControlsPartnerCore for CloudControlsPartnerCore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -158,7 +158,7 @@ impl crate::stubs::CloudControlsPartnerCore for CloudControlsPartnerCore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -180,7 +180,7 @@ impl crate::stubs::CloudControlsPartnerCore for CloudControlsPartnerCore {
                 reqwest::Method::GET,
                 format!("/v1/{}/accessApprovalRequests", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -203,7 +203,7 @@ impl crate::stubs::CloudControlsPartnerCore for CloudControlsPartnerCore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -248,7 +248,7 @@ impl crate::stubs::CloudControlsPartnerMonitoring for CloudControlsPartnerMonito
                 reqwest::Method::GET,
                 format!("/v1/{}/violations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -281,7 +281,7 @@ impl crate::stubs::CloudControlsPartnerMonitoring for CloudControlsPartnerMonito
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/clouddms/v1/src/model.rs
+++ b/src/generated/cloud/clouddms/v1/src/model.rs
@@ -2985,47 +2985,65 @@ pub mod describe_database_entities_request {
 
     /// The type of a tree to return
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DBTreeType(std::borrow::Cow<'static, str>);
+    pub struct DBTreeType(i32);
 
     impl DBTreeType {
+        /// Unspecified tree type.
+        pub const DB_TREE_TYPE_UNSPECIFIED: DBTreeType = DBTreeType::new(0);
+
+        /// The source database tree.
+        pub const SOURCE_TREE: DBTreeType = DBTreeType::new(1);
+
+        /// The draft database tree.
+        pub const DRAFT_TREE: DBTreeType = DBTreeType::new(2);
+
+        /// The destination database tree.
+        pub const DESTINATION_TREE: DBTreeType = DBTreeType::new(3);
+
         /// Creates a new DBTreeType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DB_TREE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SOURCE_TREE"),
+                2 => std::borrow::Cow::Borrowed("DRAFT_TREE"),
+                3 => std::borrow::Cow::Borrowed("DESTINATION_TREE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DB_TREE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DB_TREE_TYPE_UNSPECIFIED)
+                }
+                "SOURCE_TREE" => std::option::Option::Some(Self::SOURCE_TREE),
+                "DRAFT_TREE" => std::option::Option::Some(Self::DRAFT_TREE),
+                "DESTINATION_TREE" => std::option::Option::Some(Self::DESTINATION_TREE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DBTreeType](DBTreeType)
-    pub mod db_tree_type {
-        use super::DBTreeType;
-
-        /// Unspecified tree type.
-        pub const DB_TREE_TYPE_UNSPECIFIED: DBTreeType =
-            DBTreeType::new("DB_TREE_TYPE_UNSPECIFIED");
-
-        /// The source database tree.
-        pub const SOURCE_TREE: DBTreeType = DBTreeType::new("SOURCE_TREE");
-
-        /// The draft database tree.
-        pub const DRAFT_TREE: DBTreeType = DBTreeType::new("DRAFT_TREE");
-
-        /// The destination database tree.
-        pub const DESTINATION_TREE: DBTreeType = DBTreeType::new("DESTINATION_TREE");
-    }
-
-    impl std::convert::From<std::string::String> for DBTreeType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DBTreeType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DBTreeType {
         fn default() -> Self {
-            db_tree_type::DB_TREE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3562,44 +3580,59 @@ pub mod ssl_config {
 
     /// Specifies The kind of ssl configuration used.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SslType(std::borrow::Cow<'static, str>);
+    pub struct SslType(i32);
 
     impl SslType {
-        /// Creates a new SslType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [SslType](SslType)
-    pub mod ssl_type {
-        use super::SslType;
-
         /// Unspecified.
-        pub const SSL_TYPE_UNSPECIFIED: SslType = SslType::new("SSL_TYPE_UNSPECIFIED");
+        pub const SSL_TYPE_UNSPECIFIED: SslType = SslType::new(0);
 
         /// Only 'ca_certificate' specified.
-        pub const SERVER_ONLY: SslType = SslType::new("SERVER_ONLY");
+        pub const SERVER_ONLY: SslType = SslType::new(1);
 
         /// Both server ('ca_certificate'), and client ('client_key',
         /// 'client_certificate') specified.
-        pub const SERVER_CLIENT: SslType = SslType::new("SERVER_CLIENT");
+        pub const SERVER_CLIENT: SslType = SslType::new(2);
+
+        /// Creates a new SslType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SSL_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SERVER_ONLY"),
+                2 => std::borrow::Cow::Borrowed("SERVER_CLIENT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SSL_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SSL_TYPE_UNSPECIFIED),
+                "SERVER_ONLY" => std::option::Option::Some(Self::SERVER_ONLY),
+                "SERVER_CLIENT" => std::option::Option::Some(Self::SERVER_CLIENT),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for SslType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SslType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SslType {
         fn default() -> Self {
-            ssl_type::SSL_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4789,240 +4822,337 @@ pub mod cloud_sql_settings {
 
     /// Specifies when the instance should be activated.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlActivationPolicy(std::borrow::Cow<'static, str>);
+    pub struct SqlActivationPolicy(i32);
 
     impl SqlActivationPolicy {
+        /// unspecified policy.
+        pub const SQL_ACTIVATION_POLICY_UNSPECIFIED: SqlActivationPolicy =
+            SqlActivationPolicy::new(0);
+
+        /// The instance is always up and running.
+        pub const ALWAYS: SqlActivationPolicy = SqlActivationPolicy::new(1);
+
+        /// The instance should never spin up.
+        pub const NEVER: SqlActivationPolicy = SqlActivationPolicy::new(2);
+
         /// Creates a new SqlActivationPolicy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SQL_ACTIVATION_POLICY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALWAYS"),
+                2 => std::borrow::Cow::Borrowed("NEVER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SQL_ACTIVATION_POLICY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SQL_ACTIVATION_POLICY_UNSPECIFIED)
+                }
+                "ALWAYS" => std::option::Option::Some(Self::ALWAYS),
+                "NEVER" => std::option::Option::Some(Self::NEVER),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SqlActivationPolicy](SqlActivationPolicy)
-    pub mod sql_activation_policy {
-        use super::SqlActivationPolicy;
-
-        /// unspecified policy.
-        pub const SQL_ACTIVATION_POLICY_UNSPECIFIED: SqlActivationPolicy =
-            SqlActivationPolicy::new("SQL_ACTIVATION_POLICY_UNSPECIFIED");
-
-        /// The instance is always up and running.
-        pub const ALWAYS: SqlActivationPolicy = SqlActivationPolicy::new("ALWAYS");
-
-        /// The instance should never spin up.
-        pub const NEVER: SqlActivationPolicy = SqlActivationPolicy::new("NEVER");
-    }
-
-    impl std::convert::From<std::string::String> for SqlActivationPolicy {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SqlActivationPolicy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SqlActivationPolicy {
         fn default() -> Self {
-            sql_activation_policy::SQL_ACTIVATION_POLICY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The storage options for Cloud SQL databases.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlDataDiskType(std::borrow::Cow<'static, str>);
+    pub struct SqlDataDiskType(i32);
 
     impl SqlDataDiskType {
+        /// Unspecified.
+        pub const SQL_DATA_DISK_TYPE_UNSPECIFIED: SqlDataDiskType = SqlDataDiskType::new(0);
+
+        /// SSD disk.
+        pub const PD_SSD: SqlDataDiskType = SqlDataDiskType::new(1);
+
+        /// HDD disk.
+        pub const PD_HDD: SqlDataDiskType = SqlDataDiskType::new(2);
+
         /// Creates a new SqlDataDiskType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SQL_DATA_DISK_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PD_SSD"),
+                2 => std::borrow::Cow::Borrowed("PD_HDD"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SQL_DATA_DISK_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SQL_DATA_DISK_TYPE_UNSPECIFIED)
+                }
+                "PD_SSD" => std::option::Option::Some(Self::PD_SSD),
+                "PD_HDD" => std::option::Option::Some(Self::PD_HDD),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SqlDataDiskType](SqlDataDiskType)
-    pub mod sql_data_disk_type {
-        use super::SqlDataDiskType;
-
-        /// Unspecified.
-        pub const SQL_DATA_DISK_TYPE_UNSPECIFIED: SqlDataDiskType =
-            SqlDataDiskType::new("SQL_DATA_DISK_TYPE_UNSPECIFIED");
-
-        /// SSD disk.
-        pub const PD_SSD: SqlDataDiskType = SqlDataDiskType::new("PD_SSD");
-
-        /// HDD disk.
-        pub const PD_HDD: SqlDataDiskType = SqlDataDiskType::new("PD_HDD");
-    }
-
-    impl std::convert::From<std::string::String> for SqlDataDiskType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SqlDataDiskType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SqlDataDiskType {
         fn default() -> Self {
-            sql_data_disk_type::SQL_DATA_DISK_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The database engine type and version.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlDatabaseVersion(std::borrow::Cow<'static, str>);
+    pub struct SqlDatabaseVersion(i32);
 
     impl SqlDatabaseVersion {
+        /// Unspecified version.
+        pub const SQL_DATABASE_VERSION_UNSPECIFIED: SqlDatabaseVersion = SqlDatabaseVersion::new(0);
+
+        /// MySQL 5.6.
+        pub const MYSQL_5_6: SqlDatabaseVersion = SqlDatabaseVersion::new(1);
+
+        /// MySQL 5.7.
+        pub const MYSQL_5_7: SqlDatabaseVersion = SqlDatabaseVersion::new(2);
+
+        /// PostgreSQL 9.6.
+        pub const POSTGRES_9_6: SqlDatabaseVersion = SqlDatabaseVersion::new(3);
+
+        /// PostgreSQL 11.
+        pub const POSTGRES_11: SqlDatabaseVersion = SqlDatabaseVersion::new(4);
+
+        /// PostgreSQL 10.
+        pub const POSTGRES_10: SqlDatabaseVersion = SqlDatabaseVersion::new(5);
+
+        /// MySQL 8.0.
+        pub const MYSQL_8_0: SqlDatabaseVersion = SqlDatabaseVersion::new(6);
+
+        /// PostgreSQL 12.
+        pub const POSTGRES_12: SqlDatabaseVersion = SqlDatabaseVersion::new(7);
+
+        /// PostgreSQL 13.
+        pub const POSTGRES_13: SqlDatabaseVersion = SqlDatabaseVersion::new(8);
+
+        /// PostgreSQL 14.
+        pub const POSTGRES_14: SqlDatabaseVersion = SqlDatabaseVersion::new(17);
+
+        /// PostgreSQL 15.
+        pub const POSTGRES_15: SqlDatabaseVersion = SqlDatabaseVersion::new(18);
+
         /// Creates a new SqlDatabaseVersion instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SQL_DATABASE_VERSION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MYSQL_5_6"),
+                2 => std::borrow::Cow::Borrowed("MYSQL_5_7"),
+                3 => std::borrow::Cow::Borrowed("POSTGRES_9_6"),
+                4 => std::borrow::Cow::Borrowed("POSTGRES_11"),
+                5 => std::borrow::Cow::Borrowed("POSTGRES_10"),
+                6 => std::borrow::Cow::Borrowed("MYSQL_8_0"),
+                7 => std::borrow::Cow::Borrowed("POSTGRES_12"),
+                8 => std::borrow::Cow::Borrowed("POSTGRES_13"),
+                17 => std::borrow::Cow::Borrowed("POSTGRES_14"),
+                18 => std::borrow::Cow::Borrowed("POSTGRES_15"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SQL_DATABASE_VERSION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SQL_DATABASE_VERSION_UNSPECIFIED)
+                }
+                "MYSQL_5_6" => std::option::Option::Some(Self::MYSQL_5_6),
+                "MYSQL_5_7" => std::option::Option::Some(Self::MYSQL_5_7),
+                "POSTGRES_9_6" => std::option::Option::Some(Self::POSTGRES_9_6),
+                "POSTGRES_11" => std::option::Option::Some(Self::POSTGRES_11),
+                "POSTGRES_10" => std::option::Option::Some(Self::POSTGRES_10),
+                "MYSQL_8_0" => std::option::Option::Some(Self::MYSQL_8_0),
+                "POSTGRES_12" => std::option::Option::Some(Self::POSTGRES_12),
+                "POSTGRES_13" => std::option::Option::Some(Self::POSTGRES_13),
+                "POSTGRES_14" => std::option::Option::Some(Self::POSTGRES_14),
+                "POSTGRES_15" => std::option::Option::Some(Self::POSTGRES_15),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SqlDatabaseVersion](SqlDatabaseVersion)
-    pub mod sql_database_version {
-        use super::SqlDatabaseVersion;
-
-        /// Unspecified version.
-        pub const SQL_DATABASE_VERSION_UNSPECIFIED: SqlDatabaseVersion =
-            SqlDatabaseVersion::new("SQL_DATABASE_VERSION_UNSPECIFIED");
-
-        /// MySQL 5.6.
-        pub const MYSQL_5_6: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_5_6");
-
-        /// MySQL 5.7.
-        pub const MYSQL_5_7: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_5_7");
-
-        /// PostgreSQL 9.6.
-        pub const POSTGRES_9_6: SqlDatabaseVersion = SqlDatabaseVersion::new("POSTGRES_9_6");
-
-        /// PostgreSQL 11.
-        pub const POSTGRES_11: SqlDatabaseVersion = SqlDatabaseVersion::new("POSTGRES_11");
-
-        /// PostgreSQL 10.
-        pub const POSTGRES_10: SqlDatabaseVersion = SqlDatabaseVersion::new("POSTGRES_10");
-
-        /// MySQL 8.0.
-        pub const MYSQL_8_0: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_8_0");
-
-        /// PostgreSQL 12.
-        pub const POSTGRES_12: SqlDatabaseVersion = SqlDatabaseVersion::new("POSTGRES_12");
-
-        /// PostgreSQL 13.
-        pub const POSTGRES_13: SqlDatabaseVersion = SqlDatabaseVersion::new("POSTGRES_13");
-
-        /// PostgreSQL 14.
-        pub const POSTGRES_14: SqlDatabaseVersion = SqlDatabaseVersion::new("POSTGRES_14");
-
-        /// PostgreSQL 15.
-        pub const POSTGRES_15: SqlDatabaseVersion = SqlDatabaseVersion::new("POSTGRES_15");
-    }
-
-    impl std::convert::From<std::string::String> for SqlDatabaseVersion {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SqlDatabaseVersion {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SqlDatabaseVersion {
         fn default() -> Self {
-            sql_database_version::SQL_DATABASE_VERSION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The availability type of the given Cloud SQL instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlAvailabilityType(std::borrow::Cow<'static, str>);
+    pub struct SqlAvailabilityType(i32);
 
     impl SqlAvailabilityType {
+        /// This is an unknown Availability type.
+        pub const SQL_AVAILABILITY_TYPE_UNSPECIFIED: SqlAvailabilityType =
+            SqlAvailabilityType::new(0);
+
+        /// Zonal availablility instance.
+        pub const ZONAL: SqlAvailabilityType = SqlAvailabilityType::new(1);
+
+        /// Regional availability instance.
+        pub const REGIONAL: SqlAvailabilityType = SqlAvailabilityType::new(2);
+
         /// Creates a new SqlAvailabilityType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SQL_AVAILABILITY_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ZONAL"),
+                2 => std::borrow::Cow::Borrowed("REGIONAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SQL_AVAILABILITY_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SQL_AVAILABILITY_TYPE_UNSPECIFIED)
+                }
+                "ZONAL" => std::option::Option::Some(Self::ZONAL),
+                "REGIONAL" => std::option::Option::Some(Self::REGIONAL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SqlAvailabilityType](SqlAvailabilityType)
-    pub mod sql_availability_type {
-        use super::SqlAvailabilityType;
-
-        /// This is an unknown Availability type.
-        pub const SQL_AVAILABILITY_TYPE_UNSPECIFIED: SqlAvailabilityType =
-            SqlAvailabilityType::new("SQL_AVAILABILITY_TYPE_UNSPECIFIED");
-
-        /// Zonal availablility instance.
-        pub const ZONAL: SqlAvailabilityType = SqlAvailabilityType::new("ZONAL");
-
-        /// Regional availability instance.
-        pub const REGIONAL: SqlAvailabilityType = SqlAvailabilityType::new("REGIONAL");
-    }
-
-    impl std::convert::From<std::string::String> for SqlAvailabilityType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SqlAvailabilityType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SqlAvailabilityType {
         fn default() -> Self {
-            sql_availability_type::SQL_AVAILABILITY_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The edition of the given Cloud SQL instance.
     /// Can be ENTERPRISE or ENTERPRISE_PLUS.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Edition(std::borrow::Cow<'static, str>);
+    pub struct Edition(i32);
 
     impl Edition {
+        /// The instance did not specify the edition.
+        pub const EDITION_UNSPECIFIED: Edition = Edition::new(0);
+
+        /// The instance is an enterprise edition.
+        pub const ENTERPRISE: Edition = Edition::new(2);
+
+        /// The instance is an enterprise plus edition.
+        pub const ENTERPRISE_PLUS: Edition = Edition::new(3);
+
         /// Creates a new Edition instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EDITION_UNSPECIFIED"),
+                2 => std::borrow::Cow::Borrowed("ENTERPRISE"),
+                3 => std::borrow::Cow::Borrowed("ENTERPRISE_PLUS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EDITION_UNSPECIFIED" => std::option::Option::Some(Self::EDITION_UNSPECIFIED),
+                "ENTERPRISE" => std::option::Option::Some(Self::ENTERPRISE),
+                "ENTERPRISE_PLUS" => std::option::Option::Some(Self::ENTERPRISE_PLUS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Edition](Edition)
-    pub mod edition {
-        use super::Edition;
-
-        /// The instance did not specify the edition.
-        pub const EDITION_UNSPECIFIED: Edition = Edition::new("EDITION_UNSPECIFIED");
-
-        /// The instance is an enterprise edition.
-        pub const ENTERPRISE: Edition = Edition::new("ENTERPRISE");
-
-        /// The instance is an enterprise plus edition.
-        pub const ENTERPRISE_PLUS: Edition = Edition::new("ENTERPRISE_PLUS");
-    }
-
-    impl std::convert::From<std::string::String> for Edition {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Edition {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Edition {
         fn default() -> Self {
-            edition::EDITION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6273,223 +6403,320 @@ pub mod migration_job {
 
         /// Describes the parallelism level during initial dump.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct DumpParallelLevel(std::borrow::Cow<'static, str>);
+        pub struct DumpParallelLevel(i32);
 
         impl DumpParallelLevel {
+            /// Unknown dump parallel level. Will be defaulted to OPTIMAL.
+            pub const DUMP_PARALLEL_LEVEL_UNSPECIFIED: DumpParallelLevel =
+                DumpParallelLevel::new(0);
+
+            /// Minimal parallel level.
+            pub const MIN: DumpParallelLevel = DumpParallelLevel::new(1);
+
+            /// Optimal parallel level.
+            pub const OPTIMAL: DumpParallelLevel = DumpParallelLevel::new(2);
+
+            /// Maximum parallel level.
+            pub const MAX: DumpParallelLevel = DumpParallelLevel::new(3);
+
             /// Creates a new DumpParallelLevel instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("DUMP_PARALLEL_LEVEL_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("MIN"),
+                    2 => std::borrow::Cow::Borrowed("OPTIMAL"),
+                    3 => std::borrow::Cow::Borrowed("MAX"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "DUMP_PARALLEL_LEVEL_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::DUMP_PARALLEL_LEVEL_UNSPECIFIED)
+                    }
+                    "MIN" => std::option::Option::Some(Self::MIN),
+                    "OPTIMAL" => std::option::Option::Some(Self::OPTIMAL),
+                    "MAX" => std::option::Option::Some(Self::MAX),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [DumpParallelLevel](DumpParallelLevel)
-        pub mod dump_parallel_level {
-            use super::DumpParallelLevel;
-
-            /// Unknown dump parallel level. Will be defaulted to OPTIMAL.
-            pub const DUMP_PARALLEL_LEVEL_UNSPECIFIED: DumpParallelLevel =
-                DumpParallelLevel::new("DUMP_PARALLEL_LEVEL_UNSPECIFIED");
-
-            /// Minimal parallel level.
-            pub const MIN: DumpParallelLevel = DumpParallelLevel::new("MIN");
-
-            /// Optimal parallel level.
-            pub const OPTIMAL: DumpParallelLevel = DumpParallelLevel::new("OPTIMAL");
-
-            /// Maximum parallel level.
-            pub const MAX: DumpParallelLevel = DumpParallelLevel::new("MAX");
-        }
-
-        impl std::convert::From<std::string::String> for DumpParallelLevel {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for DumpParallelLevel {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for DumpParallelLevel {
             fn default() -> Self {
-                dump_parallel_level::DUMP_PARALLEL_LEVEL_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// The current migration job states.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The state of the migration job is unknown.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The migration job is down for maintenance.
+        pub const MAINTENANCE: State = State::new(1);
+
+        /// The migration job is in draft mode and no resources are created.
+        pub const DRAFT: State = State::new(2);
+
+        /// The migration job is being created.
+        pub const CREATING: State = State::new(3);
+
+        /// The migration job is created and not started.
+        pub const NOT_STARTED: State = State::new(4);
+
+        /// The migration job is running.
+        pub const RUNNING: State = State::new(5);
+
+        /// The migration job failed.
+        pub const FAILED: State = State::new(6);
+
+        /// The migration job has been completed.
+        pub const COMPLETED: State = State::new(7);
+
+        /// The migration job is being deleted.
+        pub const DELETING: State = State::new(8);
+
+        /// The migration job is being stopped.
+        pub const STOPPING: State = State::new(9);
+
+        /// The migration job is currently stopped.
+        pub const STOPPED: State = State::new(10);
+
+        /// The migration job has been deleted.
+        pub const DELETED: State = State::new(11);
+
+        /// The migration job is being updated.
+        pub const UPDATING: State = State::new(12);
+
+        /// The migration job is starting.
+        pub const STARTING: State = State::new(13);
+
+        /// The migration job is restarting.
+        pub const RESTARTING: State = State::new(14);
+
+        /// The migration job is resuming.
+        pub const RESUMING: State = State::new(15);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MAINTENANCE"),
+                2 => std::borrow::Cow::Borrowed("DRAFT"),
+                3 => std::borrow::Cow::Borrowed("CREATING"),
+                4 => std::borrow::Cow::Borrowed("NOT_STARTED"),
+                5 => std::borrow::Cow::Borrowed("RUNNING"),
+                6 => std::borrow::Cow::Borrowed("FAILED"),
+                7 => std::borrow::Cow::Borrowed("COMPLETED"),
+                8 => std::borrow::Cow::Borrowed("DELETING"),
+                9 => std::borrow::Cow::Borrowed("STOPPING"),
+                10 => std::borrow::Cow::Borrowed("STOPPED"),
+                11 => std::borrow::Cow::Borrowed("DELETED"),
+                12 => std::borrow::Cow::Borrowed("UPDATING"),
+                13 => std::borrow::Cow::Borrowed("STARTING"),
+                14 => std::borrow::Cow::Borrowed("RESTARTING"),
+                15 => std::borrow::Cow::Borrowed("RESUMING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "MAINTENANCE" => std::option::Option::Some(Self::MAINTENANCE),
+                "DRAFT" => std::option::Option::Some(Self::DRAFT),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "NOT_STARTED" => std::option::Option::Some(Self::NOT_STARTED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "COMPLETED" => std::option::Option::Some(Self::COMPLETED),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "STOPPING" => std::option::Option::Some(Self::STOPPING),
+                "STOPPED" => std::option::Option::Some(Self::STOPPED),
+                "DELETED" => std::option::Option::Some(Self::DELETED),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "STARTING" => std::option::Option::Some(Self::STARTING),
+                "RESTARTING" => std::option::Option::Some(Self::RESTARTING),
+                "RESUMING" => std::option::Option::Some(Self::RESUMING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The state of the migration job is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The migration job is down for maintenance.
-        pub const MAINTENANCE: State = State::new("MAINTENANCE");
-
-        /// The migration job is in draft mode and no resources are created.
-        pub const DRAFT: State = State::new("DRAFT");
-
-        /// The migration job is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The migration job is created and not started.
-        pub const NOT_STARTED: State = State::new("NOT_STARTED");
-
-        /// The migration job is running.
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// The migration job failed.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// The migration job has been completed.
-        pub const COMPLETED: State = State::new("COMPLETED");
-
-        /// The migration job is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// The migration job is being stopped.
-        pub const STOPPING: State = State::new("STOPPING");
-
-        /// The migration job is currently stopped.
-        pub const STOPPED: State = State::new("STOPPED");
-
-        /// The migration job has been deleted.
-        pub const DELETED: State = State::new("DELETED");
-
-        /// The migration job is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// The migration job is starting.
-        pub const STARTING: State = State::new("STARTING");
-
-        /// The migration job is restarting.
-        pub const RESTARTING: State = State::new("RESTARTING");
-
-        /// The migration job is resuming.
-        pub const RESUMING: State = State::new("RESUMING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The current migration job phase.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Phase(std::borrow::Cow<'static, str>);
+    pub struct Phase(i32);
 
     impl Phase {
+        /// The phase of the migration job is unknown.
+        pub const PHASE_UNSPECIFIED: Phase = Phase::new(0);
+
+        /// The migration job is in the full dump phase.
+        pub const FULL_DUMP: Phase = Phase::new(1);
+
+        /// The migration job is CDC phase.
+        pub const CDC: Phase = Phase::new(2);
+
+        /// The migration job is running the promote phase.
+        pub const PROMOTE_IN_PROGRESS: Phase = Phase::new(3);
+
+        /// Only RDS flow - waiting for source writes to stop
+        pub const WAITING_FOR_SOURCE_WRITES_TO_STOP: Phase = Phase::new(4);
+
+        /// Only RDS flow - the sources writes stopped, waiting for dump to begin
+        pub const PREPARING_THE_DUMP: Phase = Phase::new(5);
+
         /// Creates a new Phase instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PHASE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FULL_DUMP"),
+                2 => std::borrow::Cow::Borrowed("CDC"),
+                3 => std::borrow::Cow::Borrowed("PROMOTE_IN_PROGRESS"),
+                4 => std::borrow::Cow::Borrowed("WAITING_FOR_SOURCE_WRITES_TO_STOP"),
+                5 => std::borrow::Cow::Borrowed("PREPARING_THE_DUMP"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PHASE_UNSPECIFIED" => std::option::Option::Some(Self::PHASE_UNSPECIFIED),
+                "FULL_DUMP" => std::option::Option::Some(Self::FULL_DUMP),
+                "CDC" => std::option::Option::Some(Self::CDC),
+                "PROMOTE_IN_PROGRESS" => std::option::Option::Some(Self::PROMOTE_IN_PROGRESS),
+                "WAITING_FOR_SOURCE_WRITES_TO_STOP" => {
+                    std::option::Option::Some(Self::WAITING_FOR_SOURCE_WRITES_TO_STOP)
+                }
+                "PREPARING_THE_DUMP" => std::option::Option::Some(Self::PREPARING_THE_DUMP),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Phase](Phase)
-    pub mod phase {
-        use super::Phase;
-
-        /// The phase of the migration job is unknown.
-        pub const PHASE_UNSPECIFIED: Phase = Phase::new("PHASE_UNSPECIFIED");
-
-        /// The migration job is in the full dump phase.
-        pub const FULL_DUMP: Phase = Phase::new("FULL_DUMP");
-
-        /// The migration job is CDC phase.
-        pub const CDC: Phase = Phase::new("CDC");
-
-        /// The migration job is running the promote phase.
-        pub const PROMOTE_IN_PROGRESS: Phase = Phase::new("PROMOTE_IN_PROGRESS");
-
-        /// Only RDS flow - waiting for source writes to stop
-        pub const WAITING_FOR_SOURCE_WRITES_TO_STOP: Phase =
-            Phase::new("WAITING_FOR_SOURCE_WRITES_TO_STOP");
-
-        /// Only RDS flow - the sources writes stopped, waiting for dump to begin
-        pub const PREPARING_THE_DUMP: Phase = Phase::new("PREPARING_THE_DUMP");
-    }
-
-    impl std::convert::From<std::string::String> for Phase {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Phase {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Phase {
         fn default() -> Self {
-            phase::PHASE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The type of migration job (one-time or continuous).
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// The type of the migration job is unknown.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// The migration job is a one time migration.
+        pub const ONE_TIME: Type = Type::new(1);
+
+        /// The migration job is a continuous migration.
+        pub const CONTINUOUS: Type = Type::new(2);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ONE_TIME"),
+                2 => std::borrow::Cow::Borrowed("CONTINUOUS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "ONE_TIME" => std::option::Option::Some(Self::ONE_TIME),
+                "CONTINUOUS" => std::option::Option::Some(Self::CONTINUOUS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// The type of the migration job is unknown.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// The migration job is a one time migration.
-        pub const ONE_TIME: Type = Type::new("ONE_TIME");
-
-        /// The migration job is a continuous migration.
-        pub const CONTINUOUS: Type = Type::new("CONTINUOUS");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -6859,58 +7086,83 @@ pub mod connection_profile {
 
     /// The current connection profile state (e.g. DRAFT, READY, or FAILED).
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The state of the connection profile is unknown.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The connection profile is in draft mode and fully editable.
+        pub const DRAFT: State = State::new(1);
+
+        /// The connection profile is being created.
+        pub const CREATING: State = State::new(2);
+
+        /// The connection profile is ready.
+        pub const READY: State = State::new(3);
+
+        /// The connection profile is being updated.
+        pub const UPDATING: State = State::new(4);
+
+        /// The connection profile is being deleted.
+        pub const DELETING: State = State::new(5);
+
+        /// The connection profile has been deleted.
+        pub const DELETED: State = State::new(6);
+
+        /// The last action on the connection profile failed.
+        pub const FAILED: State = State::new(7);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DRAFT"),
+                2 => std::borrow::Cow::Borrowed("CREATING"),
+                3 => std::borrow::Cow::Borrowed("READY"),
+                4 => std::borrow::Cow::Borrowed("UPDATING"),
+                5 => std::borrow::Cow::Borrowed("DELETING"),
+                6 => std::borrow::Cow::Borrowed("DELETED"),
+                7 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "DRAFT" => std::option::Option::Some(Self::DRAFT),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "DELETED" => std::option::Option::Some(Self::DELETED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The state of the connection profile is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The connection profile is in draft mode and fully editable.
-        pub const DRAFT: State = State::new("DRAFT");
-
-        /// The connection profile is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The connection profile is ready.
-        pub const READY: State = State::new("READY");
-
-        /// The connection profile is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// The connection profile is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// The connection profile has been deleted.
-        pub const DELETED: State = State::new("DELETED");
-
-        /// The last action on the connection profile failed.
-        pub const FAILED: State = State::new("FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -6996,141 +7248,225 @@ pub mod migration_job_verification_error {
 
     /// A general error code describing the type of error that occurred.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ErrorCode(std::borrow::Cow<'static, str>);
+    pub struct ErrorCode(i32);
 
     impl ErrorCode {
-        /// Creates a new ErrorCode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ErrorCode](ErrorCode)
-    pub mod error_code {
-        use super::ErrorCode;
-
         /// An unknown error occurred
-        pub const ERROR_CODE_UNSPECIFIED: ErrorCode = ErrorCode::new("ERROR_CODE_UNSPECIFIED");
+        pub const ERROR_CODE_UNSPECIFIED: ErrorCode = ErrorCode::new(0);
 
         /// We failed to connect to one of the connection profile.
-        pub const CONNECTION_FAILURE: ErrorCode = ErrorCode::new("CONNECTION_FAILURE");
+        pub const CONNECTION_FAILURE: ErrorCode = ErrorCode::new(1);
 
         /// We failed to authenticate to one of the connection profile.
-        pub const AUTHENTICATION_FAILURE: ErrorCode = ErrorCode::new("AUTHENTICATION_FAILURE");
+        pub const AUTHENTICATION_FAILURE: ErrorCode = ErrorCode::new(2);
 
         /// One of the involved connection profiles has an invalid configuration.
-        pub const INVALID_CONNECTION_PROFILE_CONFIG: ErrorCode =
-            ErrorCode::new("INVALID_CONNECTION_PROFILE_CONFIG");
+        pub const INVALID_CONNECTION_PROFILE_CONFIG: ErrorCode = ErrorCode::new(3);
 
         /// The versions of the source and the destination are incompatible.
-        pub const VERSION_INCOMPATIBILITY: ErrorCode = ErrorCode::new("VERSION_INCOMPATIBILITY");
+        pub const VERSION_INCOMPATIBILITY: ErrorCode = ErrorCode::new(4);
 
         /// The types of the source and the destination are incompatible.
-        pub const CONNECTION_PROFILE_TYPES_INCOMPATIBILITY: ErrorCode =
-            ErrorCode::new("CONNECTION_PROFILE_TYPES_INCOMPATIBILITY");
+        pub const CONNECTION_PROFILE_TYPES_INCOMPATIBILITY: ErrorCode = ErrorCode::new(5);
 
         /// No pglogical extension installed on databases, applicable for postgres.
-        pub const NO_PGLOGICAL_INSTALLED: ErrorCode = ErrorCode::new("NO_PGLOGICAL_INSTALLED");
+        pub const NO_PGLOGICAL_INSTALLED: ErrorCode = ErrorCode::new(7);
 
         /// pglogical node already exists on databases, applicable for postgres.
-        pub const PGLOGICAL_NODE_ALREADY_EXISTS: ErrorCode =
-            ErrorCode::new("PGLOGICAL_NODE_ALREADY_EXISTS");
+        pub const PGLOGICAL_NODE_ALREADY_EXISTS: ErrorCode = ErrorCode::new(8);
 
         /// The value of parameter wal_level is not set to logical.
-        pub const INVALID_WAL_LEVEL: ErrorCode = ErrorCode::new("INVALID_WAL_LEVEL");
+        pub const INVALID_WAL_LEVEL: ErrorCode = ErrorCode::new(9);
 
         /// The value of parameter shared_preload_libraries does not include
         /// pglogical.
-        pub const INVALID_SHARED_PRELOAD_LIBRARY: ErrorCode =
-            ErrorCode::new("INVALID_SHARED_PRELOAD_LIBRARY");
+        pub const INVALID_SHARED_PRELOAD_LIBRARY: ErrorCode = ErrorCode::new(10);
 
         /// The value of parameter max_replication_slots is not sufficient.
-        pub const INSUFFICIENT_MAX_REPLICATION_SLOTS: ErrorCode =
-            ErrorCode::new("INSUFFICIENT_MAX_REPLICATION_SLOTS");
+        pub const INSUFFICIENT_MAX_REPLICATION_SLOTS: ErrorCode = ErrorCode::new(11);
 
         /// The value of parameter max_wal_senders is not sufficient.
-        pub const INSUFFICIENT_MAX_WAL_SENDERS: ErrorCode =
-            ErrorCode::new("INSUFFICIENT_MAX_WAL_SENDERS");
+        pub const INSUFFICIENT_MAX_WAL_SENDERS: ErrorCode = ErrorCode::new(12);
 
         /// The value of parameter max_worker_processes is not sufficient.
-        pub const INSUFFICIENT_MAX_WORKER_PROCESSES: ErrorCode =
-            ErrorCode::new("INSUFFICIENT_MAX_WORKER_PROCESSES");
+        pub const INSUFFICIENT_MAX_WORKER_PROCESSES: ErrorCode = ErrorCode::new(13);
 
         /// Extensions installed are either not supported or having unsupported
         /// versions.
-        pub const UNSUPPORTED_EXTENSIONS: ErrorCode = ErrorCode::new("UNSUPPORTED_EXTENSIONS");
+        pub const UNSUPPORTED_EXTENSIONS: ErrorCode = ErrorCode::new(14);
 
         /// Unsupported migration type.
-        pub const UNSUPPORTED_MIGRATION_TYPE: ErrorCode =
-            ErrorCode::new("UNSUPPORTED_MIGRATION_TYPE");
+        pub const UNSUPPORTED_MIGRATION_TYPE: ErrorCode = ErrorCode::new(15);
 
         /// Invalid RDS logical replication.
-        pub const INVALID_RDS_LOGICAL_REPLICATION: ErrorCode =
-            ErrorCode::new("INVALID_RDS_LOGICAL_REPLICATION");
+        pub const INVALID_RDS_LOGICAL_REPLICATION: ErrorCode = ErrorCode::new(16);
 
         /// The gtid_mode is not supported, applicable for MySQL.
-        pub const UNSUPPORTED_GTID_MODE: ErrorCode = ErrorCode::new("UNSUPPORTED_GTID_MODE");
+        pub const UNSUPPORTED_GTID_MODE: ErrorCode = ErrorCode::new(17);
 
         /// The table definition is not support due to missing primary key or replica
         /// identity.
-        pub const UNSUPPORTED_TABLE_DEFINITION: ErrorCode =
-            ErrorCode::new("UNSUPPORTED_TABLE_DEFINITION");
+        pub const UNSUPPORTED_TABLE_DEFINITION: ErrorCode = ErrorCode::new(18);
 
         /// The definer is not supported.
-        pub const UNSUPPORTED_DEFINER: ErrorCode = ErrorCode::new("UNSUPPORTED_DEFINER");
+        pub const UNSUPPORTED_DEFINER: ErrorCode = ErrorCode::new(19);
 
         /// Migration is already running at the time of restart request.
-        pub const CANT_RESTART_RUNNING_MIGRATION: ErrorCode =
-            ErrorCode::new("CANT_RESTART_RUNNING_MIGRATION");
+        pub const CANT_RESTART_RUNNING_MIGRATION: ErrorCode = ErrorCode::new(21);
 
         /// The source already has a replication setup.
-        pub const SOURCE_ALREADY_SETUP: ErrorCode = ErrorCode::new("SOURCE_ALREADY_SETUP");
+        pub const SOURCE_ALREADY_SETUP: ErrorCode = ErrorCode::new(23);
 
         /// The source has tables with limited support.
         /// E.g. PostgreSQL tables without primary keys.
-        pub const TABLES_WITH_LIMITED_SUPPORT: ErrorCode =
-            ErrorCode::new("TABLES_WITH_LIMITED_SUPPORT");
+        pub const TABLES_WITH_LIMITED_SUPPORT: ErrorCode = ErrorCode::new(24);
 
         /// The source uses an unsupported locale.
-        pub const UNSUPPORTED_DATABASE_LOCALE: ErrorCode =
-            ErrorCode::new("UNSUPPORTED_DATABASE_LOCALE");
+        pub const UNSUPPORTED_DATABASE_LOCALE: ErrorCode = ErrorCode::new(25);
 
         /// The source uses an unsupported Foreign Data Wrapper configuration.
-        pub const UNSUPPORTED_DATABASE_FDW_CONFIG: ErrorCode =
-            ErrorCode::new("UNSUPPORTED_DATABASE_FDW_CONFIG");
+        pub const UNSUPPORTED_DATABASE_FDW_CONFIG: ErrorCode = ErrorCode::new(26);
 
         /// There was an underlying RDBMS error.
-        pub const ERROR_RDBMS: ErrorCode = ErrorCode::new("ERROR_RDBMS");
+        pub const ERROR_RDBMS: ErrorCode = ErrorCode::new(27);
 
         /// The source DB size in Bytes exceeds a certain threshold. The migration
         /// might require an increase of quota, or might not be supported.
-        pub const SOURCE_SIZE_EXCEEDS_THRESHOLD: ErrorCode =
-            ErrorCode::new("SOURCE_SIZE_EXCEEDS_THRESHOLD");
+        pub const SOURCE_SIZE_EXCEEDS_THRESHOLD: ErrorCode = ErrorCode::new(28);
 
         /// The destination DB contains existing databases that are conflicting with
         /// those in the source DB.
-        pub const EXISTING_CONFLICTING_DATABASES: ErrorCode =
-            ErrorCode::new("EXISTING_CONFLICTING_DATABASES");
+        pub const EXISTING_CONFLICTING_DATABASES: ErrorCode = ErrorCode::new(29);
 
         /// Insufficient privilege to enable the parallelism configuration.
-        pub const PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE: ErrorCode =
-            ErrorCode::new("PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE");
+        pub const PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE: ErrorCode = ErrorCode::new(30);
+
+        /// Creates a new ErrorCode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ERROR_CODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CONNECTION_FAILURE"),
+                2 => std::borrow::Cow::Borrowed("AUTHENTICATION_FAILURE"),
+                3 => std::borrow::Cow::Borrowed("INVALID_CONNECTION_PROFILE_CONFIG"),
+                4 => std::borrow::Cow::Borrowed("VERSION_INCOMPATIBILITY"),
+                5 => std::borrow::Cow::Borrowed("CONNECTION_PROFILE_TYPES_INCOMPATIBILITY"),
+                7 => std::borrow::Cow::Borrowed("NO_PGLOGICAL_INSTALLED"),
+                8 => std::borrow::Cow::Borrowed("PGLOGICAL_NODE_ALREADY_EXISTS"),
+                9 => std::borrow::Cow::Borrowed("INVALID_WAL_LEVEL"),
+                10 => std::borrow::Cow::Borrowed("INVALID_SHARED_PRELOAD_LIBRARY"),
+                11 => std::borrow::Cow::Borrowed("INSUFFICIENT_MAX_REPLICATION_SLOTS"),
+                12 => std::borrow::Cow::Borrowed("INSUFFICIENT_MAX_WAL_SENDERS"),
+                13 => std::borrow::Cow::Borrowed("INSUFFICIENT_MAX_WORKER_PROCESSES"),
+                14 => std::borrow::Cow::Borrowed("UNSUPPORTED_EXTENSIONS"),
+                15 => std::borrow::Cow::Borrowed("UNSUPPORTED_MIGRATION_TYPE"),
+                16 => std::borrow::Cow::Borrowed("INVALID_RDS_LOGICAL_REPLICATION"),
+                17 => std::borrow::Cow::Borrowed("UNSUPPORTED_GTID_MODE"),
+                18 => std::borrow::Cow::Borrowed("UNSUPPORTED_TABLE_DEFINITION"),
+                19 => std::borrow::Cow::Borrowed("UNSUPPORTED_DEFINER"),
+                21 => std::borrow::Cow::Borrowed("CANT_RESTART_RUNNING_MIGRATION"),
+                23 => std::borrow::Cow::Borrowed("SOURCE_ALREADY_SETUP"),
+                24 => std::borrow::Cow::Borrowed("TABLES_WITH_LIMITED_SUPPORT"),
+                25 => std::borrow::Cow::Borrowed("UNSUPPORTED_DATABASE_LOCALE"),
+                26 => std::borrow::Cow::Borrowed("UNSUPPORTED_DATABASE_FDW_CONFIG"),
+                27 => std::borrow::Cow::Borrowed("ERROR_RDBMS"),
+                28 => std::borrow::Cow::Borrowed("SOURCE_SIZE_EXCEEDS_THRESHOLD"),
+                29 => std::borrow::Cow::Borrowed("EXISTING_CONFLICTING_DATABASES"),
+                30 => std::borrow::Cow::Borrowed("PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ERROR_CODE_UNSPECIFIED" => std::option::Option::Some(Self::ERROR_CODE_UNSPECIFIED),
+                "CONNECTION_FAILURE" => std::option::Option::Some(Self::CONNECTION_FAILURE),
+                "AUTHENTICATION_FAILURE" => std::option::Option::Some(Self::AUTHENTICATION_FAILURE),
+                "INVALID_CONNECTION_PROFILE_CONFIG" => {
+                    std::option::Option::Some(Self::INVALID_CONNECTION_PROFILE_CONFIG)
+                }
+                "VERSION_INCOMPATIBILITY" => {
+                    std::option::Option::Some(Self::VERSION_INCOMPATIBILITY)
+                }
+                "CONNECTION_PROFILE_TYPES_INCOMPATIBILITY" => {
+                    std::option::Option::Some(Self::CONNECTION_PROFILE_TYPES_INCOMPATIBILITY)
+                }
+                "NO_PGLOGICAL_INSTALLED" => std::option::Option::Some(Self::NO_PGLOGICAL_INSTALLED),
+                "PGLOGICAL_NODE_ALREADY_EXISTS" => {
+                    std::option::Option::Some(Self::PGLOGICAL_NODE_ALREADY_EXISTS)
+                }
+                "INVALID_WAL_LEVEL" => std::option::Option::Some(Self::INVALID_WAL_LEVEL),
+                "INVALID_SHARED_PRELOAD_LIBRARY" => {
+                    std::option::Option::Some(Self::INVALID_SHARED_PRELOAD_LIBRARY)
+                }
+                "INSUFFICIENT_MAX_REPLICATION_SLOTS" => {
+                    std::option::Option::Some(Self::INSUFFICIENT_MAX_REPLICATION_SLOTS)
+                }
+                "INSUFFICIENT_MAX_WAL_SENDERS" => {
+                    std::option::Option::Some(Self::INSUFFICIENT_MAX_WAL_SENDERS)
+                }
+                "INSUFFICIENT_MAX_WORKER_PROCESSES" => {
+                    std::option::Option::Some(Self::INSUFFICIENT_MAX_WORKER_PROCESSES)
+                }
+                "UNSUPPORTED_EXTENSIONS" => std::option::Option::Some(Self::UNSUPPORTED_EXTENSIONS),
+                "UNSUPPORTED_MIGRATION_TYPE" => {
+                    std::option::Option::Some(Self::UNSUPPORTED_MIGRATION_TYPE)
+                }
+                "INVALID_RDS_LOGICAL_REPLICATION" => {
+                    std::option::Option::Some(Self::INVALID_RDS_LOGICAL_REPLICATION)
+                }
+                "UNSUPPORTED_GTID_MODE" => std::option::Option::Some(Self::UNSUPPORTED_GTID_MODE),
+                "UNSUPPORTED_TABLE_DEFINITION" => {
+                    std::option::Option::Some(Self::UNSUPPORTED_TABLE_DEFINITION)
+                }
+                "UNSUPPORTED_DEFINER" => std::option::Option::Some(Self::UNSUPPORTED_DEFINER),
+                "CANT_RESTART_RUNNING_MIGRATION" => {
+                    std::option::Option::Some(Self::CANT_RESTART_RUNNING_MIGRATION)
+                }
+                "SOURCE_ALREADY_SETUP" => std::option::Option::Some(Self::SOURCE_ALREADY_SETUP),
+                "TABLES_WITH_LIMITED_SUPPORT" => {
+                    std::option::Option::Some(Self::TABLES_WITH_LIMITED_SUPPORT)
+                }
+                "UNSUPPORTED_DATABASE_LOCALE" => {
+                    std::option::Option::Some(Self::UNSUPPORTED_DATABASE_LOCALE)
+                }
+                "UNSUPPORTED_DATABASE_FDW_CONFIG" => {
+                    std::option::Option::Some(Self::UNSUPPORTED_DATABASE_FDW_CONFIG)
+                }
+                "ERROR_RDBMS" => std::option::Option::Some(Self::ERROR_RDBMS),
+                "SOURCE_SIZE_EXCEEDS_THRESHOLD" => {
+                    std::option::Option::Some(Self::SOURCE_SIZE_EXCEEDS_THRESHOLD)
+                }
+                "EXISTING_CONFLICTING_DATABASES" => {
+                    std::option::Option::Some(Self::EXISTING_CONFLICTING_DATABASES)
+                }
+                "PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE" => {
+                    std::option::Option::Some(Self::PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ErrorCode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ErrorCode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ErrorCode {
         fn default() -> Self {
-            error_code::ERROR_CODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7299,54 +7635,77 @@ pub mod private_connection {
 
     /// Private Connection state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The private connection is in creation state - creating resources.
+        pub const CREATING: State = State::new(1);
+
+        /// The private connection has been created with all of its resources.
+        pub const CREATED: State = State::new(2);
+
+        /// The private connection creation has failed.
+        pub const FAILED: State = State::new(3);
+
+        /// The private connection is being deleted.
+        pub const DELETING: State = State::new(4);
+
+        /// Delete request has failed, resource is in invalid state.
+        pub const FAILED_TO_DELETE: State = State::new(5);
+
+        /// The private connection has been deleted.
+        pub const DELETED: State = State::new(6);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("CREATED"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("FAILED_TO_DELETE"),
+                6 => std::borrow::Cow::Borrowed("DELETED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "CREATED" => std::option::Option::Some(Self::CREATED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "FAILED_TO_DELETE" => std::option::Option::Some(Self::FAILED_TO_DELETE),
+                "DELETED" => std::option::Option::Some(Self::DELETED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The private connection is in creation state - creating resources.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The private connection has been created with all of its resources.
-        pub const CREATED: State = State::new("CREATED");
-
-        /// The private connection creation has failed.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// The private connection is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// Delete request has failed, resource is in invalid state.
-        pub const FAILED_TO_DELETE: State = State::new("FAILED_TO_DELETE");
-
-        /// The private connection has been deleted.
-        pub const DELETED: State = State::new("DELETED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -8007,45 +8366,61 @@ pub mod background_job_log_entry {
 
     /// Final state after a job completes.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct JobCompletionState(std::borrow::Cow<'static, str>);
+    pub struct JobCompletionState(i32);
 
     impl JobCompletionState {
+        /// The status is not specified. This state is used when job is not yet
+        /// finished.
+        pub const JOB_COMPLETION_STATE_UNSPECIFIED: JobCompletionState = JobCompletionState::new(0);
+
+        /// Success.
+        pub const SUCCEEDED: JobCompletionState = JobCompletionState::new(1);
+
+        /// Error.
+        pub const FAILED: JobCompletionState = JobCompletionState::new(2);
+
         /// Creates a new JobCompletionState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("JOB_COMPLETION_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                2 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "JOB_COMPLETION_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::JOB_COMPLETION_STATE_UNSPECIFIED)
+                }
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [JobCompletionState](JobCompletionState)
-    pub mod job_completion_state {
-        use super::JobCompletionState;
-
-        /// The status is not specified. This state is used when job is not yet
-        /// finished.
-        pub const JOB_COMPLETION_STATE_UNSPECIFIED: JobCompletionState =
-            JobCompletionState::new("JOB_COMPLETION_STATE_UNSPECIFIED");
-
-        /// Success.
-        pub const SUCCEEDED: JobCompletionState = JobCompletionState::new("SUCCEEDED");
-
-        /// Error.
-        pub const FAILED: JobCompletionState = JobCompletionState::new("FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for JobCompletionState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for JobCompletionState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for JobCompletionState {
         fn default() -> Self {
-            job_completion_state::JOB_COMPLETION_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -8646,46 +9021,63 @@ pub mod mapping_rule {
 
     /// The current mapping rule state such as enabled, disabled or deleted.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The state of the mapping rule is unknown.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The rule is enabled.
+        pub const ENABLED: State = State::new(1);
+
+        /// The rule is disabled.
+        pub const DISABLED: State = State::new(2);
+
+        /// The rule is logically deleted.
+        pub const DELETED: State = State::new(3);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENABLED"),
+                2 => std::borrow::Cow::Borrowed("DISABLED"),
+                3 => std::borrow::Cow::Borrowed("DELETED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "DELETED" => std::option::Option::Some(Self::DELETED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The state of the mapping rule is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The rule is enabled.
-        pub const ENABLED: State = State::new("ENABLED");
-
-        /// The rule is disabled.
-        pub const DISABLED: State = State::new("DISABLED");
-
-        /// The rule is logically deleted.
-        pub const DELETED: State = State::new("DELETED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -10845,46 +11237,63 @@ pub mod database_entity {
 
     /// The type of database entities tree.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TreeType(std::borrow::Cow<'static, str>);
+    pub struct TreeType(i32);
 
     impl TreeType {
+        /// Tree type unspecified.
+        pub const TREE_TYPE_UNSPECIFIED: TreeType = TreeType::new(0);
+
+        /// Tree of entities loaded from a source database.
+        pub const SOURCE: TreeType = TreeType::new(1);
+
+        /// Tree of entities converted from the source tree using the mapping rules.
+        pub const DRAFT: TreeType = TreeType::new(2);
+
+        /// Tree of entities observed on the destination database.
+        pub const DESTINATION: TreeType = TreeType::new(3);
+
         /// Creates a new TreeType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TREE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SOURCE"),
+                2 => std::borrow::Cow::Borrowed("DRAFT"),
+                3 => std::borrow::Cow::Borrowed("DESTINATION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TREE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TREE_TYPE_UNSPECIFIED),
+                "SOURCE" => std::option::Option::Some(Self::SOURCE),
+                "DRAFT" => std::option::Option::Some(Self::DRAFT),
+                "DESTINATION" => std::option::Option::Some(Self::DESTINATION),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [TreeType](TreeType)
-    pub mod tree_type {
-        use super::TreeType;
-
-        /// Tree type unspecified.
-        pub const TREE_TYPE_UNSPECIFIED: TreeType = TreeType::new("TREE_TYPE_UNSPECIFIED");
-
-        /// Tree of entities loaded from a source database.
-        pub const SOURCE: TreeType = TreeType::new("SOURCE");
-
-        /// Tree of entities converted from the source tree using the mapping rules.
-        pub const DRAFT: TreeType = TreeType::new("DRAFT");
-
-        /// Tree of entities observed on the destination database.
-        pub const DESTINATION: TreeType = TreeType::new("DESTINATION");
-    }
-
-    impl std::convert::From<std::string::String> for TreeType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TreeType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TreeType {
         fn default() -> Self {
-            tree_type::TREE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -12393,685 +12802,996 @@ pub mod entity_issue {
 
     /// Type of issue.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IssueType(std::borrow::Cow<'static, str>);
+    pub struct IssueType(i32);
 
     impl IssueType {
+        /// Unspecified issue type.
+        pub const ISSUE_TYPE_UNSPECIFIED: IssueType = IssueType::new(0);
+
+        /// Issue originated from the DDL
+        pub const ISSUE_TYPE_DDL: IssueType = IssueType::new(1);
+
+        /// Issue originated during the apply process
+        pub const ISSUE_TYPE_APPLY: IssueType = IssueType::new(2);
+
+        /// Issue originated during the convert process
+        pub const ISSUE_TYPE_CONVERT: IssueType = IssueType::new(3);
+
         /// Creates a new IssueType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ISSUE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ISSUE_TYPE_DDL"),
+                2 => std::borrow::Cow::Borrowed("ISSUE_TYPE_APPLY"),
+                3 => std::borrow::Cow::Borrowed("ISSUE_TYPE_CONVERT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ISSUE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::ISSUE_TYPE_UNSPECIFIED),
+                "ISSUE_TYPE_DDL" => std::option::Option::Some(Self::ISSUE_TYPE_DDL),
+                "ISSUE_TYPE_APPLY" => std::option::Option::Some(Self::ISSUE_TYPE_APPLY),
+                "ISSUE_TYPE_CONVERT" => std::option::Option::Some(Self::ISSUE_TYPE_CONVERT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [IssueType](IssueType)
-    pub mod issue_type {
-        use super::IssueType;
-
-        /// Unspecified issue type.
-        pub const ISSUE_TYPE_UNSPECIFIED: IssueType = IssueType::new("ISSUE_TYPE_UNSPECIFIED");
-
-        /// Issue originated from the DDL
-        pub const ISSUE_TYPE_DDL: IssueType = IssueType::new("ISSUE_TYPE_DDL");
-
-        /// Issue originated during the apply process
-        pub const ISSUE_TYPE_APPLY: IssueType = IssueType::new("ISSUE_TYPE_APPLY");
-
-        /// Issue originated during the convert process
-        pub const ISSUE_TYPE_CONVERT: IssueType = IssueType::new("ISSUE_TYPE_CONVERT");
-    }
-
-    impl std::convert::From<std::string::String> for IssueType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for IssueType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for IssueType {
         fn default() -> Self {
-            issue_type::ISSUE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Severity of issue.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IssueSeverity(std::borrow::Cow<'static, str>);
+    pub struct IssueSeverity(i32);
 
     impl IssueSeverity {
+        /// Unspecified issue severity
+        pub const ISSUE_SEVERITY_UNSPECIFIED: IssueSeverity = IssueSeverity::new(0);
+
+        /// Info
+        pub const ISSUE_SEVERITY_INFO: IssueSeverity = IssueSeverity::new(1);
+
+        /// Warning
+        pub const ISSUE_SEVERITY_WARNING: IssueSeverity = IssueSeverity::new(2);
+
+        /// Error
+        pub const ISSUE_SEVERITY_ERROR: IssueSeverity = IssueSeverity::new(3);
+
         /// Creates a new IssueSeverity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ISSUE_SEVERITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ISSUE_SEVERITY_INFO"),
+                2 => std::borrow::Cow::Borrowed("ISSUE_SEVERITY_WARNING"),
+                3 => std::borrow::Cow::Borrowed("ISSUE_SEVERITY_ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ISSUE_SEVERITY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ISSUE_SEVERITY_UNSPECIFIED)
+                }
+                "ISSUE_SEVERITY_INFO" => std::option::Option::Some(Self::ISSUE_SEVERITY_INFO),
+                "ISSUE_SEVERITY_WARNING" => std::option::Option::Some(Self::ISSUE_SEVERITY_WARNING),
+                "ISSUE_SEVERITY_ERROR" => std::option::Option::Some(Self::ISSUE_SEVERITY_ERROR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [IssueSeverity](IssueSeverity)
-    pub mod issue_severity {
-        use super::IssueSeverity;
-
-        /// Unspecified issue severity
-        pub const ISSUE_SEVERITY_UNSPECIFIED: IssueSeverity =
-            IssueSeverity::new("ISSUE_SEVERITY_UNSPECIFIED");
-
-        /// Info
-        pub const ISSUE_SEVERITY_INFO: IssueSeverity = IssueSeverity::new("ISSUE_SEVERITY_INFO");
-
-        /// Warning
-        pub const ISSUE_SEVERITY_WARNING: IssueSeverity =
-            IssueSeverity::new("ISSUE_SEVERITY_WARNING");
-
-        /// Error
-        pub const ISSUE_SEVERITY_ERROR: IssueSeverity = IssueSeverity::new("ISSUE_SEVERITY_ERROR");
-    }
-
-    impl std::convert::From<std::string::String> for IssueSeverity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for IssueSeverity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for IssueSeverity {
         fn default() -> Self {
-            issue_severity::ISSUE_SEVERITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
 
 /// AIP-157 Partial Response view for Database Entity.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DatabaseEntityView(std::borrow::Cow<'static, str>);
+pub struct DatabaseEntityView(i32);
 
 impl DatabaseEntityView {
-    /// Creates a new DatabaseEntityView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [DatabaseEntityView](DatabaseEntityView)
-pub mod database_entity_view {
-    use super::DatabaseEntityView;
-
     /// Unspecified view. Defaults to basic view.
-    pub const DATABASE_ENTITY_VIEW_UNSPECIFIED: DatabaseEntityView =
-        DatabaseEntityView::new("DATABASE_ENTITY_VIEW_UNSPECIFIED");
+    pub const DATABASE_ENTITY_VIEW_UNSPECIFIED: DatabaseEntityView = DatabaseEntityView::new(0);
 
     /// Default view. Does not return DDLs or Issues.
-    pub const DATABASE_ENTITY_VIEW_BASIC: DatabaseEntityView =
-        DatabaseEntityView::new("DATABASE_ENTITY_VIEW_BASIC");
+    pub const DATABASE_ENTITY_VIEW_BASIC: DatabaseEntityView = DatabaseEntityView::new(1);
 
     /// Return full entity details including mappings, ddl and issues.
-    pub const DATABASE_ENTITY_VIEW_FULL: DatabaseEntityView =
-        DatabaseEntityView::new("DATABASE_ENTITY_VIEW_FULL");
+    pub const DATABASE_ENTITY_VIEW_FULL: DatabaseEntityView = DatabaseEntityView::new(2);
 
     /// Top-most (Database, Schema) nodes which are returned contains summary
     /// details for their decendents such as the number of entities per type and
     /// issues rollups. When this view is used, only a single page of result is
     /// returned and the page_size property of the request is ignored. The
     /// returned page will only include the top-most node types.
-    pub const DATABASE_ENTITY_VIEW_ROOT_SUMMARY: DatabaseEntityView =
-        DatabaseEntityView::new("DATABASE_ENTITY_VIEW_ROOT_SUMMARY");
+    pub const DATABASE_ENTITY_VIEW_ROOT_SUMMARY: DatabaseEntityView = DatabaseEntityView::new(3);
+
+    /// Creates a new DatabaseEntityView instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_VIEW_BASIC"),
+            2 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_VIEW_FULL"),
+            3 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_VIEW_ROOT_SUMMARY"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DATABASE_ENTITY_VIEW_UNSPECIFIED" => {
+                std::option::Option::Some(Self::DATABASE_ENTITY_VIEW_UNSPECIFIED)
+            }
+            "DATABASE_ENTITY_VIEW_BASIC" => {
+                std::option::Option::Some(Self::DATABASE_ENTITY_VIEW_BASIC)
+            }
+            "DATABASE_ENTITY_VIEW_FULL" => {
+                std::option::Option::Some(Self::DATABASE_ENTITY_VIEW_FULL)
+            }
+            "DATABASE_ENTITY_VIEW_ROOT_SUMMARY" => {
+                std::option::Option::Some(Self::DATABASE_ENTITY_VIEW_ROOT_SUMMARY)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for DatabaseEntityView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DatabaseEntityView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DatabaseEntityView {
     fn default() -> Self {
-        database_entity_view::DATABASE_ENTITY_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct NetworkArchitecture(std::borrow::Cow<'static, str>);
+pub struct NetworkArchitecture(i32);
 
 impl NetworkArchitecture {
-    /// Creates a new NetworkArchitecture instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [NetworkArchitecture](NetworkArchitecture)
-pub mod network_architecture {
-    use super::NetworkArchitecture;
-
-    pub const NETWORK_ARCHITECTURE_UNSPECIFIED: NetworkArchitecture =
-        NetworkArchitecture::new("NETWORK_ARCHITECTURE_UNSPECIFIED");
+    pub const NETWORK_ARCHITECTURE_UNSPECIFIED: NetworkArchitecture = NetworkArchitecture::new(0);
 
     /// Instance is in Cloud SQL's old producer network architecture.
     pub const NETWORK_ARCHITECTURE_OLD_CSQL_PRODUCER: NetworkArchitecture =
-        NetworkArchitecture::new("NETWORK_ARCHITECTURE_OLD_CSQL_PRODUCER");
+        NetworkArchitecture::new(1);
 
     /// Instance is in Cloud SQL's new producer network architecture.
     pub const NETWORK_ARCHITECTURE_NEW_CSQL_PRODUCER: NetworkArchitecture =
-        NetworkArchitecture::new("NETWORK_ARCHITECTURE_NEW_CSQL_PRODUCER");
+        NetworkArchitecture::new(2);
+
+    /// Creates a new NetworkArchitecture instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("NETWORK_ARCHITECTURE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("NETWORK_ARCHITECTURE_OLD_CSQL_PRODUCER"),
+            2 => std::borrow::Cow::Borrowed("NETWORK_ARCHITECTURE_NEW_CSQL_PRODUCER"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "NETWORK_ARCHITECTURE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::NETWORK_ARCHITECTURE_UNSPECIFIED)
+            }
+            "NETWORK_ARCHITECTURE_OLD_CSQL_PRODUCER" => {
+                std::option::Option::Some(Self::NETWORK_ARCHITECTURE_OLD_CSQL_PRODUCER)
+            }
+            "NETWORK_ARCHITECTURE_NEW_CSQL_PRODUCER" => {
+                std::option::Option::Some(Self::NETWORK_ARCHITECTURE_NEW_CSQL_PRODUCER)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for NetworkArchitecture {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for NetworkArchitecture {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for NetworkArchitecture {
     fn default() -> Self {
-        network_architecture::NETWORK_ARCHITECTURE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The database engine types.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DatabaseEngine(std::borrow::Cow<'static, str>);
+pub struct DatabaseEngine(i32);
 
 impl DatabaseEngine {
+    /// The source database engine of the migration job is unknown.
+    pub const DATABASE_ENGINE_UNSPECIFIED: DatabaseEngine = DatabaseEngine::new(0);
+
+    /// The source engine is MySQL.
+    pub const MYSQL: DatabaseEngine = DatabaseEngine::new(1);
+
+    /// The source engine is PostgreSQL.
+    pub const POSTGRESQL: DatabaseEngine = DatabaseEngine::new(2);
+
+    /// The source engine is Oracle.
+    pub const ORACLE: DatabaseEngine = DatabaseEngine::new(4);
+
     /// Creates a new DatabaseEngine instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DATABASE_ENGINE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("MYSQL"),
+            2 => std::borrow::Cow::Borrowed("POSTGRESQL"),
+            4 => std::borrow::Cow::Borrowed("ORACLE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DATABASE_ENGINE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::DATABASE_ENGINE_UNSPECIFIED)
+            }
+            "MYSQL" => std::option::Option::Some(Self::MYSQL),
+            "POSTGRESQL" => std::option::Option::Some(Self::POSTGRESQL),
+            "ORACLE" => std::option::Option::Some(Self::ORACLE),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [DatabaseEngine](DatabaseEngine)
-pub mod database_engine {
-    use super::DatabaseEngine;
-
-    /// The source database engine of the migration job is unknown.
-    pub const DATABASE_ENGINE_UNSPECIFIED: DatabaseEngine =
-        DatabaseEngine::new("DATABASE_ENGINE_UNSPECIFIED");
-
-    /// The source engine is MySQL.
-    pub const MYSQL: DatabaseEngine = DatabaseEngine::new("MYSQL");
-
-    /// The source engine is PostgreSQL.
-    pub const POSTGRESQL: DatabaseEngine = DatabaseEngine::new("POSTGRESQL");
-
-    /// The source engine is Oracle.
-    pub const ORACLE: DatabaseEngine = DatabaseEngine::new("ORACLE");
-}
-
-impl std::convert::From<std::string::String> for DatabaseEngine {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DatabaseEngine {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DatabaseEngine {
     fn default() -> Self {
-        database_engine::DATABASE_ENGINE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The database providers.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DatabaseProvider(std::borrow::Cow<'static, str>);
+pub struct DatabaseProvider(i32);
 
 impl DatabaseProvider {
+    /// The database provider is unknown.
+    pub const DATABASE_PROVIDER_UNSPECIFIED: DatabaseProvider = DatabaseProvider::new(0);
+
+    /// CloudSQL runs the database.
+    pub const CLOUDSQL: DatabaseProvider = DatabaseProvider::new(1);
+
+    /// RDS runs the database.
+    pub const RDS: DatabaseProvider = DatabaseProvider::new(2);
+
+    /// Amazon Aurora.
+    pub const AURORA: DatabaseProvider = DatabaseProvider::new(3);
+
+    /// AlloyDB.
+    pub const ALLOYDB: DatabaseProvider = DatabaseProvider::new(4);
+
     /// Creates a new DatabaseProvider instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DATABASE_PROVIDER_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("CLOUDSQL"),
+            2 => std::borrow::Cow::Borrowed("RDS"),
+            3 => std::borrow::Cow::Borrowed("AURORA"),
+            4 => std::borrow::Cow::Borrowed("ALLOYDB"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DATABASE_PROVIDER_UNSPECIFIED" => {
+                std::option::Option::Some(Self::DATABASE_PROVIDER_UNSPECIFIED)
+            }
+            "CLOUDSQL" => std::option::Option::Some(Self::CLOUDSQL),
+            "RDS" => std::option::Option::Some(Self::RDS),
+            "AURORA" => std::option::Option::Some(Self::AURORA),
+            "ALLOYDB" => std::option::Option::Some(Self::ALLOYDB),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [DatabaseProvider](DatabaseProvider)
-pub mod database_provider {
-    use super::DatabaseProvider;
-
-    /// The database provider is unknown.
-    pub const DATABASE_PROVIDER_UNSPECIFIED: DatabaseProvider =
-        DatabaseProvider::new("DATABASE_PROVIDER_UNSPECIFIED");
-
-    /// CloudSQL runs the database.
-    pub const CLOUDSQL: DatabaseProvider = DatabaseProvider::new("CLOUDSQL");
-
-    /// RDS runs the database.
-    pub const RDS: DatabaseProvider = DatabaseProvider::new("RDS");
-
-    /// Amazon Aurora.
-    pub const AURORA: DatabaseProvider = DatabaseProvider::new("AURORA");
-
-    /// AlloyDB.
-    pub const ALLOYDB: DatabaseProvider = DatabaseProvider::new("ALLOYDB");
-}
-
-impl std::convert::From<std::string::String> for DatabaseProvider {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DatabaseProvider {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DatabaseProvider {
     fn default() -> Self {
-        database_provider::DATABASE_PROVIDER_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Enum used by ValueListFilter to indicate whether the source value is in the
 /// supplied list
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ValuePresentInList(std::borrow::Cow<'static, str>);
+pub struct ValuePresentInList(i32);
 
 impl ValuePresentInList {
-    /// Creates a new ValuePresentInList instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ValuePresentInList](ValuePresentInList)
-pub mod value_present_in_list {
-    use super::ValuePresentInList;
-
     /// Value present in list unspecified
-    pub const VALUE_PRESENT_IN_LIST_UNSPECIFIED: ValuePresentInList =
-        ValuePresentInList::new("VALUE_PRESENT_IN_LIST_UNSPECIFIED");
+    pub const VALUE_PRESENT_IN_LIST_UNSPECIFIED: ValuePresentInList = ValuePresentInList::new(0);
 
     /// If the source value is in the supplied list at value_list
-    pub const VALUE_PRESENT_IN_LIST_IF_VALUE_LIST: ValuePresentInList =
-        ValuePresentInList::new("VALUE_PRESENT_IN_LIST_IF_VALUE_LIST");
+    pub const VALUE_PRESENT_IN_LIST_IF_VALUE_LIST: ValuePresentInList = ValuePresentInList::new(1);
 
     /// If the source value is not in the supplied list at value_list
     pub const VALUE_PRESENT_IN_LIST_IF_VALUE_NOT_LIST: ValuePresentInList =
-        ValuePresentInList::new("VALUE_PRESENT_IN_LIST_IF_VALUE_NOT_LIST");
+        ValuePresentInList::new(2);
+
+    /// Creates a new ValuePresentInList instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("VALUE_PRESENT_IN_LIST_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("VALUE_PRESENT_IN_LIST_IF_VALUE_LIST"),
+            2 => std::borrow::Cow::Borrowed("VALUE_PRESENT_IN_LIST_IF_VALUE_NOT_LIST"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "VALUE_PRESENT_IN_LIST_UNSPECIFIED" => {
+                std::option::Option::Some(Self::VALUE_PRESENT_IN_LIST_UNSPECIFIED)
+            }
+            "VALUE_PRESENT_IN_LIST_IF_VALUE_LIST" => {
+                std::option::Option::Some(Self::VALUE_PRESENT_IN_LIST_IF_VALUE_LIST)
+            }
+            "VALUE_PRESENT_IN_LIST_IF_VALUE_NOT_LIST" => {
+                std::option::Option::Some(Self::VALUE_PRESENT_IN_LIST_IF_VALUE_NOT_LIST)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ValuePresentInList {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ValuePresentInList {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ValuePresentInList {
     fn default() -> Self {
-        value_present_in_list::VALUE_PRESENT_IN_LIST_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The type of database entities supported,
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DatabaseEntityType(std::borrow::Cow<'static, str>);
+pub struct DatabaseEntityType(i32);
 
 impl DatabaseEntityType {
-    /// Creates a new DatabaseEntityType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [DatabaseEntityType](DatabaseEntityType)
-pub mod database_entity_type {
-    use super::DatabaseEntityType;
-
     /// Unspecified database entity type.
-    pub const DATABASE_ENTITY_TYPE_UNSPECIFIED: DatabaseEntityType =
-        DatabaseEntityType::new("DATABASE_ENTITY_TYPE_UNSPECIFIED");
+    pub const DATABASE_ENTITY_TYPE_UNSPECIFIED: DatabaseEntityType = DatabaseEntityType::new(0);
 
     /// Schema.
-    pub const DATABASE_ENTITY_TYPE_SCHEMA: DatabaseEntityType =
-        DatabaseEntityType::new("DATABASE_ENTITY_TYPE_SCHEMA");
+    pub const DATABASE_ENTITY_TYPE_SCHEMA: DatabaseEntityType = DatabaseEntityType::new(1);
 
     /// Table.
-    pub const DATABASE_ENTITY_TYPE_TABLE: DatabaseEntityType =
-        DatabaseEntityType::new("DATABASE_ENTITY_TYPE_TABLE");
+    pub const DATABASE_ENTITY_TYPE_TABLE: DatabaseEntityType = DatabaseEntityType::new(2);
 
     /// Column.
-    pub const DATABASE_ENTITY_TYPE_COLUMN: DatabaseEntityType =
-        DatabaseEntityType::new("DATABASE_ENTITY_TYPE_COLUMN");
+    pub const DATABASE_ENTITY_TYPE_COLUMN: DatabaseEntityType = DatabaseEntityType::new(3);
 
     /// Constraint.
-    pub const DATABASE_ENTITY_TYPE_CONSTRAINT: DatabaseEntityType =
-        DatabaseEntityType::new("DATABASE_ENTITY_TYPE_CONSTRAINT");
+    pub const DATABASE_ENTITY_TYPE_CONSTRAINT: DatabaseEntityType = DatabaseEntityType::new(4);
 
     /// Index.
-    pub const DATABASE_ENTITY_TYPE_INDEX: DatabaseEntityType =
-        DatabaseEntityType::new("DATABASE_ENTITY_TYPE_INDEX");
+    pub const DATABASE_ENTITY_TYPE_INDEX: DatabaseEntityType = DatabaseEntityType::new(5);
 
     /// Trigger.
-    pub const DATABASE_ENTITY_TYPE_TRIGGER: DatabaseEntityType =
-        DatabaseEntityType::new("DATABASE_ENTITY_TYPE_TRIGGER");
+    pub const DATABASE_ENTITY_TYPE_TRIGGER: DatabaseEntityType = DatabaseEntityType::new(6);
 
     /// View.
-    pub const DATABASE_ENTITY_TYPE_VIEW: DatabaseEntityType =
-        DatabaseEntityType::new("DATABASE_ENTITY_TYPE_VIEW");
+    pub const DATABASE_ENTITY_TYPE_VIEW: DatabaseEntityType = DatabaseEntityType::new(7);
 
     /// Sequence.
-    pub const DATABASE_ENTITY_TYPE_SEQUENCE: DatabaseEntityType =
-        DatabaseEntityType::new("DATABASE_ENTITY_TYPE_SEQUENCE");
+    pub const DATABASE_ENTITY_TYPE_SEQUENCE: DatabaseEntityType = DatabaseEntityType::new(8);
 
     /// Stored Procedure.
     pub const DATABASE_ENTITY_TYPE_STORED_PROCEDURE: DatabaseEntityType =
-        DatabaseEntityType::new("DATABASE_ENTITY_TYPE_STORED_PROCEDURE");
+        DatabaseEntityType::new(9);
 
     /// Function.
-    pub const DATABASE_ENTITY_TYPE_FUNCTION: DatabaseEntityType =
-        DatabaseEntityType::new("DATABASE_ENTITY_TYPE_FUNCTION");
+    pub const DATABASE_ENTITY_TYPE_FUNCTION: DatabaseEntityType = DatabaseEntityType::new(10);
 
     /// Synonym.
-    pub const DATABASE_ENTITY_TYPE_SYNONYM: DatabaseEntityType =
-        DatabaseEntityType::new("DATABASE_ENTITY_TYPE_SYNONYM");
+    pub const DATABASE_ENTITY_TYPE_SYNONYM: DatabaseEntityType = DatabaseEntityType::new(11);
 
     /// Package.
     pub const DATABASE_ENTITY_TYPE_DATABASE_PACKAGE: DatabaseEntityType =
-        DatabaseEntityType::new("DATABASE_ENTITY_TYPE_DATABASE_PACKAGE");
+        DatabaseEntityType::new(12);
 
     /// UDT.
-    pub const DATABASE_ENTITY_TYPE_UDT: DatabaseEntityType =
-        DatabaseEntityType::new("DATABASE_ENTITY_TYPE_UDT");
+    pub const DATABASE_ENTITY_TYPE_UDT: DatabaseEntityType = DatabaseEntityType::new(13);
 
     /// Materialized View.
     pub const DATABASE_ENTITY_TYPE_MATERIALIZED_VIEW: DatabaseEntityType =
-        DatabaseEntityType::new("DATABASE_ENTITY_TYPE_MATERIALIZED_VIEW");
+        DatabaseEntityType::new(14);
 
     /// Database.
-    pub const DATABASE_ENTITY_TYPE_DATABASE: DatabaseEntityType =
-        DatabaseEntityType::new("DATABASE_ENTITY_TYPE_DATABASE");
+    pub const DATABASE_ENTITY_TYPE_DATABASE: DatabaseEntityType = DatabaseEntityType::new(15);
+
+    /// Creates a new DatabaseEntityType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_SCHEMA"),
+            2 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_TABLE"),
+            3 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_COLUMN"),
+            4 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_CONSTRAINT"),
+            5 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_INDEX"),
+            6 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_TRIGGER"),
+            7 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_VIEW"),
+            8 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_SEQUENCE"),
+            9 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_STORED_PROCEDURE"),
+            10 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_FUNCTION"),
+            11 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_SYNONYM"),
+            12 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_DATABASE_PACKAGE"),
+            13 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_UDT"),
+            14 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_MATERIALIZED_VIEW"),
+            15 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_DATABASE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DATABASE_ENTITY_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_UNSPECIFIED)
+            }
+            "DATABASE_ENTITY_TYPE_SCHEMA" => {
+                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_SCHEMA)
+            }
+            "DATABASE_ENTITY_TYPE_TABLE" => {
+                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_TABLE)
+            }
+            "DATABASE_ENTITY_TYPE_COLUMN" => {
+                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_COLUMN)
+            }
+            "DATABASE_ENTITY_TYPE_CONSTRAINT" => {
+                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_CONSTRAINT)
+            }
+            "DATABASE_ENTITY_TYPE_INDEX" => {
+                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_INDEX)
+            }
+            "DATABASE_ENTITY_TYPE_TRIGGER" => {
+                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_TRIGGER)
+            }
+            "DATABASE_ENTITY_TYPE_VIEW" => {
+                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_VIEW)
+            }
+            "DATABASE_ENTITY_TYPE_SEQUENCE" => {
+                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_SEQUENCE)
+            }
+            "DATABASE_ENTITY_TYPE_STORED_PROCEDURE" => {
+                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_STORED_PROCEDURE)
+            }
+            "DATABASE_ENTITY_TYPE_FUNCTION" => {
+                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_FUNCTION)
+            }
+            "DATABASE_ENTITY_TYPE_SYNONYM" => {
+                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_SYNONYM)
+            }
+            "DATABASE_ENTITY_TYPE_DATABASE_PACKAGE" => {
+                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_DATABASE_PACKAGE)
+            }
+            "DATABASE_ENTITY_TYPE_UDT" => std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_UDT),
+            "DATABASE_ENTITY_TYPE_MATERIALIZED_VIEW" => {
+                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_MATERIALIZED_VIEW)
+            }
+            "DATABASE_ENTITY_TYPE_DATABASE" => {
+                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_DATABASE)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for DatabaseEntityType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DatabaseEntityType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DatabaseEntityType {
     fn default() -> Self {
-        database_entity_type::DATABASE_ENTITY_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Entity Name Transformation Types
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EntityNameTransformation(std::borrow::Cow<'static, str>);
+pub struct EntityNameTransformation(i32);
 
 impl EntityNameTransformation {
-    /// Creates a new EntityNameTransformation instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [EntityNameTransformation](EntityNameTransformation)
-pub mod entity_name_transformation {
-    use super::EntityNameTransformation;
-
     /// Entity name transformation unspecified.
     pub const ENTITY_NAME_TRANSFORMATION_UNSPECIFIED: EntityNameTransformation =
-        EntityNameTransformation::new("ENTITY_NAME_TRANSFORMATION_UNSPECIFIED");
+        EntityNameTransformation::new(0);
 
     /// No transformation.
     pub const ENTITY_NAME_TRANSFORMATION_NO_TRANSFORMATION: EntityNameTransformation =
-        EntityNameTransformation::new("ENTITY_NAME_TRANSFORMATION_NO_TRANSFORMATION");
+        EntityNameTransformation::new(1);
 
     /// Transform to lower case.
     pub const ENTITY_NAME_TRANSFORMATION_LOWER_CASE: EntityNameTransformation =
-        EntityNameTransformation::new("ENTITY_NAME_TRANSFORMATION_LOWER_CASE");
+        EntityNameTransformation::new(2);
 
     /// Transform to upper case.
     pub const ENTITY_NAME_TRANSFORMATION_UPPER_CASE: EntityNameTransformation =
-        EntityNameTransformation::new("ENTITY_NAME_TRANSFORMATION_UPPER_CASE");
+        EntityNameTransformation::new(3);
 
     /// Transform to capitalized case.
     pub const ENTITY_NAME_TRANSFORMATION_CAPITALIZED_CASE: EntityNameTransformation =
-        EntityNameTransformation::new("ENTITY_NAME_TRANSFORMATION_CAPITALIZED_CASE");
+        EntityNameTransformation::new(4);
+
+    /// Creates a new EntityNameTransformation instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ENTITY_NAME_TRANSFORMATION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ENTITY_NAME_TRANSFORMATION_NO_TRANSFORMATION"),
+            2 => std::borrow::Cow::Borrowed("ENTITY_NAME_TRANSFORMATION_LOWER_CASE"),
+            3 => std::borrow::Cow::Borrowed("ENTITY_NAME_TRANSFORMATION_UPPER_CASE"),
+            4 => std::borrow::Cow::Borrowed("ENTITY_NAME_TRANSFORMATION_CAPITALIZED_CASE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ENTITY_NAME_TRANSFORMATION_UNSPECIFIED" => {
+                std::option::Option::Some(Self::ENTITY_NAME_TRANSFORMATION_UNSPECIFIED)
+            }
+            "ENTITY_NAME_TRANSFORMATION_NO_TRANSFORMATION" => {
+                std::option::Option::Some(Self::ENTITY_NAME_TRANSFORMATION_NO_TRANSFORMATION)
+            }
+            "ENTITY_NAME_TRANSFORMATION_LOWER_CASE" => {
+                std::option::Option::Some(Self::ENTITY_NAME_TRANSFORMATION_LOWER_CASE)
+            }
+            "ENTITY_NAME_TRANSFORMATION_UPPER_CASE" => {
+                std::option::Option::Some(Self::ENTITY_NAME_TRANSFORMATION_UPPER_CASE)
+            }
+            "ENTITY_NAME_TRANSFORMATION_CAPITALIZED_CASE" => {
+                std::option::Option::Some(Self::ENTITY_NAME_TRANSFORMATION_CAPITALIZED_CASE)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for EntityNameTransformation {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for EntityNameTransformation {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for EntityNameTransformation {
     fn default() -> Self {
-        entity_name_transformation::ENTITY_NAME_TRANSFORMATION_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The types of jobs that can be executed in the background.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct BackgroundJobType(std::borrow::Cow<'static, str>);
+pub struct BackgroundJobType(i32);
 
 impl BackgroundJobType {
-    /// Creates a new BackgroundJobType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [BackgroundJobType](BackgroundJobType)
-pub mod background_job_type {
-    use super::BackgroundJobType;
-
     /// Unspecified background job type.
-    pub const BACKGROUND_JOB_TYPE_UNSPECIFIED: BackgroundJobType =
-        BackgroundJobType::new("BACKGROUND_JOB_TYPE_UNSPECIFIED");
+    pub const BACKGROUND_JOB_TYPE_UNSPECIFIED: BackgroundJobType = BackgroundJobType::new(0);
 
     /// Job to seed from the source database.
-    pub const BACKGROUND_JOB_TYPE_SOURCE_SEED: BackgroundJobType =
-        BackgroundJobType::new("BACKGROUND_JOB_TYPE_SOURCE_SEED");
+    pub const BACKGROUND_JOB_TYPE_SOURCE_SEED: BackgroundJobType = BackgroundJobType::new(1);
 
     /// Job to convert the source database into a draft of the destination
     /// database.
-    pub const BACKGROUND_JOB_TYPE_CONVERT: BackgroundJobType =
-        BackgroundJobType::new("BACKGROUND_JOB_TYPE_CONVERT");
+    pub const BACKGROUND_JOB_TYPE_CONVERT: BackgroundJobType = BackgroundJobType::new(2);
 
     /// Job to apply the draft tree onto the destination.
-    pub const BACKGROUND_JOB_TYPE_APPLY_DESTINATION: BackgroundJobType =
-        BackgroundJobType::new("BACKGROUND_JOB_TYPE_APPLY_DESTINATION");
+    pub const BACKGROUND_JOB_TYPE_APPLY_DESTINATION: BackgroundJobType = BackgroundJobType::new(3);
 
     /// Job to import and convert mapping rules from an external source such as an
     /// ora2pg config file.
-    pub const BACKGROUND_JOB_TYPE_IMPORT_RULES_FILE: BackgroundJobType =
-        BackgroundJobType::new("BACKGROUND_JOB_TYPE_IMPORT_RULES_FILE");
+    pub const BACKGROUND_JOB_TYPE_IMPORT_RULES_FILE: BackgroundJobType = BackgroundJobType::new(5);
+
+    /// Creates a new BackgroundJobType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("BACKGROUND_JOB_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("BACKGROUND_JOB_TYPE_SOURCE_SEED"),
+            2 => std::borrow::Cow::Borrowed("BACKGROUND_JOB_TYPE_CONVERT"),
+            3 => std::borrow::Cow::Borrowed("BACKGROUND_JOB_TYPE_APPLY_DESTINATION"),
+            5 => std::borrow::Cow::Borrowed("BACKGROUND_JOB_TYPE_IMPORT_RULES_FILE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "BACKGROUND_JOB_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::BACKGROUND_JOB_TYPE_UNSPECIFIED)
+            }
+            "BACKGROUND_JOB_TYPE_SOURCE_SEED" => {
+                std::option::Option::Some(Self::BACKGROUND_JOB_TYPE_SOURCE_SEED)
+            }
+            "BACKGROUND_JOB_TYPE_CONVERT" => {
+                std::option::Option::Some(Self::BACKGROUND_JOB_TYPE_CONVERT)
+            }
+            "BACKGROUND_JOB_TYPE_APPLY_DESTINATION" => {
+                std::option::Option::Some(Self::BACKGROUND_JOB_TYPE_APPLY_DESTINATION)
+            }
+            "BACKGROUND_JOB_TYPE_IMPORT_RULES_FILE" => {
+                std::option::Option::Some(Self::BACKGROUND_JOB_TYPE_IMPORT_RULES_FILE)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for BackgroundJobType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for BackgroundJobType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for BackgroundJobType {
     fn default() -> Self {
-        background_job_type::BACKGROUND_JOB_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The format for the import rules file.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ImportRulesFileFormat(std::borrow::Cow<'static, str>);
+pub struct ImportRulesFileFormat(i32);
 
 impl ImportRulesFileFormat {
-    /// Creates a new ImportRulesFileFormat instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ImportRulesFileFormat](ImportRulesFileFormat)
-pub mod import_rules_file_format {
-    use super::ImportRulesFileFormat;
-
     /// Unspecified rules format.
     pub const IMPORT_RULES_FILE_FORMAT_UNSPECIFIED: ImportRulesFileFormat =
-        ImportRulesFileFormat::new("IMPORT_RULES_FILE_FORMAT_UNSPECIFIED");
+        ImportRulesFileFormat::new(0);
 
     /// HarbourBridge session file.
     pub const IMPORT_RULES_FILE_FORMAT_HARBOUR_BRIDGE_SESSION_FILE: ImportRulesFileFormat =
-        ImportRulesFileFormat::new("IMPORT_RULES_FILE_FORMAT_HARBOUR_BRIDGE_SESSION_FILE");
+        ImportRulesFileFormat::new(1);
 
     /// Ora2Pg configuration file.
     pub const IMPORT_RULES_FILE_FORMAT_ORATOPG_CONFIG_FILE: ImportRulesFileFormat =
-        ImportRulesFileFormat::new("IMPORT_RULES_FILE_FORMAT_ORATOPG_CONFIG_FILE");
+        ImportRulesFileFormat::new(2);
+
+    /// Creates a new ImportRulesFileFormat instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("IMPORT_RULES_FILE_FORMAT_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("IMPORT_RULES_FILE_FORMAT_HARBOUR_BRIDGE_SESSION_FILE"),
+            2 => std::borrow::Cow::Borrowed("IMPORT_RULES_FILE_FORMAT_ORATOPG_CONFIG_FILE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "IMPORT_RULES_FILE_FORMAT_UNSPECIFIED" => {
+                std::option::Option::Some(Self::IMPORT_RULES_FILE_FORMAT_UNSPECIFIED)
+            }
+            "IMPORT_RULES_FILE_FORMAT_HARBOUR_BRIDGE_SESSION_FILE" => std::option::Option::Some(
+                Self::IMPORT_RULES_FILE_FORMAT_HARBOUR_BRIDGE_SESSION_FILE,
+            ),
+            "IMPORT_RULES_FILE_FORMAT_ORATOPG_CONFIG_FILE" => {
+                std::option::Option::Some(Self::IMPORT_RULES_FILE_FORMAT_ORATOPG_CONFIG_FILE)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ImportRulesFileFormat {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ImportRulesFileFormat {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ImportRulesFileFormat {
     fn default() -> Self {
-        import_rules_file_format::IMPORT_RULES_FILE_FORMAT_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Enum used by IntComparisonFilter and DoubleComparisonFilter to indicate the
 /// relation between source value and compare value.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ValueComparison(std::borrow::Cow<'static, str>);
+pub struct ValueComparison(i32);
 
 impl ValueComparison {
-    /// Creates a new ValueComparison instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ValueComparison](ValueComparison)
-pub mod value_comparison {
-    use super::ValueComparison;
-
     /// Value comparison unspecified.
-    pub const VALUE_COMPARISON_UNSPECIFIED: ValueComparison =
-        ValueComparison::new("VALUE_COMPARISON_UNSPECIFIED");
+    pub const VALUE_COMPARISON_UNSPECIFIED: ValueComparison = ValueComparison::new(0);
 
     /// Value is smaller than the Compare value.
-    pub const VALUE_COMPARISON_IF_VALUE_SMALLER_THAN: ValueComparison =
-        ValueComparison::new("VALUE_COMPARISON_IF_VALUE_SMALLER_THAN");
+    pub const VALUE_COMPARISON_IF_VALUE_SMALLER_THAN: ValueComparison = ValueComparison::new(1);
 
     /// Value is smaller or equal than the Compare value.
     pub const VALUE_COMPARISON_IF_VALUE_SMALLER_EQUAL_THAN: ValueComparison =
-        ValueComparison::new("VALUE_COMPARISON_IF_VALUE_SMALLER_EQUAL_THAN");
+        ValueComparison::new(2);
 
     /// Value is larger than the Compare value.
-    pub const VALUE_COMPARISON_IF_VALUE_LARGER_THAN: ValueComparison =
-        ValueComparison::new("VALUE_COMPARISON_IF_VALUE_LARGER_THAN");
+    pub const VALUE_COMPARISON_IF_VALUE_LARGER_THAN: ValueComparison = ValueComparison::new(3);
 
     /// Value is larger or equal than the Compare value.
     pub const VALUE_COMPARISON_IF_VALUE_LARGER_EQUAL_THAN: ValueComparison =
-        ValueComparison::new("VALUE_COMPARISON_IF_VALUE_LARGER_EQUAL_THAN");
+        ValueComparison::new(4);
+
+    /// Creates a new ValueComparison instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("VALUE_COMPARISON_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("VALUE_COMPARISON_IF_VALUE_SMALLER_THAN"),
+            2 => std::borrow::Cow::Borrowed("VALUE_COMPARISON_IF_VALUE_SMALLER_EQUAL_THAN"),
+            3 => std::borrow::Cow::Borrowed("VALUE_COMPARISON_IF_VALUE_LARGER_THAN"),
+            4 => std::borrow::Cow::Borrowed("VALUE_COMPARISON_IF_VALUE_LARGER_EQUAL_THAN"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "VALUE_COMPARISON_UNSPECIFIED" => {
+                std::option::Option::Some(Self::VALUE_COMPARISON_UNSPECIFIED)
+            }
+            "VALUE_COMPARISON_IF_VALUE_SMALLER_THAN" => {
+                std::option::Option::Some(Self::VALUE_COMPARISON_IF_VALUE_SMALLER_THAN)
+            }
+            "VALUE_COMPARISON_IF_VALUE_SMALLER_EQUAL_THAN" => {
+                std::option::Option::Some(Self::VALUE_COMPARISON_IF_VALUE_SMALLER_EQUAL_THAN)
+            }
+            "VALUE_COMPARISON_IF_VALUE_LARGER_THAN" => {
+                std::option::Option::Some(Self::VALUE_COMPARISON_IF_VALUE_LARGER_THAN)
+            }
+            "VALUE_COMPARISON_IF_VALUE_LARGER_EQUAL_THAN" => {
+                std::option::Option::Some(Self::VALUE_COMPARISON_IF_VALUE_LARGER_EQUAL_THAN)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ValueComparison {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ValueComparison {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ValueComparison {
     fn default() -> Self {
-        value_comparison::VALUE_COMPARISON_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Specifies the columns on which numeric filter needs to be applied.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct NumericFilterOption(std::borrow::Cow<'static, str>);
+pub struct NumericFilterOption(i32);
 
 impl NumericFilterOption {
-    /// Creates a new NumericFilterOption instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [NumericFilterOption](NumericFilterOption)
-pub mod numeric_filter_option {
-    use super::NumericFilterOption;
-
     /// Numeric filter option unspecified
-    pub const NUMERIC_FILTER_OPTION_UNSPECIFIED: NumericFilterOption =
-        NumericFilterOption::new("NUMERIC_FILTER_OPTION_UNSPECIFIED");
+    pub const NUMERIC_FILTER_OPTION_UNSPECIFIED: NumericFilterOption = NumericFilterOption::new(0);
 
     /// Numeric filter option that matches all numeric columns.
-    pub const NUMERIC_FILTER_OPTION_ALL: NumericFilterOption =
-        NumericFilterOption::new("NUMERIC_FILTER_OPTION_ALL");
+    pub const NUMERIC_FILTER_OPTION_ALL: NumericFilterOption = NumericFilterOption::new(1);
 
     /// Numeric filter option that matches columns having numeric datatypes with
     /// specified precision and scale within the limited range of filter.
-    pub const NUMERIC_FILTER_OPTION_LIMIT: NumericFilterOption =
-        NumericFilterOption::new("NUMERIC_FILTER_OPTION_LIMIT");
+    pub const NUMERIC_FILTER_OPTION_LIMIT: NumericFilterOption = NumericFilterOption::new(2);
 
     /// Numeric filter option that matches only the numeric columns with no
     /// precision and scale specified.
-    pub const NUMERIC_FILTER_OPTION_LIMITLESS: NumericFilterOption =
-        NumericFilterOption::new("NUMERIC_FILTER_OPTION_LIMITLESS");
+    pub const NUMERIC_FILTER_OPTION_LIMITLESS: NumericFilterOption = NumericFilterOption::new(3);
+
+    /// Creates a new NumericFilterOption instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("NUMERIC_FILTER_OPTION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("NUMERIC_FILTER_OPTION_ALL"),
+            2 => std::borrow::Cow::Borrowed("NUMERIC_FILTER_OPTION_LIMIT"),
+            3 => std::borrow::Cow::Borrowed("NUMERIC_FILTER_OPTION_LIMITLESS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "NUMERIC_FILTER_OPTION_UNSPECIFIED" => {
+                std::option::Option::Some(Self::NUMERIC_FILTER_OPTION_UNSPECIFIED)
+            }
+            "NUMERIC_FILTER_OPTION_ALL" => {
+                std::option::Option::Some(Self::NUMERIC_FILTER_OPTION_ALL)
+            }
+            "NUMERIC_FILTER_OPTION_LIMIT" => {
+                std::option::Option::Some(Self::NUMERIC_FILTER_OPTION_LIMIT)
+            }
+            "NUMERIC_FILTER_OPTION_LIMITLESS" => {
+                std::option::Option::Some(Self::NUMERIC_FILTER_OPTION_LIMITLESS)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for NumericFilterOption {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for NumericFilterOption {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for NumericFilterOption {
     fn default() -> Self {
-        numeric_filter_option::NUMERIC_FILTER_OPTION_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/clouddms/v1/src/transport.rs
+++ b/src/generated/cloud/clouddms/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
                 reqwest::Method::GET,
                 format!("/v1/{}/migrationJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
                 reqwest::Method::POST,
                 format!("/v1/{}/migrationJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -127,7 +127,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -157,7 +157,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -178,7 +178,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:start", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -195,7 +195,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:stop", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -212,7 +212,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:resume", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -229,7 +229,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:promote", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -246,7 +246,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:verify", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -263,7 +263,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:restart", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -283,7 +283,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
                 reqwest::Method::POST,
                 format!("/v1/{}:generateSshScript", req.migration_job),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -303,7 +303,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
                 reqwest::Method::POST,
                 format!("/v1/{}:generateTcpProxyScript", req.migration_job),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -323,7 +323,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
                 reqwest::Method::GET,
                 format!("/v1/{}/connectionProfiles", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -346,7 +346,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -368,7 +368,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
                 reqwest::Method::POST,
                 format!("/v1/{}/connectionProfiles", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -400,7 +400,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -432,7 +432,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -456,7 +456,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
                 reqwest::Method::POST,
                 format!("/v1/{}/privateConnections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -478,7 +478,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -500,7 +500,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
                 reqwest::Method::GET,
                 format!("/v1/{}/privateConnections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -523,7 +523,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -543,7 +543,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -565,7 +565,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
                 reqwest::Method::GET,
                 format!("/v1/{}/conversionWorkspaces", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -590,7 +590,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
                 reqwest::Method::POST,
                 format!("/v1/{}/conversionWorkspaces", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -620,7 +620,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -650,7 +650,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -674,7 +674,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
                 reqwest::Method::POST,
                 format!("/v1/{}/mappingRules", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -695,7 +695,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -718,7 +718,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
                 reqwest::Method::GET,
                 format!("/v1/{}/mappingRules", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -739,7 +739,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -758,7 +758,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:seed", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -778,7 +778,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
                 reqwest::Method::POST,
                 format!("/v1/{}/mappingRules:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -795,7 +795,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:convert", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -812,7 +812,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:commit", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -829,7 +829,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:rollback", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -846,7 +846,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:apply", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -866,7 +866,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
                 reqwest::Method::GET,
                 format!("/v1/{}:describeDatabaseEntities", req.conversion_workspace),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -895,7 +895,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
                 reqwest::Method::GET,
                 format!("/v1/{}:searchBackgroundJobs", req.conversion_workspace),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -935,7 +935,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
                     req.conversion_workspace
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -958,7 +958,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
                 reqwest::Method::GET,
                 format!("/v1/{}:fetchStaticIps", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -979,7 +979,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1001,7 +1001,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1023,7 +1023,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1043,7 +1043,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1075,7 +1075,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1092,7 +1092,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1114,7 +1114,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1133,7 +1133,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1152,7 +1152,7 @@ impl crate::stubs::DataMigrationService for DataMigrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/model.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/model.rs
@@ -1822,52 +1822,72 @@ pub mod cancel_order_request {
 
     /// Indicates the cancellation policy the customer uses to cancel the order.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CancellationPolicy(std::borrow::Cow<'static, str>);
+    pub struct CancellationPolicy(i32);
 
     impl CancellationPolicy {
-        /// Creates a new CancellationPolicy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CancellationPolicy](CancellationPolicy)
-    pub mod cancellation_policy {
-        use super::CancellationPolicy;
-
         /// If unspecified, cancellation will try to cancel the order, if order
         /// cannot be immediately cancelled, auto renewal will be turned off.
         /// However, caller should avoid using the value as it will yield a
         /// non-deterministic result. This is still supported mainly to maintain
         /// existing integrated usages and ensure backwards compatibility.
-        pub const CANCELLATION_POLICY_UNSPECIFIED: CancellationPolicy =
-            CancellationPolicy::new("CANCELLATION_POLICY_UNSPECIFIED");
+        pub const CANCELLATION_POLICY_UNSPECIFIED: CancellationPolicy = CancellationPolicy::new(0);
 
         /// Request will cancel the whole order immediately, if order cannot be
         /// immediately cancelled, the request will fail.
         pub const CANCELLATION_POLICY_CANCEL_IMMEDIATELY: CancellationPolicy =
-            CancellationPolicy::new("CANCELLATION_POLICY_CANCEL_IMMEDIATELY");
+            CancellationPolicy::new(1);
 
         /// Request will cancel the auto renewal, if order is not subscription based,
         /// the request will fail.
         pub const CANCELLATION_POLICY_CANCEL_AT_TERM_END: CancellationPolicy =
-            CancellationPolicy::new("CANCELLATION_POLICY_CANCEL_AT_TERM_END");
+            CancellationPolicy::new(2);
+
+        /// Creates a new CancellationPolicy instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CANCELLATION_POLICY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CANCELLATION_POLICY_CANCEL_IMMEDIATELY"),
+                2 => std::borrow::Cow::Borrowed("CANCELLATION_POLICY_CANCEL_AT_TERM_END"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CANCELLATION_POLICY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CANCELLATION_POLICY_UNSPECIFIED)
+                }
+                "CANCELLATION_POLICY_CANCEL_IMMEDIATELY" => {
+                    std::option::Option::Some(Self::CANCELLATION_POLICY_CANCEL_IMMEDIATELY)
+                }
+                "CANCELLATION_POLICY_CANCEL_AT_TERM_END" => {
+                    std::option::Option::Some(Self::CANCELLATION_POLICY_CANCEL_AT_TERM_END)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CancellationPolicy {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CancellationPolicy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CancellationPolicy {
         fn default() -> Self {
-            cancellation_policy::CANCELLATION_POLICY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1896,219 +1916,318 @@ impl wkt::message::Message for CancelOrderMetadata {
 
 /// Type of a line item change.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LineItemChangeType(std::borrow::Cow<'static, str>);
+pub struct LineItemChangeType(i32);
 
 impl LineItemChangeType {
-    /// Creates a new LineItemChangeType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [LineItemChangeType](LineItemChangeType)
-pub mod line_item_change_type {
-    use super::LineItemChangeType;
-
     /// Sentinel value. Do not use.
-    pub const LINE_ITEM_CHANGE_TYPE_UNSPECIFIED: LineItemChangeType =
-        LineItemChangeType::new("LINE_ITEM_CHANGE_TYPE_UNSPECIFIED");
+    pub const LINE_ITEM_CHANGE_TYPE_UNSPECIFIED: LineItemChangeType = LineItemChangeType::new(0);
 
     /// The change is to create a new line item.
-    pub const LINE_ITEM_CHANGE_TYPE_CREATE: LineItemChangeType =
-        LineItemChangeType::new("LINE_ITEM_CHANGE_TYPE_CREATE");
+    pub const LINE_ITEM_CHANGE_TYPE_CREATE: LineItemChangeType = LineItemChangeType::new(1);
 
     /// The change is to update an existing line item.
-    pub const LINE_ITEM_CHANGE_TYPE_UPDATE: LineItemChangeType =
-        LineItemChangeType::new("LINE_ITEM_CHANGE_TYPE_UPDATE");
+    pub const LINE_ITEM_CHANGE_TYPE_UPDATE: LineItemChangeType = LineItemChangeType::new(2);
 
     /// The change is to cancel an existing line item.
-    pub const LINE_ITEM_CHANGE_TYPE_CANCEL: LineItemChangeType =
-        LineItemChangeType::new("LINE_ITEM_CHANGE_TYPE_CANCEL");
+    pub const LINE_ITEM_CHANGE_TYPE_CANCEL: LineItemChangeType = LineItemChangeType::new(3);
 
     /// The change is to revert a cancellation.
     pub const LINE_ITEM_CHANGE_TYPE_REVERT_CANCELLATION: LineItemChangeType =
-        LineItemChangeType::new("LINE_ITEM_CHANGE_TYPE_REVERT_CANCELLATION");
+        LineItemChangeType::new(4);
+
+    /// Creates a new LineItemChangeType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_TYPE_CREATE"),
+            2 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_TYPE_UPDATE"),
+            3 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_TYPE_CANCEL"),
+            4 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_TYPE_REVERT_CANCELLATION"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "LINE_ITEM_CHANGE_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::LINE_ITEM_CHANGE_TYPE_UNSPECIFIED)
+            }
+            "LINE_ITEM_CHANGE_TYPE_CREATE" => {
+                std::option::Option::Some(Self::LINE_ITEM_CHANGE_TYPE_CREATE)
+            }
+            "LINE_ITEM_CHANGE_TYPE_UPDATE" => {
+                std::option::Option::Some(Self::LINE_ITEM_CHANGE_TYPE_UPDATE)
+            }
+            "LINE_ITEM_CHANGE_TYPE_CANCEL" => {
+                std::option::Option::Some(Self::LINE_ITEM_CHANGE_TYPE_CANCEL)
+            }
+            "LINE_ITEM_CHANGE_TYPE_REVERT_CANCELLATION" => {
+                std::option::Option::Some(Self::LINE_ITEM_CHANGE_TYPE_REVERT_CANCELLATION)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for LineItemChangeType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for LineItemChangeType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for LineItemChangeType {
     fn default() -> Self {
-        line_item_change_type::LINE_ITEM_CHANGE_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// State of a change.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LineItemChangeState(std::borrow::Cow<'static, str>);
+pub struct LineItemChangeState(i32);
 
 impl LineItemChangeState {
-    /// Creates a new LineItemChangeState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [LineItemChangeState](LineItemChangeState)
-pub mod line_item_change_state {
-    use super::LineItemChangeState;
-
     /// Sentinel value. Do not use.
-    pub const LINE_ITEM_CHANGE_STATE_UNSPECIFIED: LineItemChangeState =
-        LineItemChangeState::new("LINE_ITEM_CHANGE_STATE_UNSPECIFIED");
+    pub const LINE_ITEM_CHANGE_STATE_UNSPECIFIED: LineItemChangeState = LineItemChangeState::new(0);
 
     /// Change is in this state when a change is initiated and waiting for partner
     /// approval. This state is only applicable for pending change.
     pub const LINE_ITEM_CHANGE_STATE_PENDING_APPROVAL: LineItemChangeState =
-        LineItemChangeState::new("LINE_ITEM_CHANGE_STATE_PENDING_APPROVAL");
+        LineItemChangeState::new(1);
 
     /// Change is in this state after it's approved by the partner or auto-approved
     /// but before it takes effect. The change can be overwritten or cancelled
     /// depending on the new line item info property (pending Private Offer change
     /// cannot be cancelled and can only be overwritten by another Private Offer).
     /// This state is only applicable for pending change.
-    pub const LINE_ITEM_CHANGE_STATE_APPROVED: LineItemChangeState =
-        LineItemChangeState::new("LINE_ITEM_CHANGE_STATE_APPROVED");
+    pub const LINE_ITEM_CHANGE_STATE_APPROVED: LineItemChangeState = LineItemChangeState::new(2);
 
     /// Change is in this state after it's been activated. This state is only
     /// applicable for change in history.
-    pub const LINE_ITEM_CHANGE_STATE_COMPLETED: LineItemChangeState =
-        LineItemChangeState::new("LINE_ITEM_CHANGE_STATE_COMPLETED");
+    pub const LINE_ITEM_CHANGE_STATE_COMPLETED: LineItemChangeState = LineItemChangeState::new(3);
 
     /// Change is in this state if it was rejected by the partner. This state is
     /// only applicable for change in history.
-    pub const LINE_ITEM_CHANGE_STATE_REJECTED: LineItemChangeState =
-        LineItemChangeState::new("LINE_ITEM_CHANGE_STATE_REJECTED");
+    pub const LINE_ITEM_CHANGE_STATE_REJECTED: LineItemChangeState = LineItemChangeState::new(4);
 
     /// Change is in this state if it was abandoned by the user. This state is only
     /// applicable for change in history.
-    pub const LINE_ITEM_CHANGE_STATE_ABANDONED: LineItemChangeState =
-        LineItemChangeState::new("LINE_ITEM_CHANGE_STATE_ABANDONED");
+    pub const LINE_ITEM_CHANGE_STATE_ABANDONED: LineItemChangeState = LineItemChangeState::new(5);
 
     /// Change is in this state if it's currently being provisioned downstream. The
     /// change can't be overwritten or cancelled when it's in this state. This
     /// state is only applicable for pending change.
-    pub const LINE_ITEM_CHANGE_STATE_ACTIVATING: LineItemChangeState =
-        LineItemChangeState::new("LINE_ITEM_CHANGE_STATE_ACTIVATING");
+    pub const LINE_ITEM_CHANGE_STATE_ACTIVATING: LineItemChangeState = LineItemChangeState::new(6);
+
+    /// Creates a new LineItemChangeState instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_STATE_PENDING_APPROVAL"),
+            2 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_STATE_APPROVED"),
+            3 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_STATE_COMPLETED"),
+            4 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_STATE_REJECTED"),
+            5 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_STATE_ABANDONED"),
+            6 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_STATE_ACTIVATING"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "LINE_ITEM_CHANGE_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::LINE_ITEM_CHANGE_STATE_UNSPECIFIED)
+            }
+            "LINE_ITEM_CHANGE_STATE_PENDING_APPROVAL" => {
+                std::option::Option::Some(Self::LINE_ITEM_CHANGE_STATE_PENDING_APPROVAL)
+            }
+            "LINE_ITEM_CHANGE_STATE_APPROVED" => {
+                std::option::Option::Some(Self::LINE_ITEM_CHANGE_STATE_APPROVED)
+            }
+            "LINE_ITEM_CHANGE_STATE_COMPLETED" => {
+                std::option::Option::Some(Self::LINE_ITEM_CHANGE_STATE_COMPLETED)
+            }
+            "LINE_ITEM_CHANGE_STATE_REJECTED" => {
+                std::option::Option::Some(Self::LINE_ITEM_CHANGE_STATE_REJECTED)
+            }
+            "LINE_ITEM_CHANGE_STATE_ABANDONED" => {
+                std::option::Option::Some(Self::LINE_ITEM_CHANGE_STATE_ABANDONED)
+            }
+            "LINE_ITEM_CHANGE_STATE_ACTIVATING" => {
+                std::option::Option::Some(Self::LINE_ITEM_CHANGE_STATE_ACTIVATING)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for LineItemChangeState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for LineItemChangeState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for LineItemChangeState {
     fn default() -> Self {
-        line_item_change_state::LINE_ITEM_CHANGE_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Predefined types for line item change state reason.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LineItemChangeStateReasonType(std::borrow::Cow<'static, str>);
+pub struct LineItemChangeStateReasonType(i32);
 
 impl LineItemChangeStateReasonType {
-    /// Creates a new LineItemChangeStateReasonType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [LineItemChangeStateReasonType](LineItemChangeStateReasonType)
-pub mod line_item_change_state_reason_type {
-    use super::LineItemChangeStateReasonType;
-
     /// Default value, indicating there's no predefined type for change state
     /// reason.
     pub const LINE_ITEM_CHANGE_STATE_REASON_TYPE_UNSPECIFIED: LineItemChangeStateReasonType =
-        LineItemChangeStateReasonType::new("LINE_ITEM_CHANGE_STATE_REASON_TYPE_UNSPECIFIED");
+        LineItemChangeStateReasonType::new(0);
 
     /// Change is in current state due to term expiration.
     pub const LINE_ITEM_CHANGE_STATE_REASON_TYPE_EXPIRED: LineItemChangeStateReasonType =
-        LineItemChangeStateReasonType::new("LINE_ITEM_CHANGE_STATE_REASON_TYPE_EXPIRED");
+        LineItemChangeStateReasonType::new(1);
 
     /// Change is in current state due to user-initiated cancellation.
     pub const LINE_ITEM_CHANGE_STATE_REASON_TYPE_USER_CANCELLED: LineItemChangeStateReasonType =
-        LineItemChangeStateReasonType::new("LINE_ITEM_CHANGE_STATE_REASON_TYPE_USER_CANCELLED");
+        LineItemChangeStateReasonType::new(2);
 
     /// Change is in current state due to system-initiated cancellation.
     pub const LINE_ITEM_CHANGE_STATE_REASON_TYPE_SYSTEM_CANCELLED: LineItemChangeStateReasonType =
-        LineItemChangeStateReasonType::new("LINE_ITEM_CHANGE_STATE_REASON_TYPE_SYSTEM_CANCELLED");
+        LineItemChangeStateReasonType::new(3);
+
+    /// Creates a new LineItemChangeStateReasonType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_STATE_REASON_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_STATE_REASON_TYPE_EXPIRED"),
+            2 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_STATE_REASON_TYPE_USER_CANCELLED"),
+            3 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_STATE_REASON_TYPE_SYSTEM_CANCELLED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "LINE_ITEM_CHANGE_STATE_REASON_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::LINE_ITEM_CHANGE_STATE_REASON_TYPE_UNSPECIFIED)
+            }
+            "LINE_ITEM_CHANGE_STATE_REASON_TYPE_EXPIRED" => {
+                std::option::Option::Some(Self::LINE_ITEM_CHANGE_STATE_REASON_TYPE_EXPIRED)
+            }
+            "LINE_ITEM_CHANGE_STATE_REASON_TYPE_USER_CANCELLED" => {
+                std::option::Option::Some(Self::LINE_ITEM_CHANGE_STATE_REASON_TYPE_USER_CANCELLED)
+            }
+            "LINE_ITEM_CHANGE_STATE_REASON_TYPE_SYSTEM_CANCELLED" => {
+                std::option::Option::Some(Self::LINE_ITEM_CHANGE_STATE_REASON_TYPE_SYSTEM_CANCELLED)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for LineItemChangeStateReasonType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for LineItemChangeStateReasonType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for LineItemChangeStateReasonType {
     fn default() -> Self {
-        line_item_change_state_reason_type::LINE_ITEM_CHANGE_STATE_REASON_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Indicates the auto renewal behavior customer specifies on subscription.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AutoRenewalBehavior(std::borrow::Cow<'static, str>);
+pub struct AutoRenewalBehavior(i32);
 
 impl AutoRenewalBehavior {
+    /// If unspecified, the auto renewal behavior will follow the default config.
+    pub const AUTO_RENEWAL_BEHAVIOR_UNSPECIFIED: AutoRenewalBehavior = AutoRenewalBehavior::new(0);
+
+    /// Auto Renewal will be enabled on subscription.
+    pub const AUTO_RENEWAL_BEHAVIOR_ENABLE: AutoRenewalBehavior = AutoRenewalBehavior::new(1);
+
+    /// Auto Renewal will be disabled on subscription.
+    pub const AUTO_RENEWAL_BEHAVIOR_DISABLE: AutoRenewalBehavior = AutoRenewalBehavior::new(2);
+
     /// Creates a new AutoRenewalBehavior instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("AUTO_RENEWAL_BEHAVIOR_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("AUTO_RENEWAL_BEHAVIOR_ENABLE"),
+            2 => std::borrow::Cow::Borrowed("AUTO_RENEWAL_BEHAVIOR_DISABLE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "AUTO_RENEWAL_BEHAVIOR_UNSPECIFIED" => {
+                std::option::Option::Some(Self::AUTO_RENEWAL_BEHAVIOR_UNSPECIFIED)
+            }
+            "AUTO_RENEWAL_BEHAVIOR_ENABLE" => {
+                std::option::Option::Some(Self::AUTO_RENEWAL_BEHAVIOR_ENABLE)
+            }
+            "AUTO_RENEWAL_BEHAVIOR_DISABLE" => {
+                std::option::Option::Some(Self::AUTO_RENEWAL_BEHAVIOR_DISABLE)
+            }
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [AutoRenewalBehavior](AutoRenewalBehavior)
-pub mod auto_renewal_behavior {
-    use super::AutoRenewalBehavior;
-
-    /// If unspecified, the auto renewal behavior will follow the default config.
-    pub const AUTO_RENEWAL_BEHAVIOR_UNSPECIFIED: AutoRenewalBehavior =
-        AutoRenewalBehavior::new("AUTO_RENEWAL_BEHAVIOR_UNSPECIFIED");
-
-    /// Auto Renewal will be enabled on subscription.
-    pub const AUTO_RENEWAL_BEHAVIOR_ENABLE: AutoRenewalBehavior =
-        AutoRenewalBehavior::new("AUTO_RENEWAL_BEHAVIOR_ENABLE");
-
-    /// Auto Renewal will be disabled on subscription.
-    pub const AUTO_RENEWAL_BEHAVIOR_DISABLE: AutoRenewalBehavior =
-        AutoRenewalBehavior::new("AUTO_RENEWAL_BEHAVIOR_DISABLE");
-}
-
-impl std::convert::From<std::string::String> for AutoRenewalBehavior {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for AutoRenewalBehavior {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for AutoRenewalBehavior {
     fn default() -> Self {
-        auto_renewal_behavior::AUTO_RENEWAL_BEHAVIOR_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/transport.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::LicenseManagementService for LicenseManagementService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -77,7 +77,7 @@ impl crate::stubs::LicenseManagementService for LicenseManagementService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -106,7 +106,7 @@ impl crate::stubs::LicenseManagementService for LicenseManagementService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:assign", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -126,7 +126,7 @@ impl crate::stubs::LicenseManagementService for LicenseManagementService {
                 reqwest::Method::POST,
                 format!("/v1/{}:unassign", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -146,7 +146,7 @@ impl crate::stubs::LicenseManagementService for LicenseManagementService {
                 reqwest::Method::GET,
                 format!("/v1/{}:enumerateLicensedUsers", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -167,7 +167,7 @@ impl crate::stubs::LicenseManagementService for LicenseManagementService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -212,7 +212,7 @@ impl crate::stubs::ConsumerProcurementService for ConsumerProcurementService {
                 reqwest::Method::POST,
                 format!("/v1/{}/orders:place", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -229,7 +229,7 @@ impl crate::stubs::ConsumerProcurementService for ConsumerProcurementService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -248,7 +248,7 @@ impl crate::stubs::ConsumerProcurementService for ConsumerProcurementService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/orders", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -270,7 +270,7 @@ impl crate::stubs::ConsumerProcurementService for ConsumerProcurementService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:modify", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -287,7 +287,7 @@ impl crate::stubs::ConsumerProcurementService for ConsumerProcurementService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -304,7 +304,7 @@ impl crate::stubs::ConsumerProcurementService for ConsumerProcurementService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/confidentialcomputing/v1/src/model.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/model.rs
@@ -1108,97 +1108,134 @@ impl wkt::message::Message for ContainerImageSignature {
 
 /// SigningAlgorithm enumerates all the supported signing algorithms.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SigningAlgorithm(std::borrow::Cow<'static, str>);
+pub struct SigningAlgorithm(i32);
 
 impl SigningAlgorithm {
+    /// Unspecified signing algorithm.
+    pub const SIGNING_ALGORITHM_UNSPECIFIED: SigningAlgorithm = SigningAlgorithm::new(0);
+
+    /// RSASSA-PSS with a SHA256 digest.
+    pub const RSASSA_PSS_SHA256: SigningAlgorithm = SigningAlgorithm::new(1);
+
+    /// RSASSA-PKCS1 v1.5 with a SHA256 digest.
+    pub const RSASSA_PKCS1V15_SHA256: SigningAlgorithm = SigningAlgorithm::new(2);
+
+    /// ECDSA on the P-256 Curve with a SHA256 digest.
+    pub const ECDSA_P256_SHA256: SigningAlgorithm = SigningAlgorithm::new(3);
+
     /// Creates a new SigningAlgorithm instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SIGNING_ALGORITHM_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("RSASSA_PSS_SHA256"),
+            2 => std::borrow::Cow::Borrowed("RSASSA_PKCS1V15_SHA256"),
+            3 => std::borrow::Cow::Borrowed("ECDSA_P256_SHA256"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SIGNING_ALGORITHM_UNSPECIFIED" => {
+                std::option::Option::Some(Self::SIGNING_ALGORITHM_UNSPECIFIED)
+            }
+            "RSASSA_PSS_SHA256" => std::option::Option::Some(Self::RSASSA_PSS_SHA256),
+            "RSASSA_PKCS1V15_SHA256" => std::option::Option::Some(Self::RSASSA_PKCS1V15_SHA256),
+            "ECDSA_P256_SHA256" => std::option::Option::Some(Self::ECDSA_P256_SHA256),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [SigningAlgorithm](SigningAlgorithm)
-pub mod signing_algorithm {
-    use super::SigningAlgorithm;
-
-    /// Unspecified signing algorithm.
-    pub const SIGNING_ALGORITHM_UNSPECIFIED: SigningAlgorithm =
-        SigningAlgorithm::new("SIGNING_ALGORITHM_UNSPECIFIED");
-
-    /// RSASSA-PSS with a SHA256 digest.
-    pub const RSASSA_PSS_SHA256: SigningAlgorithm = SigningAlgorithm::new("RSASSA_PSS_SHA256");
-
-    /// RSASSA-PKCS1 v1.5 with a SHA256 digest.
-    pub const RSASSA_PKCS1V15_SHA256: SigningAlgorithm =
-        SigningAlgorithm::new("RSASSA_PKCS1V15_SHA256");
-
-    /// ECDSA on the P-256 Curve with a SHA256 digest.
-    pub const ECDSA_P256_SHA256: SigningAlgorithm = SigningAlgorithm::new("ECDSA_P256_SHA256");
-}
-
-impl std::convert::From<std::string::String> for SigningAlgorithm {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SigningAlgorithm {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SigningAlgorithm {
     fn default() -> Self {
-        signing_algorithm::SIGNING_ALGORITHM_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Token type enum contains the different types of token responses Confidential
 /// Space supports
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TokenType(std::borrow::Cow<'static, str>);
+pub struct TokenType(i32);
 
 impl TokenType {
+    /// Unspecified token type
+    pub const TOKEN_TYPE_UNSPECIFIED: TokenType = TokenType::new(0);
+
+    /// OpenID Connect (OIDC) token type
+    pub const TOKEN_TYPE_OIDC: TokenType = TokenType::new(1);
+
+    /// Public Key Infrastructure (PKI) token type
+    pub const TOKEN_TYPE_PKI: TokenType = TokenType::new(2);
+
+    /// Limited claim token type for AWS integration
+    pub const TOKEN_TYPE_LIMITED_AWS: TokenType = TokenType::new(3);
+
+    /// Principal-tag-based token for AWS integration
+    pub const TOKEN_TYPE_AWS_PRINCIPALTAGS: TokenType = TokenType::new(4);
+
     /// Creates a new TokenType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("TOKEN_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("TOKEN_TYPE_OIDC"),
+            2 => std::borrow::Cow::Borrowed("TOKEN_TYPE_PKI"),
+            3 => std::borrow::Cow::Borrowed("TOKEN_TYPE_LIMITED_AWS"),
+            4 => std::borrow::Cow::Borrowed("TOKEN_TYPE_AWS_PRINCIPALTAGS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "TOKEN_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TOKEN_TYPE_UNSPECIFIED),
+            "TOKEN_TYPE_OIDC" => std::option::Option::Some(Self::TOKEN_TYPE_OIDC),
+            "TOKEN_TYPE_PKI" => std::option::Option::Some(Self::TOKEN_TYPE_PKI),
+            "TOKEN_TYPE_LIMITED_AWS" => std::option::Option::Some(Self::TOKEN_TYPE_LIMITED_AWS),
+            "TOKEN_TYPE_AWS_PRINCIPALTAGS" => {
+                std::option::Option::Some(Self::TOKEN_TYPE_AWS_PRINCIPALTAGS)
+            }
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [TokenType](TokenType)
-pub mod token_type {
-    use super::TokenType;
-
-    /// Unspecified token type
-    pub const TOKEN_TYPE_UNSPECIFIED: TokenType = TokenType::new("TOKEN_TYPE_UNSPECIFIED");
-
-    /// OpenID Connect (OIDC) token type
-    pub const TOKEN_TYPE_OIDC: TokenType = TokenType::new("TOKEN_TYPE_OIDC");
-
-    /// Public Key Infrastructure (PKI) token type
-    pub const TOKEN_TYPE_PKI: TokenType = TokenType::new("TOKEN_TYPE_PKI");
-
-    /// Limited claim token type for AWS integration
-    pub const TOKEN_TYPE_LIMITED_AWS: TokenType = TokenType::new("TOKEN_TYPE_LIMITED_AWS");
-
-    /// Principal-tag-based token for AWS integration
-    pub const TOKEN_TYPE_AWS_PRINCIPALTAGS: TokenType =
-        TokenType::new("TOKEN_TYPE_AWS_PRINCIPALTAGS");
-}
-
-impl std::convert::From<std::string::String> for TokenType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for TokenType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for TokenType {
     fn default() -> Self {
-        token_type::TOKEN_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/confidentialcomputing/v1/src/transport.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::ConfidentialComputing for ConfidentialComputing {
                 reqwest::Method::POST,
                 format!("/v1/{}/challenges", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -74,7 +74,7 @@ impl crate::stubs::ConfidentialComputing for ConfidentialComputing {
                 reqwest::Method::POST,
                 format!("/v1/{}:verifyAttestation", req.challenge),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -91,7 +91,7 @@ impl crate::stubs::ConfidentialComputing for ConfidentialComputing {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -113,7 +113,7 @@ impl crate::stubs::ConfidentialComputing for ConfidentialComputing {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/config/v1/src/model.rs
+++ b/src/generated/cloud/config/v1/src/model.rs
@@ -419,172 +419,249 @@ pub mod deployment {
 
     /// Possible states of a deployment.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The deployment is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The deployment is healthy.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(2);
 
         /// The deployment is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(3);
 
         /// The deployment is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(4);
 
         /// The deployment has encountered an unexpected error.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(5);
 
         /// The deployment is no longer being actively reconciled.
         /// This may be the result of recovering the project after deletion.
-        pub const SUSPENDED: State = State::new("SUSPENDED");
+        pub const SUSPENDED: State = State::new(6);
 
         /// The deployment has been deleted.
-        pub const DELETED: State = State::new("DELETED");
+        pub const DELETED: State = State::new(7);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("FAILED"),
+                6 => std::borrow::Cow::Borrowed("SUSPENDED"),
+                7 => std::borrow::Cow::Borrowed("DELETED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "SUSPENDED" => std::option::Option::Some(Self::SUSPENDED),
+                "DELETED" => std::option::Option::Some(Self::DELETED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Possible errors that can occur with deployments.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ErrorCode(std::borrow::Cow<'static, str>);
+    pub struct ErrorCode(i32);
 
     impl ErrorCode {
-        /// Creates a new ErrorCode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ErrorCode](ErrorCode)
-    pub mod error_code {
-        use super::ErrorCode;
-
         /// No error code was specified.
-        pub const ERROR_CODE_UNSPECIFIED: ErrorCode = ErrorCode::new("ERROR_CODE_UNSPECIFIED");
+        pub const ERROR_CODE_UNSPECIFIED: ErrorCode = ErrorCode::new(0);
 
         /// The revision failed. See Revision for more details.
-        pub const REVISION_FAILED: ErrorCode = ErrorCode::new("REVISION_FAILED");
+        pub const REVISION_FAILED: ErrorCode = ErrorCode::new(1);
 
         /// Cloud Build failed due to a permission issue.
-        pub const CLOUD_BUILD_PERMISSION_DENIED: ErrorCode =
-            ErrorCode::new("CLOUD_BUILD_PERMISSION_DENIED");
+        pub const CLOUD_BUILD_PERMISSION_DENIED: ErrorCode = ErrorCode::new(3);
 
         /// Cloud Build job associated with a deployment deletion could not be
         /// started.
-        pub const DELETE_BUILD_API_FAILED: ErrorCode = ErrorCode::new("DELETE_BUILD_API_FAILED");
+        pub const DELETE_BUILD_API_FAILED: ErrorCode = ErrorCode::new(5);
 
         /// Cloud Build job associated with a deployment deletion was started but
         /// failed.
-        pub const DELETE_BUILD_RUN_FAILED: ErrorCode = ErrorCode::new("DELETE_BUILD_RUN_FAILED");
+        pub const DELETE_BUILD_RUN_FAILED: ErrorCode = ErrorCode::new(6);
 
         /// Cloud Storage bucket creation failed due to a permission issue.
-        pub const BUCKET_CREATION_PERMISSION_DENIED: ErrorCode =
-            ErrorCode::new("BUCKET_CREATION_PERMISSION_DENIED");
+        pub const BUCKET_CREATION_PERMISSION_DENIED: ErrorCode = ErrorCode::new(7);
 
         /// Cloud Storage bucket creation failed due to an issue unrelated to
         /// permissions.
-        pub const BUCKET_CREATION_FAILED: ErrorCode = ErrorCode::new("BUCKET_CREATION_FAILED");
+        pub const BUCKET_CREATION_FAILED: ErrorCode = ErrorCode::new(8);
+
+        /// Creates a new ErrorCode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ERROR_CODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REVISION_FAILED"),
+                3 => std::borrow::Cow::Borrowed("CLOUD_BUILD_PERMISSION_DENIED"),
+                5 => std::borrow::Cow::Borrowed("DELETE_BUILD_API_FAILED"),
+                6 => std::borrow::Cow::Borrowed("DELETE_BUILD_RUN_FAILED"),
+                7 => std::borrow::Cow::Borrowed("BUCKET_CREATION_PERMISSION_DENIED"),
+                8 => std::borrow::Cow::Borrowed("BUCKET_CREATION_FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ERROR_CODE_UNSPECIFIED" => std::option::Option::Some(Self::ERROR_CODE_UNSPECIFIED),
+                "REVISION_FAILED" => std::option::Option::Some(Self::REVISION_FAILED),
+                "CLOUD_BUILD_PERMISSION_DENIED" => {
+                    std::option::Option::Some(Self::CLOUD_BUILD_PERMISSION_DENIED)
+                }
+                "DELETE_BUILD_API_FAILED" => {
+                    std::option::Option::Some(Self::DELETE_BUILD_API_FAILED)
+                }
+                "DELETE_BUILD_RUN_FAILED" => {
+                    std::option::Option::Some(Self::DELETE_BUILD_RUN_FAILED)
+                }
+                "BUCKET_CREATION_PERMISSION_DENIED" => {
+                    std::option::Option::Some(Self::BUCKET_CREATION_PERMISSION_DENIED)
+                }
+                "BUCKET_CREATION_FAILED" => std::option::Option::Some(Self::BUCKET_CREATION_FAILED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ErrorCode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ErrorCode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ErrorCode {
         fn default() -> Self {
-            error_code::ERROR_CODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Possible lock states of a deployment.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LockState(std::borrow::Cow<'static, str>);
+    pub struct LockState(i32);
 
     impl LockState {
+        /// The default value. This value is used if the lock state is omitted.
+        pub const LOCK_STATE_UNSPECIFIED: LockState = LockState::new(0);
+
+        /// The deployment is locked.
+        pub const LOCKED: LockState = LockState::new(1);
+
+        /// The deployment is unlocked.
+        pub const UNLOCKED: LockState = LockState::new(2);
+
+        /// The deployment is being locked.
+        pub const LOCKING: LockState = LockState::new(3);
+
+        /// The deployment is being unlocked.
+        pub const UNLOCKING: LockState = LockState::new(4);
+
+        /// The deployment has failed to lock.
+        pub const LOCK_FAILED: LockState = LockState::new(5);
+
+        /// The deployment has failed to unlock.
+        pub const UNLOCK_FAILED: LockState = LockState::new(6);
+
         /// Creates a new LockState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LOCK_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LOCKED"),
+                2 => std::borrow::Cow::Borrowed("UNLOCKED"),
+                3 => std::borrow::Cow::Borrowed("LOCKING"),
+                4 => std::borrow::Cow::Borrowed("UNLOCKING"),
+                5 => std::borrow::Cow::Borrowed("LOCK_FAILED"),
+                6 => std::borrow::Cow::Borrowed("UNLOCK_FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LOCK_STATE_UNSPECIFIED" => std::option::Option::Some(Self::LOCK_STATE_UNSPECIFIED),
+                "LOCKED" => std::option::Option::Some(Self::LOCKED),
+                "UNLOCKED" => std::option::Option::Some(Self::UNLOCKED),
+                "LOCKING" => std::option::Option::Some(Self::LOCKING),
+                "UNLOCKING" => std::option::Option::Some(Self::UNLOCKING),
+                "LOCK_FAILED" => std::option::Option::Some(Self::LOCK_FAILED),
+                "UNLOCK_FAILED" => std::option::Option::Some(Self::UNLOCK_FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [LockState](LockState)
-    pub mod lock_state {
-        use super::LockState;
-
-        /// The default value. This value is used if the lock state is omitted.
-        pub const LOCK_STATE_UNSPECIFIED: LockState = LockState::new("LOCK_STATE_UNSPECIFIED");
-
-        /// The deployment is locked.
-        pub const LOCKED: LockState = LockState::new("LOCKED");
-
-        /// The deployment is unlocked.
-        pub const UNLOCKED: LockState = LockState::new("UNLOCKED");
-
-        /// The deployment is being locked.
-        pub const LOCKING: LockState = LockState::new("LOCKING");
-
-        /// The deployment is being unlocked.
-        pub const UNLOCKING: LockState = LockState::new("UNLOCKING");
-
-        /// The deployment has failed to lock.
-        pub const LOCK_FAILED: LockState = LockState::new("LOCK_FAILED");
-
-        /// The deployment has failed to unlock.
-        pub const UNLOCK_FAILED: LockState = LockState::new("UNLOCK_FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for LockState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LockState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LockState {
         fn default() -> Self {
-            lock_state::LOCK_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1491,44 +1568,60 @@ pub mod delete_deployment_request {
 
     /// Policy on how resources actuated by the deployment should be deleted.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DeletePolicy(std::borrow::Cow<'static, str>);
+    pub struct DeletePolicy(i32);
 
     impl DeletePolicy {
+        /// Unspecified policy, resources will be deleted.
+        pub const DELETE_POLICY_UNSPECIFIED: DeletePolicy = DeletePolicy::new(0);
+
+        /// Deletes resources actuated by the deployment.
+        pub const DELETE: DeletePolicy = DeletePolicy::new(1);
+
+        /// Abandons resources and only deletes the deployment and its metadata.
+        pub const ABANDON: DeletePolicy = DeletePolicy::new(2);
+
         /// Creates a new DeletePolicy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DELETE_POLICY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DELETE"),
+                2 => std::borrow::Cow::Borrowed("ABANDON"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DELETE_POLICY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DELETE_POLICY_UNSPECIFIED)
+                }
+                "DELETE" => std::option::Option::Some(Self::DELETE),
+                "ABANDON" => std::option::Option::Some(Self::ABANDON),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DeletePolicy](DeletePolicy)
-    pub mod delete_policy {
-        use super::DeletePolicy;
-
-        /// Unspecified policy, resources will be deleted.
-        pub const DELETE_POLICY_UNSPECIFIED: DeletePolicy =
-            DeletePolicy::new("DELETE_POLICY_UNSPECIFIED");
-
-        /// Deletes resources actuated by the deployment.
-        pub const DELETE: DeletePolicy = DeletePolicy::new("DELETE");
-
-        /// Abandons resources and only deletes the deployment and its metadata.
-        pub const ABANDON: DeletePolicy = DeletePolicy::new("ABANDON");
-    }
-
-    impl std::convert::From<std::string::String> for DeletePolicy {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DeletePolicy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DeletePolicy {
         fn default() -> Self {
-            delete_policy::DELETE_POLICY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2047,143 +2140,199 @@ pub mod revision {
 
     /// Actions that generate a revision.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(std::borrow::Cow<'static, str>);
+    pub struct Action(i32);
 
     impl Action {
+        /// The default value. This value is used if the action is omitted.
+        pub const ACTION_UNSPECIFIED: Action = Action::new(0);
+
+        /// The revision was generated by creating a deployment.
+        pub const CREATE: Action = Action::new(1);
+
+        /// The revision was generated by updating a deployment.
+        pub const UPDATE: Action = Action::new(2);
+
+        /// The revision was deleted.
+        pub const DELETE: Action = Action::new(3);
+
         /// Creates a new Action instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ACTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATE"),
+                2 => std::borrow::Cow::Borrowed("UPDATE"),
+                3 => std::borrow::Cow::Borrowed("DELETE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ACTION_UNSPECIFIED" => std::option::Option::Some(Self::ACTION_UNSPECIFIED),
+                "CREATE" => std::option::Option::Some(Self::CREATE),
+                "UPDATE" => std::option::Option::Some(Self::UPDATE),
+                "DELETE" => std::option::Option::Some(Self::DELETE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Action](Action)
-    pub mod action {
-        use super::Action;
-
-        /// The default value. This value is used if the action is omitted.
-        pub const ACTION_UNSPECIFIED: Action = Action::new("ACTION_UNSPECIFIED");
-
-        /// The revision was generated by creating a deployment.
-        pub const CREATE: Action = Action::new("CREATE");
-
-        /// The revision was generated by updating a deployment.
-        pub const UPDATE: Action = Action::new("UPDATE");
-
-        /// The revision was deleted.
-        pub const DELETE: Action = Action::new("DELETE");
-    }
-
-    impl std::convert::From<std::string::String> for Action {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            action::ACTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Possible states of a revision.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The default value. This value is used if the state is omitted.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The revision is being applied.
+        pub const APPLYING: State = State::new(1);
+
+        /// The revision was applied successfully.
+        pub const APPLIED: State = State::new(2);
+
+        /// The revision could not be applied successfully.
+        pub const FAILED: State = State::new(3);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("APPLYING"),
+                2 => std::borrow::Cow::Borrowed("APPLIED"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "APPLYING" => std::option::Option::Some(Self::APPLYING),
+                "APPLIED" => std::option::Option::Some(Self::APPLIED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The revision is being applied.
-        pub const APPLYING: State = State::new("APPLYING");
-
-        /// The revision was applied successfully.
-        pub const APPLIED: State = State::new("APPLIED");
-
-        /// The revision could not be applied successfully.
-        pub const FAILED: State = State::new("FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Possible errors if Revision could not be created or updated successfully.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ErrorCode(std::borrow::Cow<'static, str>);
+    pub struct ErrorCode(i32);
 
     impl ErrorCode {
-        /// Creates a new ErrorCode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ErrorCode](ErrorCode)
-    pub mod error_code {
-        use super::ErrorCode;
-
         /// No error code was specified.
-        pub const ERROR_CODE_UNSPECIFIED: ErrorCode = ErrorCode::new("ERROR_CODE_UNSPECIFIED");
+        pub const ERROR_CODE_UNSPECIFIED: ErrorCode = ErrorCode::new(0);
 
         /// Cloud Build failed due to a permission issue.
-        pub const CLOUD_BUILD_PERMISSION_DENIED: ErrorCode =
-            ErrorCode::new("CLOUD_BUILD_PERMISSION_DENIED");
+        pub const CLOUD_BUILD_PERMISSION_DENIED: ErrorCode = ErrorCode::new(1);
 
         /// Cloud Build job associated with creating or updating a deployment could
         /// not be started.
-        pub const APPLY_BUILD_API_FAILED: ErrorCode = ErrorCode::new("APPLY_BUILD_API_FAILED");
+        pub const APPLY_BUILD_API_FAILED: ErrorCode = ErrorCode::new(4);
 
         /// Cloud Build job associated with creating or updating a deployment was
         /// started but failed.
-        pub const APPLY_BUILD_RUN_FAILED: ErrorCode = ErrorCode::new("APPLY_BUILD_RUN_FAILED");
+        pub const APPLY_BUILD_RUN_FAILED: ErrorCode = ErrorCode::new(5);
 
         /// quota validation failed for one or more resources in terraform
         /// configuration files.
-        pub const QUOTA_VALIDATION_FAILED: ErrorCode = ErrorCode::new("QUOTA_VALIDATION_FAILED");
+        pub const QUOTA_VALIDATION_FAILED: ErrorCode = ErrorCode::new(7);
+
+        /// Creates a new ErrorCode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ERROR_CODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CLOUD_BUILD_PERMISSION_DENIED"),
+                4 => std::borrow::Cow::Borrowed("APPLY_BUILD_API_FAILED"),
+                5 => std::borrow::Cow::Borrowed("APPLY_BUILD_RUN_FAILED"),
+                7 => std::borrow::Cow::Borrowed("QUOTA_VALIDATION_FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ERROR_CODE_UNSPECIFIED" => std::option::Option::Some(Self::ERROR_CODE_UNSPECIFIED),
+                "CLOUD_BUILD_PERMISSION_DENIED" => {
+                    std::option::Option::Some(Self::CLOUD_BUILD_PERMISSION_DENIED)
+                }
+                "APPLY_BUILD_API_FAILED" => std::option::Option::Some(Self::APPLY_BUILD_API_FAILED),
+                "APPLY_BUILD_RUN_FAILED" => std::option::Option::Some(Self::APPLY_BUILD_RUN_FAILED),
+                "QUOTA_VALIDATION_FAILED" => {
+                    std::option::Option::Some(Self::QUOTA_VALIDATION_FAILED)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ErrorCode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ErrorCode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ErrorCode {
         fn default() -> Self {
-            error_code::ERROR_CODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -2405,80 +2554,115 @@ pub mod deployment_operation_metadata {
 
     /// The possible steps a deployment may be running.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DeploymentStep(std::borrow::Cow<'static, str>);
+    pub struct DeploymentStep(i32);
 
     impl DeploymentStep {
-        /// Creates a new DeploymentStep instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DeploymentStep](DeploymentStep)
-    pub mod deployment_step {
-        use super::DeploymentStep;
-
         /// Unspecified deployment step
-        pub const DEPLOYMENT_STEP_UNSPECIFIED: DeploymentStep =
-            DeploymentStep::new("DEPLOYMENT_STEP_UNSPECIFIED");
+        pub const DEPLOYMENT_STEP_UNSPECIFIED: DeploymentStep = DeploymentStep::new(0);
 
         /// Infra Manager is creating a Google Cloud Storage bucket to store
         /// artifacts and metadata about the deployment and revision
-        pub const PREPARING_STORAGE_BUCKET: DeploymentStep =
-            DeploymentStep::new("PREPARING_STORAGE_BUCKET");
+        pub const PREPARING_STORAGE_BUCKET: DeploymentStep = DeploymentStep::new(1);
 
         /// Downloading the blueprint onto the Google Cloud Storage bucket
-        pub const DOWNLOADING_BLUEPRINT: DeploymentStep =
-            DeploymentStep::new("DOWNLOADING_BLUEPRINT");
+        pub const DOWNLOADING_BLUEPRINT: DeploymentStep = DeploymentStep::new(2);
 
         /// Initializing Terraform using `terraform init`
-        pub const RUNNING_TF_INIT: DeploymentStep = DeploymentStep::new("RUNNING_TF_INIT");
+        pub const RUNNING_TF_INIT: DeploymentStep = DeploymentStep::new(3);
 
         /// Running `terraform plan`
-        pub const RUNNING_TF_PLAN: DeploymentStep = DeploymentStep::new("RUNNING_TF_PLAN");
+        pub const RUNNING_TF_PLAN: DeploymentStep = DeploymentStep::new(4);
 
         /// Actuating resources using Terraform using `terraform apply`
-        pub const RUNNING_TF_APPLY: DeploymentStep = DeploymentStep::new("RUNNING_TF_APPLY");
+        pub const RUNNING_TF_APPLY: DeploymentStep = DeploymentStep::new(5);
 
         /// Destroying resources using Terraform using `terraform destroy`
-        pub const RUNNING_TF_DESTROY: DeploymentStep = DeploymentStep::new("RUNNING_TF_DESTROY");
+        pub const RUNNING_TF_DESTROY: DeploymentStep = DeploymentStep::new(6);
 
         /// Validating the uploaded TF state file when unlocking a deployment
-        pub const RUNNING_TF_VALIDATE: DeploymentStep = DeploymentStep::new("RUNNING_TF_VALIDATE");
+        pub const RUNNING_TF_VALIDATE: DeploymentStep = DeploymentStep::new(7);
 
         /// Unlocking a deployment
-        pub const UNLOCKING_DEPLOYMENT: DeploymentStep =
-            DeploymentStep::new("UNLOCKING_DEPLOYMENT");
+        pub const UNLOCKING_DEPLOYMENT: DeploymentStep = DeploymentStep::new(8);
 
         /// Operation was successful
-        pub const SUCCEEDED: DeploymentStep = DeploymentStep::new("SUCCEEDED");
+        pub const SUCCEEDED: DeploymentStep = DeploymentStep::new(9);
 
         /// Operation failed
-        pub const FAILED: DeploymentStep = DeploymentStep::new("FAILED");
+        pub const FAILED: DeploymentStep = DeploymentStep::new(10);
 
         /// Validating the provided repository.
-        pub const VALIDATING_REPOSITORY: DeploymentStep =
-            DeploymentStep::new("VALIDATING_REPOSITORY");
+        pub const VALIDATING_REPOSITORY: DeploymentStep = DeploymentStep::new(11);
 
         /// Running quota validation
-        pub const RUNNING_QUOTA_VALIDATION: DeploymentStep =
-            DeploymentStep::new("RUNNING_QUOTA_VALIDATION");
+        pub const RUNNING_QUOTA_VALIDATION: DeploymentStep = DeploymentStep::new(12);
+
+        /// Creates a new DeploymentStep instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DEPLOYMENT_STEP_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PREPARING_STORAGE_BUCKET"),
+                2 => std::borrow::Cow::Borrowed("DOWNLOADING_BLUEPRINT"),
+                3 => std::borrow::Cow::Borrowed("RUNNING_TF_INIT"),
+                4 => std::borrow::Cow::Borrowed("RUNNING_TF_PLAN"),
+                5 => std::borrow::Cow::Borrowed("RUNNING_TF_APPLY"),
+                6 => std::borrow::Cow::Borrowed("RUNNING_TF_DESTROY"),
+                7 => std::borrow::Cow::Borrowed("RUNNING_TF_VALIDATE"),
+                8 => std::borrow::Cow::Borrowed("UNLOCKING_DEPLOYMENT"),
+                9 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                10 => std::borrow::Cow::Borrowed("FAILED"),
+                11 => std::borrow::Cow::Borrowed("VALIDATING_REPOSITORY"),
+                12 => std::borrow::Cow::Borrowed("RUNNING_QUOTA_VALIDATION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DEPLOYMENT_STEP_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DEPLOYMENT_STEP_UNSPECIFIED)
+                }
+                "PREPARING_STORAGE_BUCKET" => {
+                    std::option::Option::Some(Self::PREPARING_STORAGE_BUCKET)
+                }
+                "DOWNLOADING_BLUEPRINT" => std::option::Option::Some(Self::DOWNLOADING_BLUEPRINT),
+                "RUNNING_TF_INIT" => std::option::Option::Some(Self::RUNNING_TF_INIT),
+                "RUNNING_TF_PLAN" => std::option::Option::Some(Self::RUNNING_TF_PLAN),
+                "RUNNING_TF_APPLY" => std::option::Option::Some(Self::RUNNING_TF_APPLY),
+                "RUNNING_TF_DESTROY" => std::option::Option::Some(Self::RUNNING_TF_DESTROY),
+                "RUNNING_TF_VALIDATE" => std::option::Option::Some(Self::RUNNING_TF_VALIDATE),
+                "UNLOCKING_DEPLOYMENT" => std::option::Option::Some(Self::UNLOCKING_DEPLOYMENT),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "VALIDATING_REPOSITORY" => std::option::Option::Some(Self::VALIDATING_REPOSITORY),
+                "RUNNING_QUOTA_VALIDATION" => {
+                    std::option::Option::Some(Self::RUNNING_QUOTA_VALIDATION)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DeploymentStep {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DeploymentStep {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DeploymentStep {
         fn default() -> Self {
-            deployment_step::DEPLOYMENT_STEP_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2577,100 +2761,140 @@ pub mod resource {
 
     /// Possible intent of the resource.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Intent(std::borrow::Cow<'static, str>);
+    pub struct Intent(i32);
 
     impl Intent {
+        /// The default value. This value is used if the intent is omitted.
+        pub const INTENT_UNSPECIFIED: Intent = Intent::new(0);
+
+        /// Infra Manager will create this Resource.
+        pub const CREATE: Intent = Intent::new(1);
+
+        /// Infra Manager will update this Resource.
+        pub const UPDATE: Intent = Intent::new(2);
+
+        /// Infra Manager will delete this Resource.
+        pub const DELETE: Intent = Intent::new(3);
+
+        /// Infra Manager will destroy and recreate this Resource.
+        pub const RECREATE: Intent = Intent::new(4);
+
+        /// Infra Manager will leave this Resource untouched.
+        pub const UNCHANGED: Intent = Intent::new(5);
+
         /// Creates a new Intent instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("INTENT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATE"),
+                2 => std::borrow::Cow::Borrowed("UPDATE"),
+                3 => std::borrow::Cow::Borrowed("DELETE"),
+                4 => std::borrow::Cow::Borrowed("RECREATE"),
+                5 => std::borrow::Cow::Borrowed("UNCHANGED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "INTENT_UNSPECIFIED" => std::option::Option::Some(Self::INTENT_UNSPECIFIED),
+                "CREATE" => std::option::Option::Some(Self::CREATE),
+                "UPDATE" => std::option::Option::Some(Self::UPDATE),
+                "DELETE" => std::option::Option::Some(Self::DELETE),
+                "RECREATE" => std::option::Option::Some(Self::RECREATE),
+                "UNCHANGED" => std::option::Option::Some(Self::UNCHANGED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Intent](Intent)
-    pub mod intent {
-        use super::Intent;
-
-        /// The default value. This value is used if the intent is omitted.
-        pub const INTENT_UNSPECIFIED: Intent = Intent::new("INTENT_UNSPECIFIED");
-
-        /// Infra Manager will create this Resource.
-        pub const CREATE: Intent = Intent::new("CREATE");
-
-        /// Infra Manager will update this Resource.
-        pub const UPDATE: Intent = Intent::new("UPDATE");
-
-        /// Infra Manager will delete this Resource.
-        pub const DELETE: Intent = Intent::new("DELETE");
-
-        /// Infra Manager will destroy and recreate this Resource.
-        pub const RECREATE: Intent = Intent::new("RECREATE");
-
-        /// Infra Manager will leave this Resource untouched.
-        pub const UNCHANGED: Intent = Intent::new("UNCHANGED");
-    }
-
-    impl std::convert::From<std::string::String> for Intent {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Intent {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Intent {
         fn default() -> Self {
-            intent::INTENT_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Possible states of a resource.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The default value. This value is used if the state is omitted.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Resource has been planned for reconcile.
+        pub const PLANNED: State = State::new(1);
+
+        /// Resource is actively reconciling into the intended state.
+        pub const IN_PROGRESS: State = State::new(2);
+
+        /// Resource has reconciled to intended state.
+        pub const RECONCILED: State = State::new(3);
+
+        /// Resource failed to reconcile.
+        pub const FAILED: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PLANNED"),
+                2 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                3 => std::borrow::Cow::Borrowed("RECONCILED"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PLANNED" => std::option::Option::Some(Self::PLANNED),
+                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                "RECONCILED" => std::option::Option::Some(Self::RECONCILED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Resource has been planned for reconcile.
-        pub const PLANNED: State = State::new("PLANNED");
-
-        /// Resource is actively reconciling into the intended state.
-        pub const IN_PROGRESS: State = State::new("IN_PROGRESS");
-
-        /// Resource has reconciled to intended state.
-        pub const RECONCILED: State = State::new("RECONCILED");
-
-        /// Resource failed to reconcile.
-        pub const FAILED: State = State::new("FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3667,160 +3891,231 @@ pub mod preview {
 
     /// Possible states of a preview.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The default value. This value is used if the state is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The preview is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The preview has succeeded.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
+        pub const SUCCEEDED: State = State::new(2);
 
         /// The preview is being applied.
-        pub const APPLYING: State = State::new("APPLYING");
+        pub const APPLYING: State = State::new(3);
 
         /// The preview is stale. A preview can become stale if a revision has been
         /// applied after this preview was created.
-        pub const STALE: State = State::new("STALE");
+        pub const STALE: State = State::new(4);
 
         /// The preview is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(5);
 
         /// The preview has encountered an unexpected error.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(6);
 
         /// The preview has been deleted.
-        pub const DELETED: State = State::new("DELETED");
+        pub const DELETED: State = State::new(7);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                3 => std::borrow::Cow::Borrowed("APPLYING"),
+                4 => std::borrow::Cow::Borrowed("STALE"),
+                5 => std::borrow::Cow::Borrowed("DELETING"),
+                6 => std::borrow::Cow::Borrowed("FAILED"),
+                7 => std::borrow::Cow::Borrowed("DELETED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "APPLYING" => std::option::Option::Some(Self::APPLYING),
+                "STALE" => std::option::Option::Some(Self::STALE),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "DELETED" => std::option::Option::Some(Self::DELETED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Preview mode provides options for customizing preview operations.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PreviewMode(std::borrow::Cow<'static, str>);
+    pub struct PreviewMode(i32);
 
     impl PreviewMode {
-        /// Creates a new PreviewMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PreviewMode](PreviewMode)
-    pub mod preview_mode {
-        use super::PreviewMode;
-
         /// Unspecified policy, default mode will be used.
-        pub const PREVIEW_MODE_UNSPECIFIED: PreviewMode =
-            PreviewMode::new("PREVIEW_MODE_UNSPECIFIED");
+        pub const PREVIEW_MODE_UNSPECIFIED: PreviewMode = PreviewMode::new(0);
 
         /// DEFAULT mode generates an execution plan for reconciling current resource
         /// state into expected resource state.
-        pub const DEFAULT: PreviewMode = PreviewMode::new("DEFAULT");
+        pub const DEFAULT: PreviewMode = PreviewMode::new(1);
 
         /// DELETE mode generates as execution plan for destroying current resources.
-        pub const DELETE: PreviewMode = PreviewMode::new("DELETE");
+        pub const DELETE: PreviewMode = PreviewMode::new(2);
+
+        /// Creates a new PreviewMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PREVIEW_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DEFAULT"),
+                2 => std::borrow::Cow::Borrowed("DELETE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PREVIEW_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PREVIEW_MODE_UNSPECIFIED)
+                }
+                "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
+                "DELETE" => std::option::Option::Some(Self::DELETE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PreviewMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PreviewMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PreviewMode {
         fn default() -> Self {
-            preview_mode::PREVIEW_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Possible errors that can occur with previews.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ErrorCode(std::borrow::Cow<'static, str>);
+    pub struct ErrorCode(i32);
 
     impl ErrorCode {
+        /// No error code was specified.
+        pub const ERROR_CODE_UNSPECIFIED: ErrorCode = ErrorCode::new(0);
+
+        /// Cloud Build failed due to a permissions issue.
+        pub const CLOUD_BUILD_PERMISSION_DENIED: ErrorCode = ErrorCode::new(1);
+
+        /// Cloud Storage bucket failed to create due to a permissions issue.
+        pub const BUCKET_CREATION_PERMISSION_DENIED: ErrorCode = ErrorCode::new(2);
+
+        /// Cloud Storage bucket failed for a non-permissions-related issue.
+        pub const BUCKET_CREATION_FAILED: ErrorCode = ErrorCode::new(3);
+
+        /// Acquiring lock on provided deployment reference failed.
+        pub const DEPLOYMENT_LOCK_ACQUIRE_FAILED: ErrorCode = ErrorCode::new(4);
+
+        /// Preview encountered an error when trying to access Cloud Build API.
+        pub const PREVIEW_BUILD_API_FAILED: ErrorCode = ErrorCode::new(5);
+
+        /// Preview created a build but build failed and logs were generated.
+        pub const PREVIEW_BUILD_RUN_FAILED: ErrorCode = ErrorCode::new(6);
+
         /// Creates a new ErrorCode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ERROR_CODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CLOUD_BUILD_PERMISSION_DENIED"),
+                2 => std::borrow::Cow::Borrowed("BUCKET_CREATION_PERMISSION_DENIED"),
+                3 => std::borrow::Cow::Borrowed("BUCKET_CREATION_FAILED"),
+                4 => std::borrow::Cow::Borrowed("DEPLOYMENT_LOCK_ACQUIRE_FAILED"),
+                5 => std::borrow::Cow::Borrowed("PREVIEW_BUILD_API_FAILED"),
+                6 => std::borrow::Cow::Borrowed("PREVIEW_BUILD_RUN_FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ERROR_CODE_UNSPECIFIED" => std::option::Option::Some(Self::ERROR_CODE_UNSPECIFIED),
+                "CLOUD_BUILD_PERMISSION_DENIED" => {
+                    std::option::Option::Some(Self::CLOUD_BUILD_PERMISSION_DENIED)
+                }
+                "BUCKET_CREATION_PERMISSION_DENIED" => {
+                    std::option::Option::Some(Self::BUCKET_CREATION_PERMISSION_DENIED)
+                }
+                "BUCKET_CREATION_FAILED" => std::option::Option::Some(Self::BUCKET_CREATION_FAILED),
+                "DEPLOYMENT_LOCK_ACQUIRE_FAILED" => {
+                    std::option::Option::Some(Self::DEPLOYMENT_LOCK_ACQUIRE_FAILED)
+                }
+                "PREVIEW_BUILD_API_FAILED" => {
+                    std::option::Option::Some(Self::PREVIEW_BUILD_API_FAILED)
+                }
+                "PREVIEW_BUILD_RUN_FAILED" => {
+                    std::option::Option::Some(Self::PREVIEW_BUILD_RUN_FAILED)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ErrorCode](ErrorCode)
-    pub mod error_code {
-        use super::ErrorCode;
-
-        /// No error code was specified.
-        pub const ERROR_CODE_UNSPECIFIED: ErrorCode = ErrorCode::new("ERROR_CODE_UNSPECIFIED");
-
-        /// Cloud Build failed due to a permissions issue.
-        pub const CLOUD_BUILD_PERMISSION_DENIED: ErrorCode =
-            ErrorCode::new("CLOUD_BUILD_PERMISSION_DENIED");
-
-        /// Cloud Storage bucket failed to create due to a permissions issue.
-        pub const BUCKET_CREATION_PERMISSION_DENIED: ErrorCode =
-            ErrorCode::new("BUCKET_CREATION_PERMISSION_DENIED");
-
-        /// Cloud Storage bucket failed for a non-permissions-related issue.
-        pub const BUCKET_CREATION_FAILED: ErrorCode = ErrorCode::new("BUCKET_CREATION_FAILED");
-
-        /// Acquiring lock on provided deployment reference failed.
-        pub const DEPLOYMENT_LOCK_ACQUIRE_FAILED: ErrorCode =
-            ErrorCode::new("DEPLOYMENT_LOCK_ACQUIRE_FAILED");
-
-        /// Preview encountered an error when trying to access Cloud Build API.
-        pub const PREVIEW_BUILD_API_FAILED: ErrorCode = ErrorCode::new("PREVIEW_BUILD_API_FAILED");
-
-        /// Preview created a build but build failed and logs were generated.
-        pub const PREVIEW_BUILD_RUN_FAILED: ErrorCode = ErrorCode::new("PREVIEW_BUILD_RUN_FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for ErrorCode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ErrorCode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ErrorCode {
         fn default() -> Self {
-            error_code::ERROR_CODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -3909,70 +4204,103 @@ pub mod preview_operation_metadata {
 
     /// The possible steps a preview may be running.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PreviewStep(std::borrow::Cow<'static, str>);
+    pub struct PreviewStep(i32);
 
     impl PreviewStep {
-        /// Creates a new PreviewStep instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PreviewStep](PreviewStep)
-    pub mod preview_step {
-        use super::PreviewStep;
-
         /// Unspecified preview step.
-        pub const PREVIEW_STEP_UNSPECIFIED: PreviewStep =
-            PreviewStep::new("PREVIEW_STEP_UNSPECIFIED");
+        pub const PREVIEW_STEP_UNSPECIFIED: PreviewStep = PreviewStep::new(0);
 
         /// Infra Manager is creating a Google Cloud Storage bucket to store
         /// artifacts and metadata about the preview.
-        pub const PREPARING_STORAGE_BUCKET: PreviewStep =
-            PreviewStep::new("PREPARING_STORAGE_BUCKET");
+        pub const PREPARING_STORAGE_BUCKET: PreviewStep = PreviewStep::new(1);
 
         /// Downloading the blueprint onto the Google Cloud Storage bucket.
-        pub const DOWNLOADING_BLUEPRINT: PreviewStep = PreviewStep::new("DOWNLOADING_BLUEPRINT");
+        pub const DOWNLOADING_BLUEPRINT: PreviewStep = PreviewStep::new(2);
 
         /// Initializing Terraform using `terraform init`.
-        pub const RUNNING_TF_INIT: PreviewStep = PreviewStep::new("RUNNING_TF_INIT");
+        pub const RUNNING_TF_INIT: PreviewStep = PreviewStep::new(3);
 
         /// Running `terraform plan`.
-        pub const RUNNING_TF_PLAN: PreviewStep = PreviewStep::new("RUNNING_TF_PLAN");
+        pub const RUNNING_TF_PLAN: PreviewStep = PreviewStep::new(4);
 
         /// Fetching a deployment.
-        pub const FETCHING_DEPLOYMENT: PreviewStep = PreviewStep::new("FETCHING_DEPLOYMENT");
+        pub const FETCHING_DEPLOYMENT: PreviewStep = PreviewStep::new(5);
 
         /// Locking a deployment.
-        pub const LOCKING_DEPLOYMENT: PreviewStep = PreviewStep::new("LOCKING_DEPLOYMENT");
+        pub const LOCKING_DEPLOYMENT: PreviewStep = PreviewStep::new(6);
 
         /// Unlocking a deployment.
-        pub const UNLOCKING_DEPLOYMENT: PreviewStep = PreviewStep::new("UNLOCKING_DEPLOYMENT");
+        pub const UNLOCKING_DEPLOYMENT: PreviewStep = PreviewStep::new(7);
 
         /// Operation was successful.
-        pub const SUCCEEDED: PreviewStep = PreviewStep::new("SUCCEEDED");
+        pub const SUCCEEDED: PreviewStep = PreviewStep::new(8);
 
         /// Operation failed.
-        pub const FAILED: PreviewStep = PreviewStep::new("FAILED");
+        pub const FAILED: PreviewStep = PreviewStep::new(9);
 
         /// Validating the provided repository.
-        pub const VALIDATING_REPOSITORY: PreviewStep = PreviewStep::new("VALIDATING_REPOSITORY");
+        pub const VALIDATING_REPOSITORY: PreviewStep = PreviewStep::new(10);
+
+        /// Creates a new PreviewStep instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PREVIEW_STEP_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PREPARING_STORAGE_BUCKET"),
+                2 => std::borrow::Cow::Borrowed("DOWNLOADING_BLUEPRINT"),
+                3 => std::borrow::Cow::Borrowed("RUNNING_TF_INIT"),
+                4 => std::borrow::Cow::Borrowed("RUNNING_TF_PLAN"),
+                5 => std::borrow::Cow::Borrowed("FETCHING_DEPLOYMENT"),
+                6 => std::borrow::Cow::Borrowed("LOCKING_DEPLOYMENT"),
+                7 => std::borrow::Cow::Borrowed("UNLOCKING_DEPLOYMENT"),
+                8 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                9 => std::borrow::Cow::Borrowed("FAILED"),
+                10 => std::borrow::Cow::Borrowed("VALIDATING_REPOSITORY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PREVIEW_STEP_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PREVIEW_STEP_UNSPECIFIED)
+                }
+                "PREPARING_STORAGE_BUCKET" => {
+                    std::option::Option::Some(Self::PREPARING_STORAGE_BUCKET)
+                }
+                "DOWNLOADING_BLUEPRINT" => std::option::Option::Some(Self::DOWNLOADING_BLUEPRINT),
+                "RUNNING_TF_INIT" => std::option::Option::Some(Self::RUNNING_TF_INIT),
+                "RUNNING_TF_PLAN" => std::option::Option::Some(Self::RUNNING_TF_PLAN),
+                "FETCHING_DEPLOYMENT" => std::option::Option::Some(Self::FETCHING_DEPLOYMENT),
+                "LOCKING_DEPLOYMENT" => std::option::Option::Some(Self::LOCKING_DEPLOYMENT),
+                "UNLOCKING_DEPLOYMENT" => std::option::Option::Some(Self::UNLOCKING_DEPLOYMENT),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "VALIDATING_REPOSITORY" => std::option::Option::Some(Self::VALIDATING_REPOSITORY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PreviewStep {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PreviewStep {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PreviewStep {
         fn default() -> Self {
-            preview_step::PREVIEW_STEP_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4727,46 +5055,63 @@ pub mod terraform_version {
 
     /// Possible states of a TerraformVersion.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The default value. This value is used if the state is omitted.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The version is actively supported.
+        pub const ACTIVE: State = State::new(1);
+
+        /// The version is deprecated.
+        pub const DEPRECATED: State = State::new(2);
+
+        /// The version is obsolete.
+        pub const OBSOLETE: State = State::new(3);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("DEPRECATED"),
+                3 => std::borrow::Cow::Borrowed("OBSOLETE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DEPRECATED" => std::option::Option::Some(Self::DEPRECATED),
+                "OBSOLETE" => std::option::Option::Some(Self::OBSOLETE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The version is actively supported.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The version is deprecated.
-        pub const DEPRECATED: State = State::new("DEPRECATED");
-
-        /// The version is obsolete.
-        pub const OBSOLETE: State = State::new("OBSOLETE");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4774,47 +5119,63 @@ pub mod terraform_version {
 /// Enum values to control quota checks for resources in terraform
 /// configuration files.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct QuotaValidation(std::borrow::Cow<'static, str>);
+pub struct QuotaValidation(i32);
 
 impl QuotaValidation {
-    /// Creates a new QuotaValidation instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [QuotaValidation](QuotaValidation)
-pub mod quota_validation {
-    use super::QuotaValidation;
-
     /// The default value.
     /// QuotaValidation on terraform configuration files will be disabled in
     /// this case.
-    pub const QUOTA_VALIDATION_UNSPECIFIED: QuotaValidation =
-        QuotaValidation::new("QUOTA_VALIDATION_UNSPECIFIED");
+    pub const QUOTA_VALIDATION_UNSPECIFIED: QuotaValidation = QuotaValidation::new(0);
 
     /// Enable computing quotas for resources in terraform configuration files to
     /// get visibility on resources with insufficient quotas.
-    pub const ENABLED: QuotaValidation = QuotaValidation::new("ENABLED");
+    pub const ENABLED: QuotaValidation = QuotaValidation::new(1);
 
     /// Enforce quota checks so deployment fails if there isn't sufficient quotas
     /// available to deploy resources in terraform configuration files.
-    pub const ENFORCED: QuotaValidation = QuotaValidation::new("ENFORCED");
+    pub const ENFORCED: QuotaValidation = QuotaValidation::new(2);
+
+    /// Creates a new QuotaValidation instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("QUOTA_VALIDATION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ENABLED"),
+            2 => std::borrow::Cow::Borrowed("ENFORCED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "QUOTA_VALIDATION_UNSPECIFIED" => {
+                std::option::Option::Some(Self::QUOTA_VALIDATION_UNSPECIFIED)
+            }
+            "ENABLED" => std::option::Option::Some(Self::ENABLED),
+            "ENFORCED" => std::option::Option::Some(Self::ENFORCED),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for QuotaValidation {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for QuotaValidation {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for QuotaValidation {
     fn default() -> Self {
-        quota_validation::QUOTA_VALIDATION_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/config/v1/src/transport.rs
+++ b/src/generated/cloud/config/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::Config for Config {
                 reqwest::Method::GET,
                 format!("/v1/{}/deployments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::Config for Config {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::Config for Config {
                 reqwest::Method::POST,
                 format!("/v1/{}/deployments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -127,7 +127,7 @@ impl crate::stubs::Config for Config {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -157,7 +157,7 @@ impl crate::stubs::Config for Config {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -182,7 +182,7 @@ impl crate::stubs::Config for Config {
                 reqwest::Method::GET,
                 format!("/v1/{}/revisions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -205,7 +205,7 @@ impl crate::stubs::Config for Config {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -224,7 +224,7 @@ impl crate::stubs::Config for Config {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -246,7 +246,7 @@ impl crate::stubs::Config for Config {
                 reqwest::Method::GET,
                 format!("/v1/{}/resources", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -272,7 +272,7 @@ impl crate::stubs::Config for Config {
                 reqwest::Method::POST,
                 format!("/v1/{}:exportState", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -292,7 +292,7 @@ impl crate::stubs::Config for Config {
                 reqwest::Method::POST,
                 format!("/v1/{}:exportState", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -312,7 +312,7 @@ impl crate::stubs::Config for Config {
                 reqwest::Method::POST,
                 format!("/v1/{}:importState", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -332,7 +332,7 @@ impl crate::stubs::Config for Config {
                 reqwest::Method::POST,
                 format!("/v1/{}:deleteState", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -349,7 +349,7 @@ impl crate::stubs::Config for Config {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:lock", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -366,7 +366,7 @@ impl crate::stubs::Config for Config {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:unlock", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -383,7 +383,7 @@ impl crate::stubs::Config for Config {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}:exportLock", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -405,7 +405,7 @@ impl crate::stubs::Config for Config {
                 reqwest::Method::POST,
                 format!("/v1/{}/previews", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -426,7 +426,7 @@ impl crate::stubs::Config for Config {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -445,7 +445,7 @@ impl crate::stubs::Config for Config {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/previews", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -468,7 +468,7 @@ impl crate::stubs::Config for Config {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -488,7 +488,7 @@ impl crate::stubs::Config for Config {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:export", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -508,7 +508,7 @@ impl crate::stubs::Config for Config {
                 reqwest::Method::GET,
                 format!("/v1/{}/terraformVersions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -531,7 +531,7 @@ impl crate::stubs::Config for Config {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -550,7 +550,7 @@ impl crate::stubs::Config for Config {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -572,7 +572,7 @@ impl crate::stubs::Config for Config {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -594,7 +594,7 @@ impl crate::stubs::Config for Config {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -614,7 +614,7 @@ impl crate::stubs::Config for Config {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -646,7 +646,7 @@ impl crate::stubs::Config for Config {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -663,7 +663,7 @@ impl crate::stubs::Config for Config {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -685,7 +685,7 @@ impl crate::stubs::Config for Config {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -704,7 +704,7 @@ impl crate::stubs::Config for Config {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -723,7 +723,7 @@ impl crate::stubs::Config for Config {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/connectors/v1/src/model.rs
+++ b/src/generated/cloud/connectors/v1/src/model.rs
@@ -825,97 +825,135 @@ pub mod config_variable_template {
 
     /// ValueType indicates the data type of the value.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ValueType(std::borrow::Cow<'static, str>);
+    pub struct ValueType(i32);
 
     impl ValueType {
+        /// Value type is not specified.
+        pub const VALUE_TYPE_UNSPECIFIED: ValueType = ValueType::new(0);
+
+        /// Value type is string.
+        pub const STRING: ValueType = ValueType::new(1);
+
+        /// Value type is integer.
+        pub const INT: ValueType = ValueType::new(2);
+
+        /// Value type is boolean.
+        pub const BOOL: ValueType = ValueType::new(3);
+
+        /// Value type is secret.
+        pub const SECRET: ValueType = ValueType::new(4);
+
+        /// Value type is enum.
+        pub const ENUM: ValueType = ValueType::new(5);
+
+        /// Value type is authorization code.
+        pub const AUTHORIZATION_CODE: ValueType = ValueType::new(6);
+
         /// Creates a new ValueType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VALUE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STRING"),
+                2 => std::borrow::Cow::Borrowed("INT"),
+                3 => std::borrow::Cow::Borrowed("BOOL"),
+                4 => std::borrow::Cow::Borrowed("SECRET"),
+                5 => std::borrow::Cow::Borrowed("ENUM"),
+                6 => std::borrow::Cow::Borrowed("AUTHORIZATION_CODE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VALUE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::VALUE_TYPE_UNSPECIFIED),
+                "STRING" => std::option::Option::Some(Self::STRING),
+                "INT" => std::option::Option::Some(Self::INT),
+                "BOOL" => std::option::Option::Some(Self::BOOL),
+                "SECRET" => std::option::Option::Some(Self::SECRET),
+                "ENUM" => std::option::Option::Some(Self::ENUM),
+                "AUTHORIZATION_CODE" => std::option::Option::Some(Self::AUTHORIZATION_CODE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ValueType](ValueType)
-    pub mod value_type {
-        use super::ValueType;
-
-        /// Value type is not specified.
-        pub const VALUE_TYPE_UNSPECIFIED: ValueType = ValueType::new("VALUE_TYPE_UNSPECIFIED");
-
-        /// Value type is string.
-        pub const STRING: ValueType = ValueType::new("STRING");
-
-        /// Value type is integer.
-        pub const INT: ValueType = ValueType::new("INT");
-
-        /// Value type is boolean.
-        pub const BOOL: ValueType = ValueType::new("BOOL");
-
-        /// Value type is secret.
-        pub const SECRET: ValueType = ValueType::new("SECRET");
-
-        /// Value type is enum.
-        pub const ENUM: ValueType = ValueType::new("ENUM");
-
-        /// Value type is authorization code.
-        pub const AUTHORIZATION_CODE: ValueType = ValueType::new("AUTHORIZATION_CODE");
-    }
-
-    impl std::convert::From<std::string::String> for ValueType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ValueType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ValueType {
         fn default() -> Self {
-            value_type::VALUE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Indicates the state of the config variable.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Status is unspecified.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Config variable is active
+        pub const ACTIVE: State = State::new(1);
+
+        /// Config variable is deprecated.
+        pub const DEPRECATED: State = State::new(2);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("DEPRECATED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DEPRECATED" => std::option::Option::Some(Self::DEPRECATED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Status is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Config variable is active
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// Config variable is deprecated.
-        pub const DEPRECATED: State = State::new("DEPRECATED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1283,92 +1321,127 @@ pub mod role_grant {
 
         /// Resource Type definition.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(std::borrow::Cow<'static, str>);
+        pub struct Type(i32);
 
         impl Type {
+            /// Value type is not specified.
+            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+            /// GCP Project Resource.
+            pub const GCP_PROJECT: Type = Type::new(1);
+
+            /// Any GCP Resource which is identified uniquely by IAM.
+            pub const GCP_RESOURCE: Type = Type::new(2);
+
+            /// GCP Secret Resource.
+            pub const GCP_SECRETMANAGER_SECRET: Type = Type::new(3);
+
+            /// GCP Secret Version Resource.
+            pub const GCP_SECRETMANAGER_SECRET_VERSION: Type = Type::new(4);
+
             /// Creates a new Type instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("GCP_PROJECT"),
+                    2 => std::borrow::Cow::Borrowed("GCP_RESOURCE"),
+                    3 => std::borrow::Cow::Borrowed("GCP_SECRETMANAGER_SECRET"),
+                    4 => std::borrow::Cow::Borrowed("GCP_SECRETMANAGER_SECRET_VERSION"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                    "GCP_PROJECT" => std::option::Option::Some(Self::GCP_PROJECT),
+                    "GCP_RESOURCE" => std::option::Option::Some(Self::GCP_RESOURCE),
+                    "GCP_SECRETMANAGER_SECRET" => {
+                        std::option::Option::Some(Self::GCP_SECRETMANAGER_SECRET)
+                    }
+                    "GCP_SECRETMANAGER_SECRET_VERSION" => {
+                        std::option::Option::Some(Self::GCP_SECRETMANAGER_SECRET_VERSION)
+                    }
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Type](Type)
-        pub mod r#type {
-            use super::Type;
-
-            /// Value type is not specified.
-            pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-            /// GCP Project Resource.
-            pub const GCP_PROJECT: Type = Type::new("GCP_PROJECT");
-
-            /// Any GCP Resource which is identified uniquely by IAM.
-            pub const GCP_RESOURCE: Type = Type::new("GCP_RESOURCE");
-
-            /// GCP Secret Resource.
-            pub const GCP_SECRETMANAGER_SECRET: Type = Type::new("GCP_SECRETMANAGER_SECRET");
-
-            /// GCP Secret Version Resource.
-            pub const GCP_SECRETMANAGER_SECRET_VERSION: Type =
-                Type::new("GCP_SECRETMANAGER_SECRET_VERSION");
-        }
-
-        impl std::convert::From<std::string::String> for Type {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                r#type::TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// Supported Principal values.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Principal(std::borrow::Cow<'static, str>);
+    pub struct Principal(i32);
 
     impl Principal {
-        /// Creates a new Principal instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Principal](Principal)
-    pub mod principal {
-        use super::Principal;
-
         /// Value type is not specified.
-        pub const PRINCIPAL_UNSPECIFIED: Principal = Principal::new("PRINCIPAL_UNSPECIFIED");
+        pub const PRINCIPAL_UNSPECIFIED: Principal = Principal::new(0);
 
         /// Service Account used for Connector workload identity
         /// This is either the default service account if unspecified or Service
         /// Account provided by Customers through BYOSA.
-        pub const CONNECTOR_SA: Principal = Principal::new("CONNECTOR_SA");
+        pub const CONNECTOR_SA: Principal = Principal::new(1);
+
+        /// Creates a new Principal instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PRINCIPAL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CONNECTOR_SA"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PRINCIPAL_UNSPECIFIED" => std::option::Option::Some(Self::PRINCIPAL_UNSPECIFIED),
+                "CONNECTOR_SA" => std::option::Option::Some(Self::CONNECTOR_SA),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Principal {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Principal {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Principal {
         fn default() -> Self {
-            principal::PRINCIPAL_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1847,43 +1920,58 @@ pub mod connection_schema_metadata {
 
     /// State of connection runtime schema.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Default state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Schema refresh is in progress.
+        pub const REFRESHING: State = State::new(1);
+
+        /// Schema has been updated.
+        pub const UPDATED: State = State::new(2);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REFRESHING"),
+                2 => std::borrow::Cow::Borrowed("UPDATED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "REFRESHING" => std::option::Option::Some(Self::REFRESHING),
+                "UPDATED" => std::option::Option::Some(Self::UPDATED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Default state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Schema refresh is in progress.
-        pub const REFRESHING: State = State::new("REFRESHING");
-
-        /// Schema has been updated.
-        pub const UPDATED: State = State::new("UPDATED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2983,59 +3071,84 @@ pub mod connection_status {
 
     /// All the possible Connection State.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Connection does not have a state yet.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Connection is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// Connection is running and ready for requests.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(2);
 
         /// Connection is stopped.
-        pub const INACTIVE: State = State::new("INACTIVE");
+        pub const INACTIVE: State = State::new(3);
 
         /// Connection is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(4);
 
         /// Connection is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(5);
 
         /// Connection is not running due to an error.
-        pub const ERROR: State = State::new("ERROR");
+        pub const ERROR: State = State::new(6);
 
         /// Connection is not running due to an auth error for the Oauth2 Auth Code
         /// based connector.
-        pub const AUTHORIZATION_REQUIRED: State = State::new("AUTHORIZATION_REQUIRED");
+        pub const AUTHORIZATION_REQUIRED: State = State::new(7);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("INACTIVE"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("UPDATING"),
+                6 => std::borrow::Cow::Borrowed("ERROR"),
+                7 => std::borrow::Cow::Borrowed("AUTHORIZATION_REQUIRED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "AUTHORIZATION_REQUIRED" => std::option::Option::Some(Self::AUTHORIZATION_REQUIRED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4022,40 +4135,55 @@ pub mod extraction_rule {
 
     /// Supported Source types for extraction.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SourceType(std::borrow::Cow<'static, str>);
+    pub struct SourceType(i32);
 
     impl SourceType {
+        /// Default SOURCE.
+        pub const SOURCE_TYPE_UNSPECIFIED: SourceType = SourceType::new(0);
+
+        /// Config Variable source type.
+        pub const CONFIG_VARIABLE: SourceType = SourceType::new(1);
+
         /// Creates a new SourceType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SOURCE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CONFIG_VARIABLE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SOURCE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SOURCE_TYPE_UNSPECIFIED)
+                }
+                "CONFIG_VARIABLE" => std::option::Option::Some(Self::CONFIG_VARIABLE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SourceType](SourceType)
-    pub mod source_type {
-        use super::SourceType;
-
-        /// Default SOURCE.
-        pub const SOURCE_TYPE_UNSPECIFIED: SourceType = SourceType::new("SOURCE_TYPE_UNSPECIFIED");
-
-        /// Config Variable source type.
-        pub const CONFIG_VARIABLE: SourceType = SourceType::new("CONFIG_VARIABLE");
-    }
-
-    impl std::convert::From<std::string::String> for SourceType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SourceType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SourceType {
         fn default() -> Self {
-            source_type::SOURCE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4694,55 +4822,78 @@ pub mod runtime_config {
 
     /// State of the location.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// STATE_UNSPECIFIED.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// INACTIVE.
+        pub const INACTIVE: State = State::new(1);
+
+        /// ACTIVATING.
+        pub const ACTIVATING: State = State::new(2);
+
+        /// ACTIVE.
+        pub const ACTIVE: State = State::new(3);
+
+        /// CREATING.
+        pub const CREATING: State = State::new(4);
+
+        /// DELETING.
+        pub const DELETING: State = State::new(5);
+
+        /// UPDATING.
+        pub const UPDATING: State = State::new(6);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INACTIVE"),
+                2 => std::borrow::Cow::Borrowed("ACTIVATING"),
+                3 => std::borrow::Cow::Borrowed("ACTIVE"),
+                4 => std::borrow::Cow::Borrowed("CREATING"),
+                5 => std::borrow::Cow::Borrowed("DELETING"),
+                6 => std::borrow::Cow::Borrowed("UPDATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
+                "ACTIVATING" => std::option::Option::Some(Self::ACTIVATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// STATE_UNSPECIFIED.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// INACTIVE.
-        pub const INACTIVE: State = State::new("INACTIVE");
-
-        /// ACTIVATING.
-        pub const ACTIVATING: State = State::new("ACTIVATING");
-
-        /// ACTIVE.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// CREATING.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// DELETING.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// UPDATING.
-        pub const UPDATING: State = State::new("UPDATING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5063,483 +5214,704 @@ pub mod ssl_config {
 
     /// Enum for Ttust Model
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TrustModel(std::borrow::Cow<'static, str>);
+    pub struct TrustModel(i32);
 
     impl TrustModel {
+        /// Public Trust Model. Takes the Default Java trust store.
+        pub const PUBLIC: TrustModel = TrustModel::new(0);
+
+        /// Private Trust Model. Takes custom/private trust store.
+        pub const PRIVATE: TrustModel = TrustModel::new(1);
+
+        /// Insecure Trust Model. Accept all certificates.
+        pub const INSECURE: TrustModel = TrustModel::new(2);
+
         /// Creates a new TrustModel instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PUBLIC"),
+                1 => std::borrow::Cow::Borrowed("PRIVATE"),
+                2 => std::borrow::Cow::Borrowed("INSECURE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PUBLIC" => std::option::Option::Some(Self::PUBLIC),
+                "PRIVATE" => std::option::Option::Some(Self::PRIVATE),
+                "INSECURE" => std::option::Option::Some(Self::INSECURE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [TrustModel](TrustModel)
-    pub mod trust_model {
-        use super::TrustModel;
-
-        /// Public Trust Model. Takes the Default Java trust store.
-        pub const PUBLIC: TrustModel = TrustModel::new("PUBLIC");
-
-        /// Private Trust Model. Takes custom/private trust store.
-        pub const PRIVATE: TrustModel = TrustModel::new("PRIVATE");
-
-        /// Insecure Trust Model. Accept all certificates.
-        pub const INSECURE: TrustModel = TrustModel::new("INSECURE");
-    }
-
-    impl std::convert::From<std::string::String> for TrustModel {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TrustModel {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TrustModel {
         fn default() -> Self {
-            trust_model::PUBLIC
+            Self::new(0)
         }
     }
 }
 
 /// AuthType defines different authentication types.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AuthType(std::borrow::Cow<'static, str>);
+pub struct AuthType(i32);
 
 impl AuthType {
-    /// Creates a new AuthType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [AuthType](AuthType)
-pub mod auth_type {
-    use super::AuthType;
-
     /// Authentication type not specified.
-    pub const AUTH_TYPE_UNSPECIFIED: AuthType = AuthType::new("AUTH_TYPE_UNSPECIFIED");
+    pub const AUTH_TYPE_UNSPECIFIED: AuthType = AuthType::new(0);
 
     /// Username and Password Authentication.
-    pub const USER_PASSWORD: AuthType = AuthType::new("USER_PASSWORD");
+    pub const USER_PASSWORD: AuthType = AuthType::new(1);
 
     /// JSON Web Token (JWT) Profile for Oauth 2.0
     /// Authorization Grant based authentication
-    pub const OAUTH2_JWT_BEARER: AuthType = AuthType::new("OAUTH2_JWT_BEARER");
+    pub const OAUTH2_JWT_BEARER: AuthType = AuthType::new(2);
 
     /// Oauth 2.0 Client Credentials Grant Authentication
-    pub const OAUTH2_CLIENT_CREDENTIALS: AuthType = AuthType::new("OAUTH2_CLIENT_CREDENTIALS");
+    pub const OAUTH2_CLIENT_CREDENTIALS: AuthType = AuthType::new(3);
 
     /// SSH Public Key Authentication
-    pub const SSH_PUBLIC_KEY: AuthType = AuthType::new("SSH_PUBLIC_KEY");
+    pub const SSH_PUBLIC_KEY: AuthType = AuthType::new(4);
 
     /// Oauth 2.0 Authorization Code Flow
-    pub const OAUTH2_AUTH_CODE_FLOW: AuthType = AuthType::new("OAUTH2_AUTH_CODE_FLOW");
+    pub const OAUTH2_AUTH_CODE_FLOW: AuthType = AuthType::new(5);
+
+    /// Creates a new AuthType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("AUTH_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("USER_PASSWORD"),
+            2 => std::borrow::Cow::Borrowed("OAUTH2_JWT_BEARER"),
+            3 => std::borrow::Cow::Borrowed("OAUTH2_CLIENT_CREDENTIALS"),
+            4 => std::borrow::Cow::Borrowed("SSH_PUBLIC_KEY"),
+            5 => std::borrow::Cow::Borrowed("OAUTH2_AUTH_CODE_FLOW"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "AUTH_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::AUTH_TYPE_UNSPECIFIED),
+            "USER_PASSWORD" => std::option::Option::Some(Self::USER_PASSWORD),
+            "OAUTH2_JWT_BEARER" => std::option::Option::Some(Self::OAUTH2_JWT_BEARER),
+            "OAUTH2_CLIENT_CREDENTIALS" => {
+                std::option::Option::Some(Self::OAUTH2_CLIENT_CREDENTIALS)
+            }
+            "SSH_PUBLIC_KEY" => std::option::Option::Some(Self::SSH_PUBLIC_KEY),
+            "OAUTH2_AUTH_CODE_FLOW" => std::option::Option::Some(Self::OAUTH2_AUTH_CODE_FLOW),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for AuthType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for AuthType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for AuthType {
     fn default() -> Self {
-        auth_type::AUTH_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// LaunchStage is a enum to indicate launch stage:
 /// PREVIEW, GA, DEPRECATED, PRIVATE_PREVIEW.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LaunchStage(std::borrow::Cow<'static, str>);
+pub struct LaunchStage(i32);
 
 impl LaunchStage {
+    /// LAUNCH_STAGE_UNSPECIFIED.
+    pub const LAUNCH_STAGE_UNSPECIFIED: LaunchStage = LaunchStage::new(0);
+
+    /// PREVIEW.
+    pub const PREVIEW: LaunchStage = LaunchStage::new(1);
+
+    /// GA.
+    pub const GA: LaunchStage = LaunchStage::new(2);
+
+    /// DEPRECATED.
+    pub const DEPRECATED: LaunchStage = LaunchStage::new(3);
+
+    /// PRIVATE_PREVIEW.
+    pub const PRIVATE_PREVIEW: LaunchStage = LaunchStage::new(5);
+
     /// Creates a new LaunchStage instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("LAUNCH_STAGE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PREVIEW"),
+            2 => std::borrow::Cow::Borrowed("GA"),
+            3 => std::borrow::Cow::Borrowed("DEPRECATED"),
+            5 => std::borrow::Cow::Borrowed("PRIVATE_PREVIEW"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "LAUNCH_STAGE_UNSPECIFIED" => std::option::Option::Some(Self::LAUNCH_STAGE_UNSPECIFIED),
+            "PREVIEW" => std::option::Option::Some(Self::PREVIEW),
+            "GA" => std::option::Option::Some(Self::GA),
+            "DEPRECATED" => std::option::Option::Some(Self::DEPRECATED),
+            "PRIVATE_PREVIEW" => std::option::Option::Some(Self::PRIVATE_PREVIEW),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [LaunchStage](LaunchStage)
-pub mod launch_stage {
-    use super::LaunchStage;
-
-    /// LAUNCH_STAGE_UNSPECIFIED.
-    pub const LAUNCH_STAGE_UNSPECIFIED: LaunchStage = LaunchStage::new("LAUNCH_STAGE_UNSPECIFIED");
-
-    /// PREVIEW.
-    pub const PREVIEW: LaunchStage = LaunchStage::new("PREVIEW");
-
-    /// GA.
-    pub const GA: LaunchStage = LaunchStage::new("GA");
-
-    /// DEPRECATED.
-    pub const DEPRECATED: LaunchStage = LaunchStage::new("DEPRECATED");
-
-    /// PRIVATE_PREVIEW.
-    pub const PRIVATE_PREVIEW: LaunchStage = LaunchStage::new("PRIVATE_PREVIEW");
-}
-
-impl std::convert::From<std::string::String> for LaunchStage {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for LaunchStage {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for LaunchStage {
     fn default() -> Self {
-        launch_stage::LAUNCH_STAGE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// All possible data types of a entity or action field.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DataType(std::borrow::Cow<'static, str>);
+pub struct DataType(i32);
 
 impl DataType {
+    /// Data type is not specified.
+    pub const DATA_TYPE_UNSPECIFIED: DataType = DataType::new(0);
+
+    /// DEPRECATED! Use DATA_TYPE_INTEGER.
+    pub const DATA_TYPE_INT: DataType = DataType::new(1);
+
+    /// Short integer(int16) data type.
+    pub const DATA_TYPE_SMALLINT: DataType = DataType::new(2);
+
+    /// Double data type.
+    pub const DATA_TYPE_DOUBLE: DataType = DataType::new(3);
+
+    /// Date data type.
+    pub const DATA_TYPE_DATE: DataType = DataType::new(4);
+
+    /// DEPRECATED! Use DATA_TYPE_TIMESTAMP.
+    pub const DATA_TYPE_DATETIME: DataType = DataType::new(5);
+
+    /// Time data type.
+    pub const DATA_TYPE_TIME: DataType = DataType::new(6);
+
+    /// DEPRECATED! Use DATA_TYPE_VARCHAR.
+    pub const DATA_TYPE_STRING: DataType = DataType::new(7);
+
+    /// DEPRECATED! Use DATA_TYPE_BIGINT.
+    pub const DATA_TYPE_LONG: DataType = DataType::new(8);
+
+    /// Boolean data type.
+    pub const DATA_TYPE_BOOLEAN: DataType = DataType::new(9);
+
+    /// Decimal data type.
+    pub const DATA_TYPE_DECIMAL: DataType = DataType::new(10);
+
+    /// DEPRECATED! Use DATA_TYPE_VARCHAR.
+    pub const DATA_TYPE_UUID: DataType = DataType::new(11);
+
+    /// UNSUPPORTED! Binary data type.
+    pub const DATA_TYPE_BLOB: DataType = DataType::new(12);
+
+    /// Bit data type.
+    pub const DATA_TYPE_BIT: DataType = DataType::new(13);
+
+    /// Small integer(int8) data type.
+    pub const DATA_TYPE_TINYINT: DataType = DataType::new(14);
+
+    /// Integer(int32) data type.
+    pub const DATA_TYPE_INTEGER: DataType = DataType::new(15);
+
+    /// Long integer(int64) data type.
+    pub const DATA_TYPE_BIGINT: DataType = DataType::new(16);
+
+    /// Float data type.
+    pub const DATA_TYPE_FLOAT: DataType = DataType::new(17);
+
+    /// Real data type.
+    pub const DATA_TYPE_REAL: DataType = DataType::new(18);
+
+    /// Numeric data type.
+    pub const DATA_TYPE_NUMERIC: DataType = DataType::new(19);
+
+    /// Char data type.
+    pub const DATA_TYPE_CHAR: DataType = DataType::new(20);
+
+    /// Varchar data type.
+    pub const DATA_TYPE_VARCHAR: DataType = DataType::new(21);
+
+    /// Longvarchar data type.
+    pub const DATA_TYPE_LONGVARCHAR: DataType = DataType::new(22);
+
+    /// Timestamp data type.
+    pub const DATA_TYPE_TIMESTAMP: DataType = DataType::new(23);
+
+    /// Nchar data type.
+    pub const DATA_TYPE_NCHAR: DataType = DataType::new(24);
+
+    /// Nvarchar data type.
+    pub const DATA_TYPE_NVARCHAR: DataType = DataType::new(25);
+
+    /// Longnvarchar data type.
+    pub const DATA_TYPE_LONGNVARCHAR: DataType = DataType::new(26);
+
+    /// Null data type.
+    pub const DATA_TYPE_NULL: DataType = DataType::new(27);
+
+    /// UNSUPPORTED! Binary data type.
+    pub const DATA_TYPE_OTHER: DataType = DataType::new(28);
+
+    /// UNSUPPORTED! Binary data type.
+    pub const DATA_TYPE_JAVA_OBJECT: DataType = DataType::new(29);
+
+    /// UNSUPPORTED! Binary data type.
+    pub const DATA_TYPE_DISTINCT: DataType = DataType::new(30);
+
+    /// UNSUPPORTED! Binary data type.
+    pub const DATA_TYPE_STRUCT: DataType = DataType::new(31);
+
+    /// UNSUPPORTED! Binary data type.
+    pub const DATA_TYPE_ARRAY: DataType = DataType::new(32);
+
+    /// UNSUPPORTED! Binary data type.
+    pub const DATA_TYPE_CLOB: DataType = DataType::new(33);
+
+    /// UNSUPPORTED! Binary data type.
+    pub const DATA_TYPE_REF: DataType = DataType::new(34);
+
+    /// UNSUPPORTED! Binary data type.
+    pub const DATA_TYPE_DATALINK: DataType = DataType::new(35);
+
+    /// UNSUPPORTED! Row id data type.
+    pub const DATA_TYPE_ROWID: DataType = DataType::new(36);
+
+    /// UNSUPPORTED! Binary data type.
+    pub const DATA_TYPE_BINARY: DataType = DataType::new(37);
+
+    /// UNSUPPORTED! Variable binary data type.
+    pub const DATA_TYPE_VARBINARY: DataType = DataType::new(38);
+
+    /// UNSUPPORTED! Long variable binary data type.
+    pub const DATA_TYPE_LONGVARBINARY: DataType = DataType::new(39);
+
+    /// UNSUPPORTED! NCLOB data type.
+    pub const DATA_TYPE_NCLOB: DataType = DataType::new(40);
+
+    /// UNSUPPORTED! SQL XML data type is not supported.
+    pub const DATA_TYPE_SQLXML: DataType = DataType::new(41);
+
+    /// UNSUPPORTED! Cursor reference type is not supported.
+    pub const DATA_TYPE_REF_CURSOR: DataType = DataType::new(42);
+
+    /// UNSUPPORTED! Use TIME or TIMESTAMP instead.
+    pub const DATA_TYPE_TIME_WITH_TIMEZONE: DataType = DataType::new(43);
+
+    /// UNSUPPORTED! Use TIMESTAMP instead.
+    pub const DATA_TYPE_TIMESTAMP_WITH_TIMEZONE: DataType = DataType::new(44);
+
     /// Creates a new DataType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DATA_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("DATA_TYPE_INT"),
+            2 => std::borrow::Cow::Borrowed("DATA_TYPE_SMALLINT"),
+            3 => std::borrow::Cow::Borrowed("DATA_TYPE_DOUBLE"),
+            4 => std::borrow::Cow::Borrowed("DATA_TYPE_DATE"),
+            5 => std::borrow::Cow::Borrowed("DATA_TYPE_DATETIME"),
+            6 => std::borrow::Cow::Borrowed("DATA_TYPE_TIME"),
+            7 => std::borrow::Cow::Borrowed("DATA_TYPE_STRING"),
+            8 => std::borrow::Cow::Borrowed("DATA_TYPE_LONG"),
+            9 => std::borrow::Cow::Borrowed("DATA_TYPE_BOOLEAN"),
+            10 => std::borrow::Cow::Borrowed("DATA_TYPE_DECIMAL"),
+            11 => std::borrow::Cow::Borrowed("DATA_TYPE_UUID"),
+            12 => std::borrow::Cow::Borrowed("DATA_TYPE_BLOB"),
+            13 => std::borrow::Cow::Borrowed("DATA_TYPE_BIT"),
+            14 => std::borrow::Cow::Borrowed("DATA_TYPE_TINYINT"),
+            15 => std::borrow::Cow::Borrowed("DATA_TYPE_INTEGER"),
+            16 => std::borrow::Cow::Borrowed("DATA_TYPE_BIGINT"),
+            17 => std::borrow::Cow::Borrowed("DATA_TYPE_FLOAT"),
+            18 => std::borrow::Cow::Borrowed("DATA_TYPE_REAL"),
+            19 => std::borrow::Cow::Borrowed("DATA_TYPE_NUMERIC"),
+            20 => std::borrow::Cow::Borrowed("DATA_TYPE_CHAR"),
+            21 => std::borrow::Cow::Borrowed("DATA_TYPE_VARCHAR"),
+            22 => std::borrow::Cow::Borrowed("DATA_TYPE_LONGVARCHAR"),
+            23 => std::borrow::Cow::Borrowed("DATA_TYPE_TIMESTAMP"),
+            24 => std::borrow::Cow::Borrowed("DATA_TYPE_NCHAR"),
+            25 => std::borrow::Cow::Borrowed("DATA_TYPE_NVARCHAR"),
+            26 => std::borrow::Cow::Borrowed("DATA_TYPE_LONGNVARCHAR"),
+            27 => std::borrow::Cow::Borrowed("DATA_TYPE_NULL"),
+            28 => std::borrow::Cow::Borrowed("DATA_TYPE_OTHER"),
+            29 => std::borrow::Cow::Borrowed("DATA_TYPE_JAVA_OBJECT"),
+            30 => std::borrow::Cow::Borrowed("DATA_TYPE_DISTINCT"),
+            31 => std::borrow::Cow::Borrowed("DATA_TYPE_STRUCT"),
+            32 => std::borrow::Cow::Borrowed("DATA_TYPE_ARRAY"),
+            33 => std::borrow::Cow::Borrowed("DATA_TYPE_CLOB"),
+            34 => std::borrow::Cow::Borrowed("DATA_TYPE_REF"),
+            35 => std::borrow::Cow::Borrowed("DATA_TYPE_DATALINK"),
+            36 => std::borrow::Cow::Borrowed("DATA_TYPE_ROWID"),
+            37 => std::borrow::Cow::Borrowed("DATA_TYPE_BINARY"),
+            38 => std::borrow::Cow::Borrowed("DATA_TYPE_VARBINARY"),
+            39 => std::borrow::Cow::Borrowed("DATA_TYPE_LONGVARBINARY"),
+            40 => std::borrow::Cow::Borrowed("DATA_TYPE_NCLOB"),
+            41 => std::borrow::Cow::Borrowed("DATA_TYPE_SQLXML"),
+            42 => std::borrow::Cow::Borrowed("DATA_TYPE_REF_CURSOR"),
+            43 => std::borrow::Cow::Borrowed("DATA_TYPE_TIME_WITH_TIMEZONE"),
+            44 => std::borrow::Cow::Borrowed("DATA_TYPE_TIMESTAMP_WITH_TIMEZONE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DATA_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::DATA_TYPE_UNSPECIFIED),
+            "DATA_TYPE_INT" => std::option::Option::Some(Self::DATA_TYPE_INT),
+            "DATA_TYPE_SMALLINT" => std::option::Option::Some(Self::DATA_TYPE_SMALLINT),
+            "DATA_TYPE_DOUBLE" => std::option::Option::Some(Self::DATA_TYPE_DOUBLE),
+            "DATA_TYPE_DATE" => std::option::Option::Some(Self::DATA_TYPE_DATE),
+            "DATA_TYPE_DATETIME" => std::option::Option::Some(Self::DATA_TYPE_DATETIME),
+            "DATA_TYPE_TIME" => std::option::Option::Some(Self::DATA_TYPE_TIME),
+            "DATA_TYPE_STRING" => std::option::Option::Some(Self::DATA_TYPE_STRING),
+            "DATA_TYPE_LONG" => std::option::Option::Some(Self::DATA_TYPE_LONG),
+            "DATA_TYPE_BOOLEAN" => std::option::Option::Some(Self::DATA_TYPE_BOOLEAN),
+            "DATA_TYPE_DECIMAL" => std::option::Option::Some(Self::DATA_TYPE_DECIMAL),
+            "DATA_TYPE_UUID" => std::option::Option::Some(Self::DATA_TYPE_UUID),
+            "DATA_TYPE_BLOB" => std::option::Option::Some(Self::DATA_TYPE_BLOB),
+            "DATA_TYPE_BIT" => std::option::Option::Some(Self::DATA_TYPE_BIT),
+            "DATA_TYPE_TINYINT" => std::option::Option::Some(Self::DATA_TYPE_TINYINT),
+            "DATA_TYPE_INTEGER" => std::option::Option::Some(Self::DATA_TYPE_INTEGER),
+            "DATA_TYPE_BIGINT" => std::option::Option::Some(Self::DATA_TYPE_BIGINT),
+            "DATA_TYPE_FLOAT" => std::option::Option::Some(Self::DATA_TYPE_FLOAT),
+            "DATA_TYPE_REAL" => std::option::Option::Some(Self::DATA_TYPE_REAL),
+            "DATA_TYPE_NUMERIC" => std::option::Option::Some(Self::DATA_TYPE_NUMERIC),
+            "DATA_TYPE_CHAR" => std::option::Option::Some(Self::DATA_TYPE_CHAR),
+            "DATA_TYPE_VARCHAR" => std::option::Option::Some(Self::DATA_TYPE_VARCHAR),
+            "DATA_TYPE_LONGVARCHAR" => std::option::Option::Some(Self::DATA_TYPE_LONGVARCHAR),
+            "DATA_TYPE_TIMESTAMP" => std::option::Option::Some(Self::DATA_TYPE_TIMESTAMP),
+            "DATA_TYPE_NCHAR" => std::option::Option::Some(Self::DATA_TYPE_NCHAR),
+            "DATA_TYPE_NVARCHAR" => std::option::Option::Some(Self::DATA_TYPE_NVARCHAR),
+            "DATA_TYPE_LONGNVARCHAR" => std::option::Option::Some(Self::DATA_TYPE_LONGNVARCHAR),
+            "DATA_TYPE_NULL" => std::option::Option::Some(Self::DATA_TYPE_NULL),
+            "DATA_TYPE_OTHER" => std::option::Option::Some(Self::DATA_TYPE_OTHER),
+            "DATA_TYPE_JAVA_OBJECT" => std::option::Option::Some(Self::DATA_TYPE_JAVA_OBJECT),
+            "DATA_TYPE_DISTINCT" => std::option::Option::Some(Self::DATA_TYPE_DISTINCT),
+            "DATA_TYPE_STRUCT" => std::option::Option::Some(Self::DATA_TYPE_STRUCT),
+            "DATA_TYPE_ARRAY" => std::option::Option::Some(Self::DATA_TYPE_ARRAY),
+            "DATA_TYPE_CLOB" => std::option::Option::Some(Self::DATA_TYPE_CLOB),
+            "DATA_TYPE_REF" => std::option::Option::Some(Self::DATA_TYPE_REF),
+            "DATA_TYPE_DATALINK" => std::option::Option::Some(Self::DATA_TYPE_DATALINK),
+            "DATA_TYPE_ROWID" => std::option::Option::Some(Self::DATA_TYPE_ROWID),
+            "DATA_TYPE_BINARY" => std::option::Option::Some(Self::DATA_TYPE_BINARY),
+            "DATA_TYPE_VARBINARY" => std::option::Option::Some(Self::DATA_TYPE_VARBINARY),
+            "DATA_TYPE_LONGVARBINARY" => std::option::Option::Some(Self::DATA_TYPE_LONGVARBINARY),
+            "DATA_TYPE_NCLOB" => std::option::Option::Some(Self::DATA_TYPE_NCLOB),
+            "DATA_TYPE_SQLXML" => std::option::Option::Some(Self::DATA_TYPE_SQLXML),
+            "DATA_TYPE_REF_CURSOR" => std::option::Option::Some(Self::DATA_TYPE_REF_CURSOR),
+            "DATA_TYPE_TIME_WITH_TIMEZONE" => {
+                std::option::Option::Some(Self::DATA_TYPE_TIME_WITH_TIMEZONE)
+            }
+            "DATA_TYPE_TIMESTAMP_WITH_TIMEZONE" => {
+                std::option::Option::Some(Self::DATA_TYPE_TIMESTAMP_WITH_TIMEZONE)
+            }
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [DataType](DataType)
-pub mod data_type {
-    use super::DataType;
-
-    /// Data type is not specified.
-    pub const DATA_TYPE_UNSPECIFIED: DataType = DataType::new("DATA_TYPE_UNSPECIFIED");
-
-    /// DEPRECATED! Use DATA_TYPE_INTEGER.
-    pub const DATA_TYPE_INT: DataType = DataType::new("DATA_TYPE_INT");
-
-    /// Short integer(int16) data type.
-    pub const DATA_TYPE_SMALLINT: DataType = DataType::new("DATA_TYPE_SMALLINT");
-
-    /// Double data type.
-    pub const DATA_TYPE_DOUBLE: DataType = DataType::new("DATA_TYPE_DOUBLE");
-
-    /// Date data type.
-    pub const DATA_TYPE_DATE: DataType = DataType::new("DATA_TYPE_DATE");
-
-    /// DEPRECATED! Use DATA_TYPE_TIMESTAMP.
-    pub const DATA_TYPE_DATETIME: DataType = DataType::new("DATA_TYPE_DATETIME");
-
-    /// Time data type.
-    pub const DATA_TYPE_TIME: DataType = DataType::new("DATA_TYPE_TIME");
-
-    /// DEPRECATED! Use DATA_TYPE_VARCHAR.
-    pub const DATA_TYPE_STRING: DataType = DataType::new("DATA_TYPE_STRING");
-
-    /// DEPRECATED! Use DATA_TYPE_BIGINT.
-    pub const DATA_TYPE_LONG: DataType = DataType::new("DATA_TYPE_LONG");
-
-    /// Boolean data type.
-    pub const DATA_TYPE_BOOLEAN: DataType = DataType::new("DATA_TYPE_BOOLEAN");
-
-    /// Decimal data type.
-    pub const DATA_TYPE_DECIMAL: DataType = DataType::new("DATA_TYPE_DECIMAL");
-
-    /// DEPRECATED! Use DATA_TYPE_VARCHAR.
-    pub const DATA_TYPE_UUID: DataType = DataType::new("DATA_TYPE_UUID");
-
-    /// UNSUPPORTED! Binary data type.
-    pub const DATA_TYPE_BLOB: DataType = DataType::new("DATA_TYPE_BLOB");
-
-    /// Bit data type.
-    pub const DATA_TYPE_BIT: DataType = DataType::new("DATA_TYPE_BIT");
-
-    /// Small integer(int8) data type.
-    pub const DATA_TYPE_TINYINT: DataType = DataType::new("DATA_TYPE_TINYINT");
-
-    /// Integer(int32) data type.
-    pub const DATA_TYPE_INTEGER: DataType = DataType::new("DATA_TYPE_INTEGER");
-
-    /// Long integer(int64) data type.
-    pub const DATA_TYPE_BIGINT: DataType = DataType::new("DATA_TYPE_BIGINT");
-
-    /// Float data type.
-    pub const DATA_TYPE_FLOAT: DataType = DataType::new("DATA_TYPE_FLOAT");
-
-    /// Real data type.
-    pub const DATA_TYPE_REAL: DataType = DataType::new("DATA_TYPE_REAL");
-
-    /// Numeric data type.
-    pub const DATA_TYPE_NUMERIC: DataType = DataType::new("DATA_TYPE_NUMERIC");
-
-    /// Char data type.
-    pub const DATA_TYPE_CHAR: DataType = DataType::new("DATA_TYPE_CHAR");
-
-    /// Varchar data type.
-    pub const DATA_TYPE_VARCHAR: DataType = DataType::new("DATA_TYPE_VARCHAR");
-
-    /// Longvarchar data type.
-    pub const DATA_TYPE_LONGVARCHAR: DataType = DataType::new("DATA_TYPE_LONGVARCHAR");
-
-    /// Timestamp data type.
-    pub const DATA_TYPE_TIMESTAMP: DataType = DataType::new("DATA_TYPE_TIMESTAMP");
-
-    /// Nchar data type.
-    pub const DATA_TYPE_NCHAR: DataType = DataType::new("DATA_TYPE_NCHAR");
-
-    /// Nvarchar data type.
-    pub const DATA_TYPE_NVARCHAR: DataType = DataType::new("DATA_TYPE_NVARCHAR");
-
-    /// Longnvarchar data type.
-    pub const DATA_TYPE_LONGNVARCHAR: DataType = DataType::new("DATA_TYPE_LONGNVARCHAR");
-
-    /// Null data type.
-    pub const DATA_TYPE_NULL: DataType = DataType::new("DATA_TYPE_NULL");
-
-    /// UNSUPPORTED! Binary data type.
-    pub const DATA_TYPE_OTHER: DataType = DataType::new("DATA_TYPE_OTHER");
-
-    /// UNSUPPORTED! Binary data type.
-    pub const DATA_TYPE_JAVA_OBJECT: DataType = DataType::new("DATA_TYPE_JAVA_OBJECT");
-
-    /// UNSUPPORTED! Binary data type.
-    pub const DATA_TYPE_DISTINCT: DataType = DataType::new("DATA_TYPE_DISTINCT");
-
-    /// UNSUPPORTED! Binary data type.
-    pub const DATA_TYPE_STRUCT: DataType = DataType::new("DATA_TYPE_STRUCT");
-
-    /// UNSUPPORTED! Binary data type.
-    pub const DATA_TYPE_ARRAY: DataType = DataType::new("DATA_TYPE_ARRAY");
-
-    /// UNSUPPORTED! Binary data type.
-    pub const DATA_TYPE_CLOB: DataType = DataType::new("DATA_TYPE_CLOB");
-
-    /// UNSUPPORTED! Binary data type.
-    pub const DATA_TYPE_REF: DataType = DataType::new("DATA_TYPE_REF");
-
-    /// UNSUPPORTED! Binary data type.
-    pub const DATA_TYPE_DATALINK: DataType = DataType::new("DATA_TYPE_DATALINK");
-
-    /// UNSUPPORTED! Row id data type.
-    pub const DATA_TYPE_ROWID: DataType = DataType::new("DATA_TYPE_ROWID");
-
-    /// UNSUPPORTED! Binary data type.
-    pub const DATA_TYPE_BINARY: DataType = DataType::new("DATA_TYPE_BINARY");
-
-    /// UNSUPPORTED! Variable binary data type.
-    pub const DATA_TYPE_VARBINARY: DataType = DataType::new("DATA_TYPE_VARBINARY");
-
-    /// UNSUPPORTED! Long variable binary data type.
-    pub const DATA_TYPE_LONGVARBINARY: DataType = DataType::new("DATA_TYPE_LONGVARBINARY");
-
-    /// UNSUPPORTED! NCLOB data type.
-    pub const DATA_TYPE_NCLOB: DataType = DataType::new("DATA_TYPE_NCLOB");
-
-    /// UNSUPPORTED! SQL XML data type is not supported.
-    pub const DATA_TYPE_SQLXML: DataType = DataType::new("DATA_TYPE_SQLXML");
-
-    /// UNSUPPORTED! Cursor reference type is not supported.
-    pub const DATA_TYPE_REF_CURSOR: DataType = DataType::new("DATA_TYPE_REF_CURSOR");
-
-    /// UNSUPPORTED! Use TIME or TIMESTAMP instead.
-    pub const DATA_TYPE_TIME_WITH_TIMEZONE: DataType =
-        DataType::new("DATA_TYPE_TIME_WITH_TIMEZONE");
-
-    /// UNSUPPORTED! Use TIMESTAMP instead.
-    pub const DATA_TYPE_TIMESTAMP_WITH_TIMEZONE: DataType =
-        DataType::new("DATA_TYPE_TIMESTAMP_WITH_TIMEZONE");
-}
-
-impl std::convert::From<std::string::String> for DataType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DataType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DataType {
     fn default() -> Self {
-        data_type::DATA_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Enum to control which fields should be included in the response.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ConnectionView(std::borrow::Cow<'static, str>);
+pub struct ConnectionView(i32);
 
 impl ConnectionView {
+    /// CONNECTION_UNSPECIFIED.
+    pub const CONNECTION_VIEW_UNSPECIFIED: ConnectionView = ConnectionView::new(0);
+
+    /// Do not include runtime required configs.
+    pub const BASIC: ConnectionView = ConnectionView::new(1);
+
+    /// Include runtime required configs.
+    pub const FULL: ConnectionView = ConnectionView::new(2);
+
     /// Creates a new ConnectionView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("CONNECTION_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("BASIC"),
+            2 => std::borrow::Cow::Borrowed("FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "CONNECTION_VIEW_UNSPECIFIED" => {
+                std::option::Option::Some(Self::CONNECTION_VIEW_UNSPECIFIED)
+            }
+            "BASIC" => std::option::Option::Some(Self::BASIC),
+            "FULL" => std::option::Option::Some(Self::FULL),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [ConnectionView](ConnectionView)
-pub mod connection_view {
-    use super::ConnectionView;
-
-    /// CONNECTION_UNSPECIFIED.
-    pub const CONNECTION_VIEW_UNSPECIFIED: ConnectionView =
-        ConnectionView::new("CONNECTION_VIEW_UNSPECIFIED");
-
-    /// Do not include runtime required configs.
-    pub const BASIC: ConnectionView = ConnectionView::new("BASIC");
-
-    /// Include runtime required configs.
-    pub const FULL: ConnectionView = ConnectionView::new("FULL");
-}
-
-impl std::convert::From<std::string::String> for ConnectionView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ConnectionView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ConnectionView {
     fn default() -> Self {
-        connection_view::CONNECTION_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Enum to control which fields should be included in the response.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ConnectorVersionView(std::borrow::Cow<'static, str>);
+pub struct ConnectorVersionView(i32);
 
 impl ConnectorVersionView {
+    /// CONNECTOR_VERSION_VIEW_UNSPECIFIED.
+    pub const CONNECTOR_VERSION_VIEW_UNSPECIFIED: ConnectorVersionView =
+        ConnectorVersionView::new(0);
+
+    /// Do not include role grant configs.
+    pub const CONNECTOR_VERSION_VIEW_BASIC: ConnectorVersionView = ConnectorVersionView::new(1);
+
+    /// Include role grant configs.
+    pub const CONNECTOR_VERSION_VIEW_FULL: ConnectorVersionView = ConnectorVersionView::new(2);
+
     /// Creates a new ConnectorVersionView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("CONNECTOR_VERSION_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("CONNECTOR_VERSION_VIEW_BASIC"),
+            2 => std::borrow::Cow::Borrowed("CONNECTOR_VERSION_VIEW_FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "CONNECTOR_VERSION_VIEW_UNSPECIFIED" => {
+                std::option::Option::Some(Self::CONNECTOR_VERSION_VIEW_UNSPECIFIED)
+            }
+            "CONNECTOR_VERSION_VIEW_BASIC" => {
+                std::option::Option::Some(Self::CONNECTOR_VERSION_VIEW_BASIC)
+            }
+            "CONNECTOR_VERSION_VIEW_FULL" => {
+                std::option::Option::Some(Self::CONNECTOR_VERSION_VIEW_FULL)
+            }
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [ConnectorVersionView](ConnectorVersionView)
-pub mod connector_version_view {
-    use super::ConnectorVersionView;
-
-    /// CONNECTOR_VERSION_VIEW_UNSPECIFIED.
-    pub const CONNECTOR_VERSION_VIEW_UNSPECIFIED: ConnectorVersionView =
-        ConnectorVersionView::new("CONNECTOR_VERSION_VIEW_UNSPECIFIED");
-
-    /// Do not include role grant configs.
-    pub const CONNECTOR_VERSION_VIEW_BASIC: ConnectorVersionView =
-        ConnectorVersionView::new("CONNECTOR_VERSION_VIEW_BASIC");
-
-    /// Include role grant configs.
-    pub const CONNECTOR_VERSION_VIEW_FULL: ConnectorVersionView =
-        ConnectorVersionView::new("CONNECTOR_VERSION_VIEW_FULL");
-}
-
-impl std::convert::From<std::string::String> for ConnectorVersionView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ConnectorVersionView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ConnectorVersionView {
     fn default() -> Self {
-        connector_version_view::CONNECTOR_VERSION_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Enum for controlling the SSL Type (TLS/MTLS)
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SslType(std::borrow::Cow<'static, str>);
+pub struct SslType(i32);
 
 impl SslType {
+    /// No SSL configuration required.
+    pub const SSL_TYPE_UNSPECIFIED: SslType = SslType::new(0);
+
+    /// TLS Handshake
+    pub const TLS: SslType = SslType::new(1);
+
+    /// mutual TLS (MTLS) Handshake
+    pub const MTLS: SslType = SslType::new(2);
+
     /// Creates a new SslType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SSL_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("TLS"),
+            2 => std::borrow::Cow::Borrowed("MTLS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SSL_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SSL_TYPE_UNSPECIFIED),
+            "TLS" => std::option::Option::Some(Self::TLS),
+            "MTLS" => std::option::Option::Some(Self::MTLS),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [SslType](SslType)
-pub mod ssl_type {
-    use super::SslType;
-
-    /// No SSL configuration required.
-    pub const SSL_TYPE_UNSPECIFIED: SslType = SslType::new("SSL_TYPE_UNSPECIFIED");
-
-    /// TLS Handshake
-    pub const TLS: SslType = SslType::new("TLS");
-
-    /// mutual TLS (MTLS) Handshake
-    pub const MTLS: SslType = SslType::new("MTLS");
-}
-
-impl std::convert::From<std::string::String> for SslType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SslType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SslType {
     fn default() -> Self {
-        ssl_type::SSL_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Enum for Cert Types
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct CertType(std::borrow::Cow<'static, str>);
+pub struct CertType(i32);
 
 impl CertType {
+    /// Cert type unspecified.
+    pub const CERT_TYPE_UNSPECIFIED: CertType = CertType::new(0);
+
+    /// Privacy Enhanced Mail (PEM) Type
+    pub const PEM: CertType = CertType::new(1);
+
     /// Creates a new CertType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("CERT_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PEM"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "CERT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::CERT_TYPE_UNSPECIFIED),
+            "PEM" => std::option::Option::Some(Self::PEM),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [CertType](CertType)
-pub mod cert_type {
-    use super::CertType;
-
-    /// Cert type unspecified.
-    pub const CERT_TYPE_UNSPECIFIED: CertType = CertType::new("CERT_TYPE_UNSPECIFIED");
-
-    /// Privacy Enhanced Mail (PEM) Type
-    pub const PEM: CertType = CertType::new("PEM");
-}
-
-impl std::convert::From<std::string::String> for CertType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for CertType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for CertType {
     fn default() -> Self {
-        cert_type::CERT_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/connectors/v1/src/transport.rs
+++ b/src/generated/cloud/connectors/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::Connectors for Connectors {
                 reqwest::Method::GET,
                 format!("/v1/{}/connections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -76,7 +76,7 @@ impl crate::stubs::Connectors for Connectors {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -99,7 +99,7 @@ impl crate::stubs::Connectors for Connectors {
                 reqwest::Method::POST,
                 format!("/v1/{}/connections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -128,7 +128,7 @@ impl crate::stubs::Connectors for Connectors {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -157,7 +157,7 @@ impl crate::stubs::Connectors for Connectors {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -179,7 +179,7 @@ impl crate::stubs::Connectors for Connectors {
                 reqwest::Method::GET,
                 format!("/v1/{}/providers", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -200,7 +200,7 @@ impl crate::stubs::Connectors for Connectors {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -222,7 +222,7 @@ impl crate::stubs::Connectors for Connectors {
                 reqwest::Method::GET,
                 format!("/v1/{}/connectors", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -243,7 +243,7 @@ impl crate::stubs::Connectors for Connectors {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -262,7 +262,7 @@ impl crate::stubs::Connectors for Connectors {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/versions", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -284,7 +284,7 @@ impl crate::stubs::Connectors for Connectors {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -304,7 +304,7 @@ impl crate::stubs::Connectors for Connectors {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -323,7 +323,7 @@ impl crate::stubs::Connectors for Connectors {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:refresh", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -343,7 +343,7 @@ impl crate::stubs::Connectors for Connectors {
                 reqwest::Method::GET,
                 format!("/v1/{}/runtimeEntitySchemas", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -368,7 +368,7 @@ impl crate::stubs::Connectors for Connectors {
                 reqwest::Method::GET,
                 format!("/v1/{}/runtimeActionSchemas", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -390,7 +390,7 @@ impl crate::stubs::Connectors for Connectors {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -409,7 +409,7 @@ impl crate::stubs::Connectors for Connectors {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -428,7 +428,7 @@ impl crate::stubs::Connectors for Connectors {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -450,7 +450,7 @@ impl crate::stubs::Connectors for Connectors {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -472,7 +472,7 @@ impl crate::stubs::Connectors for Connectors {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -492,7 +492,7 @@ impl crate::stubs::Connectors for Connectors {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -524,7 +524,7 @@ impl crate::stubs::Connectors for Connectors {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -541,7 +541,7 @@ impl crate::stubs::Connectors for Connectors {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -563,7 +563,7 @@ impl crate::stubs::Connectors for Connectors {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -582,7 +582,7 @@ impl crate::stubs::Connectors for Connectors {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -601,7 +601,7 @@ impl crate::stubs::Connectors for Connectors {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/contactcenterinsights/v1/src/model.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/model.rs
@@ -1217,44 +1217,60 @@ pub mod ingest_conversations_request {
         use super::*;
 
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct BucketObjectType(std::borrow::Cow<'static, str>);
+        pub struct BucketObjectType(i32);
 
         impl BucketObjectType {
+            /// The object type is unspecified and will default to `TRANSCRIPT`.
+            pub const BUCKET_OBJECT_TYPE_UNSPECIFIED: BucketObjectType = BucketObjectType::new(0);
+
+            /// The object is a transcript.
+            pub const TRANSCRIPT: BucketObjectType = BucketObjectType::new(1);
+
+            /// The object is an audio file.
+            pub const AUDIO: BucketObjectType = BucketObjectType::new(2);
+
             /// Creates a new BucketObjectType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("BUCKET_OBJECT_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("TRANSCRIPT"),
+                    2 => std::borrow::Cow::Borrowed("AUDIO"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "BUCKET_OBJECT_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::BUCKET_OBJECT_TYPE_UNSPECIFIED)
+                    }
+                    "TRANSCRIPT" => std::option::Option::Some(Self::TRANSCRIPT),
+                    "AUDIO" => std::option::Option::Some(Self::AUDIO),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [BucketObjectType](BucketObjectType)
-        pub mod bucket_object_type {
-            use super::BucketObjectType;
-
-            /// The object type is unspecified and will default to `TRANSCRIPT`.
-            pub const BUCKET_OBJECT_TYPE_UNSPECIFIED: BucketObjectType =
-                BucketObjectType::new("BUCKET_OBJECT_TYPE_UNSPECIFIED");
-
-            /// The object is a transcript.
-            pub const TRANSCRIPT: BucketObjectType = BucketObjectType::new("TRANSCRIPT");
-
-            /// The object is an audio file.
-            pub const AUDIO: BucketObjectType = BucketObjectType::new("AUDIO");
-        }
-
-        impl std::convert::From<std::string::String> for BucketObjectType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for BucketObjectType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for BucketObjectType {
             fn default() -> Self {
-                bucket_object_type::BUCKET_OBJECT_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -2311,45 +2327,61 @@ pub mod export_insights_data_request {
 
     /// Specifies the action that occurs if the destination table already exists.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct WriteDisposition(std::borrow::Cow<'static, str>);
+    pub struct WriteDisposition(i32);
 
     impl WriteDisposition {
-        /// Creates a new WriteDisposition instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [WriteDisposition](WriteDisposition)
-    pub mod write_disposition {
-        use super::WriteDisposition;
-
         /// Write disposition is not specified. Defaults to WRITE_TRUNCATE.
-        pub const WRITE_DISPOSITION_UNSPECIFIED: WriteDisposition =
-            WriteDisposition::new("WRITE_DISPOSITION_UNSPECIFIED");
+        pub const WRITE_DISPOSITION_UNSPECIFIED: WriteDisposition = WriteDisposition::new(0);
 
         /// If the table already exists, BigQuery will overwrite the table data and
         /// use the schema from the load.
-        pub const WRITE_TRUNCATE: WriteDisposition = WriteDisposition::new("WRITE_TRUNCATE");
+        pub const WRITE_TRUNCATE: WriteDisposition = WriteDisposition::new(1);
 
         /// If the table already exists, BigQuery will append data to the table.
-        pub const WRITE_APPEND: WriteDisposition = WriteDisposition::new("WRITE_APPEND");
+        pub const WRITE_APPEND: WriteDisposition = WriteDisposition::new(2);
+
+        /// Creates a new WriteDisposition instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("WRITE_DISPOSITION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("WRITE_TRUNCATE"),
+                2 => std::borrow::Cow::Borrowed("WRITE_APPEND"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "WRITE_DISPOSITION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::WRITE_DISPOSITION_UNSPECIFIED)
+                }
+                "WRITE_TRUNCATE" => std::option::Option::Some(Self::WRITE_TRUNCATE),
+                "WRITE_APPEND" => std::option::Option::Some(Self::WRITE_APPEND),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for WriteDisposition {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for WriteDisposition {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for WriteDisposition {
         fn default() -> Self {
-            write_disposition::WRITE_DISPOSITION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -5107,65 +5139,91 @@ pub mod dimension {
 
     /// The key of the dimension.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DimensionKey(std::borrow::Cow<'static, str>);
+    pub struct DimensionKey(i32);
 
     impl DimensionKey {
-        /// Creates a new DimensionKey instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DimensionKey](DimensionKey)
-    pub mod dimension_key {
-        use super::DimensionKey;
-
         /// The key of the dimension is unspecified.
-        pub const DIMENSION_KEY_UNSPECIFIED: DimensionKey =
-            DimensionKey::new("DIMENSION_KEY_UNSPECIFIED");
+        pub const DIMENSION_KEY_UNSPECIFIED: DimensionKey = DimensionKey::new(0);
 
         /// The dimension is keyed by issues.
-        pub const ISSUE: DimensionKey = DimensionKey::new("ISSUE");
+        pub const ISSUE: DimensionKey = DimensionKey::new(1);
 
         /// The dimension is keyed by agents.
-        pub const AGENT: DimensionKey = DimensionKey::new("AGENT");
+        pub const AGENT: DimensionKey = DimensionKey::new(2);
 
         /// The dimension is keyed by agent teams.
-        pub const AGENT_TEAM: DimensionKey = DimensionKey::new("AGENT_TEAM");
+        pub const AGENT_TEAM: DimensionKey = DimensionKey::new(3);
 
         /// The dimension is keyed by QaQuestionIds.
         /// Note that: We only group by the QuestionId and not the revision-id of the
         /// scorecard this question is a part of. This allows for showing stats for
         /// the same question across different scorecard revisions.
-        pub const QA_QUESTION_ID: DimensionKey = DimensionKey::new("QA_QUESTION_ID");
+        pub const QA_QUESTION_ID: DimensionKey = DimensionKey::new(4);
 
         /// The dimension is keyed by QaQuestionIds-Answer value pairs.
         /// Note that: We only group by the QuestionId and not the revision-id of the
         /// scorecard this question is a part of. This allows for showing
         /// distribution of answers per question across different scorecard
         /// revisions.
-        pub const QA_QUESTION_ANSWER_VALUE: DimensionKey =
-            DimensionKey::new("QA_QUESTION_ANSWER_VALUE");
+        pub const QA_QUESTION_ANSWER_VALUE: DimensionKey = DimensionKey::new(5);
 
         /// The dimension is keyed by the conversation profile ID.
-        pub const CONVERSATION_PROFILE_ID: DimensionKey =
-            DimensionKey::new("CONVERSATION_PROFILE_ID");
+        pub const CONVERSATION_PROFILE_ID: DimensionKey = DimensionKey::new(6);
+
+        /// Creates a new DimensionKey instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DIMENSION_KEY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ISSUE"),
+                2 => std::borrow::Cow::Borrowed("AGENT"),
+                3 => std::borrow::Cow::Borrowed("AGENT_TEAM"),
+                4 => std::borrow::Cow::Borrowed("QA_QUESTION_ID"),
+                5 => std::borrow::Cow::Borrowed("QA_QUESTION_ANSWER_VALUE"),
+                6 => std::borrow::Cow::Borrowed("CONVERSATION_PROFILE_ID"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DIMENSION_KEY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DIMENSION_KEY_UNSPECIFIED)
+                }
+                "ISSUE" => std::option::Option::Some(Self::ISSUE),
+                "AGENT" => std::option::Option::Some(Self::AGENT),
+                "AGENT_TEAM" => std::option::Option::Some(Self::AGENT_TEAM),
+                "QA_QUESTION_ID" => std::option::Option::Some(Self::QA_QUESTION_ID),
+                "QA_QUESTION_ANSWER_VALUE" => {
+                    std::option::Option::Some(Self::QA_QUESTION_ANSWER_VALUE)
+                }
+                "CONVERSATION_PROFILE_ID" => {
+                    std::option::Option::Some(Self::CONVERSATION_PROFILE_ID)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DimensionKey {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DimensionKey {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DimensionKey {
         fn default() -> Self {
-            dimension_key::DIMENSION_KEY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -5294,62 +5352,86 @@ pub mod query_metrics_request {
     /// This is useful for defining buckets over which filtering and aggregation
     /// should be performed.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TimeGranularity(std::borrow::Cow<'static, str>);
+    pub struct TimeGranularity(i32);
 
     impl TimeGranularity {
-        /// Creates a new TimeGranularity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [TimeGranularity](TimeGranularity)
-    pub mod time_granularity {
-        use super::TimeGranularity;
-
         /// The time granularity is unspecified and will default to NONE.
-        pub const TIME_GRANULARITY_UNSPECIFIED: TimeGranularity =
-            TimeGranularity::new("TIME_GRANULARITY_UNSPECIFIED");
+        pub const TIME_GRANULARITY_UNSPECIFIED: TimeGranularity = TimeGranularity::new(0);
 
         /// No time granularity. The response won't contain a time series.
         /// This is the default value if no time granularity is specified.
-        pub const NONE: TimeGranularity = TimeGranularity::new("NONE");
+        pub const NONE: TimeGranularity = TimeGranularity::new(1);
 
         /// Data points in the time series will aggregate at a daily granularity.
         /// 1 day means [midnight to midnight).
-        pub const DAILY: TimeGranularity = TimeGranularity::new("DAILY");
+        pub const DAILY: TimeGranularity = TimeGranularity::new(2);
 
         /// Data points in the time series will aggregate at a daily granularity.
         /// 1 HOUR means [01:00 to 02:00).
-        pub const HOURLY: TimeGranularity = TimeGranularity::new("HOURLY");
+        pub const HOURLY: TimeGranularity = TimeGranularity::new(3);
 
         /// Data points in the time series will aggregate at a daily granularity.
         /// PER_MINUTE means [01:00 to 01:01).
-        pub const PER_MINUTE: TimeGranularity = TimeGranularity::new("PER_MINUTE");
+        pub const PER_MINUTE: TimeGranularity = TimeGranularity::new(4);
 
         /// Data points in the time series will aggregate at a 1 minute  granularity.
         /// PER_5_MINUTES means [01:00 to 01:05).
-        pub const PER_5_MINUTES: TimeGranularity = TimeGranularity::new("PER_5_MINUTES");
+        pub const PER_5_MINUTES: TimeGranularity = TimeGranularity::new(5);
 
         /// Data points in the time series will aggregate at a monthly granularity.
         /// 1 MONTH means [01st of the month to 1st of the next month).
-        pub const MONTHLY: TimeGranularity = TimeGranularity::new("MONTHLY");
+        pub const MONTHLY: TimeGranularity = TimeGranularity::new(6);
+
+        /// Creates a new TimeGranularity instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TIME_GRANULARITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NONE"),
+                2 => std::borrow::Cow::Borrowed("DAILY"),
+                3 => std::borrow::Cow::Borrowed("HOURLY"),
+                4 => std::borrow::Cow::Borrowed("PER_MINUTE"),
+                5 => std::borrow::Cow::Borrowed("PER_5_MINUTES"),
+                6 => std::borrow::Cow::Borrowed("MONTHLY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TIME_GRANULARITY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::TIME_GRANULARITY_UNSPECIFIED)
+                }
+                "NONE" => std::option::Option::Some(Self::NONE),
+                "DAILY" => std::option::Option::Some(Self::DAILY),
+                "HOURLY" => std::option::Option::Some(Self::HOURLY),
+                "PER_MINUTE" => std::option::Option::Some(Self::PER_MINUTE),
+                "PER_5_MINUTES" => std::option::Option::Some(Self::PER_5_MINUTES),
+                "MONTHLY" => std::option::Option::Some(Self::MONTHLY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for TimeGranularity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TimeGranularity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TimeGranularity {
         fn default() -> Self {
-            time_granularity::TIME_GRANULARITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7693,43 +7775,58 @@ pub mod bulk_upload_feedback_labels_request {
 
         /// All permissible file formats.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Format(std::borrow::Cow<'static, str>);
+        pub struct Format(i32);
 
         impl Format {
+            /// Unspecified format.
+            pub const FORMAT_UNSPECIFIED: Format = Format::new(0);
+
+            /// CSV format.
+            pub const CSV: Format = Format::new(1);
+
+            /// JSON format.
+            pub const JSON: Format = Format::new(2);
+
             /// Creates a new Format instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("FORMAT_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("CSV"),
+                    2 => std::borrow::Cow::Borrowed("JSON"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "FORMAT_UNSPECIFIED" => std::option::Option::Some(Self::FORMAT_UNSPECIFIED),
+                    "CSV" => std::option::Option::Some(Self::CSV),
+                    "JSON" => std::option::Option::Some(Self::JSON),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Format](Format)
-        pub mod format {
-            use super::Format;
-
-            /// Unspecified format.
-            pub const FORMAT_UNSPECIFIED: Format = Format::new("FORMAT_UNSPECIFIED");
-
-            /// CSV format.
-            pub const CSV: Format = Format::new("CSV");
-
-            /// JSON format.
-            pub const JSON: Format = Format::new("JSON");
-        }
-
-        impl std::convert::From<std::string::String> for Format {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Format {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Format {
             fn default() -> Self {
-                format::FORMAT_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -8171,90 +8268,121 @@ pub mod bulk_download_feedback_labels_request {
         /// See `records_per_file_count` to override the default number of records
         /// per file.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Format(std::borrow::Cow<'static, str>);
+        pub struct Format(i32);
 
         impl Format {
-            /// Creates a new Format instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [Format](Format)
-        pub mod format {
-            use super::Format;
-
             /// Unspecified format.
-            pub const FORMAT_UNSPECIFIED: Format = Format::new("FORMAT_UNSPECIFIED");
+            pub const FORMAT_UNSPECIFIED: Format = Format::new(0);
 
             /// CSV format.
             /// 1,000 labels are stored per CSV file by default.
-            pub const CSV: Format = Format::new("CSV");
+            pub const CSV: Format = Format::new(1);
 
             /// JSON format.
             /// 1 label stored per JSON file by default.
-            pub const JSON: Format = Format::new("JSON");
+            pub const JSON: Format = Format::new(2);
+
+            /// Creates a new Format instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("FORMAT_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("CSV"),
+                    2 => std::borrow::Cow::Borrowed("JSON"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "FORMAT_UNSPECIFIED" => std::option::Option::Some(Self::FORMAT_UNSPECIFIED),
+                    "CSV" => std::option::Option::Some(Self::CSV),
+                    "JSON" => std::option::Option::Some(Self::JSON),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for Format {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Format {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Format {
             fn default() -> Self {
-                format::FORMAT_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// Possible feedback label types that will be downloaded.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FeedbackLabelType(std::borrow::Cow<'static, str>);
+    pub struct FeedbackLabelType(i32);
 
     impl FeedbackLabelType {
-        /// Creates a new FeedbackLabelType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [FeedbackLabelType](FeedbackLabelType)
-    pub mod feedback_label_type {
-        use super::FeedbackLabelType;
-
         /// Unspecified format
-        pub const FEEDBACK_LABEL_TYPE_UNSPECIFIED: FeedbackLabelType =
-            FeedbackLabelType::new("FEEDBACK_LABEL_TYPE_UNSPECIFIED");
+        pub const FEEDBACK_LABEL_TYPE_UNSPECIFIED: FeedbackLabelType = FeedbackLabelType::new(0);
 
         /// Downloaded file will contain all Quality AI labels from the latest
         /// scorecard revision.
-        pub const QUALITY_AI: FeedbackLabelType = FeedbackLabelType::new("QUALITY_AI");
+        pub const QUALITY_AI: FeedbackLabelType = FeedbackLabelType::new(1);
 
         /// Downloaded file will contain only Topic Modeling labels.
-        pub const TOPIC_MODELING: FeedbackLabelType = FeedbackLabelType::new("TOPIC_MODELING");
+        pub const TOPIC_MODELING: FeedbackLabelType = FeedbackLabelType::new(2);
+
+        /// Creates a new FeedbackLabelType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FEEDBACK_LABEL_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("QUALITY_AI"),
+                2 => std::borrow::Cow::Borrowed("TOPIC_MODELING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FEEDBACK_LABEL_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::FEEDBACK_LABEL_TYPE_UNSPECIFIED)
+                }
+                "QUALITY_AI" => std::option::Option::Some(Self::QUALITY_AI),
+                "TOPIC_MODELING" => std::option::Option::Some(Self::TOPIC_MODELING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for FeedbackLabelType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for FeedbackLabelType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for FeedbackLabelType {
         fn default() -> Self {
-            feedback_label_type::FEEDBACK_LABEL_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -9334,43 +9462,58 @@ pub mod conversation {
 
     /// Possible media for the conversation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Medium(std::borrow::Cow<'static, str>);
+    pub struct Medium(i32);
 
     impl Medium {
+        /// Default value, if unspecified will default to PHONE_CALL.
+        pub const MEDIUM_UNSPECIFIED: Medium = Medium::new(0);
+
+        /// The format for conversations that took place over the phone.
+        pub const PHONE_CALL: Medium = Medium::new(1);
+
+        /// The format for conversations that took place over chat.
+        pub const CHAT: Medium = Medium::new(2);
+
         /// Creates a new Medium instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MEDIUM_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PHONE_CALL"),
+                2 => std::borrow::Cow::Borrowed("CHAT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MEDIUM_UNSPECIFIED" => std::option::Option::Some(Self::MEDIUM_UNSPECIFIED),
+                "PHONE_CALL" => std::option::Option::Some(Self::PHONE_CALL),
+                "CHAT" => std::option::Option::Some(Self::CHAT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Medium](Medium)
-    pub mod medium {
-        use super::Medium;
-
-        /// Default value, if unspecified will default to PHONE_CALL.
-        pub const MEDIUM_UNSPECIFIED: Medium = Medium::new("MEDIUM_UNSPECIFIED");
-
-        /// The format for conversations that took place over the phone.
-        pub const PHONE_CALL: Medium = Medium::new("PHONE_CALL");
-
-        /// The format for conversations that took place over chat.
-        pub const CHAT: Medium = Medium::new("CHAT");
-    }
-
-    impl std::convert::From<std::string::String> for Medium {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Medium {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Medium {
         fn default() -> Self {
-            medium::MEDIUM_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -10785,47 +10928,32 @@ pub mod entity {
     /// below lists the associated fields for entities that have different
     /// metadata.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// Unspecified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// Person.
-        pub const PERSON: Type = Type::new("PERSON");
+        pub const PERSON: Type = Type::new(1);
 
         /// Location.
-        pub const LOCATION: Type = Type::new("LOCATION");
+        pub const LOCATION: Type = Type::new(2);
 
         /// Organization.
-        pub const ORGANIZATION: Type = Type::new("ORGANIZATION");
+        pub const ORGANIZATION: Type = Type::new(3);
 
         /// Event.
-        pub const EVENT: Type = Type::new("EVENT");
+        pub const EVENT: Type = Type::new(4);
 
         /// Artwork.
-        pub const WORK_OF_ART: Type = Type::new("WORK_OF_ART");
+        pub const WORK_OF_ART: Type = Type::new(5);
 
         /// Consumer product.
-        pub const CONSUMER_GOOD: Type = Type::new("CONSUMER_GOOD");
+        pub const CONSUMER_GOOD: Type = Type::new(6);
 
         /// Other types of entities.
-        pub const OTHER: Type = Type::new("OTHER");
+        pub const OTHER: Type = Type::new(7);
 
         /// Phone number.
         ///
@@ -10838,7 +10966,7 @@ pub mod entity {
         /// * `area_code` - Region or area code, if detected.
         /// * `extension` - Phone extension (to be dialed after connection), if
         ///   detected.
-        pub const PHONE_NUMBER: Type = Type::new("PHONE_NUMBER");
+        pub const PHONE_NUMBER: Type = Type::new(9);
 
         /// Address.
         ///
@@ -10855,7 +10983,7 @@ pub mod entity {
         ///   detected.
         /// * `sublocality` - Used in Asian addresses to demark a district within a
         ///   city, if detected.
-        pub const ADDRESS: Type = Type::new("ADDRESS");
+        pub const ADDRESS: Type = Type::new(10);
 
         /// Date.
         ///
@@ -10864,28 +10992,78 @@ pub mod entity {
         /// * `year` - Four digit year, if detected.
         /// * `month` - Two digit month number, if detected.
         /// * `day` - Two digit day number, if detected.
-        pub const DATE: Type = Type::new("DATE");
+        pub const DATE: Type = Type::new(11);
 
         /// Number.
         ///
         /// The metadata is the number itself.
-        pub const NUMBER: Type = Type::new("NUMBER");
+        pub const NUMBER: Type = Type::new(12);
 
         /// Price.
         ///
         /// The metadata identifies the `value` and `currency`.
-        pub const PRICE: Type = Type::new("PRICE");
+        pub const PRICE: Type = Type::new(13);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PERSON"),
+                2 => std::borrow::Cow::Borrowed("LOCATION"),
+                3 => std::borrow::Cow::Borrowed("ORGANIZATION"),
+                4 => std::borrow::Cow::Borrowed("EVENT"),
+                5 => std::borrow::Cow::Borrowed("WORK_OF_ART"),
+                6 => std::borrow::Cow::Borrowed("CONSUMER_GOOD"),
+                7 => std::borrow::Cow::Borrowed("OTHER"),
+                9 => std::borrow::Cow::Borrowed("PHONE_NUMBER"),
+                10 => std::borrow::Cow::Borrowed("ADDRESS"),
+                11 => std::borrow::Cow::Borrowed("DATE"),
+                12 => std::borrow::Cow::Borrowed("NUMBER"),
+                13 => std::borrow::Cow::Borrowed("PRICE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "PERSON" => std::option::Option::Some(Self::PERSON),
+                "LOCATION" => std::option::Option::Some(Self::LOCATION),
+                "ORGANIZATION" => std::option::Option::Some(Self::ORGANIZATION),
+                "EVENT" => std::option::Option::Some(Self::EVENT),
+                "WORK_OF_ART" => std::option::Option::Some(Self::WORK_OF_ART),
+                "CONSUMER_GOOD" => std::option::Option::Some(Self::CONSUMER_GOOD),
+                "OTHER" => std::option::Option::Some(Self::OTHER),
+                "PHONE_NUMBER" => std::option::Option::Some(Self::PHONE_NUMBER),
+                "ADDRESS" => std::option::Option::Some(Self::ADDRESS),
+                "DATE" => std::option::Option::Some(Self::DATE),
+                "NUMBER" => std::option::Option::Some(Self::NUMBER),
+                "PRICE" => std::option::Option::Some(Self::PRICE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -11126,44 +11304,60 @@ pub mod entity_mention_data {
 
     /// The supported types of mentions.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MentionType(std::borrow::Cow<'static, str>);
+    pub struct MentionType(i32);
 
     impl MentionType {
+        /// Unspecified.
+        pub const MENTION_TYPE_UNSPECIFIED: MentionType = MentionType::new(0);
+
+        /// Proper noun.
+        pub const PROPER: MentionType = MentionType::new(1);
+
+        /// Common noun (or noun compound).
+        pub const COMMON: MentionType = MentionType::new(2);
+
         /// Creates a new MentionType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MENTION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROPER"),
+                2 => std::borrow::Cow::Borrowed("COMMON"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MENTION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MENTION_TYPE_UNSPECIFIED)
+                }
+                "PROPER" => std::option::Option::Some(Self::PROPER),
+                "COMMON" => std::option::Option::Some(Self::COMMON),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [MentionType](MentionType)
-    pub mod mention_type {
-        use super::MentionType;
-
-        /// Unspecified.
-        pub const MENTION_TYPE_UNSPECIFIED: MentionType =
-            MentionType::new("MENTION_TYPE_UNSPECIFIED");
-
-        /// Proper noun.
-        pub const PROPER: MentionType = MentionType::new("PROPER");
-
-        /// Common noun (or noun compound).
-        pub const COMMON: MentionType = MentionType::new("COMMON");
-    }
-
-    impl std::convert::From<std::string::String> for MentionType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MentionType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MentionType {
         fn default() -> Self {
-            mention_type::MENTION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -11482,95 +11676,131 @@ pub mod issue_model {
 
     /// State of the model.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Model is not deployed but is ready to deploy.
-        pub const UNDEPLOYED: State = State::new("UNDEPLOYED");
+        pub const UNDEPLOYED: State = State::new(1);
 
         /// Model is being deployed.
-        pub const DEPLOYING: State = State::new("DEPLOYING");
+        pub const DEPLOYING: State = State::new(2);
 
         /// Model is deployed and is ready to be used. A model can only be used in
         /// analysis if it's in this state.
-        pub const DEPLOYED: State = State::new("DEPLOYED");
+        pub const DEPLOYED: State = State::new(3);
 
         /// Model is being undeployed.
-        pub const UNDEPLOYING: State = State::new("UNDEPLOYING");
+        pub const UNDEPLOYING: State = State::new(4);
 
         /// Model is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("UNDEPLOYED"),
+                2 => std::borrow::Cow::Borrowed("DEPLOYING"),
+                3 => std::borrow::Cow::Borrowed("DEPLOYED"),
+                4 => std::borrow::Cow::Borrowed("UNDEPLOYING"),
+                5 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "UNDEPLOYED" => std::option::Option::Some(Self::UNDEPLOYED),
+                "DEPLOYING" => std::option::Option::Some(Self::DEPLOYING),
+                "DEPLOYED" => std::option::Option::Some(Self::DEPLOYED),
+                "UNDEPLOYING" => std::option::Option::Some(Self::UNDEPLOYING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Type of the model.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ModelType(std::borrow::Cow<'static, str>);
+    pub struct ModelType(i32);
 
     impl ModelType {
+        /// Unspecified model type.
+        pub const MODEL_TYPE_UNSPECIFIED: ModelType = ModelType::new(0);
+
+        /// Type V1.
+        pub const TYPE_V1: ModelType = ModelType::new(1);
+
+        /// Type V2.
+        pub const TYPE_V2: ModelType = ModelType::new(2);
+
         /// Creates a new ModelType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MODEL_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TYPE_V1"),
+                2 => std::borrow::Cow::Borrowed("TYPE_V2"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MODEL_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::MODEL_TYPE_UNSPECIFIED),
+                "TYPE_V1" => std::option::Option::Some(Self::TYPE_V1),
+                "TYPE_V2" => std::option::Option::Some(Self::TYPE_V2),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ModelType](ModelType)
-    pub mod model_type {
-        use super::ModelType;
-
-        /// Unspecified model type.
-        pub const MODEL_TYPE_UNSPECIFIED: ModelType = ModelType::new("MODEL_TYPE_UNSPECIFIED");
-
-        /// Type V1.
-        pub const TYPE_V1: ModelType = ModelType::new("TYPE_V1");
-
-        /// Type V2.
-        pub const TYPE_V2: ModelType = ModelType::new("TYPE_V2");
-    }
-
-    impl std::convert::From<std::string::String> for ModelType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ModelType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ModelType {
         fn default() -> Self {
-            model_type::MODEL_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -11960,44 +12190,60 @@ pub mod phrase_matcher {
     /// Specifies how to combine each phrase match rule group to determine whether
     /// there is a match.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PhraseMatcherType(std::borrow::Cow<'static, str>);
+    pub struct PhraseMatcherType(i32);
 
     impl PhraseMatcherType {
+        /// Unspecified.
+        pub const PHRASE_MATCHER_TYPE_UNSPECIFIED: PhraseMatcherType = PhraseMatcherType::new(0);
+
+        /// Must meet all phrase match rule groups or there is no match.
+        pub const ALL_OF: PhraseMatcherType = PhraseMatcherType::new(1);
+
+        /// If any of the phrase match rule groups are met, there is a match.
+        pub const ANY_OF: PhraseMatcherType = PhraseMatcherType::new(2);
+
         /// Creates a new PhraseMatcherType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PHRASE_MATCHER_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALL_OF"),
+                2 => std::borrow::Cow::Borrowed("ANY_OF"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PHRASE_MATCHER_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PHRASE_MATCHER_TYPE_UNSPECIFIED)
+                }
+                "ALL_OF" => std::option::Option::Some(Self::ALL_OF),
+                "ANY_OF" => std::option::Option::Some(Self::ANY_OF),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [PhraseMatcherType](PhraseMatcherType)
-    pub mod phrase_matcher_type {
-        use super::PhraseMatcherType;
-
-        /// Unspecified.
-        pub const PHRASE_MATCHER_TYPE_UNSPECIFIED: PhraseMatcherType =
-            PhraseMatcherType::new("PHRASE_MATCHER_TYPE_UNSPECIFIED");
-
-        /// Must meet all phrase match rule groups or there is no match.
-        pub const ALL_OF: PhraseMatcherType = PhraseMatcherType::new("ALL_OF");
-
-        /// If any of the phrase match rule groups are met, there is a match.
-        pub const ANY_OF: PhraseMatcherType = PhraseMatcherType::new("ANY_OF");
-    }
-
-    impl std::convert::From<std::string::String> for PhraseMatcherType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PhraseMatcherType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PhraseMatcherType {
         fn default() -> Self {
-            phrase_matcher_type::PHRASE_MATCHER_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -12059,44 +12305,61 @@ pub mod phrase_match_rule_group {
     /// Specifies how to combine each phrase match rule for whether there is a
     /// match.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PhraseMatchRuleGroupType(std::borrow::Cow<'static, str>);
+    pub struct PhraseMatchRuleGroupType(i32);
 
     impl PhraseMatchRuleGroupType {
+        /// Unspecified.
+        pub const PHRASE_MATCH_RULE_GROUP_TYPE_UNSPECIFIED: PhraseMatchRuleGroupType =
+            PhraseMatchRuleGroupType::new(0);
+
+        /// Must meet all phrase match rules or there is no match.
+        pub const ALL_OF: PhraseMatchRuleGroupType = PhraseMatchRuleGroupType::new(1);
+
+        /// If any of the phrase match rules are met, there is a match.
+        pub const ANY_OF: PhraseMatchRuleGroupType = PhraseMatchRuleGroupType::new(2);
+
         /// Creates a new PhraseMatchRuleGroupType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PHRASE_MATCH_RULE_GROUP_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALL_OF"),
+                2 => std::borrow::Cow::Borrowed("ANY_OF"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PHRASE_MATCH_RULE_GROUP_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PHRASE_MATCH_RULE_GROUP_TYPE_UNSPECIFIED)
+                }
+                "ALL_OF" => std::option::Option::Some(Self::ALL_OF),
+                "ANY_OF" => std::option::Option::Some(Self::ANY_OF),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [PhraseMatchRuleGroupType](PhraseMatchRuleGroupType)
-    pub mod phrase_match_rule_group_type {
-        use super::PhraseMatchRuleGroupType;
-
-        /// Unspecified.
-        pub const PHRASE_MATCH_RULE_GROUP_TYPE_UNSPECIFIED: PhraseMatchRuleGroupType =
-            PhraseMatchRuleGroupType::new("PHRASE_MATCH_RULE_GROUP_TYPE_UNSPECIFIED");
-
-        /// Must meet all phrase match rules or there is no match.
-        pub const ALL_OF: PhraseMatchRuleGroupType = PhraseMatchRuleGroupType::new("ALL_OF");
-
-        /// If any of the phrase match rules are met, there is a match.
-        pub const ANY_OF: PhraseMatchRuleGroupType = PhraseMatchRuleGroupType::new("ANY_OF");
-    }
-
-    impl std::convert::From<std::string::String> for PhraseMatchRuleGroupType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PhraseMatchRuleGroupType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PhraseMatchRuleGroupType {
         fn default() -> Self {
-            phrase_match_rule_group_type::PHRASE_MATCH_RULE_GROUP_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -13148,45 +13411,61 @@ pub mod runtime_annotation {
 
         /// The source of the query.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct QuerySource(std::borrow::Cow<'static, str>);
+        pub struct QuerySource(i32);
 
         impl QuerySource {
-            /// Creates a new QuerySource instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [QuerySource](QuerySource)
-        pub mod query_source {
-            use super::QuerySource;
-
             /// Unknown query source.
-            pub const QUERY_SOURCE_UNSPECIFIED: QuerySource =
-                QuerySource::new("QUERY_SOURCE_UNSPECIFIED");
+            pub const QUERY_SOURCE_UNSPECIFIED: QuerySource = QuerySource::new(0);
 
             /// The query is from agents.
-            pub const AGENT_QUERY: QuerySource = QuerySource::new("AGENT_QUERY");
+            pub const AGENT_QUERY: QuerySource = QuerySource::new(1);
 
             /// The query is a query from previous suggestions, e.g. from a preceding
             /// SuggestKnowledgeAssist response.
-            pub const SUGGESTED_QUERY: QuerySource = QuerySource::new("SUGGESTED_QUERY");
+            pub const SUGGESTED_QUERY: QuerySource = QuerySource::new(2);
+
+            /// Creates a new QuerySource instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("QUERY_SOURCE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("AGENT_QUERY"),
+                    2 => std::borrow::Cow::Borrowed("SUGGESTED_QUERY"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "QUERY_SOURCE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::QUERY_SOURCE_UNSPECIFIED)
+                    }
+                    "AGENT_QUERY" => std::option::Option::Some(Self::AGENT_QUERY),
+                    "SUGGESTED_QUERY" => std::option::Option::Some(Self::SUGGESTED_QUERY),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for QuerySource {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for QuerySource {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for QuerySource {
             fn default() -> Self {
-                query_source::QUERY_SOURCE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -13273,47 +13552,65 @@ pub mod answer_feedback {
 
     /// The correctness level of an answer.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CorrectnessLevel(std::borrow::Cow<'static, str>);
+    pub struct CorrectnessLevel(i32);
 
     impl CorrectnessLevel {
+        /// Correctness level unspecified.
+        pub const CORRECTNESS_LEVEL_UNSPECIFIED: CorrectnessLevel = CorrectnessLevel::new(0);
+
+        /// Answer is totally wrong.
+        pub const NOT_CORRECT: CorrectnessLevel = CorrectnessLevel::new(1);
+
+        /// Answer is partially correct.
+        pub const PARTIALLY_CORRECT: CorrectnessLevel = CorrectnessLevel::new(2);
+
+        /// Answer is fully correct.
+        pub const FULLY_CORRECT: CorrectnessLevel = CorrectnessLevel::new(3);
+
         /// Creates a new CorrectnessLevel instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CORRECTNESS_LEVEL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NOT_CORRECT"),
+                2 => std::borrow::Cow::Borrowed("PARTIALLY_CORRECT"),
+                3 => std::borrow::Cow::Borrowed("FULLY_CORRECT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CORRECTNESS_LEVEL_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CORRECTNESS_LEVEL_UNSPECIFIED)
+                }
+                "NOT_CORRECT" => std::option::Option::Some(Self::NOT_CORRECT),
+                "PARTIALLY_CORRECT" => std::option::Option::Some(Self::PARTIALLY_CORRECT),
+                "FULLY_CORRECT" => std::option::Option::Some(Self::FULLY_CORRECT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [CorrectnessLevel](CorrectnessLevel)
-    pub mod correctness_level {
-        use super::CorrectnessLevel;
-
-        /// Correctness level unspecified.
-        pub const CORRECTNESS_LEVEL_UNSPECIFIED: CorrectnessLevel =
-            CorrectnessLevel::new("CORRECTNESS_LEVEL_UNSPECIFIED");
-
-        /// Answer is totally wrong.
-        pub const NOT_CORRECT: CorrectnessLevel = CorrectnessLevel::new("NOT_CORRECT");
-
-        /// Answer is partially correct.
-        pub const PARTIALLY_CORRECT: CorrectnessLevel = CorrectnessLevel::new("PARTIALLY_CORRECT");
-
-        /// Answer is fully correct.
-        pub const FULLY_CORRECT: CorrectnessLevel = CorrectnessLevel::new("FULLY_CORRECT");
-    }
-
-    impl std::convert::From<std::string::String> for CorrectnessLevel {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CorrectnessLevel {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CorrectnessLevel {
         fn default() -> Self {
-            correctness_level::CORRECTNESS_LEVEL_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -13918,49 +14215,68 @@ pub mod conversation_participant {
 
     /// The role of the participant.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Role(std::borrow::Cow<'static, str>);
+    pub struct Role(i32);
 
     impl Role {
+        /// Participant's role is not set.
+        pub const ROLE_UNSPECIFIED: Role = Role::new(0);
+
+        /// Participant is a human agent.
+        pub const HUMAN_AGENT: Role = Role::new(1);
+
+        /// Participant is an automated agent.
+        pub const AUTOMATED_AGENT: Role = Role::new(2);
+
+        /// Participant is an end user who conversed with the contact center.
+        pub const END_USER: Role = Role::new(3);
+
+        /// Participant is either a human or automated agent.
+        pub const ANY_AGENT: Role = Role::new(4);
+
         /// Creates a new Role instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ROLE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("HUMAN_AGENT"),
+                2 => std::borrow::Cow::Borrowed("AUTOMATED_AGENT"),
+                3 => std::borrow::Cow::Borrowed("END_USER"),
+                4 => std::borrow::Cow::Borrowed("ANY_AGENT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ROLE_UNSPECIFIED" => std::option::Option::Some(Self::ROLE_UNSPECIFIED),
+                "HUMAN_AGENT" => std::option::Option::Some(Self::HUMAN_AGENT),
+                "AUTOMATED_AGENT" => std::option::Option::Some(Self::AUTOMATED_AGENT),
+                "END_USER" => std::option::Option::Some(Self::END_USER),
+                "ANY_AGENT" => std::option::Option::Some(Self::ANY_AGENT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Role](Role)
-    pub mod role {
-        use super::Role;
-
-        /// Participant's role is not set.
-        pub const ROLE_UNSPECIFIED: Role = Role::new("ROLE_UNSPECIFIED");
-
-        /// Participant is a human agent.
-        pub const HUMAN_AGENT: Role = Role::new("HUMAN_AGENT");
-
-        /// Participant is an automated agent.
-        pub const AUTOMATED_AGENT: Role = Role::new("AUTOMATED_AGENT");
-
-        /// Participant is an end user who conversed with the contact center.
-        pub const END_USER: Role = Role::new("END_USER");
-
-        /// Participant is either a human or automated agent.
-        pub const ANY_AGENT: Role = Role::new("ANY_AGENT");
-    }
-
-    impl std::convert::From<std::string::String> for Role {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Role {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Role {
         fn default() -> Self {
-            role::ROLE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -14342,46 +14658,61 @@ pub mod annotator_selector {
 
         /// Summarization model to use, if `conversation_profile` is not used.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SummarizationModel(std::borrow::Cow<'static, str>);
+        pub struct SummarizationModel(i32);
 
         impl SummarizationModel {
+            /// Unspecified summarization model.
+            pub const SUMMARIZATION_MODEL_UNSPECIFIED: SummarizationModel =
+                SummarizationModel::new(0);
+
+            /// The CCAI baseline model.
+            pub const BASELINE_MODEL: SummarizationModel = SummarizationModel::new(1);
+
+            /// The CCAI baseline model, V2.0.
+            pub const BASELINE_MODEL_V2_0: SummarizationModel = SummarizationModel::new(2);
+
             /// Creates a new SummarizationModel instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("SUMMARIZATION_MODEL_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("BASELINE_MODEL"),
+                    2 => std::borrow::Cow::Borrowed("BASELINE_MODEL_V2_0"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "SUMMARIZATION_MODEL_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::SUMMARIZATION_MODEL_UNSPECIFIED)
+                    }
+                    "BASELINE_MODEL" => std::option::Option::Some(Self::BASELINE_MODEL),
+                    "BASELINE_MODEL_V2_0" => std::option::Option::Some(Self::BASELINE_MODEL_V2_0),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [SummarizationModel](SummarizationModel)
-        pub mod summarization_model {
-            use super::SummarizationModel;
-
-            /// Unspecified summarization model.
-            pub const SUMMARIZATION_MODEL_UNSPECIFIED: SummarizationModel =
-                SummarizationModel::new("SUMMARIZATION_MODEL_UNSPECIFIED");
-
-            /// The CCAI baseline model.
-            pub const BASELINE_MODEL: SummarizationModel =
-                SummarizationModel::new("BASELINE_MODEL");
-
-            /// The CCAI baseline model, V2.0.
-            pub const BASELINE_MODEL_V2_0: SummarizationModel =
-                SummarizationModel::new("BASELINE_MODEL_V2_0");
-        }
-
-        impl std::convert::From<std::string::String> for SummarizationModel {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for SummarizationModel {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for SummarizationModel {
             fn default() -> Self {
-                summarization_model::SUMMARIZATION_MODEL_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -15148,55 +15479,78 @@ pub mod qa_scorecard_revision {
 
     /// Enum representing the set of states a scorecard revision may be in.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The scorecard revision can be edited.
+        pub const EDITABLE: State = State::new(12);
+
+        /// Scorecard model training is in progress.
+        pub const TRAINING: State = State::new(2);
+
+        /// Scorecard revision model training failed.
+        pub const TRAINING_FAILED: State = State::new(9);
+
+        /// The revision can be used in analysis.
+        pub const READY: State = State::new(11);
+
+        /// Scorecard is being deleted.
+        pub const DELETING: State = State::new(7);
+
+        /// Scorecard model training was explicitly cancelled by the user.
+        pub const TRAINING_CANCELLED: State = State::new(14);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                2 => std::borrow::Cow::Borrowed("TRAINING"),
+                7 => std::borrow::Cow::Borrowed("DELETING"),
+                9 => std::borrow::Cow::Borrowed("TRAINING_FAILED"),
+                11 => std::borrow::Cow::Borrowed("READY"),
+                12 => std::borrow::Cow::Borrowed("EDITABLE"),
+                14 => std::borrow::Cow::Borrowed("TRAINING_CANCELLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "EDITABLE" => std::option::Option::Some(Self::EDITABLE),
+                "TRAINING" => std::option::Option::Some(Self::TRAINING),
+                "TRAINING_FAILED" => std::option::Option::Some(Self::TRAINING_FAILED),
+                "READY" => std::option::Option::Some(Self::READY),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "TRAINING_CANCELLED" => std::option::Option::Some(Self::TRAINING_CANCELLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The scorecard revision can be edited.
-        pub const EDITABLE: State = State::new("EDITABLE");
-
-        /// Scorecard model training is in progress.
-        pub const TRAINING: State = State::new("TRAINING");
-
-        /// Scorecard revision model training failed.
-        pub const TRAINING_FAILED: State = State::new("TRAINING_FAILED");
-
-        /// The revision can be used in analysis.
-        pub const READY: State = State::new("READY");
-
-        /// Scorecard is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// Scorecard model training was explicitly cancelled by the user.
-        pub const TRAINING_CANCELLED: State = State::new("TRAINING_CANCELLED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -15568,44 +15922,60 @@ pub mod qa_answer {
 
         /// What created the answer.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SourceType(std::borrow::Cow<'static, str>);
+        pub struct SourceType(i32);
 
         impl SourceType {
+            /// Source type is unspecified.
+            pub const SOURCE_TYPE_UNSPECIFIED: SourceType = SourceType::new(0);
+
+            /// Answer was system-generated; created during an Insights analysis.
+            pub const SYSTEM_GENERATED: SourceType = SourceType::new(1);
+
+            /// Answer was created by a human via manual edit.
+            pub const MANUAL_EDIT: SourceType = SourceType::new(2);
+
             /// Creates a new SourceType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("SOURCE_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("SYSTEM_GENERATED"),
+                    2 => std::borrow::Cow::Borrowed("MANUAL_EDIT"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "SOURCE_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::SOURCE_TYPE_UNSPECIFIED)
+                    }
+                    "SYSTEM_GENERATED" => std::option::Option::Some(Self::SYSTEM_GENERATED),
+                    "MANUAL_EDIT" => std::option::Option::Some(Self::MANUAL_EDIT),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [SourceType](SourceType)
-        pub mod source_type {
-            use super::SourceType;
-
-            /// Source type is unspecified.
-            pub const SOURCE_TYPE_UNSPECIFIED: SourceType =
-                SourceType::new("SOURCE_TYPE_UNSPECIFIED");
-
-            /// Answer was system-generated; created during an Insights analysis.
-            pub const SYSTEM_GENERATED: SourceType = SourceType::new("SYSTEM_GENERATED");
-
-            /// Answer was created by a human via manual edit.
-            pub const MANUAL_EDIT: SourceType = SourceType::new("MANUAL_EDIT");
-        }
-
-        impl std::convert::From<std::string::String> for SourceType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for SourceType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for SourceType {
             fn default() -> Self {
-                source_type::SOURCE_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -15937,45 +16307,65 @@ pub mod qa_scorecard_result {
 
         /// What created the score.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SourceType(std::borrow::Cow<'static, str>);
+        pub struct SourceType(i32);
 
         impl SourceType {
-            /// Creates a new SourceType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [SourceType](SourceType)
-        pub mod source_type {
-            use super::SourceType;
-
             /// Source type is unspecified.
-            pub const SOURCE_TYPE_UNSPECIFIED: SourceType =
-                SourceType::new("SOURCE_TYPE_UNSPECIFIED");
+            pub const SOURCE_TYPE_UNSPECIFIED: SourceType = SourceType::new(0);
 
             /// Score is derived only from system-generated answers.
-            pub const SYSTEM_GENERATED_ONLY: SourceType = SourceType::new("SYSTEM_GENERATED_ONLY");
+            pub const SYSTEM_GENERATED_ONLY: SourceType = SourceType::new(1);
 
             /// Score is derived from both system-generated answers, and includes
             /// any manual edits if they exist.
-            pub const INCLUDES_MANUAL_EDITS: SourceType = SourceType::new("INCLUDES_MANUAL_EDITS");
+            pub const INCLUDES_MANUAL_EDITS: SourceType = SourceType::new(2);
+
+            /// Creates a new SourceType instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("SOURCE_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("SYSTEM_GENERATED_ONLY"),
+                    2 => std::borrow::Cow::Borrowed("INCLUDES_MANUAL_EDITS"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "SOURCE_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::SOURCE_TYPE_UNSPECIFIED)
+                    }
+                    "SYSTEM_GENERATED_ONLY" => {
+                        std::option::Option::Some(Self::SYSTEM_GENERATED_ONLY)
+                    }
+                    "INCLUDES_MANUAL_EDITS" => {
+                        std::option::Option::Some(Self::INCLUDES_MANUAL_EDITS)
+                    }
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for SourceType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for SourceType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for SourceType {
             fn default() -> Self {
-                source_type::SOURCE_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -15983,47 +16373,63 @@ pub mod qa_scorecard_result {
 
 /// Represents the options for viewing a conversation.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ConversationView(std::borrow::Cow<'static, str>);
+pub struct ConversationView(i32);
 
 impl ConversationView {
-    /// Creates a new ConversationView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ConversationView](ConversationView)
-pub mod conversation_view {
-    use super::ConversationView;
-
     /// The conversation view is not specified.
     ///
     /// * Defaults to `FULL` in `GetConversationRequest`.
     /// * Defaults to `BASIC` in `ListConversationsRequest`.
-    pub const CONVERSATION_VIEW_UNSPECIFIED: ConversationView =
-        ConversationView::new("CONVERSATION_VIEW_UNSPECIFIED");
+    pub const CONVERSATION_VIEW_UNSPECIFIED: ConversationView = ConversationView::new(0);
 
     /// Populates all fields in the conversation.
-    pub const FULL: ConversationView = ConversationView::new("FULL");
+    pub const FULL: ConversationView = ConversationView::new(2);
 
     /// Populates all fields in the conversation except the transcript.
-    pub const BASIC: ConversationView = ConversationView::new("BASIC");
+    pub const BASIC: ConversationView = ConversationView::new(1);
+
+    /// Creates a new ConversationView instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("CONVERSATION_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("BASIC"),
+            2 => std::borrow::Cow::Borrowed("FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "CONVERSATION_VIEW_UNSPECIFIED" => {
+                std::option::Option::Some(Self::CONVERSATION_VIEW_UNSPECIFIED)
+            }
+            "FULL" => std::option::Option::Some(Self::FULL),
+            "BASIC" => std::option::Option::Some(Self::BASIC),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ConversationView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ConversationView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ConversationView {
     fn default() -> Self {
-        conversation_view::CONVERSATION_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -16031,55 +16437,84 @@ impl std::default::Default for ConversationView {
 /// These warnings are currentlyraised when trying to validate a dataset for
 /// tuning a scorecard.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DatasetValidationWarning(std::borrow::Cow<'static, str>);
+pub struct DatasetValidationWarning(i32);
 
 impl DatasetValidationWarning {
-    /// Creates a new DatasetValidationWarning instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [DatasetValidationWarning](DatasetValidationWarning)
-pub mod dataset_validation_warning {
-    use super::DatasetValidationWarning;
-
     /// Unspecified data validation warning.
     pub const DATASET_VALIDATION_WARNING_UNSPECIFIED: DatasetValidationWarning =
-        DatasetValidationWarning::new("DATASET_VALIDATION_WARNING_UNSPECIFIED");
+        DatasetValidationWarning::new(0);
 
     /// A non-trivial percentage of the feedback labels are invalid.
     pub const TOO_MANY_INVALID_FEEDBACK_LABELS: DatasetValidationWarning =
-        DatasetValidationWarning::new("TOO_MANY_INVALID_FEEDBACK_LABELS");
+        DatasetValidationWarning::new(1);
 
     /// The quantity of valid feedback labels provided is less than the
     /// recommended minimum.
     pub const INSUFFICIENT_FEEDBACK_LABELS: DatasetValidationWarning =
-        DatasetValidationWarning::new("INSUFFICIENT_FEEDBACK_LABELS");
+        DatasetValidationWarning::new(2);
 
     /// One or more of the answers have less than the recommended minimum of
     /// feedback labels.
     pub const INSUFFICIENT_FEEDBACK_LABELS_PER_ANSWER: DatasetValidationWarning =
-        DatasetValidationWarning::new("INSUFFICIENT_FEEDBACK_LABELS_PER_ANSWER");
+        DatasetValidationWarning::new(3);
 
     /// All the labels in the dataset come from a single answer choice.
     pub const ALL_FEEDBACK_LABELS_HAVE_THE_SAME_ANSWER: DatasetValidationWarning =
-        DatasetValidationWarning::new("ALL_FEEDBACK_LABELS_HAVE_THE_SAME_ANSWER");
+        DatasetValidationWarning::new(4);
+
+    /// Creates a new DatasetValidationWarning instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DATASET_VALIDATION_WARNING_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("TOO_MANY_INVALID_FEEDBACK_LABELS"),
+            2 => std::borrow::Cow::Borrowed("INSUFFICIENT_FEEDBACK_LABELS"),
+            3 => std::borrow::Cow::Borrowed("INSUFFICIENT_FEEDBACK_LABELS_PER_ANSWER"),
+            4 => std::borrow::Cow::Borrowed("ALL_FEEDBACK_LABELS_HAVE_THE_SAME_ANSWER"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DATASET_VALIDATION_WARNING_UNSPECIFIED" => {
+                std::option::Option::Some(Self::DATASET_VALIDATION_WARNING_UNSPECIFIED)
+            }
+            "TOO_MANY_INVALID_FEEDBACK_LABELS" => {
+                std::option::Option::Some(Self::TOO_MANY_INVALID_FEEDBACK_LABELS)
+            }
+            "INSUFFICIENT_FEEDBACK_LABELS" => {
+                std::option::Option::Some(Self::INSUFFICIENT_FEEDBACK_LABELS)
+            }
+            "INSUFFICIENT_FEEDBACK_LABELS_PER_ANSWER" => {
+                std::option::Option::Some(Self::INSUFFICIENT_FEEDBACK_LABELS_PER_ANSWER)
+            }
+            "ALL_FEEDBACK_LABELS_HAVE_THE_SAME_ANSWER" => {
+                std::option::Option::Some(Self::ALL_FEEDBACK_LABELS_HAVE_THE_SAME_ANSWER)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for DatasetValidationWarning {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DatasetValidationWarning {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DatasetValidationWarning {
     fn default() -> Self {
-        dataset_validation_warning::DATASET_VALIDATION_WARNING_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/contactcenterinsights/v1/src/transport.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::POST,
                 format!("/v1/{}/conversations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::POST,
                 format!("/v1/{}/conversations:upload", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -101,7 +101,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -130,7 +130,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -153,7 +153,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::GET,
                 format!("/v1/{}/conversations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -177,7 +177,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -200,7 +200,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::POST,
                 format!("/v1/{}/analyses", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -219,7 +219,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -238,7 +238,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/analyses", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -260,7 +260,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -282,7 +282,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::POST,
                 format!("/v1/{}/conversations:bulkAnalyze", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -302,7 +302,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::POST,
                 format!("/v1/{}/conversations:bulkDelete", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -322,7 +322,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::POST,
                 format!("/v1/{}/conversations:ingest", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -342,7 +342,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::POST,
                 format!("/v1/{}/insightsdata:export", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -362,7 +362,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::POST,
                 format!("/v1/{}/issueModels", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -390,7 +390,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -419,7 +419,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -441,7 +441,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::GET,
                 format!("/v1/{}/issueModels", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -460,7 +460,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -479,7 +479,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:deploy", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -496,7 +496,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:undeploy", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -513,7 +513,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:export", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -533,7 +533,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::POST,
                 format!("/v1/{}/issueModels:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -550,7 +550,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -569,7 +569,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/issues", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -597,7 +597,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -624,7 +624,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -646,7 +646,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::GET,
                 format!("/v1/{}:calculateIssueModelStats", req.issue_model),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -668,7 +668,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::POST,
                 format!("/v1/{}/phraseMatchers", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -687,7 +687,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -709,7 +709,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::GET,
                 format!("/v1/{}/phraseMatchers", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -731,7 +731,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -759,7 +759,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -791,7 +791,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::GET,
                 format!("/v1/{}/conversations:calculateStats", req.location),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -811,7 +811,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -839,7 +839,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -871,7 +871,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::POST,
                 format!("/v1/{}/analysisRules", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -890,7 +890,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -912,7 +912,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::GET,
                 format!("/v1/{}/analysisRules", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -942,7 +942,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -971,7 +971,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -990,7 +990,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1018,7 +1018,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1035,7 +1035,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/views", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1052,7 +1052,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1071,7 +1071,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/views", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1101,7 +1101,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1128,7 +1128,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1150,7 +1150,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::POST,
                 format!("/v1/{}:queryMetrics", req.location),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1170,7 +1170,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::POST,
                 format!("/v1/{}/qaQuestions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1190,7 +1190,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1218,7 +1218,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1247,7 +1247,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1269,7 +1269,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::GET,
                 format!("/v1/{}/qaQuestions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1293,7 +1293,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::POST,
                 format!("/v1/{}/qaScorecards", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1313,7 +1313,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1341,7 +1341,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1370,7 +1370,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1393,7 +1393,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::GET,
                 format!("/v1/{}/qaScorecards", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1417,7 +1417,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::POST,
                 format!("/v1/{}/revisions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1437,7 +1437,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1459,7 +1459,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::POST,
                 format!("/v1/{}:tuneQaScorecardRevision", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1476,7 +1476,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:deploy", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1493,7 +1493,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:undeploy", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1510,7 +1510,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1533,7 +1533,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::GET,
                 format!("/v1/{}/revisions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1558,7 +1558,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::POST,
                 format!("/v1/{}/feedbackLabels", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1581,7 +1581,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::GET,
                 format!("/v1/{}/feedbackLabels", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1603,7 +1603,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1631,7 +1631,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1660,7 +1660,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1682,7 +1682,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::GET,
                 format!("/v1/{}:listAllFeedbackLabels", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1707,7 +1707,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::POST,
                 format!("/v1/{}:bulkUploadFeedbackLabels", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1727,7 +1727,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
                 reqwest::Method::POST,
                 format!("/v1/{}:bulkDownloadFeedbackLabels", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1744,7 +1744,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1766,7 +1766,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1785,7 +1785,7 @@ impl crate::stubs::ContactCenterInsights for ContactCenterInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/datacatalog/lineage/v1/src/model.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/model.rs
@@ -216,50 +216,69 @@ pub mod run {
 
     /// The current state of the run.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The state is unknown. The true state may be any of the below or a
+        /// different state that is not supported here explicitly.
+        pub const UNKNOWN: State = State::new(0);
+
+        /// The run is still executing.
+        pub const STARTED: State = State::new(1);
+
+        /// The run completed.
+        pub const COMPLETED: State = State::new(2);
+
+        /// The run failed.
+        pub const FAILED: State = State::new(3);
+
+        /// The run aborted.
+        pub const ABORTED: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("STARTED"),
+                2 => std::borrow::Cow::Borrowed("COMPLETED"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                4 => std::borrow::Cow::Borrowed("ABORTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                "STARTED" => std::option::Option::Some(Self::STARTED),
+                "COMPLETED" => std::option::Option::Some(Self::COMPLETED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "ABORTED" => std::option::Option::Some(Self::ABORTED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The state is unknown. The true state may be any of the below or a
-        /// different state that is not supported here explicitly.
-        pub const UNKNOWN: State = State::new("UNKNOWN");
-
-        /// The run is still executing.
-        pub const STARTED: State = State::new("STARTED");
-
-        /// The run completed.
-        pub const COMPLETED: State = State::new("COMPLETED");
-
-        /// The run failed.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// The run aborted.
-        pub const ABORTED: State = State::new("ABORTED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::UNKNOWN
+            Self::new(0)
         }
     }
 }
@@ -522,91 +541,125 @@ pub mod operation_metadata {
 
     /// An enum with the state of the operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unused.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The operation has been created but is not yet started.
+        pub const PENDING: State = State::new(1);
+
+        /// The operation is underway.
+        pub const RUNNING: State = State::new(2);
+
+        /// The operation completed successfully.
+        pub const SUCCEEDED: State = State::new(3);
+
+        /// The operation is no longer running and did not succeed.
+        pub const FAILED: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unused.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The operation has been created but is not yet started.
-        pub const PENDING: State = State::new("PENDING");
-
-        /// The operation is underway.
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// The operation completed successfully.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-        /// The operation is no longer running and did not succeed.
-        pub const FAILED: State = State::new("FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Type of the long running operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Unused.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// The resource deletion operation.
+        pub const DELETE: Type = Type::new(1);
+
+        /// The resource creation operation.
+        pub const CREATE: Type = Type::new(2);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DELETE"),
+                2 => std::borrow::Cow::Borrowed("CREATE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "DELETE" => std::option::Option::Some(Self::DELETE),
+                "CREATE" => std::option::Option::Some(Self::CREATE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Unused.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// The resource deletion operation.
-        pub const DELETE: Type = Type::new("DELETE");
-
-        /// The resource creation operation.
-        pub const CREATE: Type = Type::new("CREATE");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2176,55 +2229,80 @@ pub mod origin {
 
     /// Type of the source of a process.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SourceType(std::borrow::Cow<'static, str>);
+    pub struct SourceType(i32);
 
     impl SourceType {
+        /// Source is Unspecified
+        pub const SOURCE_TYPE_UNSPECIFIED: SourceType = SourceType::new(0);
+
+        /// A custom source
+        pub const CUSTOM: SourceType = SourceType::new(1);
+
+        /// BigQuery
+        pub const BIGQUERY: SourceType = SourceType::new(2);
+
+        /// Data Fusion
+        pub const DATA_FUSION: SourceType = SourceType::new(3);
+
+        /// Composer
+        pub const COMPOSER: SourceType = SourceType::new(4);
+
+        /// Looker Studio
+        pub const LOOKER_STUDIO: SourceType = SourceType::new(5);
+
+        /// Dataproc
+        pub const DATAPROC: SourceType = SourceType::new(6);
+
         /// Creates a new SourceType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SOURCE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CUSTOM"),
+                2 => std::borrow::Cow::Borrowed("BIGQUERY"),
+                3 => std::borrow::Cow::Borrowed("DATA_FUSION"),
+                4 => std::borrow::Cow::Borrowed("COMPOSER"),
+                5 => std::borrow::Cow::Borrowed("LOOKER_STUDIO"),
+                6 => std::borrow::Cow::Borrowed("DATAPROC"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SOURCE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SOURCE_TYPE_UNSPECIFIED)
+                }
+                "CUSTOM" => std::option::Option::Some(Self::CUSTOM),
+                "BIGQUERY" => std::option::Option::Some(Self::BIGQUERY),
+                "DATA_FUSION" => std::option::Option::Some(Self::DATA_FUSION),
+                "COMPOSER" => std::option::Option::Some(Self::COMPOSER),
+                "LOOKER_STUDIO" => std::option::Option::Some(Self::LOOKER_STUDIO),
+                "DATAPROC" => std::option::Option::Some(Self::DATAPROC),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SourceType](SourceType)
-    pub mod source_type {
-        use super::SourceType;
-
-        /// Source is Unspecified
-        pub const SOURCE_TYPE_UNSPECIFIED: SourceType = SourceType::new("SOURCE_TYPE_UNSPECIFIED");
-
-        /// A custom source
-        pub const CUSTOM: SourceType = SourceType::new("CUSTOM");
-
-        /// BigQuery
-        pub const BIGQUERY: SourceType = SourceType::new("BIGQUERY");
-
-        /// Data Fusion
-        pub const DATA_FUSION: SourceType = SourceType::new("DATA_FUSION");
-
-        /// Composer
-        pub const COMPOSER: SourceType = SourceType::new("COMPOSER");
-
-        /// Looker Studio
-        pub const LOOKER_STUDIO: SourceType = SourceType::new("LOOKER_STUDIO");
-
-        /// Dataproc
-        pub const DATAPROC: SourceType = SourceType::new("DATAPROC");
-    }
-
-    impl std::convert::From<std::string::String> for SourceType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SourceType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SourceType {
         fn default() -> Self {
-            source_type::SOURCE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/datacatalog/lineage/v1/src/transport.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::Lineage for Lineage {
                 reqwest::Method::POST,
                 format!("/v1/{}:processOpenLineageRunEvent", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::Lineage for Lineage {
                 reqwest::Method::POST,
                 format!("/v1/{}/processes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -104,7 +104,7 @@ impl crate::stubs::Lineage for Lineage {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -134,7 +134,7 @@ impl crate::stubs::Lineage for Lineage {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -156,7 +156,7 @@ impl crate::stubs::Lineage for Lineage {
                 reqwest::Method::GET,
                 format!("/v1/{}/processes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -177,7 +177,7 @@ impl crate::stubs::Lineage for Lineage {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -197,7 +197,7 @@ impl crate::stubs::Lineage for Lineage {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/runs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -224,7 +224,7 @@ impl crate::stubs::Lineage for Lineage {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -252,7 +252,7 @@ impl crate::stubs::Lineage for Lineage {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -271,7 +271,7 @@ impl crate::stubs::Lineage for Lineage {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/runs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -292,7 +292,7 @@ impl crate::stubs::Lineage for Lineage {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -315,7 +315,7 @@ impl crate::stubs::Lineage for Lineage {
                 reqwest::Method::POST,
                 format!("/v1/{}/lineageEvents", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -335,7 +335,7 @@ impl crate::stubs::Lineage for Lineage {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -357,7 +357,7 @@ impl crate::stubs::Lineage for Lineage {
                 reqwest::Method::GET,
                 format!("/v1/{}/lineageEvents", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -378,7 +378,7 @@ impl crate::stubs::Lineage for Lineage {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -401,7 +401,7 @@ impl crate::stubs::Lineage for Lineage {
                 reqwest::Method::POST,
                 format!("/v1/{}:searchLinks", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -421,7 +421,7 @@ impl crate::stubs::Lineage for Lineage {
                 reqwest::Method::POST,
                 format!("/v1/{}:batchSearchLinkProcesses", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -438,7 +438,7 @@ impl crate::stubs::Lineage for Lineage {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -460,7 +460,7 @@ impl crate::stubs::Lineage for Lineage {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -479,7 +479,7 @@ impl crate::stubs::Lineage for Lineage {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -498,7 +498,7 @@ impl crate::stubs::Lineage for Lineage {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/datacatalog/v1/src/model.rs
+++ b/src/generated/cloud/datacatalog/v1/src/model.rs
@@ -132,41 +132,55 @@ pub mod big_query_connection_spec {
 
     /// The type of the BigQuery connection.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConnectionType(std::borrow::Cow<'static, str>);
+    pub struct ConnectionType(i32);
 
     impl ConnectionType {
+        /// Unspecified type.
+        pub const CONNECTION_TYPE_UNSPECIFIED: ConnectionType = ConnectionType::new(0);
+
+        /// Cloud SQL connection.
+        pub const CLOUD_SQL: ConnectionType = ConnectionType::new(1);
+
         /// Creates a new ConnectionType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CONNECTION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CLOUD_SQL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CONNECTION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CONNECTION_TYPE_UNSPECIFIED)
+                }
+                "CLOUD_SQL" => std::option::Option::Some(Self::CLOUD_SQL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ConnectionType](ConnectionType)
-    pub mod connection_type {
-        use super::ConnectionType;
-
-        /// Unspecified type.
-        pub const CONNECTION_TYPE_UNSPECIFIED: ConnectionType =
-            ConnectionType::new("CONNECTION_TYPE_UNSPECIFIED");
-
-        /// Cloud SQL connection.
-        pub const CLOUD_SQL: ConnectionType = ConnectionType::new("CLOUD_SQL");
-    }
-
-    impl std::convert::From<std::string::String> for ConnectionType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ConnectionType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ConnectionType {
         fn default() -> Self {
-            connection_type::CONNECTION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -240,44 +254,60 @@ pub mod cloud_sql_big_query_connection_spec {
 
     /// Supported Cloud SQL database types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DatabaseType(std::borrow::Cow<'static, str>);
+    pub struct DatabaseType(i32);
 
     impl DatabaseType {
+        /// Unspecified database type.
+        pub const DATABASE_TYPE_UNSPECIFIED: DatabaseType = DatabaseType::new(0);
+
+        /// Cloud SQL for PostgreSQL.
+        pub const POSTGRES: DatabaseType = DatabaseType::new(1);
+
+        /// Cloud SQL for MySQL.
+        pub const MYSQL: DatabaseType = DatabaseType::new(2);
+
         /// Creates a new DatabaseType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATABASE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("POSTGRES"),
+                2 => std::borrow::Cow::Borrowed("MYSQL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATABASE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DATABASE_TYPE_UNSPECIFIED)
+                }
+                "POSTGRES" => std::option::Option::Some(Self::POSTGRES),
+                "MYSQL" => std::option::Option::Some(Self::MYSQL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DatabaseType](DatabaseType)
-    pub mod database_type {
-        use super::DatabaseType;
-
-        /// Unspecified database type.
-        pub const DATABASE_TYPE_UNSPECIFIED: DatabaseType =
-            DatabaseType::new("DATABASE_TYPE_UNSPECIFIED");
-
-        /// Cloud SQL for PostgreSQL.
-        pub const POSTGRES: DatabaseType = DatabaseType::new("POSTGRES");
-
-        /// Cloud SQL for MySQL.
-        pub const MYSQL: DatabaseType = DatabaseType::new("MYSQL");
-    }
-
-    impl std::convert::From<std::string::String> for DatabaseType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DatabaseType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DatabaseType {
         fn default() -> Self {
-            database_type::DATABASE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -463,43 +493,58 @@ pub mod data_source {
 
     /// Name of a service that stores the data.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Service(std::borrow::Cow<'static, str>);
+    pub struct Service(i32);
 
     impl Service {
+        /// Default unknown service.
+        pub const SERVICE_UNSPECIFIED: Service = Service::new(0);
+
+        /// Google Cloud Storage service.
+        pub const CLOUD_STORAGE: Service = Service::new(1);
+
+        /// BigQuery service.
+        pub const BIGQUERY: Service = Service::new(2);
+
         /// Creates a new Service instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SERVICE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CLOUD_STORAGE"),
+                2 => std::borrow::Cow::Borrowed("BIGQUERY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SERVICE_UNSPECIFIED" => std::option::Option::Some(Self::SERVICE_UNSPECIFIED),
+                "CLOUD_STORAGE" => std::option::Option::Some(Self::CLOUD_STORAGE),
+                "BIGQUERY" => std::option::Option::Some(Self::BIGQUERY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Service](Service)
-    pub mod service {
-        use super::Service;
-
-        /// Default unknown service.
-        pub const SERVICE_UNSPECIFIED: Service = Service::new("SERVICE_UNSPECIFIED");
-
-        /// Google Cloud Storage service.
-        pub const CLOUD_STORAGE: Service = Service::new("CLOUD_STORAGE");
-
-        /// BigQuery service.
-        pub const BIGQUERY: Service = Service::new("BIGQUERY");
-    }
-
-    impl std::convert::From<std::string::String> for Service {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Service {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Service {
         fn default() -> Self {
-            service::SERVICE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -2747,43 +2792,60 @@ pub mod database_table_spec {
 
         /// Concrete type of the view.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ViewType(std::borrow::Cow<'static, str>);
+        pub struct ViewType(i32);
 
         impl ViewType {
+            /// Default unknown view type.
+            pub const VIEW_TYPE_UNSPECIFIED: ViewType = ViewType::new(0);
+
+            /// Standard view.
+            pub const STANDARD_VIEW: ViewType = ViewType::new(1);
+
+            /// Materialized view.
+            pub const MATERIALIZED_VIEW: ViewType = ViewType::new(2);
+
             /// Creates a new ViewType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("VIEW_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("STANDARD_VIEW"),
+                    2 => std::borrow::Cow::Borrowed("MATERIALIZED_VIEW"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "VIEW_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::VIEW_TYPE_UNSPECIFIED)
+                    }
+                    "STANDARD_VIEW" => std::option::Option::Some(Self::STANDARD_VIEW),
+                    "MATERIALIZED_VIEW" => std::option::Option::Some(Self::MATERIALIZED_VIEW),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [ViewType](ViewType)
-        pub mod view_type {
-            use super::ViewType;
-
-            /// Default unknown view type.
-            pub const VIEW_TYPE_UNSPECIFIED: ViewType = ViewType::new("VIEW_TYPE_UNSPECIFIED");
-
-            /// Standard view.
-            pub const STANDARD_VIEW: ViewType = ViewType::new("STANDARD_VIEW");
-
-            /// Materialized view.
-            pub const MATERIALIZED_VIEW: ViewType = ViewType::new("MATERIALIZED_VIEW");
-        }
-
-        impl std::convert::From<std::string::String> for ViewType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for ViewType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for ViewType {
             fn default() -> Self {
-                view_type::VIEW_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -2801,43 +2863,58 @@ pub mod database_table_spec {
 
     /// Type of the table.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TableType(std::borrow::Cow<'static, str>);
+    pub struct TableType(i32);
 
     impl TableType {
+        /// Default unknown table type.
+        pub const TABLE_TYPE_UNSPECIFIED: TableType = TableType::new(0);
+
+        /// Native table.
+        pub const NATIVE: TableType = TableType::new(1);
+
+        /// External table.
+        pub const EXTERNAL: TableType = TableType::new(2);
+
         /// Creates a new TableType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TABLE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NATIVE"),
+                2 => std::borrow::Cow::Borrowed("EXTERNAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TABLE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TABLE_TYPE_UNSPECIFIED),
+                "NATIVE" => std::option::Option::Some(Self::NATIVE),
+                "EXTERNAL" => std::option::Option::Some(Self::EXTERNAL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [TableType](TableType)
-    pub mod table_type {
-        use super::TableType;
-
-        /// Default unknown table type.
-        pub const TABLE_TYPE_UNSPECIFIED: TableType = TableType::new("TABLE_TYPE_UNSPECIFIED");
-
-        /// Native table.
-        pub const NATIVE: TableType = TableType::new("NATIVE");
-
-        /// External table.
-        pub const EXTERNAL: TableType = TableType::new("EXTERNAL");
-    }
-
-    impl std::convert::From<std::string::String> for TableType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TableType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TableType {
         fn default() -> Self {
-            table_type::TABLE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3110,90 +3187,123 @@ pub mod routine_spec {
 
         /// The input or output mode of the argument.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Mode(std::borrow::Cow<'static, str>);
+        pub struct Mode(i32);
 
         impl Mode {
+            /// Unspecified mode.
+            pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
+
+            /// The argument is input-only.
+            pub const IN: Mode = Mode::new(1);
+
+            /// The argument is output-only.
+            pub const OUT: Mode = Mode::new(2);
+
+            /// The argument is both an input and an output.
+            pub const INOUT: Mode = Mode::new(3);
+
             /// Creates a new Mode instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("IN"),
+                    2 => std::borrow::Cow::Borrowed("OUT"),
+                    3 => std::borrow::Cow::Borrowed("INOUT"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
+                    "IN" => std::option::Option::Some(Self::IN),
+                    "OUT" => std::option::Option::Some(Self::OUT),
+                    "INOUT" => std::option::Option::Some(Self::INOUT),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Mode](Mode)
-        pub mod mode {
-            use super::Mode;
-
-            /// Unspecified mode.
-            pub const MODE_UNSPECIFIED: Mode = Mode::new("MODE_UNSPECIFIED");
-
-            /// The argument is input-only.
-            pub const IN: Mode = Mode::new("IN");
-
-            /// The argument is output-only.
-            pub const OUT: Mode = Mode::new("OUT");
-
-            /// The argument is both an input and an output.
-            pub const INOUT: Mode = Mode::new("INOUT");
-        }
-
-        impl std::convert::From<std::string::String> for Mode {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Mode {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Mode {
             fn default() -> Self {
-                mode::MODE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// The fine-grained type of the routine.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RoutineType(std::borrow::Cow<'static, str>);
+    pub struct RoutineType(i32);
 
     impl RoutineType {
+        /// Unspecified type.
+        pub const ROUTINE_TYPE_UNSPECIFIED: RoutineType = RoutineType::new(0);
+
+        /// Non-builtin permanent scalar function.
+        pub const SCALAR_FUNCTION: RoutineType = RoutineType::new(1);
+
+        /// Stored procedure.
+        pub const PROCEDURE: RoutineType = RoutineType::new(2);
+
         /// Creates a new RoutineType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ROUTINE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SCALAR_FUNCTION"),
+                2 => std::borrow::Cow::Borrowed("PROCEDURE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ROUTINE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ROUTINE_TYPE_UNSPECIFIED)
+                }
+                "SCALAR_FUNCTION" => std::option::Option::Some(Self::SCALAR_FUNCTION),
+                "PROCEDURE" => std::option::Option::Some(Self::PROCEDURE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RoutineType](RoutineType)
-    pub mod routine_type {
-        use super::RoutineType;
-
-        /// Unspecified type.
-        pub const ROUTINE_TYPE_UNSPECIFIED: RoutineType =
-            RoutineType::new("ROUTINE_TYPE_UNSPECIFIED");
-
-        /// Non-builtin permanent scalar function.
-        pub const SCALAR_FUNCTION: RoutineType = RoutineType::new("SCALAR_FUNCTION");
-
-        /// Stored procedure.
-        pub const PROCEDURE: RoutineType = RoutineType::new("PROCEDURE");
-    }
-
-    impl std::convert::From<std::string::String> for RoutineType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RoutineType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RoutineType {
         fn default() -> Self {
-            routine_type::ROUTINE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -3732,60 +3842,85 @@ pub mod vertex_model_source_info {
 
     /// Source of the model.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ModelSourceType(std::borrow::Cow<'static, str>);
+    pub struct ModelSourceType(i32);
 
     impl ModelSourceType {
+        /// Should not be used.
+        pub const MODEL_SOURCE_TYPE_UNSPECIFIED: ModelSourceType = ModelSourceType::new(0);
+
+        /// The Model is uploaded by automl training pipeline.
+        pub const AUTOML: ModelSourceType = ModelSourceType::new(1);
+
+        /// The Model is uploaded by user or custom training pipeline.
+        pub const CUSTOM: ModelSourceType = ModelSourceType::new(2);
+
+        /// The Model is registered and sync'ed from BigQuery ML.
+        pub const BQML: ModelSourceType = ModelSourceType::new(3);
+
+        /// The Model is saved or tuned from Model Garden.
+        pub const MODEL_GARDEN: ModelSourceType = ModelSourceType::new(4);
+
+        /// The Model is saved or tuned from Genie.
+        pub const GENIE: ModelSourceType = ModelSourceType::new(5);
+
+        /// The Model is uploaded by text embedding finetuning pipeline.
+        pub const CUSTOM_TEXT_EMBEDDING: ModelSourceType = ModelSourceType::new(6);
+
+        /// The Model is saved or tuned from Marketplace.
+        pub const MARKETPLACE: ModelSourceType = ModelSourceType::new(7);
+
         /// Creates a new ModelSourceType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MODEL_SOURCE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AUTOML"),
+                2 => std::borrow::Cow::Borrowed("CUSTOM"),
+                3 => std::borrow::Cow::Borrowed("BQML"),
+                4 => std::borrow::Cow::Borrowed("MODEL_GARDEN"),
+                5 => std::borrow::Cow::Borrowed("GENIE"),
+                6 => std::borrow::Cow::Borrowed("CUSTOM_TEXT_EMBEDDING"),
+                7 => std::borrow::Cow::Borrowed("MARKETPLACE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MODEL_SOURCE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MODEL_SOURCE_TYPE_UNSPECIFIED)
+                }
+                "AUTOML" => std::option::Option::Some(Self::AUTOML),
+                "CUSTOM" => std::option::Option::Some(Self::CUSTOM),
+                "BQML" => std::option::Option::Some(Self::BQML),
+                "MODEL_GARDEN" => std::option::Option::Some(Self::MODEL_GARDEN),
+                "GENIE" => std::option::Option::Some(Self::GENIE),
+                "CUSTOM_TEXT_EMBEDDING" => std::option::Option::Some(Self::CUSTOM_TEXT_EMBEDDING),
+                "MARKETPLACE" => std::option::Option::Some(Self::MARKETPLACE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ModelSourceType](ModelSourceType)
-    pub mod model_source_type {
-        use super::ModelSourceType;
-
-        /// Should not be used.
-        pub const MODEL_SOURCE_TYPE_UNSPECIFIED: ModelSourceType =
-            ModelSourceType::new("MODEL_SOURCE_TYPE_UNSPECIFIED");
-
-        /// The Model is uploaded by automl training pipeline.
-        pub const AUTOML: ModelSourceType = ModelSourceType::new("AUTOML");
-
-        /// The Model is uploaded by user or custom training pipeline.
-        pub const CUSTOM: ModelSourceType = ModelSourceType::new("CUSTOM");
-
-        /// The Model is registered and sync'ed from BigQuery ML.
-        pub const BQML: ModelSourceType = ModelSourceType::new("BQML");
-
-        /// The Model is saved or tuned from Model Garden.
-        pub const MODEL_GARDEN: ModelSourceType = ModelSourceType::new("MODEL_GARDEN");
-
-        /// The Model is saved or tuned from Genie.
-        pub const GENIE: ModelSourceType = ModelSourceType::new("GENIE");
-
-        /// The Model is uploaded by text embedding finetuning pipeline.
-        pub const CUSTOM_TEXT_EMBEDDING: ModelSourceType =
-            ModelSourceType::new("CUSTOM_TEXT_EMBEDDING");
-
-        /// The Model is saved or tuned from Marketplace.
-        pub const MARKETPLACE: ModelSourceType = ModelSourceType::new("MARKETPLACE");
-    }
-
-    impl std::convert::From<std::string::String> for ModelSourceType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ModelSourceType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ModelSourceType {
         fn default() -> Self {
-            model_source_type::MODEL_SOURCE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3926,78 +4061,114 @@ pub mod vertex_dataset_spec {
 
     /// Type of data stored in the dataset.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataType(std::borrow::Cow<'static, str>);
+    pub struct DataType(i32);
 
     impl DataType {
-        /// Creates a new DataType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DataType](DataType)
-    pub mod data_type {
-        use super::DataType;
-
         /// Should not be used.
-        pub const DATA_TYPE_UNSPECIFIED: DataType = DataType::new("DATA_TYPE_UNSPECIFIED");
+        pub const DATA_TYPE_UNSPECIFIED: DataType = DataType::new(0);
 
         /// Structured data dataset.
-        pub const TABLE: DataType = DataType::new("TABLE");
+        pub const TABLE: DataType = DataType::new(1);
 
         /// Image dataset which supports ImageClassification, ImageObjectDetection
         /// and ImageSegmentation problems.
-        pub const IMAGE: DataType = DataType::new("IMAGE");
+        pub const IMAGE: DataType = DataType::new(2);
 
         /// Document dataset which supports TextClassification, TextExtraction and
         /// TextSentiment problems.
-        pub const TEXT: DataType = DataType::new("TEXT");
+        pub const TEXT: DataType = DataType::new(3);
 
         /// Video dataset which supports VideoClassification, VideoObjectTracking and
         /// VideoActionRecognition problems.
-        pub const VIDEO: DataType = DataType::new("VIDEO");
+        pub const VIDEO: DataType = DataType::new(4);
 
         /// Conversation dataset which supports conversation problems.
-        pub const CONVERSATION: DataType = DataType::new("CONVERSATION");
+        pub const CONVERSATION: DataType = DataType::new(5);
 
         /// TimeSeries dataset.
-        pub const TIME_SERIES: DataType = DataType::new("TIME_SERIES");
+        pub const TIME_SERIES: DataType = DataType::new(6);
 
         /// Document dataset which supports DocumentAnnotation problems.
-        pub const DOCUMENT: DataType = DataType::new("DOCUMENT");
+        pub const DOCUMENT: DataType = DataType::new(7);
 
         /// TextToSpeech dataset which supports TextToSpeech problems.
-        pub const TEXT_TO_SPEECH: DataType = DataType::new("TEXT_TO_SPEECH");
+        pub const TEXT_TO_SPEECH: DataType = DataType::new(8);
 
         /// Translation dataset which supports Translation problems.
-        pub const TRANSLATION: DataType = DataType::new("TRANSLATION");
+        pub const TRANSLATION: DataType = DataType::new(9);
 
         /// Store Vision dataset which is used for HITL integration.
-        pub const STORE_VISION: DataType = DataType::new("STORE_VISION");
+        pub const STORE_VISION: DataType = DataType::new(10);
 
         /// Enterprise Knowledge Graph dataset which is used for HITL labeling
         /// integration.
-        pub const ENTERPRISE_KNOWLEDGE_GRAPH: DataType =
-            DataType::new("ENTERPRISE_KNOWLEDGE_GRAPH");
+        pub const ENTERPRISE_KNOWLEDGE_GRAPH: DataType = DataType::new(11);
 
         /// Text prompt dataset which supports Large Language Models.
-        pub const TEXT_PROMPT: DataType = DataType::new("TEXT_PROMPT");
+        pub const TEXT_PROMPT: DataType = DataType::new(12);
+
+        /// Creates a new DataType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATA_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TABLE"),
+                2 => std::borrow::Cow::Borrowed("IMAGE"),
+                3 => std::borrow::Cow::Borrowed("TEXT"),
+                4 => std::borrow::Cow::Borrowed("VIDEO"),
+                5 => std::borrow::Cow::Borrowed("CONVERSATION"),
+                6 => std::borrow::Cow::Borrowed("TIME_SERIES"),
+                7 => std::borrow::Cow::Borrowed("DOCUMENT"),
+                8 => std::borrow::Cow::Borrowed("TEXT_TO_SPEECH"),
+                9 => std::borrow::Cow::Borrowed("TRANSLATION"),
+                10 => std::borrow::Cow::Borrowed("STORE_VISION"),
+                11 => std::borrow::Cow::Borrowed("ENTERPRISE_KNOWLEDGE_GRAPH"),
+                12 => std::borrow::Cow::Borrowed("TEXT_PROMPT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATA_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::DATA_TYPE_UNSPECIFIED),
+                "TABLE" => std::option::Option::Some(Self::TABLE),
+                "IMAGE" => std::option::Option::Some(Self::IMAGE),
+                "TEXT" => std::option::Option::Some(Self::TEXT),
+                "VIDEO" => std::option::Option::Some(Self::VIDEO),
+                "CONVERSATION" => std::option::Option::Some(Self::CONVERSATION),
+                "TIME_SERIES" => std::option::Option::Some(Self::TIME_SERIES),
+                "DOCUMENT" => std::option::Option::Some(Self::DOCUMENT),
+                "TEXT_TO_SPEECH" => std::option::Option::Some(Self::TEXT_TO_SPEECH),
+                "TRANSLATION" => std::option::Option::Some(Self::TRANSLATION),
+                "STORE_VISION" => std::option::Option::Some(Self::STORE_VISION),
+                "ENTERPRISE_KNOWLEDGE_GRAPH" => {
+                    std::option::Option::Some(Self::ENTERPRISE_KNOWLEDGE_GRAPH)
+                }
+                "TEXT_PROMPT" => std::option::Option::Some(Self::TEXT_PROMPT),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DataType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DataType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DataType {
         fn default() -> Self {
-            data_type::DATA_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4125,44 +4296,60 @@ pub mod feature_online_store_spec {
 
     /// Type of underlaying storage type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StorageType(std::borrow::Cow<'static, str>);
+    pub struct StorageType(i32);
 
     impl StorageType {
+        /// Should not be used.
+        pub const STORAGE_TYPE_UNSPECIFIED: StorageType = StorageType::new(0);
+
+        /// Underlsying storgae is Bigtable.
+        pub const BIGTABLE: StorageType = StorageType::new(1);
+
+        /// Underlaying is optimized online server (Lightning).
+        pub const OPTIMIZED: StorageType = StorageType::new(2);
+
         /// Creates a new StorageType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STORAGE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BIGTABLE"),
+                2 => std::borrow::Cow::Borrowed("OPTIMIZED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STORAGE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::STORAGE_TYPE_UNSPECIFIED)
+                }
+                "BIGTABLE" => std::option::Option::Some(Self::BIGTABLE),
+                "OPTIMIZED" => std::option::Option::Some(Self::OPTIMIZED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [StorageType](StorageType)
-    pub mod storage_type {
-        use super::StorageType;
-
-        /// Should not be used.
-        pub const STORAGE_TYPE_UNSPECIFIED: StorageType =
-            StorageType::new("STORAGE_TYPE_UNSPECIFIED");
-
-        /// Underlsying storgae is Bigtable.
-        pub const BIGTABLE: StorageType = StorageType::new("BIGTABLE");
-
-        /// Underlaying is optimized online server (Lightning).
-        pub const OPTIMIZED: StorageType = StorageType::new("OPTIMIZED");
-    }
-
-    impl std::convert::From<std::string::String> for StorageType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for StorageType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for StorageType {
         fn default() -> Self {
-            storage_type::STORAGE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5339,50 +5526,68 @@ pub mod reconcile_tags_metadata {
 
     /// Enum holding possible states of the reconciliation operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ReconciliationState(std::borrow::Cow<'static, str>);
+    pub struct ReconciliationState(i32);
 
     impl ReconciliationState {
+        /// Default value. This value is unused.
+        pub const RECONCILIATION_STATE_UNSPECIFIED: ReconciliationState =
+            ReconciliationState::new(0);
+
+        /// The reconciliation has been queued and awaits for execution.
+        pub const RECONCILIATION_QUEUED: ReconciliationState = ReconciliationState::new(1);
+
+        /// The reconciliation is in progress.
+        pub const RECONCILIATION_IN_PROGRESS: ReconciliationState = ReconciliationState::new(2);
+
+        /// The reconciliation has been finished.
+        pub const RECONCILIATION_DONE: ReconciliationState = ReconciliationState::new(3);
+
         /// Creates a new ReconciliationState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RECONCILIATION_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RECONCILIATION_QUEUED"),
+                2 => std::borrow::Cow::Borrowed("RECONCILIATION_IN_PROGRESS"),
+                3 => std::borrow::Cow::Borrowed("RECONCILIATION_DONE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RECONCILIATION_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RECONCILIATION_STATE_UNSPECIFIED)
+                }
+                "RECONCILIATION_QUEUED" => std::option::Option::Some(Self::RECONCILIATION_QUEUED),
+                "RECONCILIATION_IN_PROGRESS" => {
+                    std::option::Option::Some(Self::RECONCILIATION_IN_PROGRESS)
+                }
+                "RECONCILIATION_DONE" => std::option::Option::Some(Self::RECONCILIATION_DONE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ReconciliationState](ReconciliationState)
-    pub mod reconciliation_state {
-        use super::ReconciliationState;
-
-        /// Default value. This value is unused.
-        pub const RECONCILIATION_STATE_UNSPECIFIED: ReconciliationState =
-            ReconciliationState::new("RECONCILIATION_STATE_UNSPECIFIED");
-
-        /// The reconciliation has been queued and awaits for execution.
-        pub const RECONCILIATION_QUEUED: ReconciliationState =
-            ReconciliationState::new("RECONCILIATION_QUEUED");
-
-        /// The reconciliation is in progress.
-        pub const RECONCILIATION_IN_PROGRESS: ReconciliationState =
-            ReconciliationState::new("RECONCILIATION_IN_PROGRESS");
-
-        /// The reconciliation has been finished.
-        pub const RECONCILIATION_DONE: ReconciliationState =
-            ReconciliationState::new("RECONCILIATION_DONE");
-    }
-
-    impl std::convert::From<std::string::String> for ReconciliationState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ReconciliationState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ReconciliationState {
         fn default() -> Self {
-            reconciliation_state::RECONCILIATION_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5843,50 +6048,70 @@ pub mod import_entries_metadata {
 
     /// Enum holding possible states of the import operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ImportState(std::borrow::Cow<'static, str>);
+    pub struct ImportState(i32);
 
     impl ImportState {
+        /// Default value. This value is unused.
+        pub const IMPORT_STATE_UNSPECIFIED: ImportState = ImportState::new(0);
+
+        /// The dump with entries has been queued for import.
+        pub const IMPORT_QUEUED: ImportState = ImportState::new(1);
+
+        /// The import of entries is in progress.
+        pub const IMPORT_IN_PROGRESS: ImportState = ImportState::new(2);
+
+        /// The import of entries has been finished.
+        pub const IMPORT_DONE: ImportState = ImportState::new(3);
+
+        /// The import of entries has been abandoned in favor of a newer request.
+        pub const IMPORT_OBSOLETE: ImportState = ImportState::new(4);
+
         /// Creates a new ImportState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("IMPORT_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IMPORT_QUEUED"),
+                2 => std::borrow::Cow::Borrowed("IMPORT_IN_PROGRESS"),
+                3 => std::borrow::Cow::Borrowed("IMPORT_DONE"),
+                4 => std::borrow::Cow::Borrowed("IMPORT_OBSOLETE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "IMPORT_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::IMPORT_STATE_UNSPECIFIED)
+                }
+                "IMPORT_QUEUED" => std::option::Option::Some(Self::IMPORT_QUEUED),
+                "IMPORT_IN_PROGRESS" => std::option::Option::Some(Self::IMPORT_IN_PROGRESS),
+                "IMPORT_DONE" => std::option::Option::Some(Self::IMPORT_DONE),
+                "IMPORT_OBSOLETE" => std::option::Option::Some(Self::IMPORT_OBSOLETE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ImportState](ImportState)
-    pub mod import_state {
-        use super::ImportState;
-
-        /// Default value. This value is unused.
-        pub const IMPORT_STATE_UNSPECIFIED: ImportState =
-            ImportState::new("IMPORT_STATE_UNSPECIFIED");
-
-        /// The dump with entries has been queued for import.
-        pub const IMPORT_QUEUED: ImportState = ImportState::new("IMPORT_QUEUED");
-
-        /// The import of entries is in progress.
-        pub const IMPORT_IN_PROGRESS: ImportState = ImportState::new("IMPORT_IN_PROGRESS");
-
-        /// The import of entries has been finished.
-        pub const IMPORT_DONE: ImportState = ImportState::new("IMPORT_DONE");
-
-        /// The import of entries has been abandoned in favor of a newer request.
-        pub const IMPORT_OBSOLETE: ImportState = ImportState::new("IMPORT_OBSOLETE");
-    }
-
-    impl std::convert::From<std::string::String> for ImportState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ImportState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ImportState {
         fn default() -> Self {
-            import_state::IMPORT_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7381,42 +7606,58 @@ pub mod taxonomy {
 
     /// Defines policy types where the policy tags can be used for.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PolicyType(std::borrow::Cow<'static, str>);
+    pub struct PolicyType(i32);
 
     impl PolicyType {
-        /// Creates a new PolicyType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PolicyType](PolicyType)
-    pub mod policy_type {
-        use super::PolicyType;
-
         /// Unspecified policy type.
-        pub const POLICY_TYPE_UNSPECIFIED: PolicyType = PolicyType::new("POLICY_TYPE_UNSPECIFIED");
+        pub const POLICY_TYPE_UNSPECIFIED: PolicyType = PolicyType::new(0);
 
         /// Fine-grained access control policy that enables access control on
         /// tagged sub-resources.
-        pub const FINE_GRAINED_ACCESS_CONTROL: PolicyType =
-            PolicyType::new("FINE_GRAINED_ACCESS_CONTROL");
+        pub const FINE_GRAINED_ACCESS_CONTROL: PolicyType = PolicyType::new(1);
+
+        /// Creates a new PolicyType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("POLICY_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FINE_GRAINED_ACCESS_CONTROL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "POLICY_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::POLICY_TYPE_UNSPECIFIED)
+                }
+                "FINE_GRAINED_ACCESS_CONTROL" => {
+                    std::option::Option::Some(Self::FINE_GRAINED_ACCESS_CONTROL)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PolicyType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PolicyType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PolicyType {
         fn default() -> Self {
-            policy_type::POLICY_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8942,53 +9183,75 @@ pub mod column_schema {
 
         /// Column type in Looker.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct LookerColumnType(std::borrow::Cow<'static, str>);
+        pub struct LookerColumnType(i32);
 
         impl LookerColumnType {
+            /// Unspecified.
+            pub const LOOKER_COLUMN_TYPE_UNSPECIFIED: LookerColumnType = LookerColumnType::new(0);
+
+            /// Dimension.
+            pub const DIMENSION: LookerColumnType = LookerColumnType::new(1);
+
+            /// Dimension group - parent for Dimension.
+            pub const DIMENSION_GROUP: LookerColumnType = LookerColumnType::new(2);
+
+            /// Filter.
+            pub const FILTER: LookerColumnType = LookerColumnType::new(3);
+
+            /// Measure.
+            pub const MEASURE: LookerColumnType = LookerColumnType::new(4);
+
+            /// Parameter.
+            pub const PARAMETER: LookerColumnType = LookerColumnType::new(5);
+
             /// Creates a new LookerColumnType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("LOOKER_COLUMN_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("DIMENSION"),
+                    2 => std::borrow::Cow::Borrowed("DIMENSION_GROUP"),
+                    3 => std::borrow::Cow::Borrowed("FILTER"),
+                    4 => std::borrow::Cow::Borrowed("MEASURE"),
+                    5 => std::borrow::Cow::Borrowed("PARAMETER"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "LOOKER_COLUMN_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::LOOKER_COLUMN_TYPE_UNSPECIFIED)
+                    }
+                    "DIMENSION" => std::option::Option::Some(Self::DIMENSION),
+                    "DIMENSION_GROUP" => std::option::Option::Some(Self::DIMENSION_GROUP),
+                    "FILTER" => std::option::Option::Some(Self::FILTER),
+                    "MEASURE" => std::option::Option::Some(Self::MEASURE),
+                    "PARAMETER" => std::option::Option::Some(Self::PARAMETER),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [LookerColumnType](LookerColumnType)
-        pub mod looker_column_type {
-            use super::LookerColumnType;
-
-            /// Unspecified.
-            pub const LOOKER_COLUMN_TYPE_UNSPECIFIED: LookerColumnType =
-                LookerColumnType::new("LOOKER_COLUMN_TYPE_UNSPECIFIED");
-
-            /// Dimension.
-            pub const DIMENSION: LookerColumnType = LookerColumnType::new("DIMENSION");
-
-            /// Dimension group - parent for Dimension.
-            pub const DIMENSION_GROUP: LookerColumnType = LookerColumnType::new("DIMENSION_GROUP");
-
-            /// Filter.
-            pub const FILTER: LookerColumnType = LookerColumnType::new("FILTER");
-
-            /// Measure.
-            pub const MEASURE: LookerColumnType = LookerColumnType::new("MEASURE");
-
-            /// Parameter.
-            pub const PARAMETER: LookerColumnType = LookerColumnType::new("PARAMETER");
-        }
-
-        impl std::convert::From<std::string::String> for LookerColumnType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for LookerColumnType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for LookerColumnType {
             fn default() -> Self {
-                looker_column_type::LOOKER_COLUMN_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -9028,52 +9291,74 @@ pub mod column_schema {
 
     /// Specifies inclusion of the column in an index
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IndexingType(std::borrow::Cow<'static, str>);
+    pub struct IndexingType(i32);
 
     impl IndexingType {
+        /// Unspecified.
+        pub const INDEXING_TYPE_UNSPECIFIED: IndexingType = IndexingType::new(0);
+
+        /// Column not a part of an index.
+        pub const INDEXING_TYPE_NONE: IndexingType = IndexingType::new(1);
+
+        /// Column Part of non unique index.
+        pub const INDEXING_TYPE_NON_UNIQUE: IndexingType = IndexingType::new(2);
+
+        /// Column part of unique index.
+        pub const INDEXING_TYPE_UNIQUE: IndexingType = IndexingType::new(3);
+
+        /// Column part of the primary key.
+        pub const INDEXING_TYPE_PRIMARY_KEY: IndexingType = IndexingType::new(4);
+
         /// Creates a new IndexingType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("INDEXING_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INDEXING_TYPE_NONE"),
+                2 => std::borrow::Cow::Borrowed("INDEXING_TYPE_NON_UNIQUE"),
+                3 => std::borrow::Cow::Borrowed("INDEXING_TYPE_UNIQUE"),
+                4 => std::borrow::Cow::Borrowed("INDEXING_TYPE_PRIMARY_KEY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "INDEXING_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::INDEXING_TYPE_UNSPECIFIED)
+                }
+                "INDEXING_TYPE_NONE" => std::option::Option::Some(Self::INDEXING_TYPE_NONE),
+                "INDEXING_TYPE_NON_UNIQUE" => {
+                    std::option::Option::Some(Self::INDEXING_TYPE_NON_UNIQUE)
+                }
+                "INDEXING_TYPE_UNIQUE" => std::option::Option::Some(Self::INDEXING_TYPE_UNIQUE),
+                "INDEXING_TYPE_PRIMARY_KEY" => {
+                    std::option::Option::Some(Self::INDEXING_TYPE_PRIMARY_KEY)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [IndexingType](IndexingType)
-    pub mod indexing_type {
-        use super::IndexingType;
-
-        /// Unspecified.
-        pub const INDEXING_TYPE_UNSPECIFIED: IndexingType =
-            IndexingType::new("INDEXING_TYPE_UNSPECIFIED");
-
-        /// Column not a part of an index.
-        pub const INDEXING_TYPE_NONE: IndexingType = IndexingType::new("INDEXING_TYPE_NONE");
-
-        /// Column Part of non unique index.
-        pub const INDEXING_TYPE_NON_UNIQUE: IndexingType =
-            IndexingType::new("INDEXING_TYPE_NON_UNIQUE");
-
-        /// Column part of unique index.
-        pub const INDEXING_TYPE_UNIQUE: IndexingType = IndexingType::new("INDEXING_TYPE_UNIQUE");
-
-        /// Column part of the primary key.
-        pub const INDEXING_TYPE_PRIMARY_KEY: IndexingType =
-            IndexingType::new("INDEXING_TYPE_PRIMARY_KEY");
-    }
-
-    impl std::convert::From<std::string::String> for IndexingType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for IndexingType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for IndexingType {
         fn default() -> Self {
-            indexing_type::INDEXING_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -10133,49 +10418,66 @@ pub mod tag_template {
 
     /// This enum describes TagTemplate transfer status to Dataplex service.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataplexTransferStatus(std::borrow::Cow<'static, str>);
+    pub struct DataplexTransferStatus(i32);
 
     impl DataplexTransferStatus {
-        /// Creates a new DataplexTransferStatus instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DataplexTransferStatus](DataplexTransferStatus)
-    pub mod dataplex_transfer_status {
-        use super::DataplexTransferStatus;
-
         /// Default value. TagTemplate and its tags are only visible and editable in
         /// DataCatalog.
         pub const DATAPLEX_TRANSFER_STATUS_UNSPECIFIED: DataplexTransferStatus =
-            DataplexTransferStatus::new("DATAPLEX_TRANSFER_STATUS_UNSPECIFIED");
+            DataplexTransferStatus::new(0);
 
         /// TagTemplate and its tags are auto-copied to Dataplex service.
         /// Visible in both services. Editable in DataCatalog, read-only in Dataplex.
         /// Deprecated: Individual TagTemplate migration is deprecated in favor of
         /// organization or project wide TagTemplate migration opt-in.
-        pub const MIGRATED: DataplexTransferStatus = DataplexTransferStatus::new("MIGRATED");
+        pub const MIGRATED: DataplexTransferStatus = DataplexTransferStatus::new(1);
 
         /// TagTemplate and its tags are auto-copied to Dataplex service.
         /// Visible in both services. Editable in Dataplex, read-only in DataCatalog.
-        pub const TRANSFERRED: DataplexTransferStatus = DataplexTransferStatus::new("TRANSFERRED");
+        pub const TRANSFERRED: DataplexTransferStatus = DataplexTransferStatus::new(2);
+
+        /// Creates a new DataplexTransferStatus instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATAPLEX_TRANSFER_STATUS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MIGRATED"),
+                2 => std::borrow::Cow::Borrowed("TRANSFERRED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATAPLEX_TRANSFER_STATUS_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DATAPLEX_TRANSFER_STATUS_UNSPECIFIED)
+                }
+                "MIGRATED" => std::option::Option::Some(Self::MIGRATED),
+                "TRANSFERRED" => std::option::Option::Some(Self::TRANSFERRED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DataplexTransferStatus {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DataplexTransferStatus {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DataplexTransferStatus {
         fn default() -> Self {
-            dataplex_transfer_status::DATAPLEX_TRANSFER_STATUS_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -10458,53 +10760,75 @@ pub mod field_type {
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PrimitiveType(std::borrow::Cow<'static, str>);
+    pub struct PrimitiveType(i32);
 
     impl PrimitiveType {
+        /// The default invalid value for a type.
+        pub const PRIMITIVE_TYPE_UNSPECIFIED: PrimitiveType = PrimitiveType::new(0);
+
+        /// A double precision number.
+        pub const DOUBLE: PrimitiveType = PrimitiveType::new(1);
+
+        /// An UTF-8 string.
+        pub const STRING: PrimitiveType = PrimitiveType::new(2);
+
+        /// A boolean value.
+        pub const BOOL: PrimitiveType = PrimitiveType::new(3);
+
+        /// A timestamp.
+        pub const TIMESTAMP: PrimitiveType = PrimitiveType::new(4);
+
+        /// A Richtext description.
+        pub const RICHTEXT: PrimitiveType = PrimitiveType::new(5);
+
         /// Creates a new PrimitiveType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PRIMITIVE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DOUBLE"),
+                2 => std::borrow::Cow::Borrowed("STRING"),
+                3 => std::borrow::Cow::Borrowed("BOOL"),
+                4 => std::borrow::Cow::Borrowed("TIMESTAMP"),
+                5 => std::borrow::Cow::Borrowed("RICHTEXT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PRIMITIVE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PRIMITIVE_TYPE_UNSPECIFIED)
+                }
+                "DOUBLE" => std::option::Option::Some(Self::DOUBLE),
+                "STRING" => std::option::Option::Some(Self::STRING),
+                "BOOL" => std::option::Option::Some(Self::BOOL),
+                "TIMESTAMP" => std::option::Option::Some(Self::TIMESTAMP),
+                "RICHTEXT" => std::option::Option::Some(Self::RICHTEXT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [PrimitiveType](PrimitiveType)
-    pub mod primitive_type {
-        use super::PrimitiveType;
-
-        /// The default invalid value for a type.
-        pub const PRIMITIVE_TYPE_UNSPECIFIED: PrimitiveType =
-            PrimitiveType::new("PRIMITIVE_TYPE_UNSPECIFIED");
-
-        /// A double precision number.
-        pub const DOUBLE: PrimitiveType = PrimitiveType::new("DOUBLE");
-
-        /// An UTF-8 string.
-        pub const STRING: PrimitiveType = PrimitiveType::new("STRING");
-
-        /// A boolean value.
-        pub const BOOL: PrimitiveType = PrimitiveType::new("BOOL");
-
-        /// A timestamp.
-        pub const TIMESTAMP: PrimitiveType = PrimitiveType::new("TIMESTAMP");
-
-        /// A Richtext description.
-        pub const RICHTEXT: PrimitiveType = PrimitiveType::new("RICHTEXT");
-    }
-
-    impl std::convert::From<std::string::String> for PrimitiveType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PrimitiveType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PrimitiveType {
         fn default() -> Self {
-            primitive_type::PRIMITIVE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -10776,110 +11100,155 @@ impl wkt::message::Message for UsageSignal {
 
 /// This enum lists all the systems that Data Catalog integrates with.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct IntegratedSystem(std::borrow::Cow<'static, str>);
+pub struct IntegratedSystem(i32);
 
 impl IntegratedSystem {
+    /// Default unknown system.
+    pub const INTEGRATED_SYSTEM_UNSPECIFIED: IntegratedSystem = IntegratedSystem::new(0);
+
+    /// BigQuery.
+    pub const BIGQUERY: IntegratedSystem = IntegratedSystem::new(1);
+
+    /// Cloud Pub/Sub.
+    pub const CLOUD_PUBSUB: IntegratedSystem = IntegratedSystem::new(2);
+
+    /// Dataproc Metastore.
+    pub const DATAPROC_METASTORE: IntegratedSystem = IntegratedSystem::new(3);
+
+    /// Dataplex.
+    pub const DATAPLEX: IntegratedSystem = IntegratedSystem::new(4);
+
+    /// Cloud Spanner
+    pub const CLOUD_SPANNER: IntegratedSystem = IntegratedSystem::new(6);
+
+    /// Cloud Bigtable
+    pub const CLOUD_BIGTABLE: IntegratedSystem = IntegratedSystem::new(7);
+
+    /// Cloud Sql
+    pub const CLOUD_SQL: IntegratedSystem = IntegratedSystem::new(8);
+
+    /// Looker
+    pub const LOOKER: IntegratedSystem = IntegratedSystem::new(9);
+
+    /// Vertex AI
+    pub const VERTEX_AI: IntegratedSystem = IntegratedSystem::new(10);
+
     /// Creates a new IntegratedSystem instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("INTEGRATED_SYSTEM_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("BIGQUERY"),
+            2 => std::borrow::Cow::Borrowed("CLOUD_PUBSUB"),
+            3 => std::borrow::Cow::Borrowed("DATAPROC_METASTORE"),
+            4 => std::borrow::Cow::Borrowed("DATAPLEX"),
+            6 => std::borrow::Cow::Borrowed("CLOUD_SPANNER"),
+            7 => std::borrow::Cow::Borrowed("CLOUD_BIGTABLE"),
+            8 => std::borrow::Cow::Borrowed("CLOUD_SQL"),
+            9 => std::borrow::Cow::Borrowed("LOOKER"),
+            10 => std::borrow::Cow::Borrowed("VERTEX_AI"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "INTEGRATED_SYSTEM_UNSPECIFIED" => {
+                std::option::Option::Some(Self::INTEGRATED_SYSTEM_UNSPECIFIED)
+            }
+            "BIGQUERY" => std::option::Option::Some(Self::BIGQUERY),
+            "CLOUD_PUBSUB" => std::option::Option::Some(Self::CLOUD_PUBSUB),
+            "DATAPROC_METASTORE" => std::option::Option::Some(Self::DATAPROC_METASTORE),
+            "DATAPLEX" => std::option::Option::Some(Self::DATAPLEX),
+            "CLOUD_SPANNER" => std::option::Option::Some(Self::CLOUD_SPANNER),
+            "CLOUD_BIGTABLE" => std::option::Option::Some(Self::CLOUD_BIGTABLE),
+            "CLOUD_SQL" => std::option::Option::Some(Self::CLOUD_SQL),
+            "LOOKER" => std::option::Option::Some(Self::LOOKER),
+            "VERTEX_AI" => std::option::Option::Some(Self::VERTEX_AI),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [IntegratedSystem](IntegratedSystem)
-pub mod integrated_system {
-    use super::IntegratedSystem;
-
-    /// Default unknown system.
-    pub const INTEGRATED_SYSTEM_UNSPECIFIED: IntegratedSystem =
-        IntegratedSystem::new("INTEGRATED_SYSTEM_UNSPECIFIED");
-
-    /// BigQuery.
-    pub const BIGQUERY: IntegratedSystem = IntegratedSystem::new("BIGQUERY");
-
-    /// Cloud Pub/Sub.
-    pub const CLOUD_PUBSUB: IntegratedSystem = IntegratedSystem::new("CLOUD_PUBSUB");
-
-    /// Dataproc Metastore.
-    pub const DATAPROC_METASTORE: IntegratedSystem = IntegratedSystem::new("DATAPROC_METASTORE");
-
-    /// Dataplex.
-    pub const DATAPLEX: IntegratedSystem = IntegratedSystem::new("DATAPLEX");
-
-    /// Cloud Spanner
-    pub const CLOUD_SPANNER: IntegratedSystem = IntegratedSystem::new("CLOUD_SPANNER");
-
-    /// Cloud Bigtable
-    pub const CLOUD_BIGTABLE: IntegratedSystem = IntegratedSystem::new("CLOUD_BIGTABLE");
-
-    /// Cloud Sql
-    pub const CLOUD_SQL: IntegratedSystem = IntegratedSystem::new("CLOUD_SQL");
-
-    /// Looker
-    pub const LOOKER: IntegratedSystem = IntegratedSystem::new("LOOKER");
-
-    /// Vertex AI
-    pub const VERTEX_AI: IntegratedSystem = IntegratedSystem::new("VERTEX_AI");
-}
-
-impl std::convert::From<std::string::String> for IntegratedSystem {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for IntegratedSystem {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for IntegratedSystem {
     fn default() -> Self {
-        integrated_system::INTEGRATED_SYSTEM_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// This enum describes all the systems that manage
 /// Taxonomy and PolicyTag resources in DataCatalog.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ManagingSystem(std::borrow::Cow<'static, str>);
+pub struct ManagingSystem(i32);
 
 impl ManagingSystem {
+    /// Default value
+    pub const MANAGING_SYSTEM_UNSPECIFIED: ManagingSystem = ManagingSystem::new(0);
+
+    /// Dataplex.
+    pub const MANAGING_SYSTEM_DATAPLEX: ManagingSystem = ManagingSystem::new(1);
+
+    /// Other
+    pub const MANAGING_SYSTEM_OTHER: ManagingSystem = ManagingSystem::new(2);
+
     /// Creates a new ManagingSystem instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("MANAGING_SYSTEM_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("MANAGING_SYSTEM_DATAPLEX"),
+            2 => std::borrow::Cow::Borrowed("MANAGING_SYSTEM_OTHER"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "MANAGING_SYSTEM_UNSPECIFIED" => {
+                std::option::Option::Some(Self::MANAGING_SYSTEM_UNSPECIFIED)
+            }
+            "MANAGING_SYSTEM_DATAPLEX" => std::option::Option::Some(Self::MANAGING_SYSTEM_DATAPLEX),
+            "MANAGING_SYSTEM_OTHER" => std::option::Option::Some(Self::MANAGING_SYSTEM_OTHER),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [ManagingSystem](ManagingSystem)
-pub mod managing_system {
-    use super::ManagingSystem;
-
-    /// Default value
-    pub const MANAGING_SYSTEM_UNSPECIFIED: ManagingSystem =
-        ManagingSystem::new("MANAGING_SYSTEM_UNSPECIFIED");
-
-    /// Dataplex.
-    pub const MANAGING_SYSTEM_DATAPLEX: ManagingSystem =
-        ManagingSystem::new("MANAGING_SYSTEM_DATAPLEX");
-
-    /// Other
-    pub const MANAGING_SYSTEM_OTHER: ManagingSystem = ManagingSystem::new("MANAGING_SYSTEM_OTHER");
-}
-
-impl std::convert::From<std::string::String> for ManagingSystem {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ManagingSystem {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ManagingSystem {
     fn default() -> Self {
-        managing_system::MANAGING_SYSTEM_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -10896,293 +11265,414 @@ impl std::default::Default for ManagingSystem {
 /// entries](/data-catalog/docs/how-to/filesets) or [Create custom entries for
 /// your data sources](/data-catalog/docs/how-to/custom-entries).
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EntryType(std::borrow::Cow<'static, str>);
+pub struct EntryType(i32);
 
 impl EntryType {
-    /// Creates a new EntryType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [EntryType](EntryType)
-pub mod entry_type {
-    use super::EntryType;
-
     /// Default unknown type.
-    pub const ENTRY_TYPE_UNSPECIFIED: EntryType = EntryType::new("ENTRY_TYPE_UNSPECIFIED");
+    pub const ENTRY_TYPE_UNSPECIFIED: EntryType = EntryType::new(0);
 
     /// The entry type that has a GoogleSQL schema, including
     /// logical views.
-    pub const TABLE: EntryType = EntryType::new("TABLE");
+    pub const TABLE: EntryType = EntryType::new(2);
 
     /// The type of models.
     ///
     /// For more information, see [Supported models in BigQuery
     /// ML](/bigquery/docs/bqml-introduction#supported_models).
-    pub const MODEL: EntryType = EntryType::new("MODEL");
+    pub const MODEL: EntryType = EntryType::new(5);
 
     /// An entry type for streaming entries. For example, a Pub/Sub topic.
-    pub const DATA_STREAM: EntryType = EntryType::new("DATA_STREAM");
+    pub const DATA_STREAM: EntryType = EntryType::new(3);
 
     /// An entry type for a set of files or objects. For example, a
     /// Cloud Storage fileset.
-    pub const FILESET: EntryType = EntryType::new("FILESET");
+    pub const FILESET: EntryType = EntryType::new(4);
 
     /// A group of servers that work together. For example, a Kafka cluster.
-    pub const CLUSTER: EntryType = EntryType::new("CLUSTER");
+    pub const CLUSTER: EntryType = EntryType::new(6);
 
     /// A database.
-    pub const DATABASE: EntryType = EntryType::new("DATABASE");
+    pub const DATABASE: EntryType = EntryType::new(7);
 
     /// Connection to a data source. For example, a BigQuery
     /// connection.
-    pub const DATA_SOURCE_CONNECTION: EntryType = EntryType::new("DATA_SOURCE_CONNECTION");
+    pub const DATA_SOURCE_CONNECTION: EntryType = EntryType::new(8);
 
     /// Routine, for example, a BigQuery routine.
-    pub const ROUTINE: EntryType = EntryType::new("ROUTINE");
+    pub const ROUTINE: EntryType = EntryType::new(9);
 
     /// A Dataplex lake.
-    pub const LAKE: EntryType = EntryType::new("LAKE");
+    pub const LAKE: EntryType = EntryType::new(10);
 
     /// A Dataplex zone.
-    pub const ZONE: EntryType = EntryType::new("ZONE");
+    pub const ZONE: EntryType = EntryType::new(11);
 
     /// A service, for example, a Dataproc Metastore service.
-    pub const SERVICE: EntryType = EntryType::new("SERVICE");
+    pub const SERVICE: EntryType = EntryType::new(14);
 
     /// Schema within a relational database.
-    pub const DATABASE_SCHEMA: EntryType = EntryType::new("DATABASE_SCHEMA");
+    pub const DATABASE_SCHEMA: EntryType = EntryType::new(15);
 
     /// A Dashboard, for example from Looker.
-    pub const DASHBOARD: EntryType = EntryType::new("DASHBOARD");
+    pub const DASHBOARD: EntryType = EntryType::new(16);
 
     /// A Looker Explore.
     ///
     /// For more information, see [Looker Explore API]
     /// (<https://developers.looker.com/api/explorer/4.0/methods/LookmlModel/lookml_model_explore>).
-    pub const EXPLORE: EntryType = EntryType::new("EXPLORE");
+    pub const EXPLORE: EntryType = EntryType::new(17);
 
     /// A Looker Look.
     ///
     /// For more information, see [Looker Look API]
     /// (<https://developers.looker.com/api/explorer/4.0/methods/Look>).
-    pub const LOOK: EntryType = EntryType::new("LOOK");
+    pub const LOOK: EntryType = EntryType::new(18);
 
     /// Feature Online Store resource in Vertex AI Feature Store.
-    pub const FEATURE_ONLINE_STORE: EntryType = EntryType::new("FEATURE_ONLINE_STORE");
+    pub const FEATURE_ONLINE_STORE: EntryType = EntryType::new(19);
 
     /// Feature View resource in Vertex AI Feature Store.
-    pub const FEATURE_VIEW: EntryType = EntryType::new("FEATURE_VIEW");
+    pub const FEATURE_VIEW: EntryType = EntryType::new(20);
 
     /// Feature Group resource in Vertex AI Feature Store.
-    pub const FEATURE_GROUP: EntryType = EntryType::new("FEATURE_GROUP");
+    pub const FEATURE_GROUP: EntryType = EntryType::new(21);
+
+    /// Creates a new EntryType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ENTRY_TYPE_UNSPECIFIED"),
+            2 => std::borrow::Cow::Borrowed("TABLE"),
+            3 => std::borrow::Cow::Borrowed("DATA_STREAM"),
+            4 => std::borrow::Cow::Borrowed("FILESET"),
+            5 => std::borrow::Cow::Borrowed("MODEL"),
+            6 => std::borrow::Cow::Borrowed("CLUSTER"),
+            7 => std::borrow::Cow::Borrowed("DATABASE"),
+            8 => std::borrow::Cow::Borrowed("DATA_SOURCE_CONNECTION"),
+            9 => std::borrow::Cow::Borrowed("ROUTINE"),
+            10 => std::borrow::Cow::Borrowed("LAKE"),
+            11 => std::borrow::Cow::Borrowed("ZONE"),
+            14 => std::borrow::Cow::Borrowed("SERVICE"),
+            15 => std::borrow::Cow::Borrowed("DATABASE_SCHEMA"),
+            16 => std::borrow::Cow::Borrowed("DASHBOARD"),
+            17 => std::borrow::Cow::Borrowed("EXPLORE"),
+            18 => std::borrow::Cow::Borrowed("LOOK"),
+            19 => std::borrow::Cow::Borrowed("FEATURE_ONLINE_STORE"),
+            20 => std::borrow::Cow::Borrowed("FEATURE_VIEW"),
+            21 => std::borrow::Cow::Borrowed("FEATURE_GROUP"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ENTRY_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::ENTRY_TYPE_UNSPECIFIED),
+            "TABLE" => std::option::Option::Some(Self::TABLE),
+            "MODEL" => std::option::Option::Some(Self::MODEL),
+            "DATA_STREAM" => std::option::Option::Some(Self::DATA_STREAM),
+            "FILESET" => std::option::Option::Some(Self::FILESET),
+            "CLUSTER" => std::option::Option::Some(Self::CLUSTER),
+            "DATABASE" => std::option::Option::Some(Self::DATABASE),
+            "DATA_SOURCE_CONNECTION" => std::option::Option::Some(Self::DATA_SOURCE_CONNECTION),
+            "ROUTINE" => std::option::Option::Some(Self::ROUTINE),
+            "LAKE" => std::option::Option::Some(Self::LAKE),
+            "ZONE" => std::option::Option::Some(Self::ZONE),
+            "SERVICE" => std::option::Option::Some(Self::SERVICE),
+            "DATABASE_SCHEMA" => std::option::Option::Some(Self::DATABASE_SCHEMA),
+            "DASHBOARD" => std::option::Option::Some(Self::DASHBOARD),
+            "EXPLORE" => std::option::Option::Some(Self::EXPLORE),
+            "LOOK" => std::option::Option::Some(Self::LOOK),
+            "FEATURE_ONLINE_STORE" => std::option::Option::Some(Self::FEATURE_ONLINE_STORE),
+            "FEATURE_VIEW" => std::option::Option::Some(Self::FEATURE_VIEW),
+            "FEATURE_GROUP" => std::option::Option::Some(Self::FEATURE_GROUP),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for EntryType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for EntryType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for EntryType {
     fn default() -> Self {
-        entry_type::ENTRY_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Configuration related to the opt-in status for the migration of TagTemplates
 /// to Dataplex.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TagTemplateMigration(std::borrow::Cow<'static, str>);
+pub struct TagTemplateMigration(i32);
 
 impl TagTemplateMigration {
-    /// Creates a new TagTemplateMigration instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [TagTemplateMigration](TagTemplateMigration)
-pub mod tag_template_migration {
-    use super::TagTemplateMigration;
-
     /// Default value. Migration of Tag Templates from Data Catalog to Dataplex is
     /// not performed.
     pub const TAG_TEMPLATE_MIGRATION_UNSPECIFIED: TagTemplateMigration =
-        TagTemplateMigration::new("TAG_TEMPLATE_MIGRATION_UNSPECIFIED");
+        TagTemplateMigration::new(0);
 
     /// Migration of Tag Templates from Data Catalog to Dataplex is enabled.
-    pub const TAG_TEMPLATE_MIGRATION_ENABLED: TagTemplateMigration =
-        TagTemplateMigration::new("TAG_TEMPLATE_MIGRATION_ENABLED");
+    pub const TAG_TEMPLATE_MIGRATION_ENABLED: TagTemplateMigration = TagTemplateMigration::new(1);
 
     /// Migration of Tag Templates from Data Catalog to Dataplex is disabled.
-    pub const TAG_TEMPLATE_MIGRATION_DISABLED: TagTemplateMigration =
-        TagTemplateMigration::new("TAG_TEMPLATE_MIGRATION_DISABLED");
+    pub const TAG_TEMPLATE_MIGRATION_DISABLED: TagTemplateMigration = TagTemplateMigration::new(2);
+
+    /// Creates a new TagTemplateMigration instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("TAG_TEMPLATE_MIGRATION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("TAG_TEMPLATE_MIGRATION_ENABLED"),
+            2 => std::borrow::Cow::Borrowed("TAG_TEMPLATE_MIGRATION_DISABLED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "TAG_TEMPLATE_MIGRATION_UNSPECIFIED" => {
+                std::option::Option::Some(Self::TAG_TEMPLATE_MIGRATION_UNSPECIFIED)
+            }
+            "TAG_TEMPLATE_MIGRATION_ENABLED" => {
+                std::option::Option::Some(Self::TAG_TEMPLATE_MIGRATION_ENABLED)
+            }
+            "TAG_TEMPLATE_MIGRATION_DISABLED" => {
+                std::option::Option::Some(Self::TAG_TEMPLATE_MIGRATION_DISABLED)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for TagTemplateMigration {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for TagTemplateMigration {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for TagTemplateMigration {
     fn default() -> Self {
-        tag_template_migration::TAG_TEMPLATE_MIGRATION_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Configuration related to the opt-in status for the UI switch to Dataplex.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct CatalogUIExperience(std::borrow::Cow<'static, str>);
+pub struct CatalogUIExperience(i32);
 
 impl CatalogUIExperience {
+    /// Default value. The default UI is Dataplex.
+    pub const CATALOG_UI_EXPERIENCE_UNSPECIFIED: CatalogUIExperience = CatalogUIExperience::new(0);
+
+    /// The UI is Dataplex.
+    pub const CATALOG_UI_EXPERIENCE_ENABLED: CatalogUIExperience = CatalogUIExperience::new(1);
+
+    /// The UI is Data Catalog.
+    pub const CATALOG_UI_EXPERIENCE_DISABLED: CatalogUIExperience = CatalogUIExperience::new(2);
+
     /// Creates a new CatalogUIExperience instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("CATALOG_UI_EXPERIENCE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("CATALOG_UI_EXPERIENCE_ENABLED"),
+            2 => std::borrow::Cow::Borrowed("CATALOG_UI_EXPERIENCE_DISABLED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "CATALOG_UI_EXPERIENCE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::CATALOG_UI_EXPERIENCE_UNSPECIFIED)
+            }
+            "CATALOG_UI_EXPERIENCE_ENABLED" => {
+                std::option::Option::Some(Self::CATALOG_UI_EXPERIENCE_ENABLED)
+            }
+            "CATALOG_UI_EXPERIENCE_DISABLED" => {
+                std::option::Option::Some(Self::CATALOG_UI_EXPERIENCE_DISABLED)
+            }
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [CatalogUIExperience](CatalogUIExperience)
-pub mod catalog_ui_experience {
-    use super::CatalogUIExperience;
-
-    /// Default value. The default UI is Dataplex.
-    pub const CATALOG_UI_EXPERIENCE_UNSPECIFIED: CatalogUIExperience =
-        CatalogUIExperience::new("CATALOG_UI_EXPERIENCE_UNSPECIFIED");
-
-    /// The UI is Dataplex.
-    pub const CATALOG_UI_EXPERIENCE_ENABLED: CatalogUIExperience =
-        CatalogUIExperience::new("CATALOG_UI_EXPERIENCE_ENABLED");
-
-    /// The UI is Data Catalog.
-    pub const CATALOG_UI_EXPERIENCE_DISABLED: CatalogUIExperience =
-        CatalogUIExperience::new("CATALOG_UI_EXPERIENCE_DISABLED");
-}
-
-impl std::convert::From<std::string::String> for CatalogUIExperience {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for CatalogUIExperience {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for CatalogUIExperience {
     fn default() -> Self {
-        catalog_ui_experience::CATALOG_UI_EXPERIENCE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The resource types that can be returned in search results.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SearchResultType(std::borrow::Cow<'static, str>);
+pub struct SearchResultType(i32);
 
 impl SearchResultType {
-    /// Creates a new SearchResultType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [SearchResultType](SearchResultType)
-pub mod search_result_type {
-    use super::SearchResultType;
-
     /// Default unknown type.
-    pub const SEARCH_RESULT_TYPE_UNSPECIFIED: SearchResultType =
-        SearchResultType::new("SEARCH_RESULT_TYPE_UNSPECIFIED");
+    pub const SEARCH_RESULT_TYPE_UNSPECIFIED: SearchResultType = SearchResultType::new(0);
 
     /// An [Entry][google.cloud.datacatalog.v1.Entry].
     ///
     /// [google.cloud.datacatalog.v1.Entry]: crate::model::Entry
-    pub const ENTRY: SearchResultType = SearchResultType::new("ENTRY");
+    pub const ENTRY: SearchResultType = SearchResultType::new(1);
 
     /// A [TagTemplate][google.cloud.datacatalog.v1.TagTemplate].
     ///
     /// [google.cloud.datacatalog.v1.TagTemplate]: crate::model::TagTemplate
-    pub const TAG_TEMPLATE: SearchResultType = SearchResultType::new("TAG_TEMPLATE");
+    pub const TAG_TEMPLATE: SearchResultType = SearchResultType::new(2);
 
     /// An [EntryGroup][google.cloud.datacatalog.v1.EntryGroup].
     ///
     /// [google.cloud.datacatalog.v1.EntryGroup]: crate::model::EntryGroup
-    pub const ENTRY_GROUP: SearchResultType = SearchResultType::new("ENTRY_GROUP");
+    pub const ENTRY_GROUP: SearchResultType = SearchResultType::new(3);
+
+    /// Creates a new SearchResultType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SEARCH_RESULT_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ENTRY"),
+            2 => std::borrow::Cow::Borrowed("TAG_TEMPLATE"),
+            3 => std::borrow::Cow::Borrowed("ENTRY_GROUP"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SEARCH_RESULT_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::SEARCH_RESULT_TYPE_UNSPECIFIED)
+            }
+            "ENTRY" => std::option::Option::Some(Self::ENTRY),
+            "TAG_TEMPLATE" => std::option::Option::Some(Self::TAG_TEMPLATE),
+            "ENTRY_GROUP" => std::option::Option::Some(Self::ENTRY_GROUP),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for SearchResultType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SearchResultType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SearchResultType {
     fn default() -> Self {
-        search_result_type::SEARCH_RESULT_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Table source type.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TableSourceType(std::borrow::Cow<'static, str>);
+pub struct TableSourceType(i32);
 
 impl TableSourceType {
+    /// Default unknown type.
+    pub const TABLE_SOURCE_TYPE_UNSPECIFIED: TableSourceType = TableSourceType::new(0);
+
+    /// Table view.
+    pub const BIGQUERY_VIEW: TableSourceType = TableSourceType::new(2);
+
+    /// BigQuery native table.
+    pub const BIGQUERY_TABLE: TableSourceType = TableSourceType::new(5);
+
+    /// BigQuery materialized view.
+    pub const BIGQUERY_MATERIALIZED_VIEW: TableSourceType = TableSourceType::new(7);
+
     /// Creates a new TableSourceType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("TABLE_SOURCE_TYPE_UNSPECIFIED"),
+            2 => std::borrow::Cow::Borrowed("BIGQUERY_VIEW"),
+            5 => std::borrow::Cow::Borrowed("BIGQUERY_TABLE"),
+            7 => std::borrow::Cow::Borrowed("BIGQUERY_MATERIALIZED_VIEW"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "TABLE_SOURCE_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::TABLE_SOURCE_TYPE_UNSPECIFIED)
+            }
+            "BIGQUERY_VIEW" => std::option::Option::Some(Self::BIGQUERY_VIEW),
+            "BIGQUERY_TABLE" => std::option::Option::Some(Self::BIGQUERY_TABLE),
+            "BIGQUERY_MATERIALIZED_VIEW" => {
+                std::option::Option::Some(Self::BIGQUERY_MATERIALIZED_VIEW)
+            }
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [TableSourceType](TableSourceType)
-pub mod table_source_type {
-    use super::TableSourceType;
-
-    /// Default unknown type.
-    pub const TABLE_SOURCE_TYPE_UNSPECIFIED: TableSourceType =
-        TableSourceType::new("TABLE_SOURCE_TYPE_UNSPECIFIED");
-
-    /// Table view.
-    pub const BIGQUERY_VIEW: TableSourceType = TableSourceType::new("BIGQUERY_VIEW");
-
-    /// BigQuery native table.
-    pub const BIGQUERY_TABLE: TableSourceType = TableSourceType::new("BIGQUERY_TABLE");
-
-    /// BigQuery materialized view.
-    pub const BIGQUERY_MATERIALIZED_VIEW: TableSourceType =
-        TableSourceType::new("BIGQUERY_MATERIALIZED_VIEW");
-}
-
-impl std::convert::From<std::string::String> for TableSourceType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for TableSourceType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for TableSourceType {
     fn default() -> Self {
-        table_source_type::TABLE_SOURCE_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/datacatalog/v1/src/transport.rs
+++ b/src/generated/cloud/datacatalog/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, "/v1/catalog:search".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -69,7 +69,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
                 reqwest::Method::POST,
                 format!("/v1/{}/entryGroups", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -89,7 +89,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -127,7 +127,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -156,7 +156,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -179,7 +179,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
                 reqwest::Method::GET,
                 format!("/v1/{}/entryGroups", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -200,7 +200,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/entries", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -227,7 +227,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -254,7 +254,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -273,7 +273,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -292,7 +292,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v1/entries:lookup".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -329,7 +329,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/entries", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -363,7 +363,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
                 reqwest::Method::POST,
                 format!("/v1/{}:modifyEntryOverview", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -383,7 +383,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
                 reqwest::Method::POST,
                 format!("/v1/{}:modifyEntryContacts", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -403,7 +403,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
                 reqwest::Method::POST,
                 format!("/v1/{}/tagTemplates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -423,7 +423,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -451,7 +451,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -480,7 +480,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -500,7 +500,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/fields", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -520,7 +520,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -549,7 +549,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:rename", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -566,7 +566,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:rename", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -583,7 +583,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -603,7 +603,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/tags", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -629,7 +629,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -656,7 +656,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -675,7 +675,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/tags", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -699,7 +699,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
                 reqwest::Method::POST,
                 format!("/v1/{}/tags:reconcile", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -716,7 +716,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:star", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -733,7 +733,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:unstar", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -753,7 +753,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -773,7 +773,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -793,7 +793,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -813,7 +813,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
                 reqwest::Method::POST,
                 format!("/v1/{}/entries:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -830,7 +830,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:setConfig", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -850,7 +850,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
                 reqwest::Method::GET,
                 format!("/v1/{}:retrieveConfig", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -872,7 +872,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
                 reqwest::Method::GET,
                 format!("/v1/{}:retrieveEffectiveConfig", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -891,7 +891,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -913,7 +913,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -932,7 +932,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -951,7 +951,7 @@ impl crate::stubs::DataCatalog for DataCatalog {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1010,7 +1010,7 @@ impl crate::stubs::PolicyTagManager for PolicyTagManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/taxonomies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1029,7 +1029,7 @@ impl crate::stubs::PolicyTagManager for PolicyTagManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1057,7 +1057,7 @@ impl crate::stubs::PolicyTagManager for PolicyTagManager {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1089,7 +1089,7 @@ impl crate::stubs::PolicyTagManager for PolicyTagManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/taxonomies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1111,7 +1111,7 @@ impl crate::stubs::PolicyTagManager for PolicyTagManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1133,7 +1133,7 @@ impl crate::stubs::PolicyTagManager for PolicyTagManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/policyTags", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1152,7 +1152,7 @@ impl crate::stubs::PolicyTagManager for PolicyTagManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1180,7 +1180,7 @@ impl crate::stubs::PolicyTagManager for PolicyTagManager {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1212,7 +1212,7 @@ impl crate::stubs::PolicyTagManager for PolicyTagManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/policyTags", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1233,7 +1233,7 @@ impl crate::stubs::PolicyTagManager for PolicyTagManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1255,7 +1255,7 @@ impl crate::stubs::PolicyTagManager for PolicyTagManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1275,7 +1275,7 @@ impl crate::stubs::PolicyTagManager for PolicyTagManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1295,7 +1295,7 @@ impl crate::stubs::PolicyTagManager for PolicyTagManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1312,7 +1312,7 @@ impl crate::stubs::PolicyTagManager for PolicyTagManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1334,7 +1334,7 @@ impl crate::stubs::PolicyTagManager for PolicyTagManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1353,7 +1353,7 @@ impl crate::stubs::PolicyTagManager for PolicyTagManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1372,7 +1372,7 @@ impl crate::stubs::PolicyTagManager for PolicyTagManager {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1414,7 +1414,7 @@ impl crate::stubs::PolicyTagManagerSerialization for PolicyTagManagerSerializati
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:replace", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1434,7 +1434,7 @@ impl crate::stubs::PolicyTagManagerSerialization for PolicyTagManagerSerializati
                 reqwest::Method::POST,
                 format!("/v1/{}/taxonomies:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1454,7 +1454,7 @@ impl crate::stubs::PolicyTagManagerSerialization for PolicyTagManagerSerializati
                 reqwest::Method::GET,
                 format!("/v1/{}/taxonomies:export", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1483,7 +1483,7 @@ impl crate::stubs::PolicyTagManagerSerialization for PolicyTagManagerSerializati
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1505,7 +1505,7 @@ impl crate::stubs::PolicyTagManagerSerialization for PolicyTagManagerSerializati
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1524,7 +1524,7 @@ impl crate::stubs::PolicyTagManagerSerialization for PolicyTagManagerSerializati
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1543,7 +1543,7 @@ impl crate::stubs::PolicyTagManagerSerialization for PolicyTagManagerSerializati
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/datafusion/v1/src/model.rs
+++ b/src/generated/cloud/datafusion/v1/src/model.rs
@@ -151,43 +151,60 @@ pub mod version {
 
     /// Each type represents the release availability of a CDF version
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Version does not have availability yet
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// Version is under development and not considered stable
+        pub const TYPE_PREVIEW: Type = Type::new(1);
+
+        /// Version is available for public use
+        pub const TYPE_GENERAL_AVAILABILITY: Type = Type::new(2);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TYPE_PREVIEW"),
+                2 => std::borrow::Cow::Borrowed("TYPE_GENERAL_AVAILABILITY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "TYPE_PREVIEW" => std::option::Option::Some(Self::TYPE_PREVIEW),
+                "TYPE_GENERAL_AVAILABILITY" => {
+                    std::option::Option::Some(Self::TYPE_GENERAL_AVAILABILITY)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Version does not have availability yet
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// Version is under development and not considered stable
-        pub const TYPE_PREVIEW: Type = Type::new("TYPE_PREVIEW");
-
-        /// Version is available for public use
-        pub const TYPE_GENERAL_AVAILABILITY: Type = Type::new("TYPE_GENERAL_AVAILABILITY");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -245,96 +262,131 @@ pub mod accelerator {
     /// Each type represents an Accelerator (Add-On) supported by Cloud Data Fusion
     /// service.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AcceleratorType(std::borrow::Cow<'static, str>);
+    pub struct AcceleratorType(i32);
 
     impl AcceleratorType {
-        /// Creates a new AcceleratorType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [AcceleratorType](AcceleratorType)
-    pub mod accelerator_type {
-        use super::AcceleratorType;
-
         /// Default value, if unspecified.
-        pub const ACCELERATOR_TYPE_UNSPECIFIED: AcceleratorType =
-            AcceleratorType::new("ACCELERATOR_TYPE_UNSPECIFIED");
+        pub const ACCELERATOR_TYPE_UNSPECIFIED: AcceleratorType = AcceleratorType::new(0);
 
         /// Change Data Capture accelerator for CDF.
-        pub const CDC: AcceleratorType = AcceleratorType::new("CDC");
+        pub const CDC: AcceleratorType = AcceleratorType::new(1);
 
         /// Cloud Healthcare accelerator for CDF. This accelerator is to enable Cloud
         /// Healthcare specific CDF plugins developed by Healthcare team.
-        pub const HEALTHCARE: AcceleratorType = AcceleratorType::new("HEALTHCARE");
+        pub const HEALTHCARE: AcceleratorType = AcceleratorType::new(2);
 
         /// Contact Center AI Insights
         /// This accelerator is used to enable import and export pipelines
         /// custom built to streamline CCAI Insights processing.
-        pub const CCAI_INSIGHTS: AcceleratorType = AcceleratorType::new("CCAI_INSIGHTS");
+        pub const CCAI_INSIGHTS: AcceleratorType = AcceleratorType::new(3);
+
+        /// Creates a new AcceleratorType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ACCELERATOR_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CDC"),
+                2 => std::borrow::Cow::Borrowed("HEALTHCARE"),
+                3 => std::borrow::Cow::Borrowed("CCAI_INSIGHTS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ACCELERATOR_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ACCELERATOR_TYPE_UNSPECIFIED)
+                }
+                "CDC" => std::option::Option::Some(Self::CDC),
+                "HEALTHCARE" => std::option::Option::Some(Self::HEALTHCARE),
+                "CCAI_INSIGHTS" => std::option::Option::Some(Self::CCAI_INSIGHTS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for AcceleratorType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AcceleratorType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AcceleratorType {
         fn default() -> Self {
-            accelerator_type::ACCELERATOR_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Different values possible for the state of an accelerator
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Default value, do not use
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Indicates that the accelerator is enabled and available to use
-        pub const ENABLED: State = State::new("ENABLED");
+        pub const ENABLED: State = State::new(1);
 
         /// Indicates that the accelerator is disabled and not available to use
-        pub const DISABLED: State = State::new("DISABLED");
+        pub const DISABLED: State = State::new(2);
 
         /// Indicates that accelerator state is currently unknown.
         /// Requests for enable, disable could be retried while in this state
-        pub const UNKNOWN: State = State::new("UNKNOWN");
+        pub const UNKNOWN: State = State::new(3);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENABLED"),
+                2 => std::borrow::Cow::Borrowed("DISABLED"),
+                3 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -743,161 +795,223 @@ pub mod instance {
     /// Represents the type of Data Fusion instance. Each type is configured with
     /// the default settings for processing and memory.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// No type specified. The instance creation will fail.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// Basic Data Fusion instance. In Basic type, the user will be able to
         /// create data pipelines using point and click UI. However, there are
         /// certain limitations, such as fewer number of concurrent pipelines, no
         /// support for streaming pipelines, etc.
-        pub const BASIC: Type = Type::new("BASIC");
+        pub const BASIC: Type = Type::new(1);
 
         /// Enterprise Data Fusion instance. In Enterprise type, the user will have
         /// all features available, such as support for streaming pipelines, higher
         /// number of concurrent pipelines, etc.
-        pub const ENTERPRISE: Type = Type::new("ENTERPRISE");
+        pub const ENTERPRISE: Type = Type::new(2);
 
         /// Developer Data Fusion instance. In Developer type, the user will have all
         /// features available but with restrictive capabilities. This is to help
         /// enterprises design and develop their data ingestion and integration
         /// pipelines at low cost.
-        pub const DEVELOPER: Type = Type::new("DEVELOPER");
+        pub const DEVELOPER: Type = Type::new(3);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BASIC"),
+                2 => std::borrow::Cow::Borrowed("ENTERPRISE"),
+                3 => std::borrow::Cow::Borrowed("DEVELOPER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "BASIC" => std::option::Option::Some(Self::BASIC),
+                "ENTERPRISE" => std::option::Option::Some(Self::ENTERPRISE),
+                "DEVELOPER" => std::option::Option::Some(Self::DEVELOPER),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Represents the state of a Data Fusion instance
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Instance does not have a state yet
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Instance is being created
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// Instance is active and ready for requests. This corresponds to 'RUNNING'
         /// in datafusion.v1beta1.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(2);
 
         /// Instance creation failed
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(3);
 
         /// Instance is being deleted
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(4);
 
         /// Instance is being upgraded
-        pub const UPGRADING: State = State::new("UPGRADING");
+        pub const UPGRADING: State = State::new(5);
 
         /// Instance is being restarted
-        pub const RESTARTING: State = State::new("RESTARTING");
+        pub const RESTARTING: State = State::new(6);
 
         /// Instance is being updated on customer request
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(7);
 
         /// Instance is being auto-updated
-        pub const AUTO_UPDATING: State = State::new("AUTO_UPDATING");
+        pub const AUTO_UPDATING: State = State::new(8);
 
         /// Instance is being auto-upgraded
-        pub const AUTO_UPGRADING: State = State::new("AUTO_UPGRADING");
+        pub const AUTO_UPGRADING: State = State::new(9);
 
         /// Instance is disabled
-        pub const DISABLED: State = State::new("DISABLED");
+        pub const DISABLED: State = State::new(10);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("UPGRADING"),
+                6 => std::borrow::Cow::Borrowed("RESTARTING"),
+                7 => std::borrow::Cow::Borrowed("UPDATING"),
+                8 => std::borrow::Cow::Borrowed("AUTO_UPDATING"),
+                9 => std::borrow::Cow::Borrowed("AUTO_UPGRADING"),
+                10 => std::borrow::Cow::Borrowed("DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "UPGRADING" => std::option::Option::Some(Self::UPGRADING),
+                "RESTARTING" => std::option::Option::Some(Self::RESTARTING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "AUTO_UPDATING" => std::option::Option::Some(Self::AUTO_UPDATING),
+                "AUTO_UPGRADING" => std::option::Option::Some(Self::AUTO_UPGRADING),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The reason for disabling the instance if the state is DISABLED.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DisabledReason(std::borrow::Cow<'static, str>);
+    pub struct DisabledReason(i32);
 
     impl DisabledReason {
+        /// This is an unknown reason for disabling.
+        pub const DISABLED_REASON_UNSPECIFIED: DisabledReason = DisabledReason::new(0);
+
+        /// The KMS key used by the instance is either revoked or denied access to
+        pub const KMS_KEY_ISSUE: DisabledReason = DisabledReason::new(1);
+
         /// Creates a new DisabledReason instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DISABLED_REASON_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("KMS_KEY_ISSUE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DISABLED_REASON_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DISABLED_REASON_UNSPECIFIED)
+                }
+                "KMS_KEY_ISSUE" => std::option::Option::Some(Self::KMS_KEY_ISSUE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DisabledReason](DisabledReason)
-    pub mod disabled_reason {
-        use super::DisabledReason;
-
-        /// This is an unknown reason for disabling.
-        pub const DISABLED_REASON_UNSPECIFIED: DisabledReason =
-            DisabledReason::new("DISABLED_REASON_UNSPECIFIED");
-
-        /// The KMS key used by the instance is either revoked or denied access to
-        pub const KMS_KEY_ISSUE: DisabledReason = DisabledReason::new("KMS_KEY_ISSUE");
-    }
-
-    impl std::convert::From<std::string::String> for DisabledReason {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DisabledReason {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DisabledReason {
         fn default() -> Self {
-            disabled_reason::DISABLED_REASON_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/datafusion/v1/src/transport.rs
+++ b/src/generated/cloud/datafusion/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::DataFusion for DataFusion {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/versions", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -74,7 +74,7 @@ impl crate::stubs::DataFusion for DataFusion {
                 reqwest::Method::GET,
                 format!("/v1/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::DataFusion for DataFusion {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -119,7 +119,7 @@ impl crate::stubs::DataFusion for DataFusion {
                 reqwest::Method::POST,
                 format!("/v1/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -139,7 +139,7 @@ impl crate::stubs::DataFusion for DataFusion {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -167,7 +167,7 @@ impl crate::stubs::DataFusion for DataFusion {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -196,7 +196,7 @@ impl crate::stubs::DataFusion for DataFusion {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:restart", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -213,7 +213,7 @@ impl crate::stubs::DataFusion for DataFusion {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -235,7 +235,7 @@ impl crate::stubs::DataFusion for DataFusion {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -254,7 +254,7 @@ impl crate::stubs::DataFusion for DataFusion {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -273,7 +273,7 @@ impl crate::stubs::DataFusion for DataFusion {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/dataproc/v1/src/model.rs
+++ b/src/generated/cloud/dataproc/v1/src/model.rs
@@ -1435,55 +1435,78 @@ pub mod batch {
 
     /// The batch state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The batch state is unknown.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The batch is created before running.
+        pub const PENDING: State = State::new(1);
+
+        /// The batch is running.
+        pub const RUNNING: State = State::new(2);
+
+        /// The batch is cancelling.
+        pub const CANCELLING: State = State::new(3);
+
+        /// The batch cancellation was successful.
+        pub const CANCELLED: State = State::new(4);
+
+        /// The batch completed successfully.
+        pub const SUCCEEDED: State = State::new(5);
+
+        /// The batch is no longer running due to an error.
+        pub const FAILED: State = State::new(6);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("CANCELLING"),
+                4 => std::borrow::Cow::Borrowed("CANCELLED"),
+                5 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                6 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The batch state is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The batch is created before running.
-        pub const PENDING: State = State::new("PENDING");
-
-        /// The batch is running.
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// The batch is cancelling.
-        pub const CANCELLING: State = State::new("CANCELLING");
-
-        /// The batch cancellation was successful.
-        pub const CANCELLED: State = State::new("CANCELLED");
-
-        /// The batch completed successfully.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-        /// The batch is no longer running due to an error.
-        pub const FAILED: State = State::new("FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -2991,57 +3014,77 @@ pub mod gce_cluster_config {
     /// [Compute Engine Instance
     /// fields](https://cloud.google.com/compute/docs/reference/rest/v1/instances).
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PrivateIpv6GoogleAccess(std::borrow::Cow<'static, str>);
+    pub struct PrivateIpv6GoogleAccess(i32);
 
     impl PrivateIpv6GoogleAccess {
-        /// Creates a new PrivateIpv6GoogleAccess instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PrivateIpv6GoogleAccess](PrivateIpv6GoogleAccess)
-    pub mod private_ipv_6_google_access {
-        use super::PrivateIpv6GoogleAccess;
-
         /// If unspecified, Compute Engine default behavior will apply, which
         /// is the same as
         /// [INHERIT_FROM_SUBNETWORK][google.cloud.dataproc.v1.GceClusterConfig.PrivateIpv6GoogleAccess.INHERIT_FROM_SUBNETWORK].
         ///
         /// [google.cloud.dataproc.v1.GceClusterConfig.PrivateIpv6GoogleAccess.INHERIT_FROM_SUBNETWORK]: crate::model::gce_cluster_config::private_ipv_6_google_access::INHERIT_FROM_SUBNETWORK
         pub const PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED: PrivateIpv6GoogleAccess =
-            PrivateIpv6GoogleAccess::new("PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED");
+            PrivateIpv6GoogleAccess::new(0);
 
         /// Private access to and from Google Services configuration
         /// inherited from the subnetwork configuration. This is the
         /// default Compute Engine behavior.
         pub const INHERIT_FROM_SUBNETWORK: PrivateIpv6GoogleAccess =
-            PrivateIpv6GoogleAccess::new("INHERIT_FROM_SUBNETWORK");
+            PrivateIpv6GoogleAccess::new(1);
 
         /// Enables outbound private IPv6 access to Google Services from the Dataproc
         /// cluster.
-        pub const OUTBOUND: PrivateIpv6GoogleAccess = PrivateIpv6GoogleAccess::new("OUTBOUND");
+        pub const OUTBOUND: PrivateIpv6GoogleAccess = PrivateIpv6GoogleAccess::new(2);
 
         /// Enables bidirectional private IPv6 access between Google Services and the
         /// Dataproc cluster.
-        pub const BIDIRECTIONAL: PrivateIpv6GoogleAccess =
-            PrivateIpv6GoogleAccess::new("BIDIRECTIONAL");
+        pub const BIDIRECTIONAL: PrivateIpv6GoogleAccess = PrivateIpv6GoogleAccess::new(3);
+
+        /// Creates a new PrivateIpv6GoogleAccess instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INHERIT_FROM_SUBNETWORK"),
+                2 => std::borrow::Cow::Borrowed("OUTBOUND"),
+                3 => std::borrow::Cow::Borrowed("BIDIRECTIONAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED)
+                }
+                "INHERIT_FROM_SUBNETWORK" => {
+                    std::option::Option::Some(Self::INHERIT_FROM_SUBNETWORK)
+                }
+                "OUTBOUND" => std::option::Option::Some(Self::OUTBOUND),
+                "BIDIRECTIONAL" => std::option::Option::Some(Self::BIDIRECTIONAL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PrivateIpv6GoogleAccess {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PrivateIpv6GoogleAccess {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PrivateIpv6GoogleAccess {
         fn default() -> Self {
-            private_ipv_6_google_access::PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3446,34 +3489,18 @@ pub mod instance_group_config {
 
     /// Controls the use of preemptible instances within the group.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Preemptibility(std::borrow::Cow<'static, str>);
+    pub struct Preemptibility(i32);
 
     impl Preemptibility {
-        /// Creates a new Preemptibility instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Preemptibility](Preemptibility)
-    pub mod preemptibility {
-        use super::Preemptibility;
-
         /// Preemptibility is unspecified, the system will choose the
         /// appropriate setting for each instance group.
-        pub const PREEMPTIBILITY_UNSPECIFIED: Preemptibility =
-            Preemptibility::new("PREEMPTIBILITY_UNSPECIFIED");
+        pub const PREEMPTIBILITY_UNSPECIFIED: Preemptibility = Preemptibility::new(0);
 
         /// Instances are non-preemptible.
         ///
         /// This option is allowed for all instance groups and is the only valid
         /// value for Master and Worker instance groups.
-        pub const NON_PREEMPTIBLE: Preemptibility = Preemptibility::new("NON_PREEMPTIBLE");
+        pub const NON_PREEMPTIBLE: Preemptibility = Preemptibility::new(1);
 
         /// Instances are [preemptible]
         /// (<https://cloud.google.com/compute/docs/instances/preemptible>).
@@ -3481,7 +3508,7 @@ pub mod instance_group_config {
         /// This option is allowed only for [secondary worker]
         /// (<https://cloud.google.com/dataproc/docs/concepts/compute/secondary-vms>)
         /// groups.
-        pub const PREEMPTIBLE: Preemptibility = Preemptibility::new("PREEMPTIBLE");
+        pub const PREEMPTIBLE: Preemptibility = Preemptibility::new(2);
 
         /// Instances are [Spot VMs]
         /// (<https://cloud.google.com/compute/docs/instances/spot>).
@@ -3491,18 +3518,52 @@ pub mod instance_group_config {
         /// groups. Spot VMs are the latest version of [preemptible VMs]
         /// (<https://cloud.google.com/compute/docs/instances/preemptible>), and
         /// provide additional features.
-        pub const SPOT: Preemptibility = Preemptibility::new("SPOT");
+        pub const SPOT: Preemptibility = Preemptibility::new(3);
+
+        /// Creates a new Preemptibility instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PREEMPTIBILITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NON_PREEMPTIBLE"),
+                2 => std::borrow::Cow::Borrowed("PREEMPTIBLE"),
+                3 => std::borrow::Cow::Borrowed("SPOT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PREEMPTIBILITY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PREEMPTIBILITY_UNSPECIFIED)
+                }
+                "NON_PREEMPTIBLE" => std::option::Option::Some(Self::NON_PREEMPTIBLE),
+                "PREEMPTIBLE" => std::option::Option::Some(Self::PREEMPTIBLE),
+                "SPOT" => std::option::Option::Some(Self::SPOT),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Preemptibility {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Preemptibility {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Preemptibility {
         fn default() -> Self {
-            preemptibility::PREEMPTIBILITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4205,40 +4266,53 @@ pub mod node_group {
 
     /// Node pool roles.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Role(std::borrow::Cow<'static, str>);
+    pub struct Role(i32);
 
     impl Role {
+        /// Required unspecified role.
+        pub const ROLE_UNSPECIFIED: Role = Role::new(0);
+
+        /// Job drivers run on the node pool.
+        pub const DRIVER: Role = Role::new(1);
+
         /// Creates a new Role instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ROLE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DRIVER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ROLE_UNSPECIFIED" => std::option::Option::Some(Self::ROLE_UNSPECIFIED),
+                "DRIVER" => std::option::Option::Some(Self::DRIVER),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Role](Role)
-    pub mod role {
-        use super::Role;
-
-        /// Required unspecified role.
-        pub const ROLE_UNSPECIFIED: Role = Role::new("ROLE_UNSPECIFIED");
-
-        /// Job drivers run on the node pool.
-        pub const DRIVER: Role = Role::new("DRIVER");
-    }
-
-    impl std::convert::From<std::string::String> for Role {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Role {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Role {
         fn default() -> Self {
-            role::ROLE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4367,121 +4441,167 @@ pub mod cluster_status {
 
     /// The cluster state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The cluster state is unknown.
-        pub const UNKNOWN: State = State::new("UNKNOWN");
+        pub const UNKNOWN: State = State::new(0);
 
         /// The cluster is being created and set up. It is not ready for use.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The cluster is currently running and healthy. It is ready for use.
         ///
         /// **Note:** The cluster state changes from "creating" to "running" status
         /// after the master node(s), first two primary worker nodes (and the last
         /// primary worker node if primary workers > 2) are running.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(2);
 
         /// The cluster encountered an error. It is not ready for use.
-        pub const ERROR: State = State::new("ERROR");
+        pub const ERROR: State = State::new(3);
 
         /// The cluster has encountered an error while being updated. Jobs can
         /// be submitted to the cluster, but the cluster cannot be updated.
-        pub const ERROR_DUE_TO_UPDATE: State = State::new("ERROR_DUE_TO_UPDATE");
+        pub const ERROR_DUE_TO_UPDATE: State = State::new(9);
 
         /// The cluster is being deleted. It cannot be used.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(4);
 
         /// The cluster is being updated. It continues to accept and process jobs.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(5);
 
         /// The cluster is being stopped. It cannot be used.
-        pub const STOPPING: State = State::new("STOPPING");
+        pub const STOPPING: State = State::new(6);
 
         /// The cluster is currently stopped. It is not ready for use.
-        pub const STOPPED: State = State::new("STOPPED");
+        pub const STOPPED: State = State::new(7);
 
         /// The cluster is being started. It is not ready for use.
-        pub const STARTING: State = State::new("STARTING");
+        pub const STARTING: State = State::new(8);
 
         /// The cluster is being repaired. It is not ready for use.
-        pub const REPAIRING: State = State::new("REPAIRING");
+        pub const REPAIRING: State = State::new(10);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("ERROR"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("UPDATING"),
+                6 => std::borrow::Cow::Borrowed("STOPPING"),
+                7 => std::borrow::Cow::Borrowed("STOPPED"),
+                8 => std::borrow::Cow::Borrowed("STARTING"),
+                9 => std::borrow::Cow::Borrowed("ERROR_DUE_TO_UPDATE"),
+                10 => std::borrow::Cow::Borrowed("REPAIRING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "ERROR_DUE_TO_UPDATE" => std::option::Option::Some(Self::ERROR_DUE_TO_UPDATE),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "STOPPING" => std::option::Option::Some(Self::STOPPING),
+                "STOPPED" => std::option::Option::Some(Self::STOPPED),
+                "STARTING" => std::option::Option::Some(Self::STARTING),
+                "REPAIRING" => std::option::Option::Some(Self::REPAIRING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::UNKNOWN
+            Self::new(0)
         }
     }
 
     /// The cluster substate.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Substate(std::borrow::Cow<'static, str>);
+    pub struct Substate(i32);
 
     impl Substate {
-        /// Creates a new Substate instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Substate](Substate)
-    pub mod substate {
-        use super::Substate;
-
         /// The cluster substate is unknown.
-        pub const UNSPECIFIED: Substate = Substate::new("UNSPECIFIED");
+        pub const UNSPECIFIED: Substate = Substate::new(0);
 
         /// The cluster is known to be in an unhealthy state
         /// (for example, critical daemons are not running or HDFS capacity is
         /// exhausted).
         ///
         /// Applies to RUNNING state.
-        pub const UNHEALTHY: Substate = Substate::new("UNHEALTHY");
+        pub const UNHEALTHY: Substate = Substate::new(1);
 
         /// The agent-reported status is out of date (may occur if
         /// Dataproc loses communication with Agent).
         ///
         /// Applies to RUNNING state.
-        pub const STALE_STATUS: Substate = Substate::new("STALE_STATUS");
+        pub const STALE_STATUS: Substate = Substate::new(2);
+
+        /// Creates a new Substate instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("UNHEALTHY"),
+                2 => std::borrow::Cow::Borrowed("STALE_STATUS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
+                "UNHEALTHY" => std::option::Option::Some(Self::UNHEALTHY),
+                "STALE_STATUS" => std::option::Option::Some(Self::STALE_STATUS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Substate {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Substate {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Substate {
         fn default() -> Self {
-            substate::UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5226,66 +5346,95 @@ pub mod dataproc_metric_config {
     /// metrics]
     /// (<https://cloud.google.com//dataproc/docs/guides/dataproc-metrics#custom_metrics>)).
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MetricSource(std::borrow::Cow<'static, str>);
+    pub struct MetricSource(i32);
 
     impl MetricSource {
-        /// Creates a new MetricSource instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [MetricSource](MetricSource)
-    pub mod metric_source {
-        use super::MetricSource;
-
         /// Required unspecified metric source.
-        pub const METRIC_SOURCE_UNSPECIFIED: MetricSource =
-            MetricSource::new("METRIC_SOURCE_UNSPECIFIED");
+        pub const METRIC_SOURCE_UNSPECIFIED: MetricSource = MetricSource::new(0);
 
         /// Monitoring agent metrics. If this source is enabled,
         /// Dataproc enables the monitoring agent in Compute Engine,
         /// and collects monitoring agent metrics, which are published
         /// with an `agent.googleapis.com` prefix.
-        pub const MONITORING_AGENT_DEFAULTS: MetricSource =
-            MetricSource::new("MONITORING_AGENT_DEFAULTS");
+        pub const MONITORING_AGENT_DEFAULTS: MetricSource = MetricSource::new(1);
 
         /// HDFS metric source.
-        pub const HDFS: MetricSource = MetricSource::new("HDFS");
+        pub const HDFS: MetricSource = MetricSource::new(2);
 
         /// Spark metric source.
-        pub const SPARK: MetricSource = MetricSource::new("SPARK");
+        pub const SPARK: MetricSource = MetricSource::new(3);
 
         /// YARN metric source.
-        pub const YARN: MetricSource = MetricSource::new("YARN");
+        pub const YARN: MetricSource = MetricSource::new(4);
 
         /// Spark History Server metric source.
-        pub const SPARK_HISTORY_SERVER: MetricSource = MetricSource::new("SPARK_HISTORY_SERVER");
+        pub const SPARK_HISTORY_SERVER: MetricSource = MetricSource::new(5);
 
         /// Hiveserver2 metric source.
-        pub const HIVESERVER2: MetricSource = MetricSource::new("HIVESERVER2");
+        pub const HIVESERVER2: MetricSource = MetricSource::new(6);
 
         /// hivemetastore metric source
-        pub const HIVEMETASTORE: MetricSource = MetricSource::new("HIVEMETASTORE");
+        pub const HIVEMETASTORE: MetricSource = MetricSource::new(7);
 
         /// flink metric source
-        pub const FLINK: MetricSource = MetricSource::new("FLINK");
+        pub const FLINK: MetricSource = MetricSource::new(8);
+
+        /// Creates a new MetricSource instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("METRIC_SOURCE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MONITORING_AGENT_DEFAULTS"),
+                2 => std::borrow::Cow::Borrowed("HDFS"),
+                3 => std::borrow::Cow::Borrowed("SPARK"),
+                4 => std::borrow::Cow::Borrowed("YARN"),
+                5 => std::borrow::Cow::Borrowed("SPARK_HISTORY_SERVER"),
+                6 => std::borrow::Cow::Borrowed("HIVESERVER2"),
+                7 => std::borrow::Cow::Borrowed("HIVEMETASTORE"),
+                8 => std::borrow::Cow::Borrowed("FLINK"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "METRIC_SOURCE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::METRIC_SOURCE_UNSPECIFIED)
+                }
+                "MONITORING_AGENT_DEFAULTS" => {
+                    std::option::Option::Some(Self::MONITORING_AGENT_DEFAULTS)
+                }
+                "HDFS" => std::option::Option::Some(Self::HDFS),
+                "SPARK" => std::option::Option::Some(Self::SPARK),
+                "YARN" => std::option::Option::Some(Self::YARN),
+                "SPARK_HISTORY_SERVER" => std::option::Option::Some(Self::SPARK_HISTORY_SERVER),
+                "HIVESERVER2" => std::option::Option::Some(Self::HIVESERVER2),
+                "HIVEMETASTORE" => std::option::Option::Some(Self::HIVEMETASTORE),
+                "FLINK" => std::option::Option::Some(Self::FLINK),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for MetricSource {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MetricSource {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MetricSource {
         fn default() -> Self {
-            metric_source::METRIC_SOURCE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6113,47 +6262,64 @@ pub mod diagnose_cluster_request {
 
     /// Defines who has access to the diagnostic tarball
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TarballAccess(std::borrow::Cow<'static, str>);
+    pub struct TarballAccess(i32);
 
     impl TarballAccess {
-        /// Creates a new TarballAccess instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [TarballAccess](TarballAccess)
-    pub mod tarball_access {
-        use super::TarballAccess;
-
         /// Tarball Access unspecified. Falls back to default access of the bucket
-        pub const TARBALL_ACCESS_UNSPECIFIED: TarballAccess =
-            TarballAccess::new("TARBALL_ACCESS_UNSPECIFIED");
+        pub const TARBALL_ACCESS_UNSPECIFIED: TarballAccess = TarballAccess::new(0);
 
         /// Google Cloud Support group has read access to the
         /// diagnostic tarball
-        pub const GOOGLE_CLOUD_SUPPORT: TarballAccess = TarballAccess::new("GOOGLE_CLOUD_SUPPORT");
+        pub const GOOGLE_CLOUD_SUPPORT: TarballAccess = TarballAccess::new(1);
 
         /// Google Cloud Dataproc Diagnose service account has read access to the
         /// diagnostic tarball
-        pub const GOOGLE_DATAPROC_DIAGNOSE: TarballAccess =
-            TarballAccess::new("GOOGLE_DATAPROC_DIAGNOSE");
+        pub const GOOGLE_DATAPROC_DIAGNOSE: TarballAccess = TarballAccess::new(2);
+
+        /// Creates a new TarballAccess instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TARBALL_ACCESS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GOOGLE_CLOUD_SUPPORT"),
+                2 => std::borrow::Cow::Borrowed("GOOGLE_DATAPROC_DIAGNOSE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TARBALL_ACCESS_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::TARBALL_ACCESS_UNSPECIFIED)
+                }
+                "GOOGLE_CLOUD_SUPPORT" => std::option::Option::Some(Self::GOOGLE_CLOUD_SUPPORT),
+                "GOOGLE_DATAPROC_DIAGNOSE" => {
+                    std::option::Option::Some(Self::GOOGLE_DATAPROC_DIAGNOSE)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for TarballAccess {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TarballAccess {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TarballAccess {
         fn default() -> Self {
-            tarball_access::TARBALL_ACCESS_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6254,46 +6420,63 @@ pub mod reservation_affinity {
 
     /// Indicates whether to consume capacity from an reservation or not.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// Do not consume from any allocated capacity.
-        pub const NO_RESERVATION: Type = Type::new("NO_RESERVATION");
+        pub const NO_RESERVATION: Type = Type::new(1);
 
         /// Consume any reservation available.
-        pub const ANY_RESERVATION: Type = Type::new("ANY_RESERVATION");
+        pub const ANY_RESERVATION: Type = Type::new(2);
 
         /// Must consume from a specific reservation. Must specify key value fields
         /// for specifying the reservations.
-        pub const SPECIFIC_RESERVATION: Type = Type::new("SPECIFIC_RESERVATION");
+        pub const SPECIFIC_RESERVATION: Type = Type::new(3);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NO_RESERVATION"),
+                2 => std::borrow::Cow::Borrowed("ANY_RESERVATION"),
+                3 => std::borrow::Cow::Borrowed("SPECIFIC_RESERVATION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "NO_RESERVATION" => std::option::Option::Some(Self::NO_RESERVATION),
+                "ANY_RESERVATION" => std::option::Option::Some(Self::ANY_RESERVATION),
+                "SPECIFIC_RESERVATION" => std::option::Option::Some(Self::SPECIFIC_RESERVATION),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6349,61 +6532,88 @@ pub mod logging_config {
     /// [Apache Hive](https://hive.apache.org/) job, Cloud
     /// Dataproc configures the Hive client to an equivalent verbosity level.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Level(std::borrow::Cow<'static, str>);
+    pub struct Level(i32);
 
     impl Level {
+        /// Level is unspecified. Use default level for log4j.
+        pub const LEVEL_UNSPECIFIED: Level = Level::new(0);
+
+        /// Use ALL level for log4j.
+        pub const ALL: Level = Level::new(1);
+
+        /// Use TRACE level for log4j.
+        pub const TRACE: Level = Level::new(2);
+
+        /// Use DEBUG level for log4j.
+        pub const DEBUG: Level = Level::new(3);
+
+        /// Use INFO level for log4j.
+        pub const INFO: Level = Level::new(4);
+
+        /// Use WARN level for log4j.
+        pub const WARN: Level = Level::new(5);
+
+        /// Use ERROR level for log4j.
+        pub const ERROR: Level = Level::new(6);
+
+        /// Use FATAL level for log4j.
+        pub const FATAL: Level = Level::new(7);
+
+        /// Turn off log4j.
+        pub const OFF: Level = Level::new(8);
+
         /// Creates a new Level instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LEVEL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALL"),
+                2 => std::borrow::Cow::Borrowed("TRACE"),
+                3 => std::borrow::Cow::Borrowed("DEBUG"),
+                4 => std::borrow::Cow::Borrowed("INFO"),
+                5 => std::borrow::Cow::Borrowed("WARN"),
+                6 => std::borrow::Cow::Borrowed("ERROR"),
+                7 => std::borrow::Cow::Borrowed("FATAL"),
+                8 => std::borrow::Cow::Borrowed("OFF"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LEVEL_UNSPECIFIED" => std::option::Option::Some(Self::LEVEL_UNSPECIFIED),
+                "ALL" => std::option::Option::Some(Self::ALL),
+                "TRACE" => std::option::Option::Some(Self::TRACE),
+                "DEBUG" => std::option::Option::Some(Self::DEBUG),
+                "INFO" => std::option::Option::Some(Self::INFO),
+                "WARN" => std::option::Option::Some(Self::WARN),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "FATAL" => std::option::Option::Some(Self::FATAL),
+                "OFF" => std::option::Option::Some(Self::OFF),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Level](Level)
-    pub mod level {
-        use super::Level;
-
-        /// Level is unspecified. Use default level for log4j.
-        pub const LEVEL_UNSPECIFIED: Level = Level::new("LEVEL_UNSPECIFIED");
-
-        /// Use ALL level for log4j.
-        pub const ALL: Level = Level::new("ALL");
-
-        /// Use TRACE level for log4j.
-        pub const TRACE: Level = Level::new("TRACE");
-
-        /// Use DEBUG level for log4j.
-        pub const DEBUG: Level = Level::new("DEBUG");
-
-        /// Use INFO level for log4j.
-        pub const INFO: Level = Level::new("INFO");
-
-        /// Use WARN level for log4j.
-        pub const WARN: Level = Level::new("WARN");
-
-        /// Use ERROR level for log4j.
-        pub const ERROR: Level = Level::new("ERROR");
-
-        /// Use FATAL level for log4j.
-        pub const FATAL: Level = Level::new("FATAL");
-
-        /// Turn off log4j.
-        pub const OFF: Level = Level::new("OFF");
-    }
-
-    impl std::convert::From<std::string::String> for Level {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Level {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Level {
         fn default() -> Self {
-            level::LEVEL_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8343,124 +8553,170 @@ pub mod job_status {
 
     /// The job state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The job state is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The job is pending; it has been submitted, but is not yet running.
-        pub const PENDING: State = State::new("PENDING");
+        pub const PENDING: State = State::new(1);
 
         /// Job has been received by the service and completed initial setup;
         /// it will soon be submitted to the cluster.
-        pub const SETUP_DONE: State = State::new("SETUP_DONE");
+        pub const SETUP_DONE: State = State::new(8);
 
         /// The job is running on the cluster.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(2);
 
         /// A CancelJob request has been received, but is pending.
-        pub const CANCEL_PENDING: State = State::new("CANCEL_PENDING");
+        pub const CANCEL_PENDING: State = State::new(3);
 
         /// Transient in-flight resources have been canceled, and the request to
         /// cancel the running job has been issued to the cluster.
-        pub const CANCEL_STARTED: State = State::new("CANCEL_STARTED");
+        pub const CANCEL_STARTED: State = State::new(7);
 
         /// The job cancellation was successful.
-        pub const CANCELLED: State = State::new("CANCELLED");
+        pub const CANCELLED: State = State::new(4);
 
         /// The job has completed successfully.
-        pub const DONE: State = State::new("DONE");
+        pub const DONE: State = State::new(5);
 
         /// The job has completed, but encountered an error.
-        pub const ERROR: State = State::new("ERROR");
+        pub const ERROR: State = State::new(6);
 
         /// Job attempt has failed. The detail field contains failure details for
         /// this attempt.
         ///
         /// Applies to restartable jobs only.
-        pub const ATTEMPT_FAILURE: State = State::new("ATTEMPT_FAILURE");
+        pub const ATTEMPT_FAILURE: State = State::new(9);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("CANCEL_PENDING"),
+                4 => std::borrow::Cow::Borrowed("CANCELLED"),
+                5 => std::borrow::Cow::Borrowed("DONE"),
+                6 => std::borrow::Cow::Borrowed("ERROR"),
+                7 => std::borrow::Cow::Borrowed("CANCEL_STARTED"),
+                8 => std::borrow::Cow::Borrowed("SETUP_DONE"),
+                9 => std::borrow::Cow::Borrowed("ATTEMPT_FAILURE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "SETUP_DONE" => std::option::Option::Some(Self::SETUP_DONE),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "CANCEL_PENDING" => std::option::Option::Some(Self::CANCEL_PENDING),
+                "CANCEL_STARTED" => std::option::Option::Some(Self::CANCEL_STARTED),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                "DONE" => std::option::Option::Some(Self::DONE),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "ATTEMPT_FAILURE" => std::option::Option::Some(Self::ATTEMPT_FAILURE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The job substate.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Substate(std::borrow::Cow<'static, str>);
+    pub struct Substate(i32);
 
     impl Substate {
-        /// Creates a new Substate instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Substate](Substate)
-    pub mod substate {
-        use super::Substate;
-
         /// The job substate is unknown.
-        pub const UNSPECIFIED: Substate = Substate::new("UNSPECIFIED");
+        pub const UNSPECIFIED: Substate = Substate::new(0);
 
         /// The Job is submitted to the agent.
         ///
         /// Applies to RUNNING state.
-        pub const SUBMITTED: Substate = Substate::new("SUBMITTED");
+        pub const SUBMITTED: Substate = Substate::new(1);
 
         /// The Job has been received and is awaiting execution (it might be waiting
         /// for a condition to be met). See the "details" field for the reason for
         /// the delay.
         ///
         /// Applies to RUNNING state.
-        pub const QUEUED: Substate = Substate::new("QUEUED");
+        pub const QUEUED: Substate = Substate::new(2);
 
         /// The agent-reported status is out of date, which can be caused by a
         /// loss of communication between the agent and Dataproc. If the
         /// agent does not send a timely update, the job will fail.
         ///
         /// Applies to RUNNING state.
-        pub const STALE_STATUS: Substate = Substate::new("STALE_STATUS");
+        pub const STALE_STATUS: Substate = Substate::new(3);
+
+        /// Creates a new Substate instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SUBMITTED"),
+                2 => std::borrow::Cow::Borrowed("QUEUED"),
+                3 => std::borrow::Cow::Borrowed("STALE_STATUS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
+                "SUBMITTED" => std::option::Option::Some(Self::SUBMITTED),
+                "QUEUED" => std::option::Option::Some(Self::QUEUED),
+                "STALE_STATUS" => std::option::Option::Some(Self::STALE_STATUS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Substate {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Substate {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Substate {
         fn default() -> Self {
-            substate::UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8585,61 +8841,88 @@ pub mod yarn_application {
     /// The application state, corresponding to
     /// \<code\>YarnProtos.YarnApplicationStateProto\</code\>.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Status is unspecified.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Status is NEW.
+        pub const NEW: State = State::new(1);
+
+        /// Status is NEW_SAVING.
+        pub const NEW_SAVING: State = State::new(2);
+
+        /// Status is SUBMITTED.
+        pub const SUBMITTED: State = State::new(3);
+
+        /// Status is ACCEPTED.
+        pub const ACCEPTED: State = State::new(4);
+
+        /// Status is RUNNING.
+        pub const RUNNING: State = State::new(5);
+
+        /// Status is FINISHED.
+        pub const FINISHED: State = State::new(6);
+
+        /// Status is FAILED.
+        pub const FAILED: State = State::new(7);
+
+        /// Status is KILLED.
+        pub const KILLED: State = State::new(8);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NEW"),
+                2 => std::borrow::Cow::Borrowed("NEW_SAVING"),
+                3 => std::borrow::Cow::Borrowed("SUBMITTED"),
+                4 => std::borrow::Cow::Borrowed("ACCEPTED"),
+                5 => std::borrow::Cow::Borrowed("RUNNING"),
+                6 => std::borrow::Cow::Borrowed("FINISHED"),
+                7 => std::borrow::Cow::Borrowed("FAILED"),
+                8 => std::borrow::Cow::Borrowed("KILLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "NEW" => std::option::Option::Some(Self::NEW),
+                "NEW_SAVING" => std::option::Option::Some(Self::NEW_SAVING),
+                "SUBMITTED" => std::option::Option::Some(Self::SUBMITTED),
+                "ACCEPTED" => std::option::Option::Some(Self::ACCEPTED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "FINISHED" => std::option::Option::Some(Self::FINISHED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "KILLED" => std::option::Option::Some(Self::KILLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Status is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Status is NEW.
-        pub const NEW: State = State::new("NEW");
-
-        /// Status is NEW_SAVING.
-        pub const NEW_SAVING: State = State::new("NEW_SAVING");
-
-        /// Status is SUBMITTED.
-        pub const SUBMITTED: State = State::new("SUBMITTED");
-
-        /// Status is ACCEPTED.
-        pub const ACCEPTED: State = State::new("ACCEPTED");
-
-        /// Status is RUNNING.
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// Status is FINISHED.
-        pub const FINISHED: State = State::new("FINISHED");
-
-        /// Status is FAILED.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// Status is KILLED.
-        pub const KILLED: State = State::new("KILLED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -9542,44 +9825,59 @@ pub mod list_jobs_request {
 
     /// A matcher that specifies categories of job states.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct JobStateMatcher(std::borrow::Cow<'static, str>);
+    pub struct JobStateMatcher(i32);
 
     impl JobStateMatcher {
-        /// Creates a new JobStateMatcher instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [JobStateMatcher](JobStateMatcher)
-    pub mod job_state_matcher {
-        use super::JobStateMatcher;
-
         /// Match all jobs, regardless of state.
-        pub const ALL: JobStateMatcher = JobStateMatcher::new("ALL");
+        pub const ALL: JobStateMatcher = JobStateMatcher::new(0);
 
         /// Only match jobs in non-terminal states: PENDING, RUNNING, or
         /// CANCEL_PENDING.
-        pub const ACTIVE: JobStateMatcher = JobStateMatcher::new("ACTIVE");
+        pub const ACTIVE: JobStateMatcher = JobStateMatcher::new(1);
 
         /// Only match jobs in terminal states: CANCELLED, DONE, or ERROR.
-        pub const NON_ACTIVE: JobStateMatcher = JobStateMatcher::new("NON_ACTIVE");
+        pub const NON_ACTIVE: JobStateMatcher = JobStateMatcher::new(2);
+
+        /// Creates a new JobStateMatcher instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ALL"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("NON_ACTIVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ALL" => std::option::Option::Some(Self::ALL),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "NON_ACTIVE" => std::option::Option::Some(Self::NON_ACTIVE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for JobStateMatcher {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for JobStateMatcher {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for JobStateMatcher {
         fn default() -> Self {
-            job_state_matcher::ALL
+            Self::new(0)
         }
     }
 }
@@ -10173,41 +10471,55 @@ pub mod batch_operation_metadata {
 
     /// Operation type for Batch resources
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BatchOperationType(std::borrow::Cow<'static, str>);
+    pub struct BatchOperationType(i32);
 
     impl BatchOperationType {
+        /// Batch operation type is unknown.
+        pub const BATCH_OPERATION_TYPE_UNSPECIFIED: BatchOperationType = BatchOperationType::new(0);
+
+        /// Batch operation type.
+        pub const BATCH: BatchOperationType = BatchOperationType::new(1);
+
         /// Creates a new BatchOperationType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("BATCH_OPERATION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BATCH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "BATCH_OPERATION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::BATCH_OPERATION_TYPE_UNSPECIFIED)
+                }
+                "BATCH" => std::option::Option::Some(Self::BATCH),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [BatchOperationType](BatchOperationType)
-    pub mod batch_operation_type {
-        use super::BatchOperationType;
-
-        /// Batch operation type is unknown.
-        pub const BATCH_OPERATION_TYPE_UNSPECIFIED: BatchOperationType =
-            BatchOperationType::new("BATCH_OPERATION_TYPE_UNSPECIFIED");
-
-        /// Batch operation type.
-        pub const BATCH: BatchOperationType = BatchOperationType::new("BATCH");
-    }
-
-    impl std::convert::From<std::string::String> for BatchOperationType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for BatchOperationType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for BatchOperationType {
         fn default() -> Self {
-            batch_operation_type::BATCH_OPERATION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -10339,47 +10651,66 @@ pub mod session_operation_metadata {
 
     /// Operation type for Session resources
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SessionOperationType(std::borrow::Cow<'static, str>);
+    pub struct SessionOperationType(i32);
 
     impl SessionOperationType {
+        /// Session operation type is unknown.
+        pub const SESSION_OPERATION_TYPE_UNSPECIFIED: SessionOperationType =
+            SessionOperationType::new(0);
+
+        /// Create Session operation type.
+        pub const CREATE: SessionOperationType = SessionOperationType::new(1);
+
+        /// Terminate Session operation type.
+        pub const TERMINATE: SessionOperationType = SessionOperationType::new(2);
+
+        /// Delete Session operation type.
+        pub const DELETE: SessionOperationType = SessionOperationType::new(3);
+
         /// Creates a new SessionOperationType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SESSION_OPERATION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATE"),
+                2 => std::borrow::Cow::Borrowed("TERMINATE"),
+                3 => std::borrow::Cow::Borrowed("DELETE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SESSION_OPERATION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SESSION_OPERATION_TYPE_UNSPECIFIED)
+                }
+                "CREATE" => std::option::Option::Some(Self::CREATE),
+                "TERMINATE" => std::option::Option::Some(Self::TERMINATE),
+                "DELETE" => std::option::Option::Some(Self::DELETE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SessionOperationType](SessionOperationType)
-    pub mod session_operation_type {
-        use super::SessionOperationType;
-
-        /// Session operation type is unknown.
-        pub const SESSION_OPERATION_TYPE_UNSPECIFIED: SessionOperationType =
-            SessionOperationType::new("SESSION_OPERATION_TYPE_UNSPECIFIED");
-
-        /// Create Session operation type.
-        pub const CREATE: SessionOperationType = SessionOperationType::new("CREATE");
-
-        /// Terminate Session operation type.
-        pub const TERMINATE: SessionOperationType = SessionOperationType::new("TERMINATE");
-
-        /// Delete Session operation type.
-        pub const DELETE: SessionOperationType = SessionOperationType::new("DELETE");
-    }
-
-    impl std::convert::From<std::string::String> for SessionOperationType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SessionOperationType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SessionOperationType {
         fn default() -> Self {
-            session_operation_type::SESSION_OPERATION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -10455,46 +10786,63 @@ pub mod cluster_operation_status {
 
     /// The operation state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unused.
+        pub const UNKNOWN: State = State::new(0);
+
+        /// The operation has been created.
+        pub const PENDING: State = State::new(1);
+
+        /// The operation is running.
+        pub const RUNNING: State = State::new(2);
+
+        /// The operation is done; either cancelled or completed.
+        pub const DONE: State = State::new(3);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("DONE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "DONE" => std::option::Option::Some(Self::DONE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unused.
-        pub const UNKNOWN: State = State::new("UNKNOWN");
-
-        /// The operation has been created.
-        pub const PENDING: State = State::new("PENDING");
-
-        /// The operation is running.
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// The operation is done; either cancelled or completed.
-        pub const DONE: State = State::new("DONE");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::UNKNOWN
+            Self::new(0)
         }
     }
 }
@@ -10765,50 +11113,71 @@ pub mod node_group_operation_metadata {
 
     /// Operation type for node group resources.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NodeGroupOperationType(std::borrow::Cow<'static, str>);
+    pub struct NodeGroupOperationType(i32);
 
     impl NodeGroupOperationType {
+        /// Node group operation type is unknown.
+        pub const NODE_GROUP_OPERATION_TYPE_UNSPECIFIED: NodeGroupOperationType =
+            NodeGroupOperationType::new(0);
+
+        /// Create node group operation type.
+        pub const CREATE: NodeGroupOperationType = NodeGroupOperationType::new(1);
+
+        /// Update node group operation type.
+        pub const UPDATE: NodeGroupOperationType = NodeGroupOperationType::new(2);
+
+        /// Delete node group operation type.
+        pub const DELETE: NodeGroupOperationType = NodeGroupOperationType::new(3);
+
+        /// Resize node group operation type.
+        pub const RESIZE: NodeGroupOperationType = NodeGroupOperationType::new(4);
+
         /// Creates a new NodeGroupOperationType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("NODE_GROUP_OPERATION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATE"),
+                2 => std::borrow::Cow::Borrowed("UPDATE"),
+                3 => std::borrow::Cow::Borrowed("DELETE"),
+                4 => std::borrow::Cow::Borrowed("RESIZE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "NODE_GROUP_OPERATION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::NODE_GROUP_OPERATION_TYPE_UNSPECIFIED)
+                }
+                "CREATE" => std::option::Option::Some(Self::CREATE),
+                "UPDATE" => std::option::Option::Some(Self::UPDATE),
+                "DELETE" => std::option::Option::Some(Self::DELETE),
+                "RESIZE" => std::option::Option::Some(Self::RESIZE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [NodeGroupOperationType](NodeGroupOperationType)
-    pub mod node_group_operation_type {
-        use super::NodeGroupOperationType;
-
-        /// Node group operation type is unknown.
-        pub const NODE_GROUP_OPERATION_TYPE_UNSPECIFIED: NodeGroupOperationType =
-            NodeGroupOperationType::new("NODE_GROUP_OPERATION_TYPE_UNSPECIFIED");
-
-        /// Create node group operation type.
-        pub const CREATE: NodeGroupOperationType = NodeGroupOperationType::new("CREATE");
-
-        /// Update node group operation type.
-        pub const UPDATE: NodeGroupOperationType = NodeGroupOperationType::new("UPDATE");
-
-        /// Delete node group operation type.
-        pub const DELETE: NodeGroupOperationType = NodeGroupOperationType::new("DELETE");
-
-        /// Resize node group operation type.
-        pub const RESIZE: NodeGroupOperationType = NodeGroupOperationType::new("RESIZE");
-    }
-
-    impl std::convert::From<std::string::String> for NodeGroupOperationType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for NodeGroupOperationType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for NodeGroupOperationType {
         fn default() -> Self {
-            node_group_operation_type::NODE_GROUP_OPERATION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -11994,52 +12363,73 @@ pub mod session {
 
     /// The session state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The session state is unknown.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The session is created prior to running.
+        pub const CREATING: State = State::new(1);
+
+        /// The session is running.
+        pub const ACTIVE: State = State::new(2);
+
+        /// The session is terminating.
+        pub const TERMINATING: State = State::new(3);
+
+        /// The session is terminated successfully.
+        pub const TERMINATED: State = State::new(4);
+
+        /// The session is no longer running due to an error.
+        pub const FAILED: State = State::new(5);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("TERMINATING"),
+                4 => std::borrow::Cow::Borrowed("TERMINATED"),
+                5 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "TERMINATING" => std::option::Option::Some(Self::TERMINATING),
+                "TERMINATED" => std::option::Option::Some(Self::TERMINATED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The session state is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The session is created prior to running.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The session is running.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The session is terminating.
-        pub const TERMINATING: State = State::new("TERMINATING");
-
-        /// The session is terminated successfully.
-        pub const TERMINATED: State = State::new("TERMINATED");
-
-        /// The session is no longer running due to an error.
-        pub const FAILED: State = State::new("FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -12103,43 +12493,58 @@ pub mod jupyter_config {
 
     /// Jupyter kernel types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Kernel(std::borrow::Cow<'static, str>);
+    pub struct Kernel(i32);
 
     impl Kernel {
+        /// The kernel is unknown.
+        pub const KERNEL_UNSPECIFIED: Kernel = Kernel::new(0);
+
+        /// Python kernel.
+        pub const PYTHON: Kernel = Kernel::new(1);
+
+        /// Scala kernel.
+        pub const SCALA: Kernel = Kernel::new(2);
+
         /// Creates a new Kernel instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("KERNEL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PYTHON"),
+                2 => std::borrow::Cow::Borrowed("SCALA"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "KERNEL_UNSPECIFIED" => std::option::Option::Some(Self::KERNEL_UNSPECIFIED),
+                "PYTHON" => std::option::Option::Some(Self::PYTHON),
+                "SCALA" => std::option::Option::Some(Self::SCALA),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Kernel](Kernel)
-    pub mod kernel {
-        use super::Kernel;
-
-        /// The kernel is unknown.
-        pub const KERNEL_UNSPECIFIED: Kernel = Kernel::new("KERNEL_UNSPECIFIED");
-
-        /// Python kernel.
-        pub const PYTHON: Kernel = Kernel::new("PYTHON");
-
-        /// Scala kernel.
-        pub const SCALA: Kernel = Kernel::new("SCALA");
-    }
-
-    impl std::convert::From<std::string::String> for Kernel {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Kernel {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Kernel {
         fn default() -> Self {
-            kernel::KERNEL_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -13203,54 +13608,73 @@ pub mod gke_node_pool_target {
     ///
     /// [google.cloud.dataproc.v1.GkeNodePoolTarget]: crate::model::GkeNodePoolTarget
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Role(std::borrow::Cow<'static, str>);
+    pub struct Role(i32);
 
     impl Role {
-        /// Creates a new Role instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Role](Role)
-    pub mod role {
-        use super::Role;
-
         /// Role is unspecified.
-        pub const ROLE_UNSPECIFIED: Role = Role::new("ROLE_UNSPECIFIED");
+        pub const ROLE_UNSPECIFIED: Role = Role::new(0);
 
         /// At least one node pool must have the `DEFAULT` role.
         /// Work assigned to a role that is not associated with a node pool
         /// is assigned to the node pool with the `DEFAULT` role. For example,
         /// work assigned to the `CONTROLLER` role will be assigned to the node pool
         /// with the `DEFAULT` role if no node pool has the `CONTROLLER` role.
-        pub const DEFAULT: Role = Role::new("DEFAULT");
+        pub const DEFAULT: Role = Role::new(1);
 
         /// Run work associated with the Dataproc control plane (for example,
         /// controllers and webhooks). Very low resource requirements.
-        pub const CONTROLLER: Role = Role::new("CONTROLLER");
+        pub const CONTROLLER: Role = Role::new(2);
 
         /// Run work associated with a Spark driver of a job.
-        pub const SPARK_DRIVER: Role = Role::new("SPARK_DRIVER");
+        pub const SPARK_DRIVER: Role = Role::new(3);
 
         /// Run work associated with a Spark executor of a job.
-        pub const SPARK_EXECUTOR: Role = Role::new("SPARK_EXECUTOR");
+        pub const SPARK_EXECUTOR: Role = Role::new(4);
+
+        /// Creates a new Role instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ROLE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DEFAULT"),
+                2 => std::borrow::Cow::Borrowed("CONTROLLER"),
+                3 => std::borrow::Cow::Borrowed("SPARK_DRIVER"),
+                4 => std::borrow::Cow::Borrowed("SPARK_EXECUTOR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ROLE_UNSPECIFIED" => std::option::Option::Some(Self::ROLE_UNSPECIFIED),
+                "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
+                "CONTROLLER" => std::option::Option::Some(Self::CONTROLLER),
+                "SPARK_DRIVER" => std::option::Option::Some(Self::SPARK_DRIVER),
+                "SPARK_EXECUTOR" => std::option::Option::Some(Self::SPARK_EXECUTOR),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Role {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Role {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Role {
         fn default() -> Self {
-            role::ROLE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -13618,48 +14042,63 @@ pub mod authentication_config {
 
     /// Authentication types for workload execution.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AuthenticationType(std::borrow::Cow<'static, str>);
+    pub struct AuthenticationType(i32);
 
     impl AuthenticationType {
-        /// Creates a new AuthenticationType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [AuthenticationType](AuthenticationType)
-    pub mod authentication_type {
-        use super::AuthenticationType;
-
         /// If AuthenticationType is unspecified then END_USER_CREDENTIALS is used
         /// for 3.0 and newer runtimes, and SERVICE_ACCOUNT is used for older
         /// runtimes.
-        pub const AUTHENTICATION_TYPE_UNSPECIFIED: AuthenticationType =
-            AuthenticationType::new("AUTHENTICATION_TYPE_UNSPECIFIED");
+        pub const AUTHENTICATION_TYPE_UNSPECIFIED: AuthenticationType = AuthenticationType::new(0);
 
         /// Use service account credentials for authenticating to other services.
-        pub const SERVICE_ACCOUNT: AuthenticationType = AuthenticationType::new("SERVICE_ACCOUNT");
+        pub const SERVICE_ACCOUNT: AuthenticationType = AuthenticationType::new(1);
 
         /// Use OAuth credentials associated with the workload creator/user for
         /// authenticating to other services.
-        pub const END_USER_CREDENTIALS: AuthenticationType =
-            AuthenticationType::new("END_USER_CREDENTIALS");
+        pub const END_USER_CREDENTIALS: AuthenticationType = AuthenticationType::new(2);
+
+        /// Creates a new AuthenticationType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("AUTHENTICATION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SERVICE_ACCOUNT"),
+                2 => std::borrow::Cow::Borrowed("END_USER_CREDENTIALS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "AUTHENTICATION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::AUTHENTICATION_TYPE_UNSPECIFIED)
+                }
+                "SERVICE_ACCOUNT" => std::option::Option::Some(Self::SERVICE_ACCOUNT),
+                "END_USER_CREDENTIALS" => std::option::Option::Some(Self::END_USER_CREDENTIALS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for AuthenticationType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AuthenticationType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AuthenticationType {
         fn default() -> Self {
-            authentication_type::AUTHENTICATION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -13706,46 +14145,63 @@ pub mod autotuning_config {
     /// Scenario represents a specific goal that autotuning will attempt to achieve
     /// by modifying workloads.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Scenario(std::borrow::Cow<'static, str>);
+    pub struct Scenario(i32);
 
     impl Scenario {
+        /// Default value.
+        pub const SCENARIO_UNSPECIFIED: Scenario = Scenario::new(0);
+
+        /// Scaling recommendations such as initialExecutors.
+        pub const SCALING: Scenario = Scenario::new(2);
+
+        /// Adding hints for potential relation broadcasts.
+        pub const BROADCAST_HASH_JOIN: Scenario = Scenario::new(3);
+
+        /// Memory management for workloads.
+        pub const MEMORY: Scenario = Scenario::new(4);
+
         /// Creates a new Scenario instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SCENARIO_UNSPECIFIED"),
+                2 => std::borrow::Cow::Borrowed("SCALING"),
+                3 => std::borrow::Cow::Borrowed("BROADCAST_HASH_JOIN"),
+                4 => std::borrow::Cow::Borrowed("MEMORY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SCENARIO_UNSPECIFIED" => std::option::Option::Some(Self::SCENARIO_UNSPECIFIED),
+                "SCALING" => std::option::Option::Some(Self::SCALING),
+                "BROADCAST_HASH_JOIN" => std::option::Option::Some(Self::BROADCAST_HASH_JOIN),
+                "MEMORY" => std::option::Option::Some(Self::MEMORY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Scenario](Scenario)
-    pub mod scenario {
-        use super::Scenario;
-
-        /// Default value.
-        pub const SCENARIO_UNSPECIFIED: Scenario = Scenario::new("SCENARIO_UNSPECIFIED");
-
-        /// Scaling recommendations such as initialExecutors.
-        pub const SCALING: Scenario = Scenario::new("SCALING");
-
-        /// Adding hints for potential relation broadcasts.
-        pub const BROADCAST_HASH_JOIN: Scenario = Scenario::new("BROADCAST_HASH_JOIN");
-
-        /// Memory management for workloads.
-        pub const MEMORY: Scenario = Scenario::new("MEMORY");
-    }
-
-    impl std::convert::From<std::string::String> for Scenario {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Scenario {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Scenario {
         fn default() -> Self {
-            scenario::SCENARIO_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -15259,46 +15715,63 @@ pub mod workflow_metadata {
 
     /// The operation state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unused.
+        pub const UNKNOWN: State = State::new(0);
+
+        /// The operation has been created.
+        pub const PENDING: State = State::new(1);
+
+        /// The operation is running.
+        pub const RUNNING: State = State::new(2);
+
+        /// The operation is done; either cancelled or completed.
+        pub const DONE: State = State::new(3);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("DONE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "DONE" => std::option::Option::Some(Self::DONE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unused.
-        pub const UNKNOWN: State = State::new("UNKNOWN");
-
-        /// The operation has been created.
-        pub const PENDING: State = State::new("PENDING");
-
-        /// The operation is running.
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// The operation is done; either cancelled or completed.
-        pub const DONE: State = State::new("DONE");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::UNKNOWN
+            Self::new(0)
         }
     }
 }
@@ -15468,53 +15941,74 @@ pub mod workflow_node {
 
     /// The workflow node state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NodeState(std::borrow::Cow<'static, str>);
+    pub struct NodeState(i32);
 
     impl NodeState {
-        /// Creates a new NodeState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [NodeState](NodeState)
-    pub mod node_state {
-        use super::NodeState;
-
         /// State is unspecified.
-        pub const NODE_STATE_UNSPECIFIED: NodeState = NodeState::new("NODE_STATE_UNSPECIFIED");
+        pub const NODE_STATE_UNSPECIFIED: NodeState = NodeState::new(0);
 
         /// The node is awaiting prerequisite node to finish.
-        pub const BLOCKED: NodeState = NodeState::new("BLOCKED");
+        pub const BLOCKED: NodeState = NodeState::new(1);
 
         /// The node is runnable but not running.
-        pub const RUNNABLE: NodeState = NodeState::new("RUNNABLE");
+        pub const RUNNABLE: NodeState = NodeState::new(2);
 
         /// The node is running.
-        pub const RUNNING: NodeState = NodeState::new("RUNNING");
+        pub const RUNNING: NodeState = NodeState::new(3);
 
         /// The node completed successfully.
-        pub const COMPLETED: NodeState = NodeState::new("COMPLETED");
+        pub const COMPLETED: NodeState = NodeState::new(4);
 
         /// The node failed. A node can be marked FAILED because
         /// its ancestor or peer failed.
-        pub const FAILED: NodeState = NodeState::new("FAILED");
+        pub const FAILED: NodeState = NodeState::new(5);
+
+        /// Creates a new NodeState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("NODE_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BLOCKED"),
+                2 => std::borrow::Cow::Borrowed("RUNNABLE"),
+                3 => std::borrow::Cow::Borrowed("RUNNING"),
+                4 => std::borrow::Cow::Borrowed("COMPLETED"),
+                5 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "NODE_STATE_UNSPECIFIED" => std::option::Option::Some(Self::NODE_STATE_UNSPECIFIED),
+                "BLOCKED" => std::option::Option::Some(Self::BLOCKED),
+                "RUNNABLE" => std::option::Option::Some(Self::RUNNABLE),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "COMPLETED" => std::option::Option::Some(Self::COMPLETED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for NodeState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for NodeState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for NodeState {
         fn default() -> Self {
-            node_state::NODE_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -16009,126 +16503,181 @@ impl wkt::message::Message for DeleteWorkflowTemplateRequest {
 
 /// Cluster components that can be activated.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Component(std::borrow::Cow<'static, str>);
+pub struct Component(i32);
 
 impl Component {
-    /// Creates a new Component instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [Component](Component)
-pub mod component {
-    use super::Component;
-
     /// Unspecified component. Specifying this will cause Cluster creation to fail.
-    pub const COMPONENT_UNSPECIFIED: Component = Component::new("COMPONENT_UNSPECIFIED");
+    pub const COMPONENT_UNSPECIFIED: Component = Component::new(0);
 
     /// The Anaconda component is no longer supported or applicable to
     /// [supported Dataproc on Compute Engine image versions]
     /// (<https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-version-clusters#supported-dataproc-image-versions>).
     /// It cannot be activated on clusters created with supported Dataproc on
     /// Compute Engine image versions.
-    pub const ANACONDA: Component = Component::new("ANACONDA");
+    pub const ANACONDA: Component = Component::new(5);
 
     /// Docker
-    pub const DOCKER: Component = Component::new("DOCKER");
+    pub const DOCKER: Component = Component::new(13);
 
     /// The Druid query engine. (alpha)
-    pub const DRUID: Component = Component::new("DRUID");
+    pub const DRUID: Component = Component::new(9);
 
     /// Flink
-    pub const FLINK: Component = Component::new("FLINK");
+    pub const FLINK: Component = Component::new(14);
 
     /// HBase. (beta)
-    pub const HBASE: Component = Component::new("HBASE");
+    pub const HBASE: Component = Component::new(11);
 
     /// The Hive Web HCatalog (the REST service for accessing HCatalog).
-    pub const HIVE_WEBHCAT: Component = Component::new("HIVE_WEBHCAT");
+    pub const HIVE_WEBHCAT: Component = Component::new(3);
 
     /// Hudi.
-    pub const HUDI: Component = Component::new("HUDI");
+    pub const HUDI: Component = Component::new(18);
 
     /// The Jupyter Notebook.
-    pub const JUPYTER: Component = Component::new("JUPYTER");
+    pub const JUPYTER: Component = Component::new(1);
 
     /// The Presto query engine.
-    pub const PRESTO: Component = Component::new("PRESTO");
+    pub const PRESTO: Component = Component::new(6);
 
     /// The Trino query engine.
-    pub const TRINO: Component = Component::new("TRINO");
+    pub const TRINO: Component = Component::new(17);
 
     /// The Ranger service.
-    pub const RANGER: Component = Component::new("RANGER");
+    pub const RANGER: Component = Component::new(12);
 
     /// The Solr service.
-    pub const SOLR: Component = Component::new("SOLR");
+    pub const SOLR: Component = Component::new(10);
 
     /// The Zeppelin notebook.
-    pub const ZEPPELIN: Component = Component::new("ZEPPELIN");
+    pub const ZEPPELIN: Component = Component::new(4);
 
     /// The Zookeeper service.
-    pub const ZOOKEEPER: Component = Component::new("ZOOKEEPER");
+    pub const ZOOKEEPER: Component = Component::new(8);
+
+    /// Creates a new Component instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("COMPONENT_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("JUPYTER"),
+            3 => std::borrow::Cow::Borrowed("HIVE_WEBHCAT"),
+            4 => std::borrow::Cow::Borrowed("ZEPPELIN"),
+            5 => std::borrow::Cow::Borrowed("ANACONDA"),
+            6 => std::borrow::Cow::Borrowed("PRESTO"),
+            8 => std::borrow::Cow::Borrowed("ZOOKEEPER"),
+            9 => std::borrow::Cow::Borrowed("DRUID"),
+            10 => std::borrow::Cow::Borrowed("SOLR"),
+            11 => std::borrow::Cow::Borrowed("HBASE"),
+            12 => std::borrow::Cow::Borrowed("RANGER"),
+            13 => std::borrow::Cow::Borrowed("DOCKER"),
+            14 => std::borrow::Cow::Borrowed("FLINK"),
+            17 => std::borrow::Cow::Borrowed("TRINO"),
+            18 => std::borrow::Cow::Borrowed("HUDI"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "COMPONENT_UNSPECIFIED" => std::option::Option::Some(Self::COMPONENT_UNSPECIFIED),
+            "ANACONDA" => std::option::Option::Some(Self::ANACONDA),
+            "DOCKER" => std::option::Option::Some(Self::DOCKER),
+            "DRUID" => std::option::Option::Some(Self::DRUID),
+            "FLINK" => std::option::Option::Some(Self::FLINK),
+            "HBASE" => std::option::Option::Some(Self::HBASE),
+            "HIVE_WEBHCAT" => std::option::Option::Some(Self::HIVE_WEBHCAT),
+            "HUDI" => std::option::Option::Some(Self::HUDI),
+            "JUPYTER" => std::option::Option::Some(Self::JUPYTER),
+            "PRESTO" => std::option::Option::Some(Self::PRESTO),
+            "TRINO" => std::option::Option::Some(Self::TRINO),
+            "RANGER" => std::option::Option::Some(Self::RANGER),
+            "SOLR" => std::option::Option::Some(Self::SOLR),
+            "ZEPPELIN" => std::option::Option::Some(Self::ZEPPELIN),
+            "ZOOKEEPER" => std::option::Option::Some(Self::ZOOKEEPER),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for Component {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Component {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Component {
     fn default() -> Self {
-        component::COMPONENT_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Actions in response to failure of a resource associated with a cluster.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct FailureAction(std::borrow::Cow<'static, str>);
+pub struct FailureAction(i32);
 
 impl FailureAction {
-    /// Creates a new FailureAction instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [FailureAction](FailureAction)
-pub mod failure_action {
-    use super::FailureAction;
-
     /// When FailureAction is unspecified, failure action defaults to NO_ACTION.
-    pub const FAILURE_ACTION_UNSPECIFIED: FailureAction =
-        FailureAction::new("FAILURE_ACTION_UNSPECIFIED");
+    pub const FAILURE_ACTION_UNSPECIFIED: FailureAction = FailureAction::new(0);
 
     /// Take no action on failure to create a cluster resource. NO_ACTION is the
     /// default.
-    pub const NO_ACTION: FailureAction = FailureAction::new("NO_ACTION");
+    pub const NO_ACTION: FailureAction = FailureAction::new(1);
 
     /// Delete the failed cluster resource.
-    pub const DELETE: FailureAction = FailureAction::new("DELETE");
+    pub const DELETE: FailureAction = FailureAction::new(2);
+
+    /// Creates a new FailureAction instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("FAILURE_ACTION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("NO_ACTION"),
+            2 => std::borrow::Cow::Borrowed("DELETE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "FAILURE_ACTION_UNSPECIFIED" => {
+                std::option::Option::Some(Self::FAILURE_ACTION_UNSPECIFIED)
+            }
+            "NO_ACTION" => std::option::Option::Some(Self::NO_ACTION),
+            "DELETE" => std::option::Option::Some(Self::DELETE),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for FailureAction {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for FailureAction {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for FailureAction {
     fn default() -> Self {
-        failure_action::FAILURE_ACTION_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/dataproc/v1/src/transport.rs
+++ b/src/generated/cloud/dataproc/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::AutoscalingPolicyService for AutoscalingPolicyService {
                 reqwest::Method::POST,
                 format!("/v1/{}/autoscalingPolicies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -78,7 +78,7 @@ impl crate::stubs::AutoscalingPolicyService for AutoscalingPolicyService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -95,7 +95,7 @@ impl crate::stubs::AutoscalingPolicyService for AutoscalingPolicyService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -117,7 +117,7 @@ impl crate::stubs::AutoscalingPolicyService for AutoscalingPolicyService {
                 reqwest::Method::GET,
                 format!("/v1/{}/autoscalingPolicies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -138,7 +138,7 @@ impl crate::stubs::AutoscalingPolicyService for AutoscalingPolicyService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -160,7 +160,7 @@ impl crate::stubs::AutoscalingPolicyService for AutoscalingPolicyService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -180,7 +180,7 @@ impl crate::stubs::AutoscalingPolicyService for AutoscalingPolicyService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -200,7 +200,7 @@ impl crate::stubs::AutoscalingPolicyService for AutoscalingPolicyService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -217,7 +217,7 @@ impl crate::stubs::AutoscalingPolicyService for AutoscalingPolicyService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -239,7 +239,7 @@ impl crate::stubs::AutoscalingPolicyService for AutoscalingPolicyService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -258,7 +258,7 @@ impl crate::stubs::AutoscalingPolicyService for AutoscalingPolicyService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -277,7 +277,7 @@ impl crate::stubs::AutoscalingPolicyService for AutoscalingPolicyService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -319,7 +319,7 @@ impl crate::stubs::BatchController for BatchController {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/batches", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -338,7 +338,7 @@ impl crate::stubs::BatchController for BatchController {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -357,7 +357,7 @@ impl crate::stubs::BatchController for BatchController {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/batches", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -380,7 +380,7 @@ impl crate::stubs::BatchController for BatchController {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -402,7 +402,7 @@ impl crate::stubs::BatchController for BatchController {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -422,7 +422,7 @@ impl crate::stubs::BatchController for BatchController {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -442,7 +442,7 @@ impl crate::stubs::BatchController for BatchController {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -459,7 +459,7 @@ impl crate::stubs::BatchController for BatchController {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -481,7 +481,7 @@ impl crate::stubs::BatchController for BatchController {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -500,7 +500,7 @@ impl crate::stubs::BatchController for BatchController {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -519,7 +519,7 @@ impl crate::stubs::BatchController for BatchController {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -581,7 +581,7 @@ impl crate::stubs::ClusterController for ClusterController {
                     req.project_id, req.region
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -611,7 +611,7 @@ impl crate::stubs::ClusterController for ClusterController {
                     req.project_id, req.region, req.cluster_name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -657,7 +657,7 @@ impl crate::stubs::ClusterController for ClusterController {
                     req.project_id, req.region, req.cluster_name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -680,7 +680,7 @@ impl crate::stubs::ClusterController for ClusterController {
                     req.project_id, req.region, req.cluster_name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -703,7 +703,7 @@ impl crate::stubs::ClusterController for ClusterController {
                     req.project_id, req.region, req.cluster_name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -730,7 +730,7 @@ impl crate::stubs::ClusterController for ClusterController {
                     req.project_id, req.region, req.cluster_name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -755,7 +755,7 @@ impl crate::stubs::ClusterController for ClusterController {
                     req.project_id, req.region
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -783,7 +783,7 @@ impl crate::stubs::ClusterController for ClusterController {
                     req.project_id, req.region, req.cluster_name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -803,7 +803,7 @@ impl crate::stubs::ClusterController for ClusterController {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -823,7 +823,7 @@ impl crate::stubs::ClusterController for ClusterController {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -843,7 +843,7 @@ impl crate::stubs::ClusterController for ClusterController {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -860,7 +860,7 @@ impl crate::stubs::ClusterController for ClusterController {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -882,7 +882,7 @@ impl crate::stubs::ClusterController for ClusterController {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -901,7 +901,7 @@ impl crate::stubs::ClusterController for ClusterController {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -920,7 +920,7 @@ impl crate::stubs::ClusterController for ClusterController {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -982,7 +982,7 @@ impl crate::stubs::JobController for JobController {
                     req.project_id, req.region
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1005,7 +1005,7 @@ impl crate::stubs::JobController for JobController {
                     req.project_id, req.region
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1028,7 +1028,7 @@ impl crate::stubs::JobController for JobController {
                     req.project_id, req.region, req.job_id
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1053,7 +1053,7 @@ impl crate::stubs::JobController for JobController {
                     req.project_id, req.region
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1083,7 +1083,7 @@ impl crate::stubs::JobController for JobController {
                     req.project_id, req.region, req.job_id
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1116,7 +1116,7 @@ impl crate::stubs::JobController for JobController {
                     req.project_id, req.region, req.job_id
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1139,7 +1139,7 @@ impl crate::stubs::JobController for JobController {
                     req.project_id, req.region, req.job_id
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1161,7 +1161,7 @@ impl crate::stubs::JobController for JobController {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1181,7 +1181,7 @@ impl crate::stubs::JobController for JobController {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1201,7 +1201,7 @@ impl crate::stubs::JobController for JobController {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1218,7 +1218,7 @@ impl crate::stubs::JobController for JobController {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1240,7 +1240,7 @@ impl crate::stubs::JobController for JobController {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1259,7 +1259,7 @@ impl crate::stubs::JobController for JobController {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1278,7 +1278,7 @@ impl crate::stubs::JobController for JobController {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1337,7 +1337,7 @@ impl crate::stubs::NodeGroupController for NodeGroupController {
                 reqwest::Method::POST,
                 format!("/v1/{}/nodeGroups", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1358,7 +1358,7 @@ impl crate::stubs::NodeGroupController for NodeGroupController {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:resize", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1375,7 +1375,7 @@ impl crate::stubs::NodeGroupController for NodeGroupController {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1397,7 +1397,7 @@ impl crate::stubs::NodeGroupController for NodeGroupController {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1417,7 +1417,7 @@ impl crate::stubs::NodeGroupController for NodeGroupController {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1437,7 +1437,7 @@ impl crate::stubs::NodeGroupController for NodeGroupController {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1454,7 +1454,7 @@ impl crate::stubs::NodeGroupController for NodeGroupController {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1476,7 +1476,7 @@ impl crate::stubs::NodeGroupController for NodeGroupController {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1495,7 +1495,7 @@ impl crate::stubs::NodeGroupController for NodeGroupController {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1514,7 +1514,7 @@ impl crate::stubs::NodeGroupController for NodeGroupController {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1573,7 +1573,7 @@ impl crate::stubs::SessionTemplateController for SessionTemplateController {
                 reqwest::Method::POST,
                 format!("/v1/{}/sessionTemplates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1601,7 +1601,7 @@ impl crate::stubs::SessionTemplateController for SessionTemplateController {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1620,7 +1620,7 @@ impl crate::stubs::SessionTemplateController for SessionTemplateController {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1642,7 +1642,7 @@ impl crate::stubs::SessionTemplateController for SessionTemplateController {
                 reqwest::Method::GET,
                 format!("/v1/{}/sessionTemplates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1664,7 +1664,7 @@ impl crate::stubs::SessionTemplateController for SessionTemplateController {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1686,7 +1686,7 @@ impl crate::stubs::SessionTemplateController for SessionTemplateController {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1706,7 +1706,7 @@ impl crate::stubs::SessionTemplateController for SessionTemplateController {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1726,7 +1726,7 @@ impl crate::stubs::SessionTemplateController for SessionTemplateController {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1743,7 +1743,7 @@ impl crate::stubs::SessionTemplateController for SessionTemplateController {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1765,7 +1765,7 @@ impl crate::stubs::SessionTemplateController for SessionTemplateController {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1784,7 +1784,7 @@ impl crate::stubs::SessionTemplateController for SessionTemplateController {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1803,7 +1803,7 @@ impl crate::stubs::SessionTemplateController for SessionTemplateController {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1848,7 +1848,7 @@ impl crate::stubs::SessionController for SessionController {
                 reqwest::Method::POST,
                 format!("/v1/{}/sessions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1869,7 +1869,7 @@ impl crate::stubs::SessionController for SessionController {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1888,7 +1888,7 @@ impl crate::stubs::SessionController for SessionController {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/sessions", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1910,7 +1910,7 @@ impl crate::stubs::SessionController for SessionController {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:terminate", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1927,7 +1927,7 @@ impl crate::stubs::SessionController for SessionController {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1950,7 +1950,7 @@ impl crate::stubs::SessionController for SessionController {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1970,7 +1970,7 @@ impl crate::stubs::SessionController for SessionController {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1990,7 +1990,7 @@ impl crate::stubs::SessionController for SessionController {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2007,7 +2007,7 @@ impl crate::stubs::SessionController for SessionController {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2029,7 +2029,7 @@ impl crate::stubs::SessionController for SessionController {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2048,7 +2048,7 @@ impl crate::stubs::SessionController for SessionController {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2067,7 +2067,7 @@ impl crate::stubs::SessionController for SessionController {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2126,7 +2126,7 @@ impl crate::stubs::WorkflowTemplateService for WorkflowTemplateService {
                 reqwest::Method::POST,
                 format!("/v1/{}/workflowTemplates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2145,7 +2145,7 @@ impl crate::stubs::WorkflowTemplateService for WorkflowTemplateService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2168,7 +2168,7 @@ impl crate::stubs::WorkflowTemplateService for WorkflowTemplateService {
                 reqwest::Method::POST,
                 format!("/v1/{}:instantiate", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2188,7 +2188,7 @@ impl crate::stubs::WorkflowTemplateService for WorkflowTemplateService {
                 reqwest::Method::POST,
                 format!("/v1/{}/workflowTemplates:instantiateInline", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2217,7 +2217,7 @@ impl crate::stubs::WorkflowTemplateService for WorkflowTemplateService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2239,7 +2239,7 @@ impl crate::stubs::WorkflowTemplateService for WorkflowTemplateService {
                 reqwest::Method::GET,
                 format!("/v1/{}/workflowTemplates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2260,7 +2260,7 @@ impl crate::stubs::WorkflowTemplateService for WorkflowTemplateService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2283,7 +2283,7 @@ impl crate::stubs::WorkflowTemplateService for WorkflowTemplateService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2303,7 +2303,7 @@ impl crate::stubs::WorkflowTemplateService for WorkflowTemplateService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2323,7 +2323,7 @@ impl crate::stubs::WorkflowTemplateService for WorkflowTemplateService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2340,7 +2340,7 @@ impl crate::stubs::WorkflowTemplateService for WorkflowTemplateService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2362,7 +2362,7 @@ impl crate::stubs::WorkflowTemplateService for WorkflowTemplateService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2381,7 +2381,7 @@ impl crate::stubs::WorkflowTemplateService for WorkflowTemplateService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2400,7 +2400,7 @@ impl crate::stubs::WorkflowTemplateService for WorkflowTemplateService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/datastream/v1/src/model.rs
+++ b/src/generated/cloud/datastream/v1/src/model.rs
@@ -3468,52 +3468,73 @@ pub mod private_connection {
 
     /// Private Connection state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The private connection is in creation state - creating resources.
+        pub const CREATING: State = State::new(1);
+
+        /// The private connection has been created with all of its resources.
+        pub const CREATED: State = State::new(2);
+
+        /// The private connection creation has failed.
+        pub const FAILED: State = State::new(3);
+
+        /// The private connection is being deleted.
+        pub const DELETING: State = State::new(4);
+
+        /// Delete request has failed, resource is in invalid state.
+        pub const FAILED_TO_DELETE: State = State::new(5);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("CREATED"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("FAILED_TO_DELETE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "CREATED" => std::option::Option::Some(Self::CREATED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "FAILED_TO_DELETE" => std::option::Option::Some(Self::FAILED_TO_DELETE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The private connection is in creation state - creating resources.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The private connection has been created with all of its resources.
-        pub const CREATED: State = State::new("CREATED");
-
-        /// The private connection creation has failed.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// The private connection is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// Delete request has failed, resource is in invalid state.
-        pub const FAILED_TO_DELETE: State = State::new("FAILED_TO_DELETE");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6628,87 +6649,119 @@ pub mod json_file_format {
 
     /// Schema file format.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SchemaFileFormat(std::borrow::Cow<'static, str>);
+    pub struct SchemaFileFormat(i32);
 
     impl SchemaFileFormat {
+        /// Unspecified schema file format.
+        pub const SCHEMA_FILE_FORMAT_UNSPECIFIED: SchemaFileFormat = SchemaFileFormat::new(0);
+
+        /// Do not attach schema file.
+        pub const NO_SCHEMA_FILE: SchemaFileFormat = SchemaFileFormat::new(1);
+
+        /// Avro schema format.
+        pub const AVRO_SCHEMA_FILE: SchemaFileFormat = SchemaFileFormat::new(2);
+
         /// Creates a new SchemaFileFormat instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SCHEMA_FILE_FORMAT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NO_SCHEMA_FILE"),
+                2 => std::borrow::Cow::Borrowed("AVRO_SCHEMA_FILE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SCHEMA_FILE_FORMAT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SCHEMA_FILE_FORMAT_UNSPECIFIED)
+                }
+                "NO_SCHEMA_FILE" => std::option::Option::Some(Self::NO_SCHEMA_FILE),
+                "AVRO_SCHEMA_FILE" => std::option::Option::Some(Self::AVRO_SCHEMA_FILE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SchemaFileFormat](SchemaFileFormat)
-    pub mod schema_file_format {
-        use super::SchemaFileFormat;
-
-        /// Unspecified schema file format.
-        pub const SCHEMA_FILE_FORMAT_UNSPECIFIED: SchemaFileFormat =
-            SchemaFileFormat::new("SCHEMA_FILE_FORMAT_UNSPECIFIED");
-
-        /// Do not attach schema file.
-        pub const NO_SCHEMA_FILE: SchemaFileFormat = SchemaFileFormat::new("NO_SCHEMA_FILE");
-
-        /// Avro schema format.
-        pub const AVRO_SCHEMA_FILE: SchemaFileFormat = SchemaFileFormat::new("AVRO_SCHEMA_FILE");
-    }
-
-    impl std::convert::From<std::string::String> for SchemaFileFormat {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SchemaFileFormat {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SchemaFileFormat {
         fn default() -> Self {
-            schema_file_format::SCHEMA_FILE_FORMAT_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Json file compression.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct JsonCompression(std::borrow::Cow<'static, str>);
+    pub struct JsonCompression(i32);
 
     impl JsonCompression {
+        /// Unspecified json file compression.
+        pub const JSON_COMPRESSION_UNSPECIFIED: JsonCompression = JsonCompression::new(0);
+
+        /// Do not compress JSON file.
+        pub const NO_COMPRESSION: JsonCompression = JsonCompression::new(1);
+
+        /// Gzip compression.
+        pub const GZIP: JsonCompression = JsonCompression::new(2);
+
         /// Creates a new JsonCompression instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("JSON_COMPRESSION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NO_COMPRESSION"),
+                2 => std::borrow::Cow::Borrowed("GZIP"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "JSON_COMPRESSION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::JSON_COMPRESSION_UNSPECIFIED)
+                }
+                "NO_COMPRESSION" => std::option::Option::Some(Self::NO_COMPRESSION),
+                "GZIP" => std::option::Option::Some(Self::GZIP),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [JsonCompression](JsonCompression)
-    pub mod json_compression {
-        use super::JsonCompression;
-
-        /// Unspecified json file compression.
-        pub const JSON_COMPRESSION_UNSPECIFIED: JsonCompression =
-            JsonCompression::new("JSON_COMPRESSION_UNSPECIFIED");
-
-        /// Do not compress JSON file.
-        pub const NO_COMPRESSION: JsonCompression = JsonCompression::new("NO_COMPRESSION");
-
-        /// Gzip compression.
-        pub const GZIP: JsonCompression = JsonCompression::new("GZIP");
-    }
-
-    impl std::convert::From<std::string::String> for JsonCompression {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for JsonCompression {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for JsonCompression {
         fn default() -> Self {
-            json_compression::JSON_COMPRESSION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7872,65 +7925,92 @@ pub mod stream {
 
     /// Stream state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified stream state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The stream has been created but has not yet started streaming data.
-        pub const NOT_STARTED: State = State::new("NOT_STARTED");
+        pub const NOT_STARTED: State = State::new(1);
 
         /// The stream is running.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(2);
 
         /// The stream is paused.
-        pub const PAUSED: State = State::new("PAUSED");
+        pub const PAUSED: State = State::new(3);
 
         /// The stream is in maintenance mode.
         ///
         /// Updates are rejected on the resource in this state.
-        pub const MAINTENANCE: State = State::new("MAINTENANCE");
+        pub const MAINTENANCE: State = State::new(4);
 
         /// The stream is experiencing an error that is preventing data from being
         /// streamed.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(5);
 
         /// The stream has experienced a terminal failure.
-        pub const FAILED_PERMANENTLY: State = State::new("FAILED_PERMANENTLY");
+        pub const FAILED_PERMANENTLY: State = State::new(6);
 
         /// The stream is starting, but not yet running.
-        pub const STARTING: State = State::new("STARTING");
+        pub const STARTING: State = State::new(7);
 
         /// The Stream is no longer reading new events, but still writing events in
         /// the buffer.
-        pub const DRAINING: State = State::new("DRAINING");
+        pub const DRAINING: State = State::new(8);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NOT_STARTED"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("PAUSED"),
+                4 => std::borrow::Cow::Borrowed("MAINTENANCE"),
+                5 => std::borrow::Cow::Borrowed("FAILED"),
+                6 => std::borrow::Cow::Borrowed("FAILED_PERMANENTLY"),
+                7 => std::borrow::Cow::Borrowed("STARTING"),
+                8 => std::borrow::Cow::Borrowed("DRAINING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "NOT_STARTED" => std::option::Option::Some(Self::NOT_STARTED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "PAUSED" => std::option::Option::Some(Self::PAUSED),
+                "MAINTENANCE" => std::option::Option::Some(Self::MAINTENANCE),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "FAILED_PERMANENTLY" => std::option::Option::Some(Self::FAILED_PERMANENTLY),
+                "STARTING" => std::option::Option::Some(Self::STARTING),
+                "DRAINING" => std::option::Option::Some(Self::DRAINING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -8516,104 +8596,144 @@ pub mod backfill_job {
 
     /// State of the stream object's backfill job.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Default value.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Backfill job was never started for the stream object (stream has backfill
         /// strategy defined as manual or object was explicitly excluded from
         /// automatic backfill).
-        pub const NOT_STARTED: State = State::new("NOT_STARTED");
+        pub const NOT_STARTED: State = State::new(1);
 
         /// Backfill job will start pending available resources.
-        pub const PENDING: State = State::new("PENDING");
+        pub const PENDING: State = State::new(2);
 
         /// Backfill job is running.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(3);
 
         /// Backfill job stopped (next job run will start from beginning).
-        pub const STOPPED: State = State::new("STOPPED");
+        pub const STOPPED: State = State::new(4);
 
         /// Backfill job failed (due to an error).
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(5);
 
         /// Backfill completed successfully.
-        pub const COMPLETED: State = State::new("COMPLETED");
+        pub const COMPLETED: State = State::new(6);
 
         /// Backfill job failed since the table structure is currently unsupported
         /// for backfill.
-        pub const UNSUPPORTED: State = State::new("UNSUPPORTED");
+        pub const UNSUPPORTED: State = State::new(7);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NOT_STARTED"),
+                2 => std::borrow::Cow::Borrowed("PENDING"),
+                3 => std::borrow::Cow::Borrowed("ACTIVE"),
+                4 => std::borrow::Cow::Borrowed("STOPPED"),
+                5 => std::borrow::Cow::Borrowed("FAILED"),
+                6 => std::borrow::Cow::Borrowed("COMPLETED"),
+                7 => std::borrow::Cow::Borrowed("UNSUPPORTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "NOT_STARTED" => std::option::Option::Some(Self::NOT_STARTED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "STOPPED" => std::option::Option::Some(Self::STOPPED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "COMPLETED" => std::option::Option::Some(Self::COMPLETED),
+                "UNSUPPORTED" => std::option::Option::Some(Self::UNSUPPORTED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Triggering reason for a backfill job.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Trigger(std::borrow::Cow<'static, str>);
+    pub struct Trigger(i32);
 
     impl Trigger {
-        /// Creates a new Trigger instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Trigger](Trigger)
-    pub mod trigger {
-        use super::Trigger;
-
         /// Default value.
-        pub const TRIGGER_UNSPECIFIED: Trigger = Trigger::new("TRIGGER_UNSPECIFIED");
+        pub const TRIGGER_UNSPECIFIED: Trigger = Trigger::new(0);
 
         /// Object backfill job was triggered automatically according to the stream's
         /// backfill strategy.
-        pub const AUTOMATIC: Trigger = Trigger::new("AUTOMATIC");
+        pub const AUTOMATIC: Trigger = Trigger::new(1);
 
         /// Object backfill job was triggered manually using the dedicated API.
-        pub const MANUAL: Trigger = Trigger::new("MANUAL");
+        pub const MANUAL: Trigger = Trigger::new(2);
+
+        /// Creates a new Trigger instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TRIGGER_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AUTOMATIC"),
+                2 => std::borrow::Cow::Borrowed("MANUAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TRIGGER_UNSPECIFIED" => std::option::Option::Some(Self::TRIGGER_UNSPECIFIED),
+                "AUTOMATIC" => std::option::Option::Some(Self::AUTOMATIC),
+                "MANUAL" => std::option::Option::Some(Self::MANUAL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Trigger {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Trigger {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Trigger {
         fn default() -> Self {
-            trigger::TRIGGER_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8805,49 +8925,68 @@ pub mod validation {
 
     /// Validation execution state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Validation did not execute.
+        pub const NOT_EXECUTED: State = State::new(1);
+
+        /// Validation failed.
+        pub const FAILED: State = State::new(2);
+
+        /// Validation passed.
+        pub const PASSED: State = State::new(3);
+
+        /// Validation executed with warnings.
+        pub const WARNING: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NOT_EXECUTED"),
+                2 => std::borrow::Cow::Borrowed("FAILED"),
+                3 => std::borrow::Cow::Borrowed("PASSED"),
+                4 => std::borrow::Cow::Borrowed("WARNING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "NOT_EXECUTED" => std::option::Option::Some(Self::NOT_EXECUTED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "PASSED" => std::option::Option::Some(Self::PASSED),
+                "WARNING" => std::option::Option::Some(Self::WARNING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Validation did not execute.
-        pub const NOT_EXECUTED: State = State::new("NOT_EXECUTED");
-
-        /// Validation failed.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// Validation passed.
-        pub const PASSED: State = State::new("PASSED");
-
-        /// Validation executed with warnings.
-        pub const WARNING: State = State::new("WARNING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8926,43 +9065,58 @@ pub mod validation_message {
 
     /// Validation message level.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Level(std::borrow::Cow<'static, str>);
+    pub struct Level(i32);
 
     impl Level {
+        /// Unspecified level.
+        pub const LEVEL_UNSPECIFIED: Level = Level::new(0);
+
+        /// Potentially cause issues with the Stream.
+        pub const WARNING: Level = Level::new(1);
+
+        /// Definitely cause issues with the Stream.
+        pub const ERROR: Level = Level::new(2);
+
         /// Creates a new Level instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LEVEL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("WARNING"),
+                2 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LEVEL_UNSPECIFIED" => std::option::Option::Some(Self::LEVEL_UNSPECIFIED),
+                "WARNING" => std::option::Option::Some(Self::WARNING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Level](Level)
-    pub mod level {
-        use super::Level;
-
-        /// Unspecified level.
-        pub const LEVEL_UNSPECIFIED: Level = Level::new("LEVEL_UNSPECIFIED");
-
-        /// Potentially cause issues with the Stream.
-        pub const WARNING: Level = Level::new("WARNING");
-
-        /// Definitely cause issues with the Stream.
-        pub const ERROR: Level = Level::new("ERROR");
-    }
-
-    impl std::convert::From<std::string::String> for Level {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Level {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Level {
         fn default() -> Self {
-            level::LEVEL_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/datastream/v1/src/transport.rs
+++ b/src/generated/cloud/datastream/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::Datastream for Datastream {
                 reqwest::Method::GET,
                 format!("/v1/{}/connectionProfiles", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::Datastream for Datastream {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::Datastream for Datastream {
                 reqwest::Method::POST,
                 format!("/v1/{}/connectionProfiles", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -129,7 +129,7 @@ impl crate::stubs::Datastream for Datastream {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -161,7 +161,7 @@ impl crate::stubs::Datastream for Datastream {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -184,7 +184,7 @@ impl crate::stubs::Datastream for Datastream {
                 reqwest::Method::POST,
                 format!("/v1/{}/connectionProfiles:discover", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -201,7 +201,7 @@ impl crate::stubs::Datastream for Datastream {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/streams", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -224,7 +224,7 @@ impl crate::stubs::Datastream for Datastream {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -243,7 +243,7 @@ impl crate::stubs::Datastream for Datastream {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/streams", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -273,7 +273,7 @@ impl crate::stubs::Datastream for Datastream {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -303,7 +303,7 @@ impl crate::stubs::Datastream for Datastream {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -323,7 +323,7 @@ impl crate::stubs::Datastream for Datastream {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:run", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -340,7 +340,7 @@ impl crate::stubs::Datastream for Datastream {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -362,7 +362,7 @@ impl crate::stubs::Datastream for Datastream {
                 reqwest::Method::POST,
                 format!("/v1/{}/objects:lookup", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -379,7 +379,7 @@ impl crate::stubs::Datastream for Datastream {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/objects", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -403,7 +403,7 @@ impl crate::stubs::Datastream for Datastream {
                 reqwest::Method::POST,
                 format!("/v1/{}:startBackfillJob", req.object),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -423,7 +423,7 @@ impl crate::stubs::Datastream for Datastream {
                 reqwest::Method::POST,
                 format!("/v1/{}:stopBackfillJob", req.object),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -443,7 +443,7 @@ impl crate::stubs::Datastream for Datastream {
                 reqwest::Method::GET,
                 format!("/v1/{}:fetchStaticIps", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -467,7 +467,7 @@ impl crate::stubs::Datastream for Datastream {
                 reqwest::Method::POST,
                 format!("/v1/{}/privateConnections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -489,7 +489,7 @@ impl crate::stubs::Datastream for Datastream {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -511,7 +511,7 @@ impl crate::stubs::Datastream for Datastream {
                 reqwest::Method::GET,
                 format!("/v1/{}/privateConnections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -534,7 +534,7 @@ impl crate::stubs::Datastream for Datastream {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -555,7 +555,7 @@ impl crate::stubs::Datastream for Datastream {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/routes", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -574,7 +574,7 @@ impl crate::stubs::Datastream for Datastream {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -593,7 +593,7 @@ impl crate::stubs::Datastream for Datastream {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/routes", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -616,7 +616,7 @@ impl crate::stubs::Datastream for Datastream {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -636,7 +636,7 @@ impl crate::stubs::Datastream for Datastream {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -658,7 +658,7 @@ impl crate::stubs::Datastream for Datastream {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -677,7 +677,7 @@ impl crate::stubs::Datastream for Datastream {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -699,7 +699,7 @@ impl crate::stubs::Datastream for Datastream {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -718,7 +718,7 @@ impl crate::stubs::Datastream for Datastream {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -737,7 +737,7 @@ impl crate::stubs::Datastream for Datastream {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/deploy/v1/src/model.rs
+++ b/src/generated/cloud/deploy/v1/src/model.rs
@@ -3158,55 +3158,76 @@ pub mod execution_config {
 
     /// Possible usages of this configuration.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ExecutionEnvironmentUsage(std::borrow::Cow<'static, str>);
+    pub struct ExecutionEnvironmentUsage(i32);
 
     impl ExecutionEnvironmentUsage {
+        /// Default value. This value is unused.
+        pub const EXECUTION_ENVIRONMENT_USAGE_UNSPECIFIED: ExecutionEnvironmentUsage =
+            ExecutionEnvironmentUsage::new(0);
+
+        /// Use for rendering.
+        pub const RENDER: ExecutionEnvironmentUsage = ExecutionEnvironmentUsage::new(1);
+
+        /// Use for deploying and deployment hooks.
+        pub const DEPLOY: ExecutionEnvironmentUsage = ExecutionEnvironmentUsage::new(2);
+
+        /// Use for deployment verification.
+        pub const VERIFY: ExecutionEnvironmentUsage = ExecutionEnvironmentUsage::new(3);
+
+        /// Use for predeploy job execution.
+        pub const PREDEPLOY: ExecutionEnvironmentUsage = ExecutionEnvironmentUsage::new(4);
+
+        /// Use for postdeploy job execution.
+        pub const POSTDEPLOY: ExecutionEnvironmentUsage = ExecutionEnvironmentUsage::new(5);
+
         /// Creates a new ExecutionEnvironmentUsage instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EXECUTION_ENVIRONMENT_USAGE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RENDER"),
+                2 => std::borrow::Cow::Borrowed("DEPLOY"),
+                3 => std::borrow::Cow::Borrowed("VERIFY"),
+                4 => std::borrow::Cow::Borrowed("PREDEPLOY"),
+                5 => std::borrow::Cow::Borrowed("POSTDEPLOY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EXECUTION_ENVIRONMENT_USAGE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::EXECUTION_ENVIRONMENT_USAGE_UNSPECIFIED)
+                }
+                "RENDER" => std::option::Option::Some(Self::RENDER),
+                "DEPLOY" => std::option::Option::Some(Self::DEPLOY),
+                "VERIFY" => std::option::Option::Some(Self::VERIFY),
+                "PREDEPLOY" => std::option::Option::Some(Self::PREDEPLOY),
+                "POSTDEPLOY" => std::option::Option::Some(Self::POSTDEPLOY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ExecutionEnvironmentUsage](ExecutionEnvironmentUsage)
-    pub mod execution_environment_usage {
-        use super::ExecutionEnvironmentUsage;
-
-        /// Default value. This value is unused.
-        pub const EXECUTION_ENVIRONMENT_USAGE_UNSPECIFIED: ExecutionEnvironmentUsage =
-            ExecutionEnvironmentUsage::new("EXECUTION_ENVIRONMENT_USAGE_UNSPECIFIED");
-
-        /// Use for rendering.
-        pub const RENDER: ExecutionEnvironmentUsage = ExecutionEnvironmentUsage::new("RENDER");
-
-        /// Use for deploying and deployment hooks.
-        pub const DEPLOY: ExecutionEnvironmentUsage = ExecutionEnvironmentUsage::new("DEPLOY");
-
-        /// Use for deployment verification.
-        pub const VERIFY: ExecutionEnvironmentUsage = ExecutionEnvironmentUsage::new("VERIFY");
-
-        /// Use for predeploy job execution.
-        pub const PREDEPLOY: ExecutionEnvironmentUsage =
-            ExecutionEnvironmentUsage::new("PREDEPLOY");
-
-        /// Use for postdeploy job execution.
-        pub const POSTDEPLOY: ExecutionEnvironmentUsage =
-            ExecutionEnvironmentUsage::new("POSTDEPLOY");
-    }
-
-    impl std::convert::From<std::string::String> for ExecutionEnvironmentUsage {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ExecutionEnvironmentUsage {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ExecutionEnvironmentUsage {
         fn default() -> Self {
-            execution_environment_usage::EXECUTION_ENVIRONMENT_USAGE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -5250,44 +5271,59 @@ pub mod deploy_policy {
     /// What invoked the action. Filters enforcing the policy depending on what
     /// invoked the action.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Invoker(std::borrow::Cow<'static, str>);
+    pub struct Invoker(i32);
 
     impl Invoker {
-        /// Creates a new Invoker instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Invoker](Invoker)
-    pub mod invoker {
-        use super::Invoker;
-
         /// Unspecified.
-        pub const INVOKER_UNSPECIFIED: Invoker = Invoker::new("INVOKER_UNSPECIFIED");
+        pub const INVOKER_UNSPECIFIED: Invoker = Invoker::new(0);
 
         /// The action is user-driven. For example, creating a rollout manually via a
         /// gcloud create command.
-        pub const USER: Invoker = Invoker::new("USER");
+        pub const USER: Invoker = Invoker::new(1);
 
         /// Automated action by Cloud Deploy.
-        pub const DEPLOY_AUTOMATION: Invoker = Invoker::new("DEPLOY_AUTOMATION");
+        pub const DEPLOY_AUTOMATION: Invoker = Invoker::new(2);
+
+        /// Creates a new Invoker instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("INVOKER_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("USER"),
+                2 => std::borrow::Cow::Borrowed("DEPLOY_AUTOMATION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "INVOKER_UNSPECIFIED" => std::option::Option::Some(Self::INVOKER_UNSPECIFIED),
+                "USER" => std::option::Option::Some(Self::USER),
+                "DEPLOY_AUTOMATION" => std::option::Option::Some(Self::DEPLOY_AUTOMATION),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Invoker {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Invoker {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Invoker {
         fn default() -> Self {
-            invoker::INVOKER_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5601,62 +5637,90 @@ pub mod rollout_restriction {
 
     /// Rollout actions to be restricted as part of the policy.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RolloutActions(std::borrow::Cow<'static, str>);
+    pub struct RolloutActions(i32);
 
     impl RolloutActions {
+        /// Unspecified.
+        pub const ROLLOUT_ACTIONS_UNSPECIFIED: RolloutActions = RolloutActions::new(0);
+
+        /// Advance the rollout to the next phase.
+        pub const ADVANCE: RolloutActions = RolloutActions::new(1);
+
+        /// Approve the rollout.
+        pub const APPROVE: RolloutActions = RolloutActions::new(2);
+
+        /// Cancel the rollout.
+        pub const CANCEL: RolloutActions = RolloutActions::new(3);
+
+        /// Create a rollout.
+        pub const CREATE: RolloutActions = RolloutActions::new(4);
+
+        /// Ignore a job result on the rollout.
+        pub const IGNORE_JOB: RolloutActions = RolloutActions::new(5);
+
+        /// Retry a job for a rollout.
+        pub const RETRY_JOB: RolloutActions = RolloutActions::new(6);
+
+        /// Rollback a rollout.
+        pub const ROLLBACK: RolloutActions = RolloutActions::new(7);
+
+        /// Terminate a jobrun.
+        pub const TERMINATE_JOBRUN: RolloutActions = RolloutActions::new(8);
+
         /// Creates a new RolloutActions instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ROLLOUT_ACTIONS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ADVANCE"),
+                2 => std::borrow::Cow::Borrowed("APPROVE"),
+                3 => std::borrow::Cow::Borrowed("CANCEL"),
+                4 => std::borrow::Cow::Borrowed("CREATE"),
+                5 => std::borrow::Cow::Borrowed("IGNORE_JOB"),
+                6 => std::borrow::Cow::Borrowed("RETRY_JOB"),
+                7 => std::borrow::Cow::Borrowed("ROLLBACK"),
+                8 => std::borrow::Cow::Borrowed("TERMINATE_JOBRUN"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ROLLOUT_ACTIONS_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ROLLOUT_ACTIONS_UNSPECIFIED)
+                }
+                "ADVANCE" => std::option::Option::Some(Self::ADVANCE),
+                "APPROVE" => std::option::Option::Some(Self::APPROVE),
+                "CANCEL" => std::option::Option::Some(Self::CANCEL),
+                "CREATE" => std::option::Option::Some(Self::CREATE),
+                "IGNORE_JOB" => std::option::Option::Some(Self::IGNORE_JOB),
+                "RETRY_JOB" => std::option::Option::Some(Self::RETRY_JOB),
+                "ROLLBACK" => std::option::Option::Some(Self::ROLLBACK),
+                "TERMINATE_JOBRUN" => std::option::Option::Some(Self::TERMINATE_JOBRUN),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RolloutActions](RolloutActions)
-    pub mod rollout_actions {
-        use super::RolloutActions;
-
-        /// Unspecified.
-        pub const ROLLOUT_ACTIONS_UNSPECIFIED: RolloutActions =
-            RolloutActions::new("ROLLOUT_ACTIONS_UNSPECIFIED");
-
-        /// Advance the rollout to the next phase.
-        pub const ADVANCE: RolloutActions = RolloutActions::new("ADVANCE");
-
-        /// Approve the rollout.
-        pub const APPROVE: RolloutActions = RolloutActions::new("APPROVE");
-
-        /// Cancel the rollout.
-        pub const CANCEL: RolloutActions = RolloutActions::new("CANCEL");
-
-        /// Create a rollout.
-        pub const CREATE: RolloutActions = RolloutActions::new("CREATE");
-
-        /// Ignore a job result on the rollout.
-        pub const IGNORE_JOB: RolloutActions = RolloutActions::new("IGNORE_JOB");
-
-        /// Retry a job for a rollout.
-        pub const RETRY_JOB: RolloutActions = RolloutActions::new("RETRY_JOB");
-
-        /// Rollback a rollout.
-        pub const ROLLBACK: RolloutActions = RolloutActions::new("ROLLBACK");
-
-        /// Terminate a jobrun.
-        pub const TERMINATE_JOBRUN: RolloutActions = RolloutActions::new("TERMINATE_JOBRUN");
-    }
-
-    impl std::convert::From<std::string::String> for RolloutActions {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RolloutActions {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RolloutActions {
         fn default() -> Self {
-            rollout_actions::ROLLOUT_ACTIONS_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6397,120 +6461,171 @@ pub mod release {
 
         /// Valid states of the render operation.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct TargetRenderState(std::borrow::Cow<'static, str>);
+        pub struct TargetRenderState(i32);
 
         impl TargetRenderState {
+            /// The render operation state is unspecified.
+            pub const TARGET_RENDER_STATE_UNSPECIFIED: TargetRenderState =
+                TargetRenderState::new(0);
+
+            /// The render operation has completed successfully.
+            pub const SUCCEEDED: TargetRenderState = TargetRenderState::new(1);
+
+            /// The render operation has failed.
+            pub const FAILED: TargetRenderState = TargetRenderState::new(2);
+
+            /// The render operation is in progress.
+            pub const IN_PROGRESS: TargetRenderState = TargetRenderState::new(3);
+
             /// Creates a new TargetRenderState instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("TARGET_RENDER_STATE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                    2 => std::borrow::Cow::Borrowed("FAILED"),
+                    3 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "TARGET_RENDER_STATE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::TARGET_RENDER_STATE_UNSPECIFIED)
+                    }
+                    "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                    "FAILED" => std::option::Option::Some(Self::FAILED),
+                    "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [TargetRenderState](TargetRenderState)
-        pub mod target_render_state {
-            use super::TargetRenderState;
-
-            /// The render operation state is unspecified.
-            pub const TARGET_RENDER_STATE_UNSPECIFIED: TargetRenderState =
-                TargetRenderState::new("TARGET_RENDER_STATE_UNSPECIFIED");
-
-            /// The render operation has completed successfully.
-            pub const SUCCEEDED: TargetRenderState = TargetRenderState::new("SUCCEEDED");
-
-            /// The render operation has failed.
-            pub const FAILED: TargetRenderState = TargetRenderState::new("FAILED");
-
-            /// The render operation is in progress.
-            pub const IN_PROGRESS: TargetRenderState = TargetRenderState::new("IN_PROGRESS");
-        }
-
-        impl std::convert::From<std::string::String> for TargetRenderState {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for TargetRenderState {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for TargetRenderState {
             fn default() -> Self {
-                target_render_state::TARGET_RENDER_STATE_UNSPECIFIED
+                Self::new(0)
             }
         }
 
         /// Well-known rendering failures.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct FailureCause(std::borrow::Cow<'static, str>);
+        pub struct FailureCause(i32);
 
         impl FailureCause {
-            /// Creates a new FailureCause instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [FailureCause](FailureCause)
-        pub mod failure_cause {
-            use super::FailureCause;
-
             /// No reason for failure is specified.
-            pub const FAILURE_CAUSE_UNSPECIFIED: FailureCause =
-                FailureCause::new("FAILURE_CAUSE_UNSPECIFIED");
+            pub const FAILURE_CAUSE_UNSPECIFIED: FailureCause = FailureCause::new(0);
 
             /// Cloud Build is not available, either because it is not enabled or
             /// because Cloud Deploy has insufficient permissions. See [required
             /// permission](https://cloud.google.com/deploy/docs/cloud-deploy-service-account#required_permissions).
-            pub const CLOUD_BUILD_UNAVAILABLE: FailureCause =
-                FailureCause::new("CLOUD_BUILD_UNAVAILABLE");
+            pub const CLOUD_BUILD_UNAVAILABLE: FailureCause = FailureCause::new(1);
 
             /// The render operation did not complete successfully; check Cloud Build
             /// logs.
-            pub const EXECUTION_FAILED: FailureCause = FailureCause::new("EXECUTION_FAILED");
+            pub const EXECUTION_FAILED: FailureCause = FailureCause::new(2);
 
             /// Cloud Build failed to fulfill Cloud Deploy's request. See
             /// failure_message for additional details.
-            pub const CLOUD_BUILD_REQUEST_FAILED: FailureCause =
-                FailureCause::new("CLOUD_BUILD_REQUEST_FAILED");
+            pub const CLOUD_BUILD_REQUEST_FAILED: FailureCause = FailureCause::new(3);
 
             /// The render operation did not complete successfully because the
             /// verification stanza required for verify was not found on the Skaffold
             /// configuration.
-            pub const VERIFICATION_CONFIG_NOT_FOUND: FailureCause =
-                FailureCause::new("VERIFICATION_CONFIG_NOT_FOUND");
+            pub const VERIFICATION_CONFIG_NOT_FOUND: FailureCause = FailureCause::new(4);
 
             /// The render operation did not complete successfully because the custom
             /// action required for predeploy or postdeploy was not found in the
             /// Skaffold configuration. See failure_message for additional details.
-            pub const CUSTOM_ACTION_NOT_FOUND: FailureCause =
-                FailureCause::new("CUSTOM_ACTION_NOT_FOUND");
+            pub const CUSTOM_ACTION_NOT_FOUND: FailureCause = FailureCause::new(5);
 
             /// Release failed during rendering because the release configuration is
             /// not supported with the specified deployment strategy.
-            pub const DEPLOYMENT_STRATEGY_NOT_SUPPORTED: FailureCause =
-                FailureCause::new("DEPLOYMENT_STRATEGY_NOT_SUPPORTED");
+            pub const DEPLOYMENT_STRATEGY_NOT_SUPPORTED: FailureCause = FailureCause::new(6);
 
             /// The render operation had a feature configured that is not supported.
-            pub const RENDER_FEATURE_NOT_SUPPORTED: FailureCause =
-                FailureCause::new("RENDER_FEATURE_NOT_SUPPORTED");
+            pub const RENDER_FEATURE_NOT_SUPPORTED: FailureCause = FailureCause::new(7);
+
+            /// Creates a new FailureCause instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("FAILURE_CAUSE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("CLOUD_BUILD_UNAVAILABLE"),
+                    2 => std::borrow::Cow::Borrowed("EXECUTION_FAILED"),
+                    3 => std::borrow::Cow::Borrowed("CLOUD_BUILD_REQUEST_FAILED"),
+                    4 => std::borrow::Cow::Borrowed("VERIFICATION_CONFIG_NOT_FOUND"),
+                    5 => std::borrow::Cow::Borrowed("CUSTOM_ACTION_NOT_FOUND"),
+                    6 => std::borrow::Cow::Borrowed("DEPLOYMENT_STRATEGY_NOT_SUPPORTED"),
+                    7 => std::borrow::Cow::Borrowed("RENDER_FEATURE_NOT_SUPPORTED"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "FAILURE_CAUSE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::FAILURE_CAUSE_UNSPECIFIED)
+                    }
+                    "CLOUD_BUILD_UNAVAILABLE" => {
+                        std::option::Option::Some(Self::CLOUD_BUILD_UNAVAILABLE)
+                    }
+                    "EXECUTION_FAILED" => std::option::Option::Some(Self::EXECUTION_FAILED),
+                    "CLOUD_BUILD_REQUEST_FAILED" => {
+                        std::option::Option::Some(Self::CLOUD_BUILD_REQUEST_FAILED)
+                    }
+                    "VERIFICATION_CONFIG_NOT_FOUND" => {
+                        std::option::Option::Some(Self::VERIFICATION_CONFIG_NOT_FOUND)
+                    }
+                    "CUSTOM_ACTION_NOT_FOUND" => {
+                        std::option::Option::Some(Self::CUSTOM_ACTION_NOT_FOUND)
+                    }
+                    "DEPLOYMENT_STRATEGY_NOT_SUPPORTED" => {
+                        std::option::Option::Some(Self::DEPLOYMENT_STRATEGY_NOT_SUPPORTED)
+                    }
+                    "RENDER_FEATURE_NOT_SUPPORTED" => {
+                        std::option::Option::Some(Self::RENDER_FEATURE_NOT_SUPPORTED)
+                    }
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for FailureCause {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for FailureCause {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for FailureCause {
             fn default() -> Self {
-                failure_cause::FAILURE_CAUSE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -6679,47 +6794,65 @@ pub mod release {
 
     /// Valid states of the render operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RenderState(std::borrow::Cow<'static, str>);
+    pub struct RenderState(i32);
 
     impl RenderState {
+        /// The render state is unspecified.
+        pub const RENDER_STATE_UNSPECIFIED: RenderState = RenderState::new(0);
+
+        /// All rendering operations have completed successfully.
+        pub const SUCCEEDED: RenderState = RenderState::new(1);
+
+        /// All rendering operations have completed, and one or more have failed.
+        pub const FAILED: RenderState = RenderState::new(2);
+
+        /// Rendering has started and is not complete.
+        pub const IN_PROGRESS: RenderState = RenderState::new(3);
+
         /// Creates a new RenderState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RENDER_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                2 => std::borrow::Cow::Borrowed("FAILED"),
+                3 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RENDER_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RENDER_STATE_UNSPECIFIED)
+                }
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RenderState](RenderState)
-    pub mod render_state {
-        use super::RenderState;
-
-        /// The render state is unspecified.
-        pub const RENDER_STATE_UNSPECIFIED: RenderState =
-            RenderState::new("RENDER_STATE_UNSPECIFIED");
-
-        /// All rendering operations have completed successfully.
-        pub const SUCCEEDED: RenderState = RenderState::new("SUCCEEDED");
-
-        /// All rendering operations have completed, and one or more have failed.
-        pub const FAILED: RenderState = RenderState::new("FAILED");
-
-        /// Rendering has started and is not complete.
-        pub const IN_PROGRESS: RenderState = RenderState::new("IN_PROGRESS");
-    }
-
-    impl std::convert::From<std::string::String> for RenderState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RenderState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RenderState {
         fn default() -> Self {
-            render_state::RENDER_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8127,187 +8260,269 @@ pub mod rollout {
 
     /// Valid approval states of a `Rollout`.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ApprovalState(std::borrow::Cow<'static, str>);
+    pub struct ApprovalState(i32);
 
     impl ApprovalState {
+        /// The `Rollout` has an unspecified approval state.
+        pub const APPROVAL_STATE_UNSPECIFIED: ApprovalState = ApprovalState::new(0);
+
+        /// The `Rollout` requires approval.
+        pub const NEEDS_APPROVAL: ApprovalState = ApprovalState::new(1);
+
+        /// The `Rollout` does not require approval.
+        pub const DOES_NOT_NEED_APPROVAL: ApprovalState = ApprovalState::new(2);
+
+        /// The `Rollout` has been approved.
+        pub const APPROVED: ApprovalState = ApprovalState::new(3);
+
+        /// The `Rollout` has been rejected.
+        pub const REJECTED: ApprovalState = ApprovalState::new(4);
+
         /// Creates a new ApprovalState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("APPROVAL_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NEEDS_APPROVAL"),
+                2 => std::borrow::Cow::Borrowed("DOES_NOT_NEED_APPROVAL"),
+                3 => std::borrow::Cow::Borrowed("APPROVED"),
+                4 => std::borrow::Cow::Borrowed("REJECTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "APPROVAL_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::APPROVAL_STATE_UNSPECIFIED)
+                }
+                "NEEDS_APPROVAL" => std::option::Option::Some(Self::NEEDS_APPROVAL),
+                "DOES_NOT_NEED_APPROVAL" => std::option::Option::Some(Self::DOES_NOT_NEED_APPROVAL),
+                "APPROVED" => std::option::Option::Some(Self::APPROVED),
+                "REJECTED" => std::option::Option::Some(Self::REJECTED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ApprovalState](ApprovalState)
-    pub mod approval_state {
-        use super::ApprovalState;
-
-        /// The `Rollout` has an unspecified approval state.
-        pub const APPROVAL_STATE_UNSPECIFIED: ApprovalState =
-            ApprovalState::new("APPROVAL_STATE_UNSPECIFIED");
-
-        /// The `Rollout` requires approval.
-        pub const NEEDS_APPROVAL: ApprovalState = ApprovalState::new("NEEDS_APPROVAL");
-
-        /// The `Rollout` does not require approval.
-        pub const DOES_NOT_NEED_APPROVAL: ApprovalState =
-            ApprovalState::new("DOES_NOT_NEED_APPROVAL");
-
-        /// The `Rollout` has been approved.
-        pub const APPROVED: ApprovalState = ApprovalState::new("APPROVED");
-
-        /// The `Rollout` has been rejected.
-        pub const REJECTED: ApprovalState = ApprovalState::new("REJECTED");
-    }
-
-    impl std::convert::From<std::string::String> for ApprovalState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ApprovalState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ApprovalState {
         fn default() -> Self {
-            approval_state::APPROVAL_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Valid states of a `Rollout`.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The `Rollout` has an unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The `Rollout` has completed successfully.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
+        pub const SUCCEEDED: State = State::new(1);
 
         /// The `Rollout` has failed.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(2);
 
         /// The `Rollout` is being deployed.
-        pub const IN_PROGRESS: State = State::new("IN_PROGRESS");
+        pub const IN_PROGRESS: State = State::new(3);
 
         /// The `Rollout` needs approval.
-        pub const PENDING_APPROVAL: State = State::new("PENDING_APPROVAL");
+        pub const PENDING_APPROVAL: State = State::new(4);
 
         /// An approver rejected the `Rollout`.
-        pub const APPROVAL_REJECTED: State = State::new("APPROVAL_REJECTED");
+        pub const APPROVAL_REJECTED: State = State::new(5);
 
         /// The `Rollout` is waiting for an earlier Rollout(s) to complete on this
         /// `Target`.
-        pub const PENDING: State = State::new("PENDING");
+        pub const PENDING: State = State::new(6);
 
         /// The `Rollout` is waiting for the `Release` to be fully rendered.
-        pub const PENDING_RELEASE: State = State::new("PENDING_RELEASE");
+        pub const PENDING_RELEASE: State = State::new(7);
 
         /// The `Rollout` is in the process of being cancelled.
-        pub const CANCELLING: State = State::new("CANCELLING");
+        pub const CANCELLING: State = State::new(8);
 
         /// The `Rollout` has been cancelled.
-        pub const CANCELLED: State = State::new("CANCELLED");
+        pub const CANCELLED: State = State::new(9);
 
         /// The `Rollout` is halted.
-        pub const HALTED: State = State::new("HALTED");
+        pub const HALTED: State = State::new(10);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                2 => std::borrow::Cow::Borrowed("FAILED"),
+                3 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                4 => std::borrow::Cow::Borrowed("PENDING_APPROVAL"),
+                5 => std::borrow::Cow::Borrowed("APPROVAL_REJECTED"),
+                6 => std::borrow::Cow::Borrowed("PENDING"),
+                7 => std::borrow::Cow::Borrowed("PENDING_RELEASE"),
+                8 => std::borrow::Cow::Borrowed("CANCELLING"),
+                9 => std::borrow::Cow::Borrowed("CANCELLED"),
+                10 => std::borrow::Cow::Borrowed("HALTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                "PENDING_APPROVAL" => std::option::Option::Some(Self::PENDING_APPROVAL),
+                "APPROVAL_REJECTED" => std::option::Option::Some(Self::APPROVAL_REJECTED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "PENDING_RELEASE" => std::option::Option::Some(Self::PENDING_RELEASE),
+                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                "HALTED" => std::option::Option::Some(Self::HALTED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Well-known rollout failures.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FailureCause(std::borrow::Cow<'static, str>);
+    pub struct FailureCause(i32);
 
     impl FailureCause {
-        /// Creates a new FailureCause instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [FailureCause](FailureCause)
-    pub mod failure_cause {
-        use super::FailureCause;
-
         /// No reason for failure is specified.
-        pub const FAILURE_CAUSE_UNSPECIFIED: FailureCause =
-            FailureCause::new("FAILURE_CAUSE_UNSPECIFIED");
+        pub const FAILURE_CAUSE_UNSPECIFIED: FailureCause = FailureCause::new(0);
 
         /// Cloud Build is not available, either because it is not enabled or because
         /// Cloud Deploy has insufficient permissions. See [required
         /// permission](https://cloud.google.com/deploy/docs/cloud-deploy-service-account#required_permissions).
-        pub const CLOUD_BUILD_UNAVAILABLE: FailureCause =
-            FailureCause::new("CLOUD_BUILD_UNAVAILABLE");
+        pub const CLOUD_BUILD_UNAVAILABLE: FailureCause = FailureCause::new(1);
 
         /// The deploy operation did not complete successfully; check Cloud Build
         /// logs.
-        pub const EXECUTION_FAILED: FailureCause = FailureCause::new("EXECUTION_FAILED");
+        pub const EXECUTION_FAILED: FailureCause = FailureCause::new(2);
 
         /// Deployment did not complete within the alloted time.
-        pub const DEADLINE_EXCEEDED: FailureCause = FailureCause::new("DEADLINE_EXCEEDED");
+        pub const DEADLINE_EXCEEDED: FailureCause = FailureCause::new(3);
 
         /// Release is in a failed state.
-        pub const RELEASE_FAILED: FailureCause = FailureCause::new("RELEASE_FAILED");
+        pub const RELEASE_FAILED: FailureCause = FailureCause::new(4);
 
         /// Release is abandoned.
-        pub const RELEASE_ABANDONED: FailureCause = FailureCause::new("RELEASE_ABANDONED");
+        pub const RELEASE_ABANDONED: FailureCause = FailureCause::new(5);
 
         /// No Skaffold verify configuration was found.
-        pub const VERIFICATION_CONFIG_NOT_FOUND: FailureCause =
-            FailureCause::new("VERIFICATION_CONFIG_NOT_FOUND");
+        pub const VERIFICATION_CONFIG_NOT_FOUND: FailureCause = FailureCause::new(6);
 
         /// Cloud Build failed to fulfill Cloud Deploy's request. See failure_message
         /// for additional details.
-        pub const CLOUD_BUILD_REQUEST_FAILED: FailureCause =
-            FailureCause::new("CLOUD_BUILD_REQUEST_FAILED");
+        pub const CLOUD_BUILD_REQUEST_FAILED: FailureCause = FailureCause::new(7);
 
         /// A Rollout operation had a feature configured that is not supported.
-        pub const OPERATION_FEATURE_NOT_SUPPORTED: FailureCause =
-            FailureCause::new("OPERATION_FEATURE_NOT_SUPPORTED");
+        pub const OPERATION_FEATURE_NOT_SUPPORTED: FailureCause = FailureCause::new(8);
+
+        /// Creates a new FailureCause instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FAILURE_CAUSE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CLOUD_BUILD_UNAVAILABLE"),
+                2 => std::borrow::Cow::Borrowed("EXECUTION_FAILED"),
+                3 => std::borrow::Cow::Borrowed("DEADLINE_EXCEEDED"),
+                4 => std::borrow::Cow::Borrowed("RELEASE_FAILED"),
+                5 => std::borrow::Cow::Borrowed("RELEASE_ABANDONED"),
+                6 => std::borrow::Cow::Borrowed("VERIFICATION_CONFIG_NOT_FOUND"),
+                7 => std::borrow::Cow::Borrowed("CLOUD_BUILD_REQUEST_FAILED"),
+                8 => std::borrow::Cow::Borrowed("OPERATION_FEATURE_NOT_SUPPORTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FAILURE_CAUSE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::FAILURE_CAUSE_UNSPECIFIED)
+                }
+                "CLOUD_BUILD_UNAVAILABLE" => {
+                    std::option::Option::Some(Self::CLOUD_BUILD_UNAVAILABLE)
+                }
+                "EXECUTION_FAILED" => std::option::Option::Some(Self::EXECUTION_FAILED),
+                "DEADLINE_EXCEEDED" => std::option::Option::Some(Self::DEADLINE_EXCEEDED),
+                "RELEASE_FAILED" => std::option::Option::Some(Self::RELEASE_FAILED),
+                "RELEASE_ABANDONED" => std::option::Option::Some(Self::RELEASE_ABANDONED),
+                "VERIFICATION_CONFIG_NOT_FOUND" => {
+                    std::option::Option::Some(Self::VERIFICATION_CONFIG_NOT_FOUND)
+                }
+                "CLOUD_BUILD_REQUEST_FAILED" => {
+                    std::option::Option::Some(Self::CLOUD_BUILD_REQUEST_FAILED)
+                }
+                "OPERATION_FEATURE_NOT_SUPPORTED" => {
+                    std::option::Option::Some(Self::OPERATION_FEATURE_NOT_SUPPORTED)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for FailureCause {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for FailureCause {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for FailureCause {
         fn default() -> Self {
-            failure_cause::FAILURE_CAUSE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8768,55 +8983,78 @@ pub mod phase {
 
     /// Valid states of a Phase.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The Phase has an unspecified state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The Phase is waiting for an earlier Phase(s) to complete.
+        pub const PENDING: State = State::new(1);
+
+        /// The Phase is in progress.
+        pub const IN_PROGRESS: State = State::new(2);
+
+        /// The Phase has succeeded.
+        pub const SUCCEEDED: State = State::new(3);
+
+        /// The Phase has failed.
+        pub const FAILED: State = State::new(4);
+
+        /// The Phase was aborted.
+        pub const ABORTED: State = State::new(5);
+
+        /// The Phase was skipped.
+        pub const SKIPPED: State = State::new(6);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                5 => std::borrow::Cow::Borrowed("ABORTED"),
+                6 => std::borrow::Cow::Borrowed("SKIPPED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "ABORTED" => std::option::Option::Some(Self::ABORTED),
+                "SKIPPED" => std::option::Option::Some(Self::SKIPPED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The Phase has an unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The Phase is waiting for an earlier Phase(s) to complete.
-        pub const PENDING: State = State::new("PENDING");
-
-        /// The Phase is in progress.
-        pub const IN_PROGRESS: State = State::new("IN_PROGRESS");
-
-        /// The Phase has succeeded.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-        /// The Phase has failed.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// The Phase was aborted.
-        pub const ABORTED: State = State::new("ABORTED");
-
-        /// The Phase was skipped.
-        pub const SKIPPED: State = State::new("SKIPPED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -9194,61 +9432,88 @@ pub mod job {
 
     /// Valid states of a Job.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The Job has an unspecified state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The Job is waiting for an earlier Phase(s) or Job(s) to complete.
+        pub const PENDING: State = State::new(1);
+
+        /// The Job is disabled.
+        pub const DISABLED: State = State::new(2);
+
+        /// The Job is in progress.
+        pub const IN_PROGRESS: State = State::new(3);
+
+        /// The Job succeeded.
+        pub const SUCCEEDED: State = State::new(4);
+
+        /// The Job failed.
+        pub const FAILED: State = State::new(5);
+
+        /// The Job was aborted.
+        pub const ABORTED: State = State::new(6);
+
+        /// The Job was skipped.
+        pub const SKIPPED: State = State::new(7);
+
+        /// The Job was ignored.
+        pub const IGNORED: State = State::new(8);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("DISABLED"),
+                3 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                5 => std::borrow::Cow::Borrowed("FAILED"),
+                6 => std::borrow::Cow::Borrowed("ABORTED"),
+                7 => std::borrow::Cow::Borrowed("SKIPPED"),
+                8 => std::borrow::Cow::Borrowed("IGNORED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "ABORTED" => std::option::Option::Some(Self::ABORTED),
+                "SKIPPED" => std::option::Option::Some(Self::SKIPPED),
+                "IGNORED" => std::option::Option::Some(Self::IGNORED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The Job has an unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The Job is waiting for an earlier Phase(s) or Job(s) to complete.
-        pub const PENDING: State = State::new("PENDING");
-
-        /// The Job is disabled.
-        pub const DISABLED: State = State::new("DISABLED");
-
-        /// The Job is in progress.
-        pub const IN_PROGRESS: State = State::new("IN_PROGRESS");
-
-        /// The Job succeeded.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-        /// The Job failed.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// The Job was aborted.
-        pub const ABORTED: State = State::new("ABORTED");
-
-        /// The Job was skipped.
-        pub const SKIPPED: State = State::new("SKIPPED");
-
-        /// The Job was ignored.
-        pub const IGNORED: State = State::new("IGNORED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -10571,52 +10836,73 @@ pub mod job_run {
 
     /// Valid states of a `JobRun`.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The `JobRun` has an unspecified state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The `JobRun` is in progress.
+        pub const IN_PROGRESS: State = State::new(1);
+
+        /// The `JobRun` has succeeded.
+        pub const SUCCEEDED: State = State::new(2);
+
+        /// The `JobRun` has failed.
+        pub const FAILED: State = State::new(3);
+
+        /// The `JobRun` is terminating.
+        pub const TERMINATING: State = State::new(4);
+
+        /// The `JobRun` was terminated.
+        pub const TERMINATED: State = State::new(5);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                4 => std::borrow::Cow::Borrowed("TERMINATING"),
+                5 => std::borrow::Cow::Borrowed("TERMINATED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "TERMINATING" => std::option::Option::Some(Self::TERMINATING),
+                "TERMINATED" => std::option::Option::Some(Self::TERMINATED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The `JobRun` has an unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The `JobRun` is in progress.
-        pub const IN_PROGRESS: State = State::new("IN_PROGRESS");
-
-        /// The `JobRun` has succeeded.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-        /// The `JobRun` has failed.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// The `JobRun` is terminating.
-        pub const TERMINATING: State = State::new("TERMINATING");
-
-        /// The `JobRun` was terminated.
-        pub const TERMINATED: State = State::new("TERMINATED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -10731,65 +11017,93 @@ pub mod deploy_job_run {
 
     /// Well-known deploy failures.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FailureCause(std::borrow::Cow<'static, str>);
+    pub struct FailureCause(i32);
 
     impl FailureCause {
-        /// Creates a new FailureCause instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [FailureCause](FailureCause)
-    pub mod failure_cause {
-        use super::FailureCause;
-
         /// No reason for failure is specified.
-        pub const FAILURE_CAUSE_UNSPECIFIED: FailureCause =
-            FailureCause::new("FAILURE_CAUSE_UNSPECIFIED");
+        pub const FAILURE_CAUSE_UNSPECIFIED: FailureCause = FailureCause::new(0);
 
         /// Cloud Build is not available, either because it is not enabled or because
         /// Cloud Deploy has insufficient permissions. See [Required
         /// permission](https://cloud.google.com/deploy/docs/cloud-deploy-service-account#required_permissions).
-        pub const CLOUD_BUILD_UNAVAILABLE: FailureCause =
-            FailureCause::new("CLOUD_BUILD_UNAVAILABLE");
+        pub const CLOUD_BUILD_UNAVAILABLE: FailureCause = FailureCause::new(1);
 
         /// The deploy operation did not complete successfully; check Cloud Build
         /// logs.
-        pub const EXECUTION_FAILED: FailureCause = FailureCause::new("EXECUTION_FAILED");
+        pub const EXECUTION_FAILED: FailureCause = FailureCause::new(2);
 
         /// The deploy job run did not complete within the alloted time.
-        pub const DEADLINE_EXCEEDED: FailureCause = FailureCause::new("DEADLINE_EXCEEDED");
+        pub const DEADLINE_EXCEEDED: FailureCause = FailureCause::new(3);
 
         /// There were missing resources in the runtime environment required for a
         /// canary deployment. Check the Cloud Build logs for more information.
-        pub const MISSING_RESOURCES_FOR_CANARY: FailureCause =
-            FailureCause::new("MISSING_RESOURCES_FOR_CANARY");
+        pub const MISSING_RESOURCES_FOR_CANARY: FailureCause = FailureCause::new(4);
 
         /// Cloud Build failed to fulfill Cloud Deploy's request. See failure_message
         /// for additional details.
-        pub const CLOUD_BUILD_REQUEST_FAILED: FailureCause =
-            FailureCause::new("CLOUD_BUILD_REQUEST_FAILED");
+        pub const CLOUD_BUILD_REQUEST_FAILED: FailureCause = FailureCause::new(5);
 
         /// The deploy operation had a feature configured that is not supported.
-        pub const DEPLOY_FEATURE_NOT_SUPPORTED: FailureCause =
-            FailureCause::new("DEPLOY_FEATURE_NOT_SUPPORTED");
+        pub const DEPLOY_FEATURE_NOT_SUPPORTED: FailureCause = FailureCause::new(6);
+
+        /// Creates a new FailureCause instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FAILURE_CAUSE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CLOUD_BUILD_UNAVAILABLE"),
+                2 => std::borrow::Cow::Borrowed("EXECUTION_FAILED"),
+                3 => std::borrow::Cow::Borrowed("DEADLINE_EXCEEDED"),
+                4 => std::borrow::Cow::Borrowed("MISSING_RESOURCES_FOR_CANARY"),
+                5 => std::borrow::Cow::Borrowed("CLOUD_BUILD_REQUEST_FAILED"),
+                6 => std::borrow::Cow::Borrowed("DEPLOY_FEATURE_NOT_SUPPORTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FAILURE_CAUSE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::FAILURE_CAUSE_UNSPECIFIED)
+                }
+                "CLOUD_BUILD_UNAVAILABLE" => {
+                    std::option::Option::Some(Self::CLOUD_BUILD_UNAVAILABLE)
+                }
+                "EXECUTION_FAILED" => std::option::Option::Some(Self::EXECUTION_FAILED),
+                "DEADLINE_EXCEEDED" => std::option::Option::Some(Self::DEADLINE_EXCEEDED),
+                "MISSING_RESOURCES_FOR_CANARY" => {
+                    std::option::Option::Some(Self::MISSING_RESOURCES_FOR_CANARY)
+                }
+                "CLOUD_BUILD_REQUEST_FAILED" => {
+                    std::option::Option::Some(Self::CLOUD_BUILD_REQUEST_FAILED)
+                }
+                "DEPLOY_FEATURE_NOT_SUPPORTED" => {
+                    std::option::Option::Some(Self::DEPLOY_FEATURE_NOT_SUPPORTED)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for FailureCause {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for FailureCause {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for FailureCause {
         fn default() -> Self {
-            failure_cause::FAILURE_CAUSE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -10877,60 +11191,85 @@ pub mod verify_job_run {
 
     /// Well-known verify failures.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FailureCause(std::borrow::Cow<'static, str>);
+    pub struct FailureCause(i32);
 
     impl FailureCause {
-        /// Creates a new FailureCause instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [FailureCause](FailureCause)
-    pub mod failure_cause {
-        use super::FailureCause;
-
         /// No reason for failure is specified.
-        pub const FAILURE_CAUSE_UNSPECIFIED: FailureCause =
-            FailureCause::new("FAILURE_CAUSE_UNSPECIFIED");
+        pub const FAILURE_CAUSE_UNSPECIFIED: FailureCause = FailureCause::new(0);
 
         /// Cloud Build is not available, either because it is not enabled or because
         /// Cloud Deploy has insufficient permissions. See [required
         /// permission](https://cloud.google.com/deploy/docs/cloud-deploy-service-account#required_permissions).
-        pub const CLOUD_BUILD_UNAVAILABLE: FailureCause =
-            FailureCause::new("CLOUD_BUILD_UNAVAILABLE");
+        pub const CLOUD_BUILD_UNAVAILABLE: FailureCause = FailureCause::new(1);
 
         /// The verify operation did not complete successfully; check Cloud Build
         /// logs.
-        pub const EXECUTION_FAILED: FailureCause = FailureCause::new("EXECUTION_FAILED");
+        pub const EXECUTION_FAILED: FailureCause = FailureCause::new(2);
 
         /// The verify job run did not complete within the alloted time.
-        pub const DEADLINE_EXCEEDED: FailureCause = FailureCause::new("DEADLINE_EXCEEDED");
+        pub const DEADLINE_EXCEEDED: FailureCause = FailureCause::new(3);
 
         /// No Skaffold verify configuration was found.
-        pub const VERIFICATION_CONFIG_NOT_FOUND: FailureCause =
-            FailureCause::new("VERIFICATION_CONFIG_NOT_FOUND");
+        pub const VERIFICATION_CONFIG_NOT_FOUND: FailureCause = FailureCause::new(4);
 
         /// Cloud Build failed to fulfill Cloud Deploy's request. See failure_message
         /// for additional details.
-        pub const CLOUD_BUILD_REQUEST_FAILED: FailureCause =
-            FailureCause::new("CLOUD_BUILD_REQUEST_FAILED");
+        pub const CLOUD_BUILD_REQUEST_FAILED: FailureCause = FailureCause::new(5);
+
+        /// Creates a new FailureCause instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FAILURE_CAUSE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CLOUD_BUILD_UNAVAILABLE"),
+                2 => std::borrow::Cow::Borrowed("EXECUTION_FAILED"),
+                3 => std::borrow::Cow::Borrowed("DEADLINE_EXCEEDED"),
+                4 => std::borrow::Cow::Borrowed("VERIFICATION_CONFIG_NOT_FOUND"),
+                5 => std::borrow::Cow::Borrowed("CLOUD_BUILD_REQUEST_FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FAILURE_CAUSE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::FAILURE_CAUSE_UNSPECIFIED)
+                }
+                "CLOUD_BUILD_UNAVAILABLE" => {
+                    std::option::Option::Some(Self::CLOUD_BUILD_UNAVAILABLE)
+                }
+                "EXECUTION_FAILED" => std::option::Option::Some(Self::EXECUTION_FAILED),
+                "DEADLINE_EXCEEDED" => std::option::Option::Some(Self::DEADLINE_EXCEEDED),
+                "VERIFICATION_CONFIG_NOT_FOUND" => {
+                    std::option::Option::Some(Self::VERIFICATION_CONFIG_NOT_FOUND)
+                }
+                "CLOUD_BUILD_REQUEST_FAILED" => {
+                    std::option::Option::Some(Self::CLOUD_BUILD_REQUEST_FAILED)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for FailureCause {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for FailureCause {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for FailureCause {
         fn default() -> Self {
-            failure_cause::FAILURE_CAUSE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -10999,56 +11338,78 @@ pub mod predeploy_job_run {
 
     /// Well-known predeploy failures.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FailureCause(std::borrow::Cow<'static, str>);
+    pub struct FailureCause(i32);
 
     impl FailureCause {
-        /// Creates a new FailureCause instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [FailureCause](FailureCause)
-    pub mod failure_cause {
-        use super::FailureCause;
-
         /// No reason for failure is specified.
-        pub const FAILURE_CAUSE_UNSPECIFIED: FailureCause =
-            FailureCause::new("FAILURE_CAUSE_UNSPECIFIED");
+        pub const FAILURE_CAUSE_UNSPECIFIED: FailureCause = FailureCause::new(0);
 
         /// Cloud Build is not available, either because it is not enabled or because
         /// Cloud Deploy has insufficient permissions. See [required
         /// permission](https://cloud.google.com/deploy/docs/cloud-deploy-service-account#required_permissions).
-        pub const CLOUD_BUILD_UNAVAILABLE: FailureCause =
-            FailureCause::new("CLOUD_BUILD_UNAVAILABLE");
+        pub const CLOUD_BUILD_UNAVAILABLE: FailureCause = FailureCause::new(1);
 
         /// The predeploy operation did not complete successfully; check Cloud Build
         /// logs.
-        pub const EXECUTION_FAILED: FailureCause = FailureCause::new("EXECUTION_FAILED");
+        pub const EXECUTION_FAILED: FailureCause = FailureCause::new(2);
 
         /// The predeploy job run did not complete within the alloted time.
-        pub const DEADLINE_EXCEEDED: FailureCause = FailureCause::new("DEADLINE_EXCEEDED");
+        pub const DEADLINE_EXCEEDED: FailureCause = FailureCause::new(3);
 
         /// Cloud Build failed to fulfill Cloud Deploy's request. See failure_message
         /// for additional details.
-        pub const CLOUD_BUILD_REQUEST_FAILED: FailureCause =
-            FailureCause::new("CLOUD_BUILD_REQUEST_FAILED");
+        pub const CLOUD_BUILD_REQUEST_FAILED: FailureCause = FailureCause::new(4);
+
+        /// Creates a new FailureCause instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FAILURE_CAUSE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CLOUD_BUILD_UNAVAILABLE"),
+                2 => std::borrow::Cow::Borrowed("EXECUTION_FAILED"),
+                3 => std::borrow::Cow::Borrowed("DEADLINE_EXCEEDED"),
+                4 => std::borrow::Cow::Borrowed("CLOUD_BUILD_REQUEST_FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FAILURE_CAUSE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::FAILURE_CAUSE_UNSPECIFIED)
+                }
+                "CLOUD_BUILD_UNAVAILABLE" => {
+                    std::option::Option::Some(Self::CLOUD_BUILD_UNAVAILABLE)
+                }
+                "EXECUTION_FAILED" => std::option::Option::Some(Self::EXECUTION_FAILED),
+                "DEADLINE_EXCEEDED" => std::option::Option::Some(Self::DEADLINE_EXCEEDED),
+                "CLOUD_BUILD_REQUEST_FAILED" => {
+                    std::option::Option::Some(Self::CLOUD_BUILD_REQUEST_FAILED)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for FailureCause {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for FailureCause {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for FailureCause {
         fn default() -> Self {
-            failure_cause::FAILURE_CAUSE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -11117,56 +11478,78 @@ pub mod postdeploy_job_run {
 
     /// Well-known postdeploy failures.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FailureCause(std::borrow::Cow<'static, str>);
+    pub struct FailureCause(i32);
 
     impl FailureCause {
-        /// Creates a new FailureCause instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [FailureCause](FailureCause)
-    pub mod failure_cause {
-        use super::FailureCause;
-
         /// No reason for failure is specified.
-        pub const FAILURE_CAUSE_UNSPECIFIED: FailureCause =
-            FailureCause::new("FAILURE_CAUSE_UNSPECIFIED");
+        pub const FAILURE_CAUSE_UNSPECIFIED: FailureCause = FailureCause::new(0);
 
         /// Cloud Build is not available, either because it is not enabled or because
         /// Cloud Deploy has insufficient permissions. See [required
         /// permission](https://cloud.google.com/deploy/docs/cloud-deploy-service-account#required_permissions).
-        pub const CLOUD_BUILD_UNAVAILABLE: FailureCause =
-            FailureCause::new("CLOUD_BUILD_UNAVAILABLE");
+        pub const CLOUD_BUILD_UNAVAILABLE: FailureCause = FailureCause::new(1);
 
         /// The postdeploy operation did not complete successfully; check Cloud Build
         /// logs.
-        pub const EXECUTION_FAILED: FailureCause = FailureCause::new("EXECUTION_FAILED");
+        pub const EXECUTION_FAILED: FailureCause = FailureCause::new(2);
 
         /// The postdeploy job run did not complete within the alloted time.
-        pub const DEADLINE_EXCEEDED: FailureCause = FailureCause::new("DEADLINE_EXCEEDED");
+        pub const DEADLINE_EXCEEDED: FailureCause = FailureCause::new(3);
 
         /// Cloud Build failed to fulfill Cloud Deploy's request. See failure_message
         /// for additional details.
-        pub const CLOUD_BUILD_REQUEST_FAILED: FailureCause =
-            FailureCause::new("CLOUD_BUILD_REQUEST_FAILED");
+        pub const CLOUD_BUILD_REQUEST_FAILED: FailureCause = FailureCause::new(4);
+
+        /// Creates a new FailureCause instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FAILURE_CAUSE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CLOUD_BUILD_UNAVAILABLE"),
+                2 => std::borrow::Cow::Borrowed("EXECUTION_FAILED"),
+                3 => std::borrow::Cow::Borrowed("DEADLINE_EXCEEDED"),
+                4 => std::borrow::Cow::Borrowed("CLOUD_BUILD_REQUEST_FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FAILURE_CAUSE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::FAILURE_CAUSE_UNSPECIFIED)
+                }
+                "CLOUD_BUILD_UNAVAILABLE" => {
+                    std::option::Option::Some(Self::CLOUD_BUILD_UNAVAILABLE)
+                }
+                "EXECUTION_FAILED" => std::option::Option::Some(Self::EXECUTION_FAILED),
+                "DEADLINE_EXCEEDED" => std::option::Option::Some(Self::DEADLINE_EXCEEDED),
+                "CLOUD_BUILD_REQUEST_FAILED" => {
+                    std::option::Option::Some(Self::CLOUD_BUILD_REQUEST_FAILED)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for FailureCause {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for FailureCause {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for FailureCause {
         fn default() -> Self {
-            failure_cause::FAILURE_CAUSE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -13670,55 +14053,78 @@ pub mod automation_run {
 
     /// Valid state of an `AutomationRun`.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The `AutomationRun` has an unspecified state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The `AutomationRun` has succeeded.
+        pub const SUCCEEDED: State = State::new(1);
+
+        /// The `AutomationRun` was cancelled.
+        pub const CANCELLED: State = State::new(2);
+
+        /// The `AutomationRun` has failed.
+        pub const FAILED: State = State::new(3);
+
+        /// The `AutomationRun` is in progress.
+        pub const IN_PROGRESS: State = State::new(4);
+
+        /// The `AutomationRun` is pending.
+        pub const PENDING: State = State::new(5);
+
+        /// The `AutomationRun` was aborted.
+        pub const ABORTED: State = State::new(6);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                2 => std::borrow::Cow::Borrowed("CANCELLED"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                4 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                5 => std::borrow::Cow::Borrowed("PENDING"),
+                6 => std::borrow::Cow::Borrowed("ABORTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "ABORTED" => std::option::Option::Some(Self::ABORTED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The `AutomationRun` has an unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The `AutomationRun` has succeeded.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-        /// The `AutomationRun` was cancelled.
-        pub const CANCELLED: State = State::new("CANCELLED");
-
-        /// The `AutomationRun` has failed.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// The `AutomationRun` is in progress.
-        pub const IN_PROGRESS: State = State::new("IN_PROGRESS");
-
-        /// The `AutomationRun` is pending.
-        pub const PENDING: State = State::new("PENDING");
-
-        /// The `AutomationRun` was aborted.
-        pub const ABORTED: State = State::new("ABORTED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -14833,92 +15239,123 @@ pub mod deploy_policy_evaluation_event {
 
     /// The policy verdict of the request.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PolicyVerdict(std::borrow::Cow<'static, str>);
+    pub struct PolicyVerdict(i32);
 
     impl PolicyVerdict {
-        /// Creates a new PolicyVerdict instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PolicyVerdict](PolicyVerdict)
-    pub mod policy_verdict {
-        use super::PolicyVerdict;
-
         /// This should never happen.
-        pub const POLICY_VERDICT_UNSPECIFIED: PolicyVerdict =
-            PolicyVerdict::new("POLICY_VERDICT_UNSPECIFIED");
+        pub const POLICY_VERDICT_UNSPECIFIED: PolicyVerdict = PolicyVerdict::new(0);
 
         /// Allowed by policy. This enum value is not currently used but may be used
         /// in the future. Currently logs are only generated when a request is denied
         /// by policy.
-        pub const ALLOWED_BY_POLICY: PolicyVerdict = PolicyVerdict::new("ALLOWED_BY_POLICY");
+        pub const ALLOWED_BY_POLICY: PolicyVerdict = PolicyVerdict::new(1);
 
         /// Denied by policy.
-        pub const DENIED_BY_POLICY: PolicyVerdict = PolicyVerdict::new("DENIED_BY_POLICY");
+        pub const DENIED_BY_POLICY: PolicyVerdict = PolicyVerdict::new(2);
+
+        /// Creates a new PolicyVerdict instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("POLICY_VERDICT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALLOWED_BY_POLICY"),
+                2 => std::borrow::Cow::Borrowed("DENIED_BY_POLICY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "POLICY_VERDICT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::POLICY_VERDICT_UNSPECIFIED)
+                }
+                "ALLOWED_BY_POLICY" => std::option::Option::Some(Self::ALLOWED_BY_POLICY),
+                "DENIED_BY_POLICY" => std::option::Option::Some(Self::DENIED_BY_POLICY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PolicyVerdict {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PolicyVerdict {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PolicyVerdict {
         fn default() -> Self {
-            policy_verdict::POLICY_VERDICT_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Things that could have overridden the policy verdict. When overrides are
     /// used, the request will be allowed even if it is DENIED_BY_POLICY.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PolicyVerdictOverride(std::borrow::Cow<'static, str>);
+    pub struct PolicyVerdictOverride(i32);
 
     impl PolicyVerdictOverride {
+        /// This should never happen.
+        pub const POLICY_VERDICT_OVERRIDE_UNSPECIFIED: PolicyVerdictOverride =
+            PolicyVerdictOverride::new(0);
+
+        /// The policy was overridden.
+        pub const POLICY_OVERRIDDEN: PolicyVerdictOverride = PolicyVerdictOverride::new(1);
+
+        /// The policy was suspended.
+        pub const POLICY_SUSPENDED: PolicyVerdictOverride = PolicyVerdictOverride::new(2);
+
         /// Creates a new PolicyVerdictOverride instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("POLICY_VERDICT_OVERRIDE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("POLICY_OVERRIDDEN"),
+                2 => std::borrow::Cow::Borrowed("POLICY_SUSPENDED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "POLICY_VERDICT_OVERRIDE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::POLICY_VERDICT_OVERRIDE_UNSPECIFIED)
+                }
+                "POLICY_OVERRIDDEN" => std::option::Option::Some(Self::POLICY_OVERRIDDEN),
+                "POLICY_SUSPENDED" => std::option::Option::Some(Self::POLICY_SUSPENDED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [PolicyVerdictOverride](PolicyVerdictOverride)
-    pub mod policy_verdict_override {
-        use super::PolicyVerdictOverride;
-
-        /// This should never happen.
-        pub const POLICY_VERDICT_OVERRIDE_UNSPECIFIED: PolicyVerdictOverride =
-            PolicyVerdictOverride::new("POLICY_VERDICT_OVERRIDE_UNSPECIFIED");
-
-        /// The policy was overridden.
-        pub const POLICY_OVERRIDDEN: PolicyVerdictOverride =
-            PolicyVerdictOverride::new("POLICY_OVERRIDDEN");
-
-        /// The policy was suspended.
-        pub const POLICY_SUSPENDED: PolicyVerdictOverride =
-            PolicyVerdictOverride::new("POLICY_SUSPENDED");
-    }
-
-    impl std::convert::From<std::string::String> for PolicyVerdictOverride {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PolicyVerdictOverride {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PolicyVerdictOverride {
         fn default() -> Self {
-            policy_verdict_override::POLICY_VERDICT_OVERRIDE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -15459,78 +15896,115 @@ pub mod rollout_update_event {
 
     /// RolloutUpdateType indicates the type of the rollout update.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RolloutUpdateType(std::borrow::Cow<'static, str>);
+    pub struct RolloutUpdateType(i32);
 
     impl RolloutUpdateType {
+        /// Rollout update type unspecified.
+        pub const ROLLOUT_UPDATE_TYPE_UNSPECIFIED: RolloutUpdateType = RolloutUpdateType::new(0);
+
+        /// rollout state updated to pending.
+        pub const PENDING: RolloutUpdateType = RolloutUpdateType::new(1);
+
+        /// Rollout state updated to pending release.
+        pub const PENDING_RELEASE: RolloutUpdateType = RolloutUpdateType::new(2);
+
+        /// Rollout state updated to in progress.
+        pub const IN_PROGRESS: RolloutUpdateType = RolloutUpdateType::new(3);
+
+        /// Rollout state updated to cancelling.
+        pub const CANCELLING: RolloutUpdateType = RolloutUpdateType::new(4);
+
+        /// Rollout state updated to cancelled.
+        pub const CANCELLED: RolloutUpdateType = RolloutUpdateType::new(5);
+
+        /// Rollout state updated to halted.
+        pub const HALTED: RolloutUpdateType = RolloutUpdateType::new(6);
+
+        /// Rollout state updated to succeeded.
+        pub const SUCCEEDED: RolloutUpdateType = RolloutUpdateType::new(7);
+
+        /// Rollout state updated to failed.
+        pub const FAILED: RolloutUpdateType = RolloutUpdateType::new(8);
+
+        /// Rollout requires approval.
+        pub const APPROVAL_REQUIRED: RolloutUpdateType = RolloutUpdateType::new(9);
+
+        /// Rollout has been approved.
+        pub const APPROVED: RolloutUpdateType = RolloutUpdateType::new(10);
+
+        /// Rollout has been rejected.
+        pub const REJECTED: RolloutUpdateType = RolloutUpdateType::new(11);
+
+        /// Rollout requires advance to the next phase.
+        pub const ADVANCE_REQUIRED: RolloutUpdateType = RolloutUpdateType::new(12);
+
+        /// Rollout has been advanced.
+        pub const ADVANCED: RolloutUpdateType = RolloutUpdateType::new(13);
+
         /// Creates a new RolloutUpdateType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ROLLOUT_UPDATE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("PENDING_RELEASE"),
+                3 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                4 => std::borrow::Cow::Borrowed("CANCELLING"),
+                5 => std::borrow::Cow::Borrowed("CANCELLED"),
+                6 => std::borrow::Cow::Borrowed("HALTED"),
+                7 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                8 => std::borrow::Cow::Borrowed("FAILED"),
+                9 => std::borrow::Cow::Borrowed("APPROVAL_REQUIRED"),
+                10 => std::borrow::Cow::Borrowed("APPROVED"),
+                11 => std::borrow::Cow::Borrowed("REJECTED"),
+                12 => std::borrow::Cow::Borrowed("ADVANCE_REQUIRED"),
+                13 => std::borrow::Cow::Borrowed("ADVANCED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ROLLOUT_UPDATE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ROLLOUT_UPDATE_TYPE_UNSPECIFIED)
+                }
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "PENDING_RELEASE" => std::option::Option::Some(Self::PENDING_RELEASE),
+                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                "HALTED" => std::option::Option::Some(Self::HALTED),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "APPROVAL_REQUIRED" => std::option::Option::Some(Self::APPROVAL_REQUIRED),
+                "APPROVED" => std::option::Option::Some(Self::APPROVED),
+                "REJECTED" => std::option::Option::Some(Self::REJECTED),
+                "ADVANCE_REQUIRED" => std::option::Option::Some(Self::ADVANCE_REQUIRED),
+                "ADVANCED" => std::option::Option::Some(Self::ADVANCED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RolloutUpdateType](RolloutUpdateType)
-    pub mod rollout_update_type {
-        use super::RolloutUpdateType;
-
-        /// Rollout update type unspecified.
-        pub const ROLLOUT_UPDATE_TYPE_UNSPECIFIED: RolloutUpdateType =
-            RolloutUpdateType::new("ROLLOUT_UPDATE_TYPE_UNSPECIFIED");
-
-        /// rollout state updated to pending.
-        pub const PENDING: RolloutUpdateType = RolloutUpdateType::new("PENDING");
-
-        /// Rollout state updated to pending release.
-        pub const PENDING_RELEASE: RolloutUpdateType = RolloutUpdateType::new("PENDING_RELEASE");
-
-        /// Rollout state updated to in progress.
-        pub const IN_PROGRESS: RolloutUpdateType = RolloutUpdateType::new("IN_PROGRESS");
-
-        /// Rollout state updated to cancelling.
-        pub const CANCELLING: RolloutUpdateType = RolloutUpdateType::new("CANCELLING");
-
-        /// Rollout state updated to cancelled.
-        pub const CANCELLED: RolloutUpdateType = RolloutUpdateType::new("CANCELLED");
-
-        /// Rollout state updated to halted.
-        pub const HALTED: RolloutUpdateType = RolloutUpdateType::new("HALTED");
-
-        /// Rollout state updated to succeeded.
-        pub const SUCCEEDED: RolloutUpdateType = RolloutUpdateType::new("SUCCEEDED");
-
-        /// Rollout state updated to failed.
-        pub const FAILED: RolloutUpdateType = RolloutUpdateType::new("FAILED");
-
-        /// Rollout requires approval.
-        pub const APPROVAL_REQUIRED: RolloutUpdateType =
-            RolloutUpdateType::new("APPROVAL_REQUIRED");
-
-        /// Rollout has been approved.
-        pub const APPROVED: RolloutUpdateType = RolloutUpdateType::new("APPROVED");
-
-        /// Rollout has been rejected.
-        pub const REJECTED: RolloutUpdateType = RolloutUpdateType::new("REJECTED");
-
-        /// Rollout requires advance to the next phase.
-        pub const ADVANCE_REQUIRED: RolloutUpdateType = RolloutUpdateType::new("ADVANCE_REQUIRED");
-
-        /// Rollout has been advanced.
-        pub const ADVANCED: RolloutUpdateType = RolloutUpdateType::new("ADVANCED");
-    }
-
-    impl std::convert::From<std::string::String> for RolloutUpdateType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RolloutUpdateType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RolloutUpdateType {
         fn default() -> Self {
-            rollout_update_type::ROLLOUT_UPDATE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -15588,206 +16062,304 @@ impl wkt::message::Message for TargetNotificationEvent {
 
 /// The support state of a specific Skaffold version.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SkaffoldSupportState(std::borrow::Cow<'static, str>);
+pub struct SkaffoldSupportState(i32);
 
 impl SkaffoldSupportState {
-    /// Creates a new SkaffoldSupportState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [SkaffoldSupportState](SkaffoldSupportState)
-pub mod skaffold_support_state {
-    use super::SkaffoldSupportState;
-
     /// Default value. This value is unused.
     pub const SKAFFOLD_SUPPORT_STATE_UNSPECIFIED: SkaffoldSupportState =
-        SkaffoldSupportState::new("SKAFFOLD_SUPPORT_STATE_UNSPECIFIED");
+        SkaffoldSupportState::new(0);
 
     /// This Skaffold version is currently supported.
-    pub const SKAFFOLD_SUPPORT_STATE_SUPPORTED: SkaffoldSupportState =
-        SkaffoldSupportState::new("SKAFFOLD_SUPPORT_STATE_SUPPORTED");
+    pub const SKAFFOLD_SUPPORT_STATE_SUPPORTED: SkaffoldSupportState = SkaffoldSupportState::new(1);
 
     /// This Skaffold version is in maintenance mode.
     pub const SKAFFOLD_SUPPORT_STATE_MAINTENANCE_MODE: SkaffoldSupportState =
-        SkaffoldSupportState::new("SKAFFOLD_SUPPORT_STATE_MAINTENANCE_MODE");
+        SkaffoldSupportState::new(2);
 
     /// This Skaffold version is no longer supported.
     pub const SKAFFOLD_SUPPORT_STATE_UNSUPPORTED: SkaffoldSupportState =
-        SkaffoldSupportState::new("SKAFFOLD_SUPPORT_STATE_UNSUPPORTED");
+        SkaffoldSupportState::new(3);
+
+    /// Creates a new SkaffoldSupportState instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SKAFFOLD_SUPPORT_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SKAFFOLD_SUPPORT_STATE_SUPPORTED"),
+            2 => std::borrow::Cow::Borrowed("SKAFFOLD_SUPPORT_STATE_MAINTENANCE_MODE"),
+            3 => std::borrow::Cow::Borrowed("SKAFFOLD_SUPPORT_STATE_UNSUPPORTED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SKAFFOLD_SUPPORT_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::SKAFFOLD_SUPPORT_STATE_UNSPECIFIED)
+            }
+            "SKAFFOLD_SUPPORT_STATE_SUPPORTED" => {
+                std::option::Option::Some(Self::SKAFFOLD_SUPPORT_STATE_SUPPORTED)
+            }
+            "SKAFFOLD_SUPPORT_STATE_MAINTENANCE_MODE" => {
+                std::option::Option::Some(Self::SKAFFOLD_SUPPORT_STATE_MAINTENANCE_MODE)
+            }
+            "SKAFFOLD_SUPPORT_STATE_UNSUPPORTED" => {
+                std::option::Option::Some(Self::SKAFFOLD_SUPPORT_STATE_UNSUPPORTED)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for SkaffoldSupportState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SkaffoldSupportState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SkaffoldSupportState {
     fn default() -> Self {
-        skaffold_support_state::SKAFFOLD_SUPPORT_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The pattern of how wait time is increased.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct BackoffMode(std::borrow::Cow<'static, str>);
+pub struct BackoffMode(i32);
 
 impl BackoffMode {
+    /// No WaitMode is specified.
+    pub const BACKOFF_MODE_UNSPECIFIED: BackoffMode = BackoffMode::new(0);
+
+    /// Increases the wait time linearly.
+    pub const BACKOFF_MODE_LINEAR: BackoffMode = BackoffMode::new(1);
+
+    /// Increases the wait time exponentially.
+    pub const BACKOFF_MODE_EXPONENTIAL: BackoffMode = BackoffMode::new(2);
+
     /// Creates a new BackoffMode instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("BACKOFF_MODE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("BACKOFF_MODE_LINEAR"),
+            2 => std::borrow::Cow::Borrowed("BACKOFF_MODE_EXPONENTIAL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "BACKOFF_MODE_UNSPECIFIED" => std::option::Option::Some(Self::BACKOFF_MODE_UNSPECIFIED),
+            "BACKOFF_MODE_LINEAR" => std::option::Option::Some(Self::BACKOFF_MODE_LINEAR),
+            "BACKOFF_MODE_EXPONENTIAL" => std::option::Option::Some(Self::BACKOFF_MODE_EXPONENTIAL),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [BackoffMode](BackoffMode)
-pub mod backoff_mode {
-    use super::BackoffMode;
-
-    /// No WaitMode is specified.
-    pub const BACKOFF_MODE_UNSPECIFIED: BackoffMode = BackoffMode::new("BACKOFF_MODE_UNSPECIFIED");
-
-    /// Increases the wait time linearly.
-    pub const BACKOFF_MODE_LINEAR: BackoffMode = BackoffMode::new("BACKOFF_MODE_LINEAR");
-
-    /// Increases the wait time exponentially.
-    pub const BACKOFF_MODE_EXPONENTIAL: BackoffMode = BackoffMode::new("BACKOFF_MODE_EXPONENTIAL");
-}
-
-impl std::convert::From<std::string::String> for BackoffMode {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for BackoffMode {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for BackoffMode {
     fn default() -> Self {
-        backoff_mode::BACKOFF_MODE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Valid state of a repair attempt.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RepairState(std::borrow::Cow<'static, str>);
+pub struct RepairState(i32);
 
 impl RepairState {
+    /// The `repair` has an unspecified state.
+    pub const REPAIR_STATE_UNSPECIFIED: RepairState = RepairState::new(0);
+
+    /// The `repair` action has succeeded.
+    pub const REPAIR_STATE_SUCCEEDED: RepairState = RepairState::new(1);
+
+    /// The `repair` action was cancelled.
+    pub const REPAIR_STATE_CANCELLED: RepairState = RepairState::new(2);
+
+    /// The `repair` action has failed.
+    pub const REPAIR_STATE_FAILED: RepairState = RepairState::new(3);
+
+    /// The `repair` action is in progress.
+    pub const REPAIR_STATE_IN_PROGRESS: RepairState = RepairState::new(4);
+
+    /// The `repair` action is pending.
+    pub const REPAIR_STATE_PENDING: RepairState = RepairState::new(5);
+
+    /// The `repair` action was aborted.
+    pub const REPAIR_STATE_ABORTED: RepairState = RepairState::new(7);
+
     /// Creates a new RepairState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("REPAIR_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("REPAIR_STATE_SUCCEEDED"),
+            2 => std::borrow::Cow::Borrowed("REPAIR_STATE_CANCELLED"),
+            3 => std::borrow::Cow::Borrowed("REPAIR_STATE_FAILED"),
+            4 => std::borrow::Cow::Borrowed("REPAIR_STATE_IN_PROGRESS"),
+            5 => std::borrow::Cow::Borrowed("REPAIR_STATE_PENDING"),
+            7 => std::borrow::Cow::Borrowed("REPAIR_STATE_ABORTED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "REPAIR_STATE_UNSPECIFIED" => std::option::Option::Some(Self::REPAIR_STATE_UNSPECIFIED),
+            "REPAIR_STATE_SUCCEEDED" => std::option::Option::Some(Self::REPAIR_STATE_SUCCEEDED),
+            "REPAIR_STATE_CANCELLED" => std::option::Option::Some(Self::REPAIR_STATE_CANCELLED),
+            "REPAIR_STATE_FAILED" => std::option::Option::Some(Self::REPAIR_STATE_FAILED),
+            "REPAIR_STATE_IN_PROGRESS" => std::option::Option::Some(Self::REPAIR_STATE_IN_PROGRESS),
+            "REPAIR_STATE_PENDING" => std::option::Option::Some(Self::REPAIR_STATE_PENDING),
+            "REPAIR_STATE_ABORTED" => std::option::Option::Some(Self::REPAIR_STATE_ABORTED),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [RepairState](RepairState)
-pub mod repair_state {
-    use super::RepairState;
-
-    /// The `repair` has an unspecified state.
-    pub const REPAIR_STATE_UNSPECIFIED: RepairState = RepairState::new("REPAIR_STATE_UNSPECIFIED");
-
-    /// The `repair` action has succeeded.
-    pub const REPAIR_STATE_SUCCEEDED: RepairState = RepairState::new("REPAIR_STATE_SUCCEEDED");
-
-    /// The `repair` action was cancelled.
-    pub const REPAIR_STATE_CANCELLED: RepairState = RepairState::new("REPAIR_STATE_CANCELLED");
-
-    /// The `repair` action has failed.
-    pub const REPAIR_STATE_FAILED: RepairState = RepairState::new("REPAIR_STATE_FAILED");
-
-    /// The `repair` action is in progress.
-    pub const REPAIR_STATE_IN_PROGRESS: RepairState = RepairState::new("REPAIR_STATE_IN_PROGRESS");
-
-    /// The `repair` action is pending.
-    pub const REPAIR_STATE_PENDING: RepairState = RepairState::new("REPAIR_STATE_PENDING");
-
-    /// The `repair` action was aborted.
-    pub const REPAIR_STATE_ABORTED: RepairState = RepairState::new("REPAIR_STATE_ABORTED");
-}
-
-impl std::convert::From<std::string::String> for RepairState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for RepairState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for RepairState {
     fn default() -> Self {
-        repair_state::REPAIR_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Type indicates the type of the log entry and can be used as a filter.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Type(std::borrow::Cow<'static, str>);
+pub struct Type(i32);
 
 impl Type {
+    /// Type is unspecified.
+    pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+    /// A Pub/Sub notification failed to be sent.
+    pub const TYPE_PUBSUB_NOTIFICATION_FAILURE: Type = Type::new(1);
+
+    /// Resource state changed.
+    pub const TYPE_RESOURCE_STATE_CHANGE: Type = Type::new(3);
+
+    /// A process aborted.
+    pub const TYPE_PROCESS_ABORTED: Type = Type::new(4);
+
+    /// Restriction check failed.
+    pub const TYPE_RESTRICTION_VIOLATED: Type = Type::new(5);
+
+    /// Resource deleted.
+    pub const TYPE_RESOURCE_DELETED: Type = Type::new(6);
+
+    /// Rollout updated.
+    pub const TYPE_ROLLOUT_UPDATE: Type = Type::new(7);
+
+    /// Deploy Policy evaluation.
+    pub const TYPE_DEPLOY_POLICY_EVALUATION: Type = Type::new(8);
+
+    /// Deprecated: This field is never used. Use release_render log type instead.
+    pub const TYPE_RENDER_STATUES_CHANGE: Type = Type::new(2);
+
     /// Creates a new Type instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("TYPE_PUBSUB_NOTIFICATION_FAILURE"),
+            2 => std::borrow::Cow::Borrowed("TYPE_RENDER_STATUES_CHANGE"),
+            3 => std::borrow::Cow::Borrowed("TYPE_RESOURCE_STATE_CHANGE"),
+            4 => std::borrow::Cow::Borrowed("TYPE_PROCESS_ABORTED"),
+            5 => std::borrow::Cow::Borrowed("TYPE_RESTRICTION_VIOLATED"),
+            6 => std::borrow::Cow::Borrowed("TYPE_RESOURCE_DELETED"),
+            7 => std::borrow::Cow::Borrowed("TYPE_ROLLOUT_UPDATE"),
+            8 => std::borrow::Cow::Borrowed("TYPE_DEPLOY_POLICY_EVALUATION"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+            "TYPE_PUBSUB_NOTIFICATION_FAILURE" => {
+                std::option::Option::Some(Self::TYPE_PUBSUB_NOTIFICATION_FAILURE)
+            }
+            "TYPE_RESOURCE_STATE_CHANGE" => {
+                std::option::Option::Some(Self::TYPE_RESOURCE_STATE_CHANGE)
+            }
+            "TYPE_PROCESS_ABORTED" => std::option::Option::Some(Self::TYPE_PROCESS_ABORTED),
+            "TYPE_RESTRICTION_VIOLATED" => {
+                std::option::Option::Some(Self::TYPE_RESTRICTION_VIOLATED)
+            }
+            "TYPE_RESOURCE_DELETED" => std::option::Option::Some(Self::TYPE_RESOURCE_DELETED),
+            "TYPE_ROLLOUT_UPDATE" => std::option::Option::Some(Self::TYPE_ROLLOUT_UPDATE),
+            "TYPE_DEPLOY_POLICY_EVALUATION" => {
+                std::option::Option::Some(Self::TYPE_DEPLOY_POLICY_EVALUATION)
+            }
+            "TYPE_RENDER_STATUES_CHANGE" => {
+                std::option::Option::Some(Self::TYPE_RENDER_STATUES_CHANGE)
+            }
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [Type](Type)
-pub mod r#type {
-    use super::Type;
-
-    /// Type is unspecified.
-    pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-    /// A Pub/Sub notification failed to be sent.
-    pub const TYPE_PUBSUB_NOTIFICATION_FAILURE: Type =
-        Type::new("TYPE_PUBSUB_NOTIFICATION_FAILURE");
-
-    /// Resource state changed.
-    pub const TYPE_RESOURCE_STATE_CHANGE: Type = Type::new("TYPE_RESOURCE_STATE_CHANGE");
-
-    /// A process aborted.
-    pub const TYPE_PROCESS_ABORTED: Type = Type::new("TYPE_PROCESS_ABORTED");
-
-    /// Restriction check failed.
-    pub const TYPE_RESTRICTION_VIOLATED: Type = Type::new("TYPE_RESTRICTION_VIOLATED");
-
-    /// Resource deleted.
-    pub const TYPE_RESOURCE_DELETED: Type = Type::new("TYPE_RESOURCE_DELETED");
-
-    /// Rollout updated.
-    pub const TYPE_ROLLOUT_UPDATE: Type = Type::new("TYPE_ROLLOUT_UPDATE");
-
-    /// Deploy Policy evaluation.
-    pub const TYPE_DEPLOY_POLICY_EVALUATION: Type = Type::new("TYPE_DEPLOY_POLICY_EVALUATION");
-
-    /// Deprecated: This field is never used. Use release_render log type instead.
-    pub const TYPE_RENDER_STATUES_CHANGE: Type = Type::new("TYPE_RENDER_STATUES_CHANGE");
-}
-
-impl std::convert::From<std::string::String> for Type {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Type {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Type {
     fn default() -> Self {
-        r#type::TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/deploy/v1/src/transport.rs
+++ b/src/generated/cloud/deploy/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
                 reqwest::Method::GET,
                 format!("/v1/{}/deliveryPipelines", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
                 reqwest::Method::POST,
                 format!("/v1/{}/deliveryPipelines", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -128,7 +128,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -160,7 +160,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -184,7 +184,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/targets", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -210,7 +210,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
                 reqwest::Method::POST,
                 format!("/v1/{}:rollbackTarget", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -227,7 +227,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -246,7 +246,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/targets", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -275,7 +275,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -305,7 +305,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -331,7 +331,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
                 reqwest::Method::GET,
                 format!("/v1/{}/customTargetTypes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -354,7 +354,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -376,7 +376,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
                 reqwest::Method::POST,
                 format!("/v1/{}/customTargetTypes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -407,7 +407,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -439,7 +439,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -462,7 +462,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/releases", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -485,7 +485,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -507,7 +507,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
                 reqwest::Method::POST,
                 format!("/v1/{}/releases", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -535,7 +535,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:abandon", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -555,7 +555,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
                 reqwest::Method::POST,
                 format!("/v1/{}/deployPolicies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -586,7 +586,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -618,7 +618,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -644,7 +644,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
                 reqwest::Method::GET,
                 format!("/v1/{}/deployPolicies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -667,7 +667,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -686,7 +686,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:approve", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -703,7 +703,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:advance", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -720,7 +720,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -737,7 +737,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/rollouts", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -760,7 +760,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -782,7 +782,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
                 reqwest::Method::POST,
                 format!("/v1/{}/rollouts", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -814,7 +814,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
                 reqwest::Method::POST,
                 format!("/v1/{}:ignoreJob", req.rollout),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -834,7 +834,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
                 reqwest::Method::POST,
                 format!("/v1/{}:retryJob", req.rollout),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -851,7 +851,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/jobRuns", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -874,7 +874,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -893,7 +893,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:terminate", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -910,7 +910,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -932,7 +932,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
                 reqwest::Method::POST,
                 format!("/v1/{}/automations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -963,7 +963,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -995,7 +995,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1018,7 +1018,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1040,7 +1040,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
                 reqwest::Method::GET,
                 format!("/v1/{}/automations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1063,7 +1063,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1085,7 +1085,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
                 reqwest::Method::GET,
                 format!("/v1/{}/automationRuns", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1108,7 +1108,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1125,7 +1125,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1147,7 +1147,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1169,7 +1169,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1189,7 +1189,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1221,7 +1221,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1238,7 +1238,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1260,7 +1260,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1279,7 +1279,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1298,7 +1298,7 @@ impl crate::stubs::CloudDeploy for CloudDeploy {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/developerconnect/v1/src/model.rs
+++ b/src/generated/cloud/developerconnect/v1/src/model.rs
@@ -462,50 +462,69 @@ pub mod installation_state {
 
     /// Stage of the installation process.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Stage(std::borrow::Cow<'static, str>);
+    pub struct Stage(i32);
 
     impl Stage {
-        /// Creates a new Stage instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Stage](Stage)
-    pub mod stage {
-        use super::Stage;
-
         /// No stage specified.
-        pub const STAGE_UNSPECIFIED: Stage = Stage::new("STAGE_UNSPECIFIED");
+        pub const STAGE_UNSPECIFIED: Stage = Stage::new(0);
 
         /// Only for GitHub Enterprise. An App creation has been requested.
         /// The user needs to confirm the creation in their GitHub enterprise host.
-        pub const PENDING_CREATE_APP: Stage = Stage::new("PENDING_CREATE_APP");
+        pub const PENDING_CREATE_APP: Stage = Stage::new(1);
 
         /// User needs to authorize the GitHub (or Enterprise) App via OAuth.
-        pub const PENDING_USER_OAUTH: Stage = Stage::new("PENDING_USER_OAUTH");
+        pub const PENDING_USER_OAUTH: Stage = Stage::new(2);
 
         /// User needs to follow the link to install the GitHub (or Enterprise) App.
-        pub const PENDING_INSTALL_APP: Stage = Stage::new("PENDING_INSTALL_APP");
+        pub const PENDING_INSTALL_APP: Stage = Stage::new(3);
 
         /// Installation process has been completed.
-        pub const COMPLETE: Stage = Stage::new("COMPLETE");
+        pub const COMPLETE: Stage = Stage::new(10);
+
+        /// Creates a new Stage instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STAGE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING_CREATE_APP"),
+                2 => std::borrow::Cow::Borrowed("PENDING_USER_OAUTH"),
+                3 => std::borrow::Cow::Borrowed("PENDING_INSTALL_APP"),
+                10 => std::borrow::Cow::Borrowed("COMPLETE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STAGE_UNSPECIFIED" => std::option::Option::Some(Self::STAGE_UNSPECIFIED),
+                "PENDING_CREATE_APP" => std::option::Option::Some(Self::PENDING_CREATE_APP),
+                "PENDING_USER_OAUTH" => std::option::Option::Some(Self::PENDING_USER_OAUTH),
+                "PENDING_INSTALL_APP" => std::option::Option::Some(Self::PENDING_INSTALL_APP),
+                "COMPLETE" => std::option::Option::Some(Self::COMPLETE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Stage {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Stage {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Stage {
         fn default() -> Self {
-            stage::STAGE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -591,43 +610,60 @@ pub mod git_hub_config {
     /// Represents the various GitHub Applications that can be installed to a
     /// GitHub user or organization and used with Developer Connect.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct GitHubApp(std::borrow::Cow<'static, str>);
+    pub struct GitHubApp(i32);
 
     impl GitHubApp {
+        /// GitHub App not specified.
+        pub const GIT_HUB_APP_UNSPECIFIED: GitHubApp = GitHubApp::new(0);
+
+        /// The Developer Connect GitHub Application.
+        pub const DEVELOPER_CONNECT: GitHubApp = GitHubApp::new(1);
+
+        /// The Firebase GitHub Application.
+        pub const FIREBASE: GitHubApp = GitHubApp::new(2);
+
         /// Creates a new GitHubApp instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("GIT_HUB_APP_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DEVELOPER_CONNECT"),
+                2 => std::borrow::Cow::Borrowed("FIREBASE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "GIT_HUB_APP_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::GIT_HUB_APP_UNSPECIFIED)
+                }
+                "DEVELOPER_CONNECT" => std::option::Option::Some(Self::DEVELOPER_CONNECT),
+                "FIREBASE" => std::option::Option::Some(Self::FIREBASE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [GitHubApp](GitHubApp)
-    pub mod git_hub_app {
-        use super::GitHubApp;
-
-        /// GitHub App not specified.
-        pub const GIT_HUB_APP_UNSPECIFIED: GitHubApp = GitHubApp::new("GIT_HUB_APP_UNSPECIFIED");
-
-        /// The Developer Connect GitHub Application.
-        pub const DEVELOPER_CONNECT: GitHubApp = GitHubApp::new("DEVELOPER_CONNECT");
-
-        /// The Firebase GitHub Application.
-        pub const FIREBASE: GitHubApp = GitHubApp::new("FIREBASE");
-    }
-
-    impl std::convert::From<std::string::String> for GitHubApp {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for GitHubApp {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for GitHubApp {
         fn default() -> Self {
-            git_hub_app::GIT_HUB_APP_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2602,43 +2638,58 @@ pub mod fetch_git_refs_request {
 
     /// Type of refs.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RefType(std::borrow::Cow<'static, str>);
+    pub struct RefType(i32);
 
     impl RefType {
+        /// No type specified.
+        pub const REF_TYPE_UNSPECIFIED: RefType = RefType::new(0);
+
+        /// To fetch tags.
+        pub const TAG: RefType = RefType::new(1);
+
+        /// To fetch branches.
+        pub const BRANCH: RefType = RefType::new(2);
+
         /// Creates a new RefType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("REF_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TAG"),
+                2 => std::borrow::Cow::Borrowed("BRANCH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "REF_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::REF_TYPE_UNSPECIFIED),
+                "TAG" => std::option::Option::Some(Self::TAG),
+                "BRANCH" => std::option::Option::Some(Self::BRANCH),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RefType](RefType)
-    pub mod ref_type {
-        use super::RefType;
-
-        /// No type specified.
-        pub const REF_TYPE_UNSPECIFIED: RefType = RefType::new("REF_TYPE_UNSPECIFIED");
-
-        /// To fetch tags.
-        pub const TAG: RefType = RefType::new("TAG");
-
-        /// To fetch branches.
-        pub const BRANCH: RefType = RefType::new("BRANCH");
-    }
-
-    impl std::convert::From<std::string::String> for RefType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RefType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RefType {
         fn default() -> Self {
-            ref_type::REF_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/developerconnect/v1/src/transport.rs
+++ b/src/generated/cloud/developerconnect/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::DeveloperConnect for DeveloperConnect {
                 reqwest::Method::GET,
                 format!("/v1/{}/connections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::DeveloperConnect for DeveloperConnect {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::DeveloperConnect for DeveloperConnect {
                 reqwest::Method::POST,
                 format!("/v1/{}/connections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -128,7 +128,7 @@ impl crate::stubs::DeveloperConnect for DeveloperConnect {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -160,7 +160,7 @@ impl crate::stubs::DeveloperConnect for DeveloperConnect {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -185,7 +185,7 @@ impl crate::stubs::DeveloperConnect for DeveloperConnect {
                 reqwest::Method::POST,
                 format!("/v1/{}/gitRepositoryLinks", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -207,7 +207,7 @@ impl crate::stubs::DeveloperConnect for DeveloperConnect {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -232,7 +232,7 @@ impl crate::stubs::DeveloperConnect for DeveloperConnect {
                 reqwest::Method::GET,
                 format!("/v1/{}/gitRepositoryLinks", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -255,7 +255,7 @@ impl crate::stubs::DeveloperConnect for DeveloperConnect {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -277,7 +277,7 @@ impl crate::stubs::DeveloperConnect for DeveloperConnect {
                 reqwest::Method::POST,
                 format!("/v1/{}:fetchReadWriteToken", req.git_repository_link),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -297,7 +297,7 @@ impl crate::stubs::DeveloperConnect for DeveloperConnect {
                 reqwest::Method::POST,
                 format!("/v1/{}:fetchReadToken", req.git_repository_link),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -317,7 +317,7 @@ impl crate::stubs::DeveloperConnect for DeveloperConnect {
                 reqwest::Method::GET,
                 format!("/v1/{}:fetchLinkableGitRepositories", req.connection),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -341,7 +341,7 @@ impl crate::stubs::DeveloperConnect for DeveloperConnect {
                 reqwest::Method::GET,
                 format!("/v1/{}:fetchGitHubInstallations", req.connection),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -363,7 +363,7 @@ impl crate::stubs::DeveloperConnect for DeveloperConnect {
                 reqwest::Method::GET,
                 format!("/v1/{}:fetchGitRefs", req.git_repository_link),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -385,7 +385,7 @@ impl crate::stubs::DeveloperConnect for DeveloperConnect {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -407,7 +407,7 @@ impl crate::stubs::DeveloperConnect for DeveloperConnect {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -426,7 +426,7 @@ impl crate::stubs::DeveloperConnect for DeveloperConnect {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -448,7 +448,7 @@ impl crate::stubs::DeveloperConnect for DeveloperConnect {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -467,7 +467,7 @@ impl crate::stubs::DeveloperConnect for DeveloperConnect {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -486,7 +486,7 @@ impl crate::stubs::DeveloperConnect for DeveloperConnect {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/dialogflow/cx/v3/src/model.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/model.rs
@@ -1541,43 +1541,60 @@ pub mod export_agent_request {
 
     /// Data format of the exported agent.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataFormat(std::borrow::Cow<'static, str>);
+    pub struct DataFormat(i32);
 
     impl DataFormat {
+        /// Unspecified format.
+        pub const DATA_FORMAT_UNSPECIFIED: DataFormat = DataFormat::new(0);
+
+        /// Agent content will be exported as raw bytes.
+        pub const BLOB: DataFormat = DataFormat::new(1);
+
+        /// Agent content will be exported in JSON Package format.
+        pub const JSON_PACKAGE: DataFormat = DataFormat::new(4);
+
         /// Creates a new DataFormat instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATA_FORMAT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BLOB"),
+                4 => std::borrow::Cow::Borrowed("JSON_PACKAGE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATA_FORMAT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DATA_FORMAT_UNSPECIFIED)
+                }
+                "BLOB" => std::option::Option::Some(Self::BLOB),
+                "JSON_PACKAGE" => std::option::Option::Some(Self::JSON_PACKAGE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DataFormat](DataFormat)
-    pub mod data_format {
-        use super::DataFormat;
-
-        /// Unspecified format.
-        pub const DATA_FORMAT_UNSPECIFIED: DataFormat = DataFormat::new("DATA_FORMAT_UNSPECIFIED");
-
-        /// Agent content will be exported as raw bytes.
-        pub const BLOB: DataFormat = DataFormat::new("BLOB");
-
-        /// Agent content will be exported in JSON Package format.
-        pub const JSON_PACKAGE: DataFormat = DataFormat::new("JSON_PACKAGE");
-    }
-
-    impl std::convert::From<std::string::String> for DataFormat {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DataFormat {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DataFormat {
         fn default() -> Self {
-            data_format::DATA_FORMAT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1904,47 +1921,63 @@ pub mod restore_agent_request {
 
     /// Restore option.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RestoreOption(std::borrow::Cow<'static, str>);
+    pub struct RestoreOption(i32);
 
     impl RestoreOption {
-        /// Creates a new RestoreOption instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RestoreOption](RestoreOption)
-    pub mod restore_option {
-        use super::RestoreOption;
-
         /// Unspecified. Treated as KEEP.
-        pub const RESTORE_OPTION_UNSPECIFIED: RestoreOption =
-            RestoreOption::new("RESTORE_OPTION_UNSPECIFIED");
+        pub const RESTORE_OPTION_UNSPECIFIED: RestoreOption = RestoreOption::new(0);
 
         /// Always respect the settings from the exported agent file. It may cause
         /// a restoration failure if some settings (e.g. model type) are not
         /// supported in the target agent.
-        pub const KEEP: RestoreOption = RestoreOption::new("KEEP");
+        pub const KEEP: RestoreOption = RestoreOption::new(1);
 
         /// Fallback to default settings if some settings are not supported in the
         /// target agent.
-        pub const FALLBACK: RestoreOption = RestoreOption::new("FALLBACK");
+        pub const FALLBACK: RestoreOption = RestoreOption::new(2);
+
+        /// Creates a new RestoreOption instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RESTORE_OPTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("KEEP"),
+                2 => std::borrow::Cow::Borrowed("FALLBACK"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RESTORE_OPTION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RESTORE_OPTION_UNSPECIFIED)
+                }
+                "KEEP" => std::option::Option::Some(Self::KEEP),
+                "FALLBACK" => std::option::Option::Some(Self::FALLBACK),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RestoreOption {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RestoreOption {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RestoreOption {
         fn default() -> Self {
-            restore_option::RESTORE_OPTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -3595,98 +3628,139 @@ pub mod data_store_connection_signals {
 
         /// Represents the decision of the grounding check.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct GroundingDecision(std::borrow::Cow<'static, str>);
+        pub struct GroundingDecision(i32);
 
         impl GroundingDecision {
+            /// Decision not specified.
+            pub const GROUNDING_DECISION_UNSPECIFIED: GroundingDecision = GroundingDecision::new(0);
+
+            /// Grounding have accepted the answer.
+            pub const ACCEPTED_BY_GROUNDING: GroundingDecision = GroundingDecision::new(1);
+
+            /// Grounding have rejected the answer.
+            pub const REJECTED_BY_GROUNDING: GroundingDecision = GroundingDecision::new(2);
+
             /// Creates a new GroundingDecision instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("GROUNDING_DECISION_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("ACCEPTED_BY_GROUNDING"),
+                    2 => std::borrow::Cow::Borrowed("REJECTED_BY_GROUNDING"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "GROUNDING_DECISION_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::GROUNDING_DECISION_UNSPECIFIED)
+                    }
+                    "ACCEPTED_BY_GROUNDING" => {
+                        std::option::Option::Some(Self::ACCEPTED_BY_GROUNDING)
+                    }
+                    "REJECTED_BY_GROUNDING" => {
+                        std::option::Option::Some(Self::REJECTED_BY_GROUNDING)
+                    }
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [GroundingDecision](GroundingDecision)
-        pub mod grounding_decision {
-            use super::GroundingDecision;
-
-            /// Decision not specified.
-            pub const GROUNDING_DECISION_UNSPECIFIED: GroundingDecision =
-                GroundingDecision::new("GROUNDING_DECISION_UNSPECIFIED");
-
-            /// Grounding have accepted the answer.
-            pub const ACCEPTED_BY_GROUNDING: GroundingDecision =
-                GroundingDecision::new("ACCEPTED_BY_GROUNDING");
-
-            /// Grounding have rejected the answer.
-            pub const REJECTED_BY_GROUNDING: GroundingDecision =
-                GroundingDecision::new("REJECTED_BY_GROUNDING");
-        }
-
-        impl std::convert::From<std::string::String> for GroundingDecision {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for GroundingDecision {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for GroundingDecision {
             fn default() -> Self {
-                grounding_decision::GROUNDING_DECISION_UNSPECIFIED
+                Self::new(0)
             }
         }
 
         /// Grounding score buckets.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct GroundingScoreBucket(std::borrow::Cow<'static, str>);
+        pub struct GroundingScoreBucket(i32);
 
         impl GroundingScoreBucket {
+            /// Score not specified.
+            pub const GROUNDING_SCORE_BUCKET_UNSPECIFIED: GroundingScoreBucket =
+                GroundingScoreBucket::new(0);
+
+            /// We have very low confidence that the answer is grounded.
+            pub const VERY_LOW: GroundingScoreBucket = GroundingScoreBucket::new(1);
+
+            /// We have low confidence that the answer is grounded.
+            pub const LOW: GroundingScoreBucket = GroundingScoreBucket::new(3);
+
+            /// We have medium confidence that the answer is grounded.
+            pub const MEDIUM: GroundingScoreBucket = GroundingScoreBucket::new(4);
+
+            /// We have high confidence that the answer is grounded.
+            pub const HIGH: GroundingScoreBucket = GroundingScoreBucket::new(5);
+
+            /// We have very high confidence that the answer is grounded.
+            pub const VERY_HIGH: GroundingScoreBucket = GroundingScoreBucket::new(6);
+
             /// Creates a new GroundingScoreBucket instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("GROUNDING_SCORE_BUCKET_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("VERY_LOW"),
+                    3 => std::borrow::Cow::Borrowed("LOW"),
+                    4 => std::borrow::Cow::Borrowed("MEDIUM"),
+                    5 => std::borrow::Cow::Borrowed("HIGH"),
+                    6 => std::borrow::Cow::Borrowed("VERY_HIGH"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "GROUNDING_SCORE_BUCKET_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::GROUNDING_SCORE_BUCKET_UNSPECIFIED)
+                    }
+                    "VERY_LOW" => std::option::Option::Some(Self::VERY_LOW),
+                    "LOW" => std::option::Option::Some(Self::LOW),
+                    "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
+                    "HIGH" => std::option::Option::Some(Self::HIGH),
+                    "VERY_HIGH" => std::option::Option::Some(Self::VERY_HIGH),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [GroundingScoreBucket](GroundingScoreBucket)
-        pub mod grounding_score_bucket {
-            use super::GroundingScoreBucket;
-
-            /// Score not specified.
-            pub const GROUNDING_SCORE_BUCKET_UNSPECIFIED: GroundingScoreBucket =
-                GroundingScoreBucket::new("GROUNDING_SCORE_BUCKET_UNSPECIFIED");
-
-            /// We have very low confidence that the answer is grounded.
-            pub const VERY_LOW: GroundingScoreBucket = GroundingScoreBucket::new("VERY_LOW");
-
-            /// We have low confidence that the answer is grounded.
-            pub const LOW: GroundingScoreBucket = GroundingScoreBucket::new("LOW");
-
-            /// We have medium confidence that the answer is grounded.
-            pub const MEDIUM: GroundingScoreBucket = GroundingScoreBucket::new("MEDIUM");
-
-            /// We have high confidence that the answer is grounded.
-            pub const HIGH: GroundingScoreBucket = GroundingScoreBucket::new("HIGH");
-
-            /// We have very high confidence that the answer is grounded.
-            pub const VERY_HIGH: GroundingScoreBucket = GroundingScoreBucket::new("VERY_HIGH");
-        }
-
-        impl std::convert::From<std::string::String> for GroundingScoreBucket {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for GroundingScoreBucket {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for GroundingScoreBucket {
             fn default() -> Self {
-                grounding_score_bucket::GROUNDING_SCORE_BUCKET_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -3765,95 +3839,135 @@ pub mod data_store_connection_signals {
         /// All kinds of check are incorporated into this final decision, including
         /// banned phrases check.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SafetyDecision(std::borrow::Cow<'static, str>);
+        pub struct SafetyDecision(i32);
 
         impl SafetyDecision {
+            /// Decision not specified.
+            pub const SAFETY_DECISION_UNSPECIFIED: SafetyDecision = SafetyDecision::new(0);
+
+            /// No manual or automatic safety check fired.
+            pub const ACCEPTED_BY_SAFETY_CHECK: SafetyDecision = SafetyDecision::new(1);
+
+            /// One ore more safety checks fired.
+            pub const REJECTED_BY_SAFETY_CHECK: SafetyDecision = SafetyDecision::new(2);
+
             /// Creates a new SafetyDecision instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("SAFETY_DECISION_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("ACCEPTED_BY_SAFETY_CHECK"),
+                    2 => std::borrow::Cow::Borrowed("REJECTED_BY_SAFETY_CHECK"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "SAFETY_DECISION_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::SAFETY_DECISION_UNSPECIFIED)
+                    }
+                    "ACCEPTED_BY_SAFETY_CHECK" => {
+                        std::option::Option::Some(Self::ACCEPTED_BY_SAFETY_CHECK)
+                    }
+                    "REJECTED_BY_SAFETY_CHECK" => {
+                        std::option::Option::Some(Self::REJECTED_BY_SAFETY_CHECK)
+                    }
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [SafetyDecision](SafetyDecision)
-        pub mod safety_decision {
-            use super::SafetyDecision;
-
-            /// Decision not specified.
-            pub const SAFETY_DECISION_UNSPECIFIED: SafetyDecision =
-                SafetyDecision::new("SAFETY_DECISION_UNSPECIFIED");
-
-            /// No manual or automatic safety check fired.
-            pub const ACCEPTED_BY_SAFETY_CHECK: SafetyDecision =
-                SafetyDecision::new("ACCEPTED_BY_SAFETY_CHECK");
-
-            /// One ore more safety checks fired.
-            pub const REJECTED_BY_SAFETY_CHECK: SafetyDecision =
-                SafetyDecision::new("REJECTED_BY_SAFETY_CHECK");
-        }
-
-        impl std::convert::From<std::string::String> for SafetyDecision {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for SafetyDecision {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for SafetyDecision {
             fn default() -> Self {
-                safety_decision::SAFETY_DECISION_UNSPECIFIED
+                Self::new(0)
             }
         }
 
         /// Specifies banned phrase match subject.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct BannedPhraseMatch(std::borrow::Cow<'static, str>);
+        pub struct BannedPhraseMatch(i32);
 
         impl BannedPhraseMatch {
+            /// No banned phrase check was executed.
+            pub const BANNED_PHRASE_MATCH_UNSPECIFIED: BannedPhraseMatch =
+                BannedPhraseMatch::new(0);
+
+            /// All banned phrase checks led to no match.
+            pub const BANNED_PHRASE_MATCH_NONE: BannedPhraseMatch = BannedPhraseMatch::new(1);
+
+            /// A banned phrase matched the query.
+            pub const BANNED_PHRASE_MATCH_QUERY: BannedPhraseMatch = BannedPhraseMatch::new(2);
+
+            /// A banned phrase matched the response.
+            pub const BANNED_PHRASE_MATCH_RESPONSE: BannedPhraseMatch = BannedPhraseMatch::new(3);
+
             /// Creates a new BannedPhraseMatch instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("BANNED_PHRASE_MATCH_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("BANNED_PHRASE_MATCH_NONE"),
+                    2 => std::borrow::Cow::Borrowed("BANNED_PHRASE_MATCH_QUERY"),
+                    3 => std::borrow::Cow::Borrowed("BANNED_PHRASE_MATCH_RESPONSE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "BANNED_PHRASE_MATCH_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::BANNED_PHRASE_MATCH_UNSPECIFIED)
+                    }
+                    "BANNED_PHRASE_MATCH_NONE" => {
+                        std::option::Option::Some(Self::BANNED_PHRASE_MATCH_NONE)
+                    }
+                    "BANNED_PHRASE_MATCH_QUERY" => {
+                        std::option::Option::Some(Self::BANNED_PHRASE_MATCH_QUERY)
+                    }
+                    "BANNED_PHRASE_MATCH_RESPONSE" => {
+                        std::option::Option::Some(Self::BANNED_PHRASE_MATCH_RESPONSE)
+                    }
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [BannedPhraseMatch](BannedPhraseMatch)
-        pub mod banned_phrase_match {
-            use super::BannedPhraseMatch;
-
-            /// No banned phrase check was executed.
-            pub const BANNED_PHRASE_MATCH_UNSPECIFIED: BannedPhraseMatch =
-                BannedPhraseMatch::new("BANNED_PHRASE_MATCH_UNSPECIFIED");
-
-            /// All banned phrase checks led to no match.
-            pub const BANNED_PHRASE_MATCH_NONE: BannedPhraseMatch =
-                BannedPhraseMatch::new("BANNED_PHRASE_MATCH_NONE");
-
-            /// A banned phrase matched the query.
-            pub const BANNED_PHRASE_MATCH_QUERY: BannedPhraseMatch =
-                BannedPhraseMatch::new("BANNED_PHRASE_MATCH_QUERY");
-
-            /// A banned phrase matched the response.
-            pub const BANNED_PHRASE_MATCH_RESPONSE: BannedPhraseMatch =
-                BannedPhraseMatch::new("BANNED_PHRASE_MATCH_RESPONSE");
-        }
-
-        impl std::convert::From<std::string::String> for BannedPhraseMatch {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for BannedPhraseMatch {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for BannedPhraseMatch {
             fn default() -> Self {
-                banned_phrase_match::BANNED_PHRASE_MATCH_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -4013,46 +4127,63 @@ pub mod deployment {
 
     /// The state of the deployment.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State unspecified.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The deployment is running.
+        pub const RUNNING: State = State::new(1);
+
+        /// The deployment succeeded.
+        pub const SUCCEEDED: State = State::new(2);
+
+        /// The deployment failed.
+        pub const FAILED: State = State::new(3);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RUNNING"),
+                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The deployment is running.
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// The deployment succeeded.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-        /// The deployment failed.
-        pub const FAILED: State = State::new("FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4467,50 +4598,67 @@ pub mod entity_type {
 
     /// Represents kinds of entities.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Kind(std::borrow::Cow<'static, str>);
+    pub struct Kind(i32);
 
     impl Kind {
-        /// Creates a new Kind instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Kind](Kind)
-    pub mod kind {
-        use super::Kind;
-
         /// Not specified. This value should be never used.
-        pub const KIND_UNSPECIFIED: Kind = Kind::new("KIND_UNSPECIFIED");
+        pub const KIND_UNSPECIFIED: Kind = Kind::new(0);
 
         /// Map entity types allow mapping of a group of synonyms to a canonical
         /// value.
-        pub const KIND_MAP: Kind = Kind::new("KIND_MAP");
+        pub const KIND_MAP: Kind = Kind::new(1);
 
         /// List entity types contain a set of entries that do not map to canonical
         /// values. However, list entity types can contain references to other entity
         /// types (with or without aliases).
-        pub const KIND_LIST: Kind = Kind::new("KIND_LIST");
+        pub const KIND_LIST: Kind = Kind::new(2);
 
         /// Regexp entity types allow to specify regular expressions in entries
         /// values.
-        pub const KIND_REGEXP: Kind = Kind::new("KIND_REGEXP");
+        pub const KIND_REGEXP: Kind = Kind::new(3);
+
+        /// Creates a new Kind instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("KIND_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("KIND_MAP"),
+                2 => std::borrow::Cow::Borrowed("KIND_LIST"),
+                3 => std::borrow::Cow::Borrowed("KIND_REGEXP"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "KIND_UNSPECIFIED" => std::option::Option::Some(Self::KIND_UNSPECIFIED),
+                "KIND_MAP" => std::option::Option::Some(Self::KIND_MAP),
+                "KIND_LIST" => std::option::Option::Some(Self::KIND_LIST),
+                "KIND_REGEXP" => std::option::Option::Some(Self::KIND_REGEXP),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Kind {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Kind {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Kind {
         fn default() -> Self {
-            kind::KIND_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -4518,43 +4666,58 @@ pub mod entity_type {
     /// allows an agent to recognize values that have not been explicitly listed in
     /// the entity (for example, new kinds of shopping list items).
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AutoExpansionMode(std::borrow::Cow<'static, str>);
+    pub struct AutoExpansionMode(i32);
 
     impl AutoExpansionMode {
-        /// Creates a new AutoExpansionMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [AutoExpansionMode](AutoExpansionMode)
-    pub mod auto_expansion_mode {
-        use super::AutoExpansionMode;
-
         /// Auto expansion disabled for the entity.
-        pub const AUTO_EXPANSION_MODE_UNSPECIFIED: AutoExpansionMode =
-            AutoExpansionMode::new("AUTO_EXPANSION_MODE_UNSPECIFIED");
+        pub const AUTO_EXPANSION_MODE_UNSPECIFIED: AutoExpansionMode = AutoExpansionMode::new(0);
 
         /// Allows an agent to recognize values that have not been explicitly
         /// listed in the entity.
-        pub const AUTO_EXPANSION_MODE_DEFAULT: AutoExpansionMode =
-            AutoExpansionMode::new("AUTO_EXPANSION_MODE_DEFAULT");
+        pub const AUTO_EXPANSION_MODE_DEFAULT: AutoExpansionMode = AutoExpansionMode::new(1);
+
+        /// Creates a new AutoExpansionMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("AUTO_EXPANSION_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AUTO_EXPANSION_MODE_DEFAULT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "AUTO_EXPANSION_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::AUTO_EXPANSION_MODE_UNSPECIFIED)
+                }
+                "AUTO_EXPANSION_MODE_DEFAULT" => {
+                    std::option::Option::Some(Self::AUTO_EXPANSION_MODE_DEFAULT)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for AutoExpansionMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AutoExpansionMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AutoExpansionMode {
         fn default() -> Self {
-            auto_expansion_mode::AUTO_EXPANSION_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4724,43 +4887,60 @@ pub mod export_entity_types_request {
 
     /// Data format of the exported entity types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataFormat(std::borrow::Cow<'static, str>);
+    pub struct DataFormat(i32);
 
     impl DataFormat {
+        /// Unspecified format. Treated as `BLOB`.
+        pub const DATA_FORMAT_UNSPECIFIED: DataFormat = DataFormat::new(0);
+
+        /// EntityTypes will be exported as raw bytes.
+        pub const BLOB: DataFormat = DataFormat::new(1);
+
+        /// EntityTypes will be exported in JSON Package format.
+        pub const JSON_PACKAGE: DataFormat = DataFormat::new(5);
+
         /// Creates a new DataFormat instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATA_FORMAT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BLOB"),
+                5 => std::borrow::Cow::Borrowed("JSON_PACKAGE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATA_FORMAT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DATA_FORMAT_UNSPECIFIED)
+                }
+                "BLOB" => std::option::Option::Some(Self::BLOB),
+                "JSON_PACKAGE" => std::option::Option::Some(Self::JSON_PACKAGE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DataFormat](DataFormat)
-    pub mod data_format {
-        use super::DataFormat;
-
-        /// Unspecified format. Treated as `BLOB`.
-        pub const DATA_FORMAT_UNSPECIFIED: DataFormat = DataFormat::new("DATA_FORMAT_UNSPECIFIED");
-
-        /// EntityTypes will be exported as raw bytes.
-        pub const BLOB: DataFormat = DataFormat::new("BLOB");
-
-        /// EntityTypes will be exported in JSON Package format.
-        pub const JSON_PACKAGE: DataFormat = DataFormat::new("JSON_PACKAGE");
-    }
-
-    impl std::convert::From<std::string::String> for DataFormat {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DataFormat {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DataFormat {
         fn default() -> Self {
-            data_format::DATA_FORMAT_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -5091,58 +5271,80 @@ pub mod import_entity_types_request {
 
     /// Merge option when display name conflicts exist during import.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MergeOption(std::borrow::Cow<'static, str>);
+    pub struct MergeOption(i32);
 
     impl MergeOption {
-        /// Creates a new MergeOption instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [MergeOption](MergeOption)
-    pub mod merge_option {
-        use super::MergeOption;
-
         /// Unspecified. If used, system uses REPORT_CONFLICT as default.
-        pub const MERGE_OPTION_UNSPECIFIED: MergeOption =
-            MergeOption::new("MERGE_OPTION_UNSPECIFIED");
+        pub const MERGE_OPTION_UNSPECIFIED: MergeOption = MergeOption::new(0);
 
         /// Replace the original entity type in the agent with the new entity type
         /// when display name conflicts exist.
-        pub const REPLACE: MergeOption = MergeOption::new("REPLACE");
+        pub const REPLACE: MergeOption = MergeOption::new(1);
 
         /// Merge the original entity type with the new entity type when display name
         /// conflicts exist.
-        pub const MERGE: MergeOption = MergeOption::new("MERGE");
+        pub const MERGE: MergeOption = MergeOption::new(2);
 
         /// Create new entity types with new display names to differentiate them from
         /// the existing entity types when display name conflicts exist.
-        pub const RENAME: MergeOption = MergeOption::new("RENAME");
+        pub const RENAME: MergeOption = MergeOption::new(3);
 
         /// Report conflict information if display names conflict is detected.
         /// Otherwise, import entity types.
-        pub const REPORT_CONFLICT: MergeOption = MergeOption::new("REPORT_CONFLICT");
+        pub const REPORT_CONFLICT: MergeOption = MergeOption::new(4);
 
         /// Keep the original entity type and discard the conflicting new entity type
         /// when display name conflicts exist.
-        pub const KEEP: MergeOption = MergeOption::new("KEEP");
+        pub const KEEP: MergeOption = MergeOption::new(5);
+
+        /// Creates a new MergeOption instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MERGE_OPTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REPLACE"),
+                2 => std::borrow::Cow::Borrowed("MERGE"),
+                3 => std::borrow::Cow::Borrowed("RENAME"),
+                4 => std::borrow::Cow::Borrowed("REPORT_CONFLICT"),
+                5 => std::borrow::Cow::Borrowed("KEEP"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MERGE_OPTION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MERGE_OPTION_UNSPECIFIED)
+                }
+                "REPLACE" => std::option::Option::Some(Self::REPLACE),
+                "MERGE" => std::option::Option::Some(Self::MERGE),
+                "RENAME" => std::option::Option::Some(Self::RENAME),
+                "REPORT_CONFLICT" => std::option::Option::Some(Self::REPORT_CONFLICT),
+                "KEEP" => std::option::Option::Some(Self::KEEP),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for MergeOption {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MergeOption {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MergeOption {
         fn default() -> Self {
-            merge_option::MERGE_OPTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -6445,44 +6647,61 @@ pub mod continuous_test_result {
 
     /// The overall result for a continuous test run in an agent environment.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AggregatedTestResult(std::borrow::Cow<'static, str>);
+    pub struct AggregatedTestResult(i32);
 
     impl AggregatedTestResult {
+        /// Not specified. Should never be used.
+        pub const AGGREGATED_TEST_RESULT_UNSPECIFIED: AggregatedTestResult =
+            AggregatedTestResult::new(0);
+
+        /// All the tests passed.
+        pub const PASSED: AggregatedTestResult = AggregatedTestResult::new(1);
+
+        /// At least one test did not pass.
+        pub const FAILED: AggregatedTestResult = AggregatedTestResult::new(2);
+
         /// Creates a new AggregatedTestResult instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("AGGREGATED_TEST_RESULT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PASSED"),
+                2 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "AGGREGATED_TEST_RESULT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::AGGREGATED_TEST_RESULT_UNSPECIFIED)
+                }
+                "PASSED" => std::option::Option::Some(Self::PASSED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AggregatedTestResult](AggregatedTestResult)
-    pub mod aggregated_test_result {
-        use super::AggregatedTestResult;
-
-        /// Not specified. Should never be used.
-        pub const AGGREGATED_TEST_RESULT_UNSPECIFIED: AggregatedTestResult =
-            AggregatedTestResult::new("AGGREGATED_TEST_RESULT_UNSPECIFIED");
-
-        /// All the tests passed.
-        pub const PASSED: AggregatedTestResult = AggregatedTestResult::new("PASSED");
-
-        /// At least one test did not pass.
-        pub const FAILED: AggregatedTestResult = AggregatedTestResult::new("FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for AggregatedTestResult {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AggregatedTestResult {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AggregatedTestResult {
         fn default() -> Self {
-            aggregated_test_result::AGGREGATED_TEST_RESULT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7493,150 +7712,214 @@ pub mod experiment {
 
         /// Types of ratio-based metric for Dialogflow experiment.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct MetricType(std::borrow::Cow<'static, str>);
+        pub struct MetricType(i32);
 
         impl MetricType {
-            /// Creates a new MetricType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [MetricType](MetricType)
-        pub mod metric_type {
-            use super::MetricType;
-
             /// Metric unspecified.
-            pub const METRIC_UNSPECIFIED: MetricType = MetricType::new("METRIC_UNSPECIFIED");
+            pub const METRIC_UNSPECIFIED: MetricType = MetricType::new(0);
 
             /// Percentage of contained sessions without user calling back in 24 hours.
-            pub const CONTAINED_SESSION_NO_CALLBACK_RATE: MetricType =
-                MetricType::new("CONTAINED_SESSION_NO_CALLBACK_RATE");
+            pub const CONTAINED_SESSION_NO_CALLBACK_RATE: MetricType = MetricType::new(1);
 
             /// Percentage of sessions that were handed to a human agent.
-            pub const LIVE_AGENT_HANDOFF_RATE: MetricType =
-                MetricType::new("LIVE_AGENT_HANDOFF_RATE");
+            pub const LIVE_AGENT_HANDOFF_RATE: MetricType = MetricType::new(2);
 
             /// Percentage of sessions with the same user calling back.
-            pub const CALLBACK_SESSION_RATE: MetricType = MetricType::new("CALLBACK_SESSION_RATE");
+            pub const CALLBACK_SESSION_RATE: MetricType = MetricType::new(3);
 
             /// Percentage of sessions where user hung up.
-            pub const ABANDONED_SESSION_RATE: MetricType =
-                MetricType::new("ABANDONED_SESSION_RATE");
+            pub const ABANDONED_SESSION_RATE: MetricType = MetricType::new(4);
 
             /// Percentage of sessions reached Dialogflow 'END_PAGE' or
             /// 'END_SESSION'.
-            pub const SESSION_END_RATE: MetricType = MetricType::new("SESSION_END_RATE");
+            pub const SESSION_END_RATE: MetricType = MetricType::new(5);
+
+            /// Creates a new MetricType instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("METRIC_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("CONTAINED_SESSION_NO_CALLBACK_RATE"),
+                    2 => std::borrow::Cow::Borrowed("LIVE_AGENT_HANDOFF_RATE"),
+                    3 => std::borrow::Cow::Borrowed("CALLBACK_SESSION_RATE"),
+                    4 => std::borrow::Cow::Borrowed("ABANDONED_SESSION_RATE"),
+                    5 => std::borrow::Cow::Borrowed("SESSION_END_RATE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "METRIC_UNSPECIFIED" => std::option::Option::Some(Self::METRIC_UNSPECIFIED),
+                    "CONTAINED_SESSION_NO_CALLBACK_RATE" => {
+                        std::option::Option::Some(Self::CONTAINED_SESSION_NO_CALLBACK_RATE)
+                    }
+                    "LIVE_AGENT_HANDOFF_RATE" => {
+                        std::option::Option::Some(Self::LIVE_AGENT_HANDOFF_RATE)
+                    }
+                    "CALLBACK_SESSION_RATE" => {
+                        std::option::Option::Some(Self::CALLBACK_SESSION_RATE)
+                    }
+                    "ABANDONED_SESSION_RATE" => {
+                        std::option::Option::Some(Self::ABANDONED_SESSION_RATE)
+                    }
+                    "SESSION_END_RATE" => std::option::Option::Some(Self::SESSION_END_RATE),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for MetricType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for MetricType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for MetricType {
             fn default() -> Self {
-                metric_type::METRIC_UNSPECIFIED
+                Self::new(0)
             }
         }
 
         /// Types of count-based metric for Dialogflow experiment.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct CountType(std::borrow::Cow<'static, str>);
+        pub struct CountType(i32);
 
         impl CountType {
+            /// Count type unspecified.
+            pub const COUNT_TYPE_UNSPECIFIED: CountType = CountType::new(0);
+
+            /// Total number of occurrences of a 'NO_MATCH'.
+            pub const TOTAL_NO_MATCH_COUNT: CountType = CountType::new(1);
+
+            /// Total number of turn counts.
+            pub const TOTAL_TURN_COUNT: CountType = CountType::new(2);
+
+            /// Average turn count in a session.
+            pub const AVERAGE_TURN_COUNT: CountType = CountType::new(3);
+
             /// Creates a new CountType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("COUNT_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("TOTAL_NO_MATCH_COUNT"),
+                    2 => std::borrow::Cow::Borrowed("TOTAL_TURN_COUNT"),
+                    3 => std::borrow::Cow::Borrowed("AVERAGE_TURN_COUNT"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "COUNT_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::COUNT_TYPE_UNSPECIFIED)
+                    }
+                    "TOTAL_NO_MATCH_COUNT" => std::option::Option::Some(Self::TOTAL_NO_MATCH_COUNT),
+                    "TOTAL_TURN_COUNT" => std::option::Option::Some(Self::TOTAL_TURN_COUNT),
+                    "AVERAGE_TURN_COUNT" => std::option::Option::Some(Self::AVERAGE_TURN_COUNT),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [CountType](CountType)
-        pub mod count_type {
-            use super::CountType;
-
-            /// Count type unspecified.
-            pub const COUNT_TYPE_UNSPECIFIED: CountType = CountType::new("COUNT_TYPE_UNSPECIFIED");
-
-            /// Total number of occurrences of a 'NO_MATCH'.
-            pub const TOTAL_NO_MATCH_COUNT: CountType = CountType::new("TOTAL_NO_MATCH_COUNT");
-
-            /// Total number of turn counts.
-            pub const TOTAL_TURN_COUNT: CountType = CountType::new("TOTAL_TURN_COUNT");
-
-            /// Average turn count in a session.
-            pub const AVERAGE_TURN_COUNT: CountType = CountType::new("AVERAGE_TURN_COUNT");
-        }
-
-        impl std::convert::From<std::string::String> for CountType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for CountType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for CountType {
             fn default() -> Self {
-                count_type::COUNT_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// The state of the experiment.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State unspecified.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The experiment is created but not started yet.
+        pub const DRAFT: State = State::new(1);
+
+        /// The experiment is running.
+        pub const RUNNING: State = State::new(2);
+
+        /// The experiment is done.
+        pub const DONE: State = State::new(3);
+
+        /// The experiment with auto-rollout enabled has failed.
+        pub const ROLLOUT_FAILED: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DRAFT"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("DONE"),
+                4 => std::borrow::Cow::Borrowed("ROLLOUT_FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "DRAFT" => std::option::Option::Some(Self::DRAFT),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "DONE" => std::option::Option::Some(Self::DONE),
+                "ROLLOUT_FAILED" => std::option::Option::Some(Self::ROLLOUT_FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The experiment is created but not started yet.
-        pub const DRAFT: State = State::new("DRAFT");
-
-        /// The experiment is running.
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// The experiment is done.
-        pub const DONE: State = State::new("DONE");
-
-        /// The experiment with auto-rollout enabled has failed.
-        pub const ROLLOUT_FAILED: State = State::new("ROLLOUT_FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8434,90 +8717,123 @@ pub mod nlu_settings {
 
     /// NLU model type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ModelType(std::borrow::Cow<'static, str>);
+    pub struct ModelType(i32);
 
     impl ModelType {
+        /// Not specified. `MODEL_TYPE_STANDARD` will be used.
+        pub const MODEL_TYPE_UNSPECIFIED: ModelType = ModelType::new(0);
+
+        /// Use standard NLU model.
+        pub const MODEL_TYPE_STANDARD: ModelType = ModelType::new(1);
+
+        /// Use advanced NLU model.
+        pub const MODEL_TYPE_ADVANCED: ModelType = ModelType::new(3);
+
         /// Creates a new ModelType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MODEL_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MODEL_TYPE_STANDARD"),
+                3 => std::borrow::Cow::Borrowed("MODEL_TYPE_ADVANCED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MODEL_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::MODEL_TYPE_UNSPECIFIED),
+                "MODEL_TYPE_STANDARD" => std::option::Option::Some(Self::MODEL_TYPE_STANDARD),
+                "MODEL_TYPE_ADVANCED" => std::option::Option::Some(Self::MODEL_TYPE_ADVANCED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ModelType](ModelType)
-    pub mod model_type {
-        use super::ModelType;
-
-        /// Not specified. `MODEL_TYPE_STANDARD` will be used.
-        pub const MODEL_TYPE_UNSPECIFIED: ModelType = ModelType::new("MODEL_TYPE_UNSPECIFIED");
-
-        /// Use standard NLU model.
-        pub const MODEL_TYPE_STANDARD: ModelType = ModelType::new("MODEL_TYPE_STANDARD");
-
-        /// Use advanced NLU model.
-        pub const MODEL_TYPE_ADVANCED: ModelType = ModelType::new("MODEL_TYPE_ADVANCED");
-    }
-
-    impl std::convert::From<std::string::String> for ModelType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ModelType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ModelType {
         fn default() -> Self {
-            model_type::MODEL_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// NLU model training mode.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ModelTrainingMode(std::borrow::Cow<'static, str>);
+    pub struct ModelTrainingMode(i32);
 
     impl ModelTrainingMode {
-        /// Creates a new ModelTrainingMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ModelTrainingMode](ModelTrainingMode)
-    pub mod model_training_mode {
-        use super::ModelTrainingMode;
-
         /// Not specified. `MODEL_TRAINING_MODE_AUTOMATIC` will be used.
-        pub const MODEL_TRAINING_MODE_UNSPECIFIED: ModelTrainingMode =
-            ModelTrainingMode::new("MODEL_TRAINING_MODE_UNSPECIFIED");
+        pub const MODEL_TRAINING_MODE_UNSPECIFIED: ModelTrainingMode = ModelTrainingMode::new(0);
 
         /// NLU model training is automatically triggered when a flow gets modified.
         /// User can also manually trigger model training in this mode.
-        pub const MODEL_TRAINING_MODE_AUTOMATIC: ModelTrainingMode =
-            ModelTrainingMode::new("MODEL_TRAINING_MODE_AUTOMATIC");
+        pub const MODEL_TRAINING_MODE_AUTOMATIC: ModelTrainingMode = ModelTrainingMode::new(1);
 
         /// User needs to manually trigger NLU model training. Best for large flows
         /// whose models take long time to train.
-        pub const MODEL_TRAINING_MODE_MANUAL: ModelTrainingMode =
-            ModelTrainingMode::new("MODEL_TRAINING_MODE_MANUAL");
+        pub const MODEL_TRAINING_MODE_MANUAL: ModelTrainingMode = ModelTrainingMode::new(2);
+
+        /// Creates a new ModelTrainingMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MODEL_TRAINING_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MODEL_TRAINING_MODE_AUTOMATIC"),
+                2 => std::borrow::Cow::Borrowed("MODEL_TRAINING_MODE_MANUAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MODEL_TRAINING_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MODEL_TRAINING_MODE_UNSPECIFIED)
+                }
+                "MODEL_TRAINING_MODE_AUTOMATIC" => {
+                    std::option::Option::Some(Self::MODEL_TRAINING_MODE_AUTOMATIC)
+                }
+                "MODEL_TRAINING_MODE_MANUAL" => {
+                    std::option::Option::Some(Self::MODEL_TRAINING_MODE_MANUAL)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ModelTrainingMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ModelTrainingMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ModelTrainingMode {
         fn default() -> Self {
-            model_training_mode::MODEL_TRAINING_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -9514,48 +9830,64 @@ pub mod import_flow_request {
 
     /// Import option.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ImportOption(std::borrow::Cow<'static, str>);
+    pub struct ImportOption(i32);
 
     impl ImportOption {
-        /// Creates a new ImportOption instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ImportOption](ImportOption)
-    pub mod import_option {
-        use super::ImportOption;
-
         /// Unspecified. Treated as `KEEP`.
-        pub const IMPORT_OPTION_UNSPECIFIED: ImportOption =
-            ImportOption::new("IMPORT_OPTION_UNSPECIFIED");
+        pub const IMPORT_OPTION_UNSPECIFIED: ImportOption = ImportOption::new(0);
 
         /// Always respect settings in exported flow content. It may cause a
         /// import failure if some settings (e.g. custom NLU) are not supported in
         /// the agent to import into.
-        pub const KEEP: ImportOption = ImportOption::new("KEEP");
+        pub const KEEP: ImportOption = ImportOption::new(1);
 
         /// Fallback to default settings if some settings are not supported in the
         /// agent to import into. E.g. Standard NLU will be used if custom NLU is
         /// not available.
-        pub const FALLBACK: ImportOption = ImportOption::new("FALLBACK");
+        pub const FALLBACK: ImportOption = ImportOption::new(2);
+
+        /// Creates a new ImportOption instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("IMPORT_OPTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("KEEP"),
+                2 => std::borrow::Cow::Borrowed("FALLBACK"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "IMPORT_OPTION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::IMPORT_OPTION_UNSPECIFIED)
+                }
+                "KEEP" => std::option::Option::Some(Self::KEEP),
+                "FALLBACK" => std::option::Option::Some(Self::FALLBACK),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ImportOption {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ImportOption {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ImportOption {
         fn default() -> Self {
-            import_option::IMPORT_OPTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -12090,64 +12422,88 @@ pub mod import_intents_request {
 
     /// Merge option when display name conflicts exist during import.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MergeOption(std::borrow::Cow<'static, str>);
+    pub struct MergeOption(i32);
 
     impl MergeOption {
-        /// Creates a new MergeOption instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [MergeOption](MergeOption)
-    pub mod merge_option {
-        use super::MergeOption;
-
         /// Unspecified. Should not be used.
-        pub const MERGE_OPTION_UNSPECIFIED: MergeOption =
-            MergeOption::new("MERGE_OPTION_UNSPECIFIED");
+        pub const MERGE_OPTION_UNSPECIFIED: MergeOption = MergeOption::new(0);
 
         /// DEPRECATED: Please use
         /// [REPORT_CONFLICT][ImportIntentsRequest.REPORT_CONFLICT] instead.
         /// Fail the request if there are intents whose display names conflict with
         /// the display names of intents in the agent.
-        pub const REJECT: MergeOption = MergeOption::new("REJECT");
+        pub const REJECT: MergeOption = MergeOption::new(1);
 
         /// Replace the original intent in the agent with the new intent when display
         /// name conflicts exist.
-        pub const REPLACE: MergeOption = MergeOption::new("REPLACE");
+        pub const REPLACE: MergeOption = MergeOption::new(2);
 
         /// Merge the original intent with the new intent when display name conflicts
         /// exist.
-        pub const MERGE: MergeOption = MergeOption::new("MERGE");
+        pub const MERGE: MergeOption = MergeOption::new(3);
 
         /// Create new intents with new display names to differentiate them from the
         /// existing intents when display name conflicts exist.
-        pub const RENAME: MergeOption = MergeOption::new("RENAME");
+        pub const RENAME: MergeOption = MergeOption::new(4);
 
         /// Report conflict information if display names conflict is detected.
         /// Otherwise, import intents.
-        pub const REPORT_CONFLICT: MergeOption = MergeOption::new("REPORT_CONFLICT");
+        pub const REPORT_CONFLICT: MergeOption = MergeOption::new(5);
 
         /// Keep the original intent and discard the conflicting new intent when
         /// display name conflicts exist.
-        pub const KEEP: MergeOption = MergeOption::new("KEEP");
+        pub const KEEP: MergeOption = MergeOption::new(6);
+
+        /// Creates a new MergeOption instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MERGE_OPTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REJECT"),
+                2 => std::borrow::Cow::Borrowed("REPLACE"),
+                3 => std::borrow::Cow::Borrowed("MERGE"),
+                4 => std::borrow::Cow::Borrowed("RENAME"),
+                5 => std::borrow::Cow::Borrowed("REPORT_CONFLICT"),
+                6 => std::borrow::Cow::Borrowed("KEEP"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MERGE_OPTION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MERGE_OPTION_UNSPECIFIED)
+                }
+                "REJECT" => std::option::Option::Some(Self::REJECT),
+                "REPLACE" => std::option::Option::Some(Self::REPLACE),
+                "MERGE" => std::option::Option::Some(Self::MERGE),
+                "RENAME" => std::option::Option::Some(Self::RENAME),
+                "REPORT_CONFLICT" => std::option::Option::Some(Self::REPORT_CONFLICT),
+                "KEEP" => std::option::Option::Some(Self::KEEP),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for MergeOption {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MergeOption {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MergeOption {
         fn default() -> Self {
-            merge_option::MERGE_OPTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -12447,46 +12803,65 @@ pub mod export_intents_request {
 
     /// Data format of the exported intents.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataFormat(std::borrow::Cow<'static, str>);
+    pub struct DataFormat(i32);
 
     impl DataFormat {
+        /// Unspecified format. Treated as `BLOB`.
+        pub const DATA_FORMAT_UNSPECIFIED: DataFormat = DataFormat::new(0);
+
+        /// Intents will be exported as raw bytes.
+        pub const BLOB: DataFormat = DataFormat::new(1);
+
+        /// Intents will be exported in JSON format.
+        pub const JSON: DataFormat = DataFormat::new(2);
+
+        /// Intents will be exported in CSV format.
+        pub const CSV: DataFormat = DataFormat::new(3);
+
         /// Creates a new DataFormat instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATA_FORMAT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BLOB"),
+                2 => std::borrow::Cow::Borrowed("JSON"),
+                3 => std::borrow::Cow::Borrowed("CSV"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATA_FORMAT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DATA_FORMAT_UNSPECIFIED)
+                }
+                "BLOB" => std::option::Option::Some(Self::BLOB),
+                "JSON" => std::option::Option::Some(Self::JSON),
+                "CSV" => std::option::Option::Some(Self::CSV),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DataFormat](DataFormat)
-    pub mod data_format {
-        use super::DataFormat;
-
-        /// Unspecified format. Treated as `BLOB`.
-        pub const DATA_FORMAT_UNSPECIFIED: DataFormat = DataFormat::new("DATA_FORMAT_UNSPECIFIED");
-
-        /// Intents will be exported as raw bytes.
-        pub const BLOB: DataFormat = DataFormat::new("BLOB");
-
-        /// Intents will be exported in JSON format.
-        pub const JSON: DataFormat = DataFormat::new("JSON");
-
-        /// Intents will be exported in CSV format.
-        pub const CSV: DataFormat = DataFormat::new("CSV");
-    }
-
-    impl std::convert::From<std::string::String> for DataFormat {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DataFormat {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DataFormat {
         fn default() -> Self {
-            data_format::DATA_FORMAT_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -15115,41 +15490,25 @@ pub mod response_message {
 
     /// Represents different response types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ResponseType(std::borrow::Cow<'static, str>);
+    pub struct ResponseType(i32);
 
     impl ResponseType {
-        /// Creates a new ResponseType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ResponseType](ResponseType)
-    pub mod response_type {
-        use super::ResponseType;
-
         /// Not specified.
-        pub const RESPONSE_TYPE_UNSPECIFIED: ResponseType =
-            ResponseType::new("RESPONSE_TYPE_UNSPECIFIED");
+        pub const RESPONSE_TYPE_UNSPECIFIED: ResponseType = ResponseType::new(0);
 
         /// The response is from an [entry
         /// prompt][google.cloud.dialogflow.cx.v3.Page.entry_fulfillment] in the
         /// page.
         ///
         /// [google.cloud.dialogflow.cx.v3.Page.entry_fulfillment]: crate::model::Page::entry_fulfillment
-        pub const ENTRY_PROMPT: ResponseType = ResponseType::new("ENTRY_PROMPT");
+        pub const ENTRY_PROMPT: ResponseType = ResponseType::new(1);
 
         /// The response is from [form-filling
         /// prompt][google.cloud.dialogflow.cx.v3.Form.Parameter.fill_behavior] in
         /// the page.
         ///
         /// [google.cloud.dialogflow.cx.v3.Form.Parameter.fill_behavior]: crate::model::form::Parameter::fill_behavior
-        pub const PARAMETER_PROMPT: ResponseType = ResponseType::new("PARAMETER_PROMPT");
+        pub const PARAMETER_PROMPT: ResponseType = ResponseType::new(2);
 
         /// The response is from a [transition
         /// route][google.cloud.dialogflow.cx.v3.TransitionRoute] or an [event
@@ -15157,18 +15516,52 @@ pub mod response_message {
         ///
         /// [EventHandler]: crate::model::EventHandler
         /// [google.cloud.dialogflow.cx.v3.TransitionRoute]: crate::model::TransitionRoute
-        pub const HANDLER_PROMPT: ResponseType = ResponseType::new("HANDLER_PROMPT");
+        pub const HANDLER_PROMPT: ResponseType = ResponseType::new(3);
+
+        /// Creates a new ResponseType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RESPONSE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENTRY_PROMPT"),
+                2 => std::borrow::Cow::Borrowed("PARAMETER_PROMPT"),
+                3 => std::borrow::Cow::Borrowed("HANDLER_PROMPT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RESPONSE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RESPONSE_TYPE_UNSPECIFIED)
+                }
+                "ENTRY_PROMPT" => std::option::Option::Some(Self::ENTRY_PROMPT),
+                "PARAMETER_PROMPT" => std::option::Option::Some(Self::PARAMETER_PROMPT),
+                "HANDLER_PROMPT" => std::option::Option::Some(Self::HANDLER_PROMPT),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ResponseType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ResponseType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ResponseType {
         fn default() -> Self {
-            response_type::RESPONSE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -15966,47 +16359,65 @@ pub mod security_settings {
         /// File format for exported audio file. Currently only in telephony
         /// recordings.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct AudioFormat(std::borrow::Cow<'static, str>);
+        pub struct AudioFormat(i32);
 
         impl AudioFormat {
+            /// Unspecified. Do not use.
+            pub const AUDIO_FORMAT_UNSPECIFIED: AudioFormat = AudioFormat::new(0);
+
+            /// G.711 mu-law PCM with 8kHz sample rate.
+            pub const MULAW: AudioFormat = AudioFormat::new(1);
+
+            /// MP3 file format.
+            pub const MP3: AudioFormat = AudioFormat::new(2);
+
+            /// OGG Vorbis.
+            pub const OGG: AudioFormat = AudioFormat::new(3);
+
             /// Creates a new AudioFormat instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("AUDIO_FORMAT_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("MULAW"),
+                    2 => std::borrow::Cow::Borrowed("MP3"),
+                    3 => std::borrow::Cow::Borrowed("OGG"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "AUDIO_FORMAT_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::AUDIO_FORMAT_UNSPECIFIED)
+                    }
+                    "MULAW" => std::option::Option::Some(Self::MULAW),
+                    "MP3" => std::option::Option::Some(Self::MP3),
+                    "OGG" => std::option::Option::Some(Self::OGG),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [AudioFormat](AudioFormat)
-        pub mod audio_format {
-            use super::AudioFormat;
-
-            /// Unspecified. Do not use.
-            pub const AUDIO_FORMAT_UNSPECIFIED: AudioFormat =
-                AudioFormat::new("AUDIO_FORMAT_UNSPECIFIED");
-
-            /// G.711 mu-law PCM with 8kHz sample rate.
-            pub const MULAW: AudioFormat = AudioFormat::new("MULAW");
-
-            /// MP3 file format.
-            pub const MP3: AudioFormat = AudioFormat::new("MP3");
-
-            /// OGG Vorbis.
-            pub const OGG: AudioFormat = AudioFormat::new("OGG");
-        }
-
-        impl std::convert::From<std::string::String> for AudioFormat {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for AudioFormat {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for AudioFormat {
             fn default() -> Self {
-                audio_format::AUDIO_FORMAT_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -16043,168 +16454,224 @@ pub mod security_settings {
 
     /// Defines how we redact data.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RedactionStrategy(std::borrow::Cow<'static, str>);
+    pub struct RedactionStrategy(i32);
 
     impl RedactionStrategy {
+        /// Do not redact.
+        pub const REDACTION_STRATEGY_UNSPECIFIED: RedactionStrategy = RedactionStrategy::new(0);
+
+        /// Call redaction service to clean up the data to be persisted.
+        pub const REDACT_WITH_SERVICE: RedactionStrategy = RedactionStrategy::new(1);
+
         /// Creates a new RedactionStrategy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("REDACTION_STRATEGY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REDACT_WITH_SERVICE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "REDACTION_STRATEGY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::REDACTION_STRATEGY_UNSPECIFIED)
+                }
+                "REDACT_WITH_SERVICE" => std::option::Option::Some(Self::REDACT_WITH_SERVICE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RedactionStrategy](RedactionStrategy)
-    pub mod redaction_strategy {
-        use super::RedactionStrategy;
-
-        /// Do not redact.
-        pub const REDACTION_STRATEGY_UNSPECIFIED: RedactionStrategy =
-            RedactionStrategy::new("REDACTION_STRATEGY_UNSPECIFIED");
-
-        /// Call redaction service to clean up the data to be persisted.
-        pub const REDACT_WITH_SERVICE: RedactionStrategy =
-            RedactionStrategy::new("REDACT_WITH_SERVICE");
-    }
-
-    impl std::convert::From<std::string::String> for RedactionStrategy {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RedactionStrategy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RedactionStrategy {
         fn default() -> Self {
-            redaction_strategy::REDACTION_STRATEGY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Defines what types of data to redact.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RedactionScope(std::borrow::Cow<'static, str>);
+    pub struct RedactionScope(i32);
 
     impl RedactionScope {
-        /// Creates a new RedactionScope instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RedactionScope](RedactionScope)
-    pub mod redaction_scope {
-        use super::RedactionScope;
-
         /// Don't redact any kind of data.
-        pub const REDACTION_SCOPE_UNSPECIFIED: RedactionScope =
-            RedactionScope::new("REDACTION_SCOPE_UNSPECIFIED");
+        pub const REDACTION_SCOPE_UNSPECIFIED: RedactionScope = RedactionScope::new(0);
 
         /// On data to be written to disk or similar devices that are capable of
         /// holding data even if power is disconnected. This includes data that are
         /// temporarily saved on disk.
-        pub const REDACT_DISK_STORAGE: RedactionScope = RedactionScope::new("REDACT_DISK_STORAGE");
+        pub const REDACT_DISK_STORAGE: RedactionScope = RedactionScope::new(2);
+
+        /// Creates a new RedactionScope instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("REDACTION_SCOPE_UNSPECIFIED"),
+                2 => std::borrow::Cow::Borrowed("REDACT_DISK_STORAGE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "REDACTION_SCOPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::REDACTION_SCOPE_UNSPECIFIED)
+                }
+                "REDACT_DISK_STORAGE" => std::option::Option::Some(Self::REDACT_DISK_STORAGE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RedactionScope {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RedactionScope {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RedactionScope {
         fn default() -> Self {
-            redaction_scope::REDACTION_SCOPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Defines how long we retain persisted data that contains sensitive info.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RetentionStrategy(std::borrow::Cow<'static, str>);
+    pub struct RetentionStrategy(i32);
 
     impl RetentionStrategy {
-        /// Creates a new RetentionStrategy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RetentionStrategy](RetentionStrategy)
-    pub mod retention_strategy {
-        use super::RetentionStrategy;
-
         /// Retains the persisted data with Dialogflow's internal default 365d TTLs.
-        pub const RETENTION_STRATEGY_UNSPECIFIED: RetentionStrategy =
-            RetentionStrategy::new("RETENTION_STRATEGY_UNSPECIFIED");
+        pub const RETENTION_STRATEGY_UNSPECIFIED: RetentionStrategy = RetentionStrategy::new(0);
 
         /// Removes data when the conversation ends. If there is no [Conversation][]
         /// explicitly established, a default conversation ends when the
         /// corresponding Dialogflow session ends.
-        pub const REMOVE_AFTER_CONVERSATION: RetentionStrategy =
-            RetentionStrategy::new("REMOVE_AFTER_CONVERSATION");
+        pub const REMOVE_AFTER_CONVERSATION: RetentionStrategy = RetentionStrategy::new(1);
+
+        /// Creates a new RetentionStrategy instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RETENTION_STRATEGY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REMOVE_AFTER_CONVERSATION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RETENTION_STRATEGY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RETENTION_STRATEGY_UNSPECIFIED)
+                }
+                "REMOVE_AFTER_CONVERSATION" => {
+                    std::option::Option::Some(Self::REMOVE_AFTER_CONVERSATION)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RetentionStrategy {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RetentionStrategy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RetentionStrategy {
         fn default() -> Self {
-            retention_strategy::RETENTION_STRATEGY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Type of data we purge after retention settings triggers purge.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PurgeDataType(std::borrow::Cow<'static, str>);
+    pub struct PurgeDataType(i32);
 
     impl PurgeDataType {
-        /// Creates a new PurgeDataType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PurgeDataType](PurgeDataType)
-    pub mod purge_data_type {
-        use super::PurgeDataType;
-
         /// Unspecified. Do not use.
-        pub const PURGE_DATA_TYPE_UNSPECIFIED: PurgeDataType =
-            PurgeDataType::new("PURGE_DATA_TYPE_UNSPECIFIED");
+        pub const PURGE_DATA_TYPE_UNSPECIFIED: PurgeDataType = PurgeDataType::new(0);
 
         /// Dialogflow history. This does not include Cloud logging, which is
         /// owned by the user - not Dialogflow.
-        pub const DIALOGFLOW_HISTORY: PurgeDataType = PurgeDataType::new("DIALOGFLOW_HISTORY");
+        pub const DIALOGFLOW_HISTORY: PurgeDataType = PurgeDataType::new(1);
+
+        /// Creates a new PurgeDataType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PURGE_DATA_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DIALOGFLOW_HISTORY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PURGE_DATA_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PURGE_DATA_TYPE_UNSPECIFIED)
+                }
+                "DIALOGFLOW_HISTORY" => std::option::Option::Some(Self::DIALOGFLOW_HISTORY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PurgeDataType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PurgeDataType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PurgeDataType {
         fn default() -> Self {
-            purge_data_type::PURGE_DATA_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -16345,43 +16812,58 @@ pub mod answer_feedback {
 
     /// Represents thumbs up/down rating provided by user about a response.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Rating(std::borrow::Cow<'static, str>);
+    pub struct Rating(i32);
 
     impl Rating {
+        /// Rating not specified.
+        pub const RATING_UNSPECIFIED: Rating = Rating::new(0);
+
+        /// Thumbs up feedback from user.
+        pub const THUMBS_UP: Rating = Rating::new(1);
+
+        /// Thumbs down feedback from user.
+        pub const THUMBS_DOWN: Rating = Rating::new(2);
+
         /// Creates a new Rating instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RATING_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("THUMBS_UP"),
+                2 => std::borrow::Cow::Borrowed("THUMBS_DOWN"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RATING_UNSPECIFIED" => std::option::Option::Some(Self::RATING_UNSPECIFIED),
+                "THUMBS_UP" => std::option::Option::Some(Self::THUMBS_UP),
+                "THUMBS_DOWN" => std::option::Option::Some(Self::THUMBS_DOWN),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Rating](Rating)
-    pub mod rating {
-        use super::Rating;
-
-        /// Rating not specified.
-        pub const RATING_UNSPECIFIED: Rating = Rating::new("RATING_UNSPECIFIED");
-
-        /// Thumbs up feedback from user.
-        pub const THUMBS_UP: Rating = Rating::new("THUMBS_UP");
-
-        /// Thumbs down feedback from user.
-        pub const THUMBS_DOWN: Rating = Rating::new("THUMBS_DOWN");
-    }
-
-    impl std::convert::From<std::string::String> for Rating {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Rating {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Rating {
         fn default() -> Self {
-            rating::RATING_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -16658,46 +17140,62 @@ pub mod detect_intent_response {
 
     /// Represents different DetectIntentResponse types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ResponseType(std::borrow::Cow<'static, str>);
+    pub struct ResponseType(i32);
 
     impl ResponseType {
-        /// Creates a new ResponseType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ResponseType](ResponseType)
-    pub mod response_type {
-        use super::ResponseType;
-
         /// Not specified. This should never happen.
-        pub const RESPONSE_TYPE_UNSPECIFIED: ResponseType =
-            ResponseType::new("RESPONSE_TYPE_UNSPECIFIED");
+        pub const RESPONSE_TYPE_UNSPECIFIED: ResponseType = ResponseType::new(0);
 
         /// Partial response. e.g. Aggregated responses in a Fulfillment that enables
         /// `return_partial_response` can be returned as partial response.
         /// WARNING: partial response is not eligible for barge-in.
-        pub const PARTIAL: ResponseType = ResponseType::new("PARTIAL");
+        pub const PARTIAL: ResponseType = ResponseType::new(1);
 
         /// Final response.
-        pub const FINAL: ResponseType = ResponseType::new("FINAL");
+        pub const FINAL: ResponseType = ResponseType::new(2);
+
+        /// Creates a new ResponseType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RESPONSE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PARTIAL"),
+                2 => std::borrow::Cow::Borrowed("FINAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RESPONSE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RESPONSE_TYPE_UNSPECIFIED)
+                }
+                "PARTIAL" => std::option::Option::Some(Self::PARTIAL),
+                "FINAL" => std::option::Option::Some(Self::FINAL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ResponseType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ResponseType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ResponseType {
         fn default() -> Self {
-            response_type::RESPONSE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -17440,30 +17938,14 @@ pub mod streaming_recognition_result {
 
     /// Type of the response message.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MessageType(std::borrow::Cow<'static, str>);
+    pub struct MessageType(i32);
 
     impl MessageType {
-        /// Creates a new MessageType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [MessageType](MessageType)
-    pub mod message_type {
-        use super::MessageType;
-
         /// Not specified. Should never be used.
-        pub const MESSAGE_TYPE_UNSPECIFIED: MessageType =
-            MessageType::new("MESSAGE_TYPE_UNSPECIFIED");
+        pub const MESSAGE_TYPE_UNSPECIFIED: MessageType = MessageType::new(0);
 
         /// Message contains a (possibly partial) transcript.
-        pub const TRANSCRIPT: MessageType = MessageType::new("TRANSCRIPT");
+        pub const TRANSCRIPT: MessageType = MessageType::new(1);
 
         /// This event indicates that the server has detected the end of the user's
         /// speech utterance and expects no additional speech. Therefore, the server
@@ -17475,19 +17957,52 @@ pub mod streaming_recognition_result {
         /// was set to `true`, and is not used otherwise.
         ///
         /// [google.cloud.dialogflow.cx.v3.InputAudioConfig.single_utterance]: crate::model::InputAudioConfig::single_utterance
-        pub const END_OF_SINGLE_UTTERANCE: MessageType =
-            MessageType::new("END_OF_SINGLE_UTTERANCE");
+        pub const END_OF_SINGLE_UTTERANCE: MessageType = MessageType::new(2);
+
+        /// Creates a new MessageType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MESSAGE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TRANSCRIPT"),
+                2 => std::borrow::Cow::Borrowed("END_OF_SINGLE_UTTERANCE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MESSAGE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MESSAGE_TYPE_UNSPECIFIED)
+                }
+                "TRANSCRIPT" => std::option::Option::Some(Self::TRANSCRIPT),
+                "END_OF_SINGLE_UTTERANCE" => {
+                    std::option::Option::Some(Self::END_OF_SINGLE_UTTERANCE)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for MessageType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MessageType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MessageType {
         fn default() -> Self {
-            message_type::MESSAGE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -18129,33 +18644,17 @@ pub mod boost_spec {
             /// The attribute(or function) for which the custom ranking is to be
             /// applied.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct AttributeType(std::borrow::Cow<'static, str>);
+            pub struct AttributeType(i32);
 
             impl AttributeType {
-                /// Creates a new AttributeType instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [AttributeType](AttributeType)
-            pub mod attribute_type {
-                use super::AttributeType;
-
                 /// Unspecified AttributeType.
-                pub const ATTRIBUTE_TYPE_UNSPECIFIED: AttributeType =
-                    AttributeType::new("ATTRIBUTE_TYPE_UNSPECIFIED");
+                pub const ATTRIBUTE_TYPE_UNSPECIFIED: AttributeType = AttributeType::new(0);
 
                 /// The value of the numerical field will be used to dynamically update
                 /// the boost amount. In this case, the attribute_value (the x value)
                 /// of the control point will be the actual value of the numerical
                 /// field for which the boost_amount is specified.
-                pub const NUMERICAL: AttributeType = AttributeType::new("NUMERICAL");
+                pub const NUMERICAL: AttributeType = AttributeType::new(1);
 
                 /// For the freshness use case the attribute value will be the duration
                 /// between the current time and the date in the datetime field
@@ -18163,60 +18662,107 @@ pub mod boost_spec {
                 /// value (a restricted subset of an ISO 8601 duration value). The
                 /// pattern for this is: `[nD][T[nH][nM][nS]]`.
                 /// E.g. `5D`, `3DT12H30M`, `T24H`.
-                pub const FRESHNESS: AttributeType = AttributeType::new("FRESHNESS");
+                pub const FRESHNESS: AttributeType = AttributeType::new(2);
+
+                /// Creates a new AttributeType instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("ATTRIBUTE_TYPE_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("NUMERICAL"),
+                        2 => std::borrow::Cow::Borrowed("FRESHNESS"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "ATTRIBUTE_TYPE_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::ATTRIBUTE_TYPE_UNSPECIFIED)
+                        }
+                        "NUMERICAL" => std::option::Option::Some(Self::NUMERICAL),
+                        "FRESHNESS" => std::option::Option::Some(Self::FRESHNESS),
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for AttributeType {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for AttributeType {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for AttributeType {
                 fn default() -> Self {
-                    attribute_type::ATTRIBUTE_TYPE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
 
             /// The interpolation type to be applied. Default will be linear
             /// (Piecewise Linear).
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct InterpolationType(std::borrow::Cow<'static, str>);
+            pub struct InterpolationType(i32);
 
             impl InterpolationType {
-                /// Creates a new InterpolationType instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [InterpolationType](InterpolationType)
-            pub mod interpolation_type {
-                use super::InterpolationType;
-
                 /// Interpolation type is unspecified. In this case, it defaults to
                 /// Linear.
                 pub const INTERPOLATION_TYPE_UNSPECIFIED: InterpolationType =
-                    InterpolationType::new("INTERPOLATION_TYPE_UNSPECIFIED");
+                    InterpolationType::new(0);
 
                 /// Piecewise linear interpolation will be applied.
-                pub const LINEAR: InterpolationType = InterpolationType::new("LINEAR");
+                pub const LINEAR: InterpolationType = InterpolationType::new(1);
+
+                /// Creates a new InterpolationType instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("INTERPOLATION_TYPE_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("LINEAR"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "INTERPOLATION_TYPE_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::INTERPOLATION_TYPE_UNSPECIFIED)
+                        }
+                        "LINEAR" => std::option::Option::Some(Self::LINEAR),
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for InterpolationType {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for InterpolationType {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for InterpolationType {
                 fn default() -> Self {
-                    interpolation_type::INTERPOLATION_TYPE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -19359,61 +19905,88 @@ pub mod r#match {
 
     /// Type of a Match.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MatchType(std::borrow::Cow<'static, str>);
+    pub struct MatchType(i32);
 
     impl MatchType {
+        /// Not specified. Should never be used.
+        pub const MATCH_TYPE_UNSPECIFIED: MatchType = MatchType::new(0);
+
+        /// The query was matched to an intent.
+        pub const INTENT: MatchType = MatchType::new(1);
+
+        /// The query directly triggered an intent.
+        pub const DIRECT_INTENT: MatchType = MatchType::new(2);
+
+        /// The query was used for parameter filling.
+        pub const PARAMETER_FILLING: MatchType = MatchType::new(3);
+
+        /// No match was found for the query.
+        pub const NO_MATCH: MatchType = MatchType::new(4);
+
+        /// Indicates an empty query.
+        pub const NO_INPUT: MatchType = MatchType::new(5);
+
+        /// The query directly triggered an event.
+        pub const EVENT: MatchType = MatchType::new(6);
+
+        /// The query was matched to a Knowledge Connector answer.
+        pub const KNOWLEDGE_CONNECTOR: MatchType = MatchType::new(8);
+
+        /// The query was handled by a [`Playbook`][Playbook].
+        pub const PLAYBOOK: MatchType = MatchType::new(9);
+
         /// Creates a new MatchType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MATCH_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INTENT"),
+                2 => std::borrow::Cow::Borrowed("DIRECT_INTENT"),
+                3 => std::borrow::Cow::Borrowed("PARAMETER_FILLING"),
+                4 => std::borrow::Cow::Borrowed("NO_MATCH"),
+                5 => std::borrow::Cow::Borrowed("NO_INPUT"),
+                6 => std::borrow::Cow::Borrowed("EVENT"),
+                8 => std::borrow::Cow::Borrowed("KNOWLEDGE_CONNECTOR"),
+                9 => std::borrow::Cow::Borrowed("PLAYBOOK"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MATCH_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::MATCH_TYPE_UNSPECIFIED),
+                "INTENT" => std::option::Option::Some(Self::INTENT),
+                "DIRECT_INTENT" => std::option::Option::Some(Self::DIRECT_INTENT),
+                "PARAMETER_FILLING" => std::option::Option::Some(Self::PARAMETER_FILLING),
+                "NO_MATCH" => std::option::Option::Some(Self::NO_MATCH),
+                "NO_INPUT" => std::option::Option::Some(Self::NO_INPUT),
+                "EVENT" => std::option::Option::Some(Self::EVENT),
+                "KNOWLEDGE_CONNECTOR" => std::option::Option::Some(Self::KNOWLEDGE_CONNECTOR),
+                "PLAYBOOK" => std::option::Option::Some(Self::PLAYBOOK),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [MatchType](MatchType)
-    pub mod match_type {
-        use super::MatchType;
-
-        /// Not specified. Should never be used.
-        pub const MATCH_TYPE_UNSPECIFIED: MatchType = MatchType::new("MATCH_TYPE_UNSPECIFIED");
-
-        /// The query was matched to an intent.
-        pub const INTENT: MatchType = MatchType::new("INTENT");
-
-        /// The query directly triggered an intent.
-        pub const DIRECT_INTENT: MatchType = MatchType::new("DIRECT_INTENT");
-
-        /// The query was used for parameter filling.
-        pub const PARAMETER_FILLING: MatchType = MatchType::new("PARAMETER_FILLING");
-
-        /// No match was found for the query.
-        pub const NO_MATCH: MatchType = MatchType::new("NO_MATCH");
-
-        /// Indicates an empty query.
-        pub const NO_INPUT: MatchType = MatchType::new("NO_INPUT");
-
-        /// The query directly triggered an event.
-        pub const EVENT: MatchType = MatchType::new("EVENT");
-
-        /// The query was matched to a Knowledge Connector answer.
-        pub const KNOWLEDGE_CONNECTOR: MatchType = MatchType::new("KNOWLEDGE_CONNECTOR");
-
-        /// The query was handled by a [`Playbook`][Playbook].
-        pub const PLAYBOOK: MatchType = MatchType::new("PLAYBOOK");
-    }
-
-    impl std::convert::From<std::string::String> for MatchType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MatchType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MatchType {
         fn default() -> Self {
-            match_type::MATCH_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -19970,32 +20543,15 @@ pub mod session_entity_type {
 
     /// The types of modifications for the session entity type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EntityOverrideMode(std::borrow::Cow<'static, str>);
+    pub struct EntityOverrideMode(i32);
 
     impl EntityOverrideMode {
-        /// Creates a new EntityOverrideMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [EntityOverrideMode](EntityOverrideMode)
-    pub mod entity_override_mode {
-        use super::EntityOverrideMode;
-
         /// Not specified. This value should be never used.
-        pub const ENTITY_OVERRIDE_MODE_UNSPECIFIED: EntityOverrideMode =
-            EntityOverrideMode::new("ENTITY_OVERRIDE_MODE_UNSPECIFIED");
+        pub const ENTITY_OVERRIDE_MODE_UNSPECIFIED: EntityOverrideMode = EntityOverrideMode::new(0);
 
         /// The collection of session entities overrides the collection of entities
         /// in the corresponding custom entity type.
-        pub const ENTITY_OVERRIDE_MODE_OVERRIDE: EntityOverrideMode =
-            EntityOverrideMode::new("ENTITY_OVERRIDE_MODE_OVERRIDE");
+        pub const ENTITY_OVERRIDE_MODE_OVERRIDE: EntityOverrideMode = EntityOverrideMode::new(1);
 
         /// The collection of session entities extends the collection of entities in
         /// the corresponding custom entity type.
@@ -20009,19 +20565,54 @@ pub mod session_entity_type {
         /// on the custom entity type and merge.
         ///
         /// [google.cloud.dialogflow.cx.v3.EntityTypes.GetEntityType]: crate::client::EntityTypes::get_entity_type
-        pub const ENTITY_OVERRIDE_MODE_SUPPLEMENT: EntityOverrideMode =
-            EntityOverrideMode::new("ENTITY_OVERRIDE_MODE_SUPPLEMENT");
+        pub const ENTITY_OVERRIDE_MODE_SUPPLEMENT: EntityOverrideMode = EntityOverrideMode::new(2);
+
+        /// Creates a new EntityOverrideMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ENTITY_OVERRIDE_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENTITY_OVERRIDE_MODE_OVERRIDE"),
+                2 => std::borrow::Cow::Borrowed("ENTITY_OVERRIDE_MODE_SUPPLEMENT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ENTITY_OVERRIDE_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ENTITY_OVERRIDE_MODE_UNSPECIFIED)
+                }
+                "ENTITY_OVERRIDE_MODE_OVERRIDE" => {
+                    std::option::Option::Some(Self::ENTITY_OVERRIDE_MODE_OVERRIDE)
+                }
+                "ENTITY_OVERRIDE_MODE_SUPPLEMENT" => {
+                    std::option::Option::Some(Self::ENTITY_OVERRIDE_MODE_SUPPLEMENT)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for EntityOverrideMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EntityOverrideMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EntityOverrideMode {
         fn default() -> Self {
-            entity_override_mode::ENTITY_OVERRIDE_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -20924,52 +21515,73 @@ pub mod test_run_difference {
 
     /// What part of the message replay differs from the test case.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DiffType(std::borrow::Cow<'static, str>);
+    pub struct DiffType(i32);
 
     impl DiffType {
+        /// Should never be used.
+        pub const DIFF_TYPE_UNSPECIFIED: DiffType = DiffType::new(0);
+
+        /// The intent.
+        pub const INTENT: DiffType = DiffType::new(1);
+
+        /// The page.
+        pub const PAGE: DiffType = DiffType::new(2);
+
+        /// The parameters.
+        pub const PARAMETERS: DiffType = DiffType::new(3);
+
+        /// The message utterance.
+        pub const UTTERANCE: DiffType = DiffType::new(4);
+
+        /// The flow.
+        pub const FLOW: DiffType = DiffType::new(5);
+
         /// Creates a new DiffType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DIFF_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INTENT"),
+                2 => std::borrow::Cow::Borrowed("PAGE"),
+                3 => std::borrow::Cow::Borrowed("PARAMETERS"),
+                4 => std::borrow::Cow::Borrowed("UTTERANCE"),
+                5 => std::borrow::Cow::Borrowed("FLOW"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DIFF_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::DIFF_TYPE_UNSPECIFIED),
+                "INTENT" => std::option::Option::Some(Self::INTENT),
+                "PAGE" => std::option::Option::Some(Self::PAGE),
+                "PARAMETERS" => std::option::Option::Some(Self::PARAMETERS),
+                "UTTERANCE" => std::option::Option::Some(Self::UTTERANCE),
+                "FLOW" => std::option::Option::Some(Self::FLOW),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DiffType](DiffType)
-    pub mod diff_type {
-        use super::DiffType;
-
-        /// Should never be used.
-        pub const DIFF_TYPE_UNSPECIFIED: DiffType = DiffType::new("DIFF_TYPE_UNSPECIFIED");
-
-        /// The intent.
-        pub const INTENT: DiffType = DiffType::new("INTENT");
-
-        /// The page.
-        pub const PAGE: DiffType = DiffType::new("PAGE");
-
-        /// The parameters.
-        pub const PARAMETERS: DiffType = DiffType::new("PARAMETERS");
-
-        /// The message utterance.
-        pub const UTTERANCE: DiffType = DiffType::new("UTTERANCE");
-
-        /// The flow.
-        pub const FLOW: DiffType = DiffType::new("FLOW");
-    }
-
-    impl std::convert::From<std::string::String> for DiffType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DiffType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DiffType {
         fn default() -> Self {
-            diff_type::DIFF_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -21618,48 +22230,65 @@ pub mod calculate_coverage_request {
 
     /// The type of coverage score requested.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CoverageType(std::borrow::Cow<'static, str>);
+    pub struct CoverageType(i32);
 
     impl CoverageType {
+        /// Should never be used.
+        pub const COVERAGE_TYPE_UNSPECIFIED: CoverageType = CoverageType::new(0);
+
+        /// Intent coverage.
+        pub const INTENT: CoverageType = CoverageType::new(1);
+
+        /// Page transition coverage.
+        pub const PAGE_TRANSITION: CoverageType = CoverageType::new(2);
+
+        /// Transition route group coverage.
+        pub const TRANSITION_ROUTE_GROUP: CoverageType = CoverageType::new(3);
+
         /// Creates a new CoverageType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COVERAGE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INTENT"),
+                2 => std::borrow::Cow::Borrowed("PAGE_TRANSITION"),
+                3 => std::borrow::Cow::Borrowed("TRANSITION_ROUTE_GROUP"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COVERAGE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::COVERAGE_TYPE_UNSPECIFIED)
+                }
+                "INTENT" => std::option::Option::Some(Self::INTENT),
+                "PAGE_TRANSITION" => std::option::Option::Some(Self::PAGE_TRANSITION),
+                "TRANSITION_ROUTE_GROUP" => std::option::Option::Some(Self::TRANSITION_ROUTE_GROUP),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [CoverageType](CoverageType)
-    pub mod coverage_type {
-        use super::CoverageType;
-
-        /// Should never be used.
-        pub const COVERAGE_TYPE_UNSPECIFIED: CoverageType =
-            CoverageType::new("COVERAGE_TYPE_UNSPECIFIED");
-
-        /// Intent coverage.
-        pub const INTENT: CoverageType = CoverageType::new("INTENT");
-
-        /// Page transition coverage.
-        pub const PAGE_TRANSITION: CoverageType = CoverageType::new("PAGE_TRANSITION");
-
-        /// Transition route group coverage.
-        pub const TRANSITION_ROUTE_GROUP: CoverageType =
-            CoverageType::new("TRANSITION_ROUTE_GROUP");
-    }
-
-    impl std::convert::From<std::string::String> for CoverageType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CoverageType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CoverageType {
         fn default() -> Self {
-            coverage_type::COVERAGE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -21902,46 +22531,62 @@ pub mod list_test_cases_request {
 
     /// Specifies how much test case information to include in the response.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TestCaseView(std::borrow::Cow<'static, str>);
+    pub struct TestCaseView(i32);
 
     impl TestCaseView {
-        /// Creates a new TestCaseView instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [TestCaseView](TestCaseView)
-    pub mod test_case_view {
-        use super::TestCaseView;
-
         /// The default / unset value.
         /// The API will default to the BASIC view.
-        pub const TEST_CASE_VIEW_UNSPECIFIED: TestCaseView =
-            TestCaseView::new("TEST_CASE_VIEW_UNSPECIFIED");
+        pub const TEST_CASE_VIEW_UNSPECIFIED: TestCaseView = TestCaseView::new(0);
 
         /// Include basic metadata about the test case, but not the conversation
         /// turns. This is the default value.
-        pub const BASIC: TestCaseView = TestCaseView::new("BASIC");
+        pub const BASIC: TestCaseView = TestCaseView::new(1);
 
         /// Include everything.
-        pub const FULL: TestCaseView = TestCaseView::new("FULL");
+        pub const FULL: TestCaseView = TestCaseView::new(2);
+
+        /// Creates a new TestCaseView instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TEST_CASE_VIEW_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BASIC"),
+                2 => std::borrow::Cow::Borrowed("FULL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TEST_CASE_VIEW_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::TEST_CASE_VIEW_UNSPECIFIED)
+                }
+                "BASIC" => std::option::Option::Some(Self::BASIC),
+                "FULL" => std::option::Option::Some(Self::FULL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for TestCaseView {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TestCaseView {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TestCaseView {
         fn default() -> Self {
-            test_case_view::TEST_CASE_VIEW_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -22850,43 +23495,60 @@ pub mod export_test_cases_request {
 
     /// Data format of the exported test cases.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataFormat(std::borrow::Cow<'static, str>);
+    pub struct DataFormat(i32);
 
     impl DataFormat {
+        /// Unspecified format.
+        pub const DATA_FORMAT_UNSPECIFIED: DataFormat = DataFormat::new(0);
+
+        /// Raw bytes.
+        pub const BLOB: DataFormat = DataFormat::new(1);
+
+        /// JSON format.
+        pub const JSON: DataFormat = DataFormat::new(2);
+
         /// Creates a new DataFormat instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATA_FORMAT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BLOB"),
+                2 => std::borrow::Cow::Borrowed("JSON"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATA_FORMAT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DATA_FORMAT_UNSPECIFIED)
+                }
+                "BLOB" => std::option::Option::Some(Self::BLOB),
+                "JSON" => std::option::Option::Some(Self::JSON),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DataFormat](DataFormat)
-    pub mod data_format {
-        use super::DataFormat;
-
-        /// Unspecified format.
-        pub const DATA_FORMAT_UNSPECIFIED: DataFormat = DataFormat::new("DATA_FORMAT_UNSPECIFIED");
-
-        /// Raw bytes.
-        pub const BLOB: DataFormat = DataFormat::new("BLOB");
-
-        /// JSON format.
-        pub const JSON: DataFormat = DataFormat::new("JSON");
-    }
-
-    impl std::convert::From<std::string::String> for DataFormat {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DataFormat {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DataFormat {
         fn default() -> Self {
-            data_format::DATA_FORMAT_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -23786,129 +24448,186 @@ pub mod validation_message {
 
     /// Resource types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ResourceType(std::borrow::Cow<'static, str>);
+    pub struct ResourceType(i32);
 
     impl ResourceType {
+        /// Unspecified.
+        pub const RESOURCE_TYPE_UNSPECIFIED: ResourceType = ResourceType::new(0);
+
+        /// Agent.
+        pub const AGENT: ResourceType = ResourceType::new(1);
+
+        /// Intent.
+        pub const INTENT: ResourceType = ResourceType::new(2);
+
+        /// Intent training phrase.
+        pub const INTENT_TRAINING_PHRASE: ResourceType = ResourceType::new(8);
+
+        /// Intent parameter.
+        pub const INTENT_PARAMETER: ResourceType = ResourceType::new(9);
+
+        /// Multiple intents.
+        pub const INTENTS: ResourceType = ResourceType::new(10);
+
+        /// Multiple training phrases.
+        pub const INTENT_TRAINING_PHRASES: ResourceType = ResourceType::new(11);
+
+        /// Entity type.
+        pub const ENTITY_TYPE: ResourceType = ResourceType::new(3);
+
+        /// Multiple entity types.
+        pub const ENTITY_TYPES: ResourceType = ResourceType::new(12);
+
+        /// Webhook.
+        pub const WEBHOOK: ResourceType = ResourceType::new(4);
+
+        /// Flow.
+        pub const FLOW: ResourceType = ResourceType::new(5);
+
+        /// Page.
+        pub const PAGE: ResourceType = ResourceType::new(6);
+
+        /// Multiple pages.
+        pub const PAGES: ResourceType = ResourceType::new(13);
+
+        /// Transition route group.
+        pub const TRANSITION_ROUTE_GROUP: ResourceType = ResourceType::new(7);
+
+        /// Agent transition route group.
+        pub const AGENT_TRANSITION_ROUTE_GROUP: ResourceType = ResourceType::new(14);
+
         /// Creates a new ResourceType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RESOURCE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AGENT"),
+                2 => std::borrow::Cow::Borrowed("INTENT"),
+                3 => std::borrow::Cow::Borrowed("ENTITY_TYPE"),
+                4 => std::borrow::Cow::Borrowed("WEBHOOK"),
+                5 => std::borrow::Cow::Borrowed("FLOW"),
+                6 => std::borrow::Cow::Borrowed("PAGE"),
+                7 => std::borrow::Cow::Borrowed("TRANSITION_ROUTE_GROUP"),
+                8 => std::borrow::Cow::Borrowed("INTENT_TRAINING_PHRASE"),
+                9 => std::borrow::Cow::Borrowed("INTENT_PARAMETER"),
+                10 => std::borrow::Cow::Borrowed("INTENTS"),
+                11 => std::borrow::Cow::Borrowed("INTENT_TRAINING_PHRASES"),
+                12 => std::borrow::Cow::Borrowed("ENTITY_TYPES"),
+                13 => std::borrow::Cow::Borrowed("PAGES"),
+                14 => std::borrow::Cow::Borrowed("AGENT_TRANSITION_ROUTE_GROUP"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RESOURCE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RESOURCE_TYPE_UNSPECIFIED)
+                }
+                "AGENT" => std::option::Option::Some(Self::AGENT),
+                "INTENT" => std::option::Option::Some(Self::INTENT),
+                "INTENT_TRAINING_PHRASE" => std::option::Option::Some(Self::INTENT_TRAINING_PHRASE),
+                "INTENT_PARAMETER" => std::option::Option::Some(Self::INTENT_PARAMETER),
+                "INTENTS" => std::option::Option::Some(Self::INTENTS),
+                "INTENT_TRAINING_PHRASES" => {
+                    std::option::Option::Some(Self::INTENT_TRAINING_PHRASES)
+                }
+                "ENTITY_TYPE" => std::option::Option::Some(Self::ENTITY_TYPE),
+                "ENTITY_TYPES" => std::option::Option::Some(Self::ENTITY_TYPES),
+                "WEBHOOK" => std::option::Option::Some(Self::WEBHOOK),
+                "FLOW" => std::option::Option::Some(Self::FLOW),
+                "PAGE" => std::option::Option::Some(Self::PAGE),
+                "PAGES" => std::option::Option::Some(Self::PAGES),
+                "TRANSITION_ROUTE_GROUP" => std::option::Option::Some(Self::TRANSITION_ROUTE_GROUP),
+                "AGENT_TRANSITION_ROUTE_GROUP" => {
+                    std::option::Option::Some(Self::AGENT_TRANSITION_ROUTE_GROUP)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ResourceType](ResourceType)
-    pub mod resource_type {
-        use super::ResourceType;
-
-        /// Unspecified.
-        pub const RESOURCE_TYPE_UNSPECIFIED: ResourceType =
-            ResourceType::new("RESOURCE_TYPE_UNSPECIFIED");
-
-        /// Agent.
-        pub const AGENT: ResourceType = ResourceType::new("AGENT");
-
-        /// Intent.
-        pub const INTENT: ResourceType = ResourceType::new("INTENT");
-
-        /// Intent training phrase.
-        pub const INTENT_TRAINING_PHRASE: ResourceType =
-            ResourceType::new("INTENT_TRAINING_PHRASE");
-
-        /// Intent parameter.
-        pub const INTENT_PARAMETER: ResourceType = ResourceType::new("INTENT_PARAMETER");
-
-        /// Multiple intents.
-        pub const INTENTS: ResourceType = ResourceType::new("INTENTS");
-
-        /// Multiple training phrases.
-        pub const INTENT_TRAINING_PHRASES: ResourceType =
-            ResourceType::new("INTENT_TRAINING_PHRASES");
-
-        /// Entity type.
-        pub const ENTITY_TYPE: ResourceType = ResourceType::new("ENTITY_TYPE");
-
-        /// Multiple entity types.
-        pub const ENTITY_TYPES: ResourceType = ResourceType::new("ENTITY_TYPES");
-
-        /// Webhook.
-        pub const WEBHOOK: ResourceType = ResourceType::new("WEBHOOK");
-
-        /// Flow.
-        pub const FLOW: ResourceType = ResourceType::new("FLOW");
-
-        /// Page.
-        pub const PAGE: ResourceType = ResourceType::new("PAGE");
-
-        /// Multiple pages.
-        pub const PAGES: ResourceType = ResourceType::new("PAGES");
-
-        /// Transition route group.
-        pub const TRANSITION_ROUTE_GROUP: ResourceType =
-            ResourceType::new("TRANSITION_ROUTE_GROUP");
-
-        /// Agent transition route group.
-        pub const AGENT_TRANSITION_ROUTE_GROUP: ResourceType =
-            ResourceType::new("AGENT_TRANSITION_ROUTE_GROUP");
-    }
-
-    impl std::convert::From<std::string::String> for ResourceType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ResourceType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ResourceType {
         fn default() -> Self {
-            resource_type::RESOURCE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Severity level.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(std::borrow::Cow<'static, str>);
+    pub struct Severity(i32);
 
     impl Severity {
+        /// Unspecified.
+        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
+
+        /// The agent doesn't follow Dialogflow best practices.
+        pub const INFO: Severity = Severity::new(1);
+
+        /// The agent may not behave as expected.
+        pub const WARNING: Severity = Severity::new(2);
+
+        /// The agent may experience failures.
+        pub const ERROR: Severity = Severity::new(3);
+
         /// Creates a new Severity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INFO"),
+                2 => std::borrow::Cow::Borrowed("WARNING"),
+                3 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
+                "INFO" => std::option::Option::Some(Self::INFO),
+                "WARNING" => std::option::Option::Some(Self::WARNING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Severity](Severity)
-    pub mod severity {
-        use super::Severity;
-
-        /// Unspecified.
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new("SEVERITY_UNSPECIFIED");
-
-        /// The agent doesn't follow Dialogflow best practices.
-        pub const INFO: Severity = Severity::new("INFO");
-
-        /// The agent may not behave as expected.
-        pub const WARNING: Severity = Severity::new("WARNING");
-
-        /// The agent may experience failures.
-        pub const ERROR: Severity = Severity::new("ERROR");
-    }
-
-    impl std::convert::From<std::string::String> for Severity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            severity::SEVERITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -24084,46 +24803,63 @@ pub mod version {
 
     /// The state of the version.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Not specified. This value is not used.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Version is not ready to serve (e.g. training is running).
+        pub const RUNNING: State = State::new(1);
+
+        /// Training has succeeded and this version is ready to serve.
+        pub const SUCCEEDED: State = State::new(2);
+
+        /// Version training failed.
+        pub const FAILED: State = State::new(3);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RUNNING"),
+                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Not specified. This value is not used.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Version is not ready to serve (e.g. training is running).
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// Training has succeeded and this version is ready to serve.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-        /// Version training failed.
-        pub const FAILED: State = State::new("FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -25022,156 +25758,216 @@ pub mod webhook {
         /// Indicate the auth token type generated from the [Diglogflow service
         /// agent](https://cloud.google.com/iam/docs/service-agents#dialogflow-service-agent).
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ServiceAgentAuth(std::borrow::Cow<'static, str>);
+        pub struct ServiceAgentAuth(i32);
 
         impl ServiceAgentAuth {
-            /// Creates a new ServiceAgentAuth instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [ServiceAgentAuth](ServiceAgentAuth)
-        pub mod service_agent_auth {
-            use super::ServiceAgentAuth;
-
             /// Service agent auth type unspecified. Default to ID_TOKEN.
-            pub const SERVICE_AGENT_AUTH_UNSPECIFIED: ServiceAgentAuth =
-                ServiceAgentAuth::new("SERVICE_AGENT_AUTH_UNSPECIFIED");
+            pub const SERVICE_AGENT_AUTH_UNSPECIFIED: ServiceAgentAuth = ServiceAgentAuth::new(0);
 
             /// No token used.
-            pub const NONE: ServiceAgentAuth = ServiceAgentAuth::new("NONE");
+            pub const NONE: ServiceAgentAuth = ServiceAgentAuth::new(1);
 
             /// Use [ID
             /// token](https://cloud.google.com/docs/authentication/token-types#id)
             /// generated from service agent. This can be used to access Cloud Function
             /// and Cloud Run after you grant Invoker role to
             /// `service-<PROJECT-NUMBER>@gcp-sa-dialogflow.iam.gserviceaccount.com`.
-            pub const ID_TOKEN: ServiceAgentAuth = ServiceAgentAuth::new("ID_TOKEN");
+            pub const ID_TOKEN: ServiceAgentAuth = ServiceAgentAuth::new(2);
 
             /// Use [access
             /// token](https://cloud.google.com/docs/authentication/token-types#access)
             /// generated from service agent. This can be used to access other Google
             /// Cloud APIs after you grant required roles to
             /// `service-<PROJECT-NUMBER>@gcp-sa-dialogflow.iam.gserviceaccount.com`.
-            pub const ACCESS_TOKEN: ServiceAgentAuth = ServiceAgentAuth::new("ACCESS_TOKEN");
+            pub const ACCESS_TOKEN: ServiceAgentAuth = ServiceAgentAuth::new(3);
+
+            /// Creates a new ServiceAgentAuth instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("SERVICE_AGENT_AUTH_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("NONE"),
+                    2 => std::borrow::Cow::Borrowed("ID_TOKEN"),
+                    3 => std::borrow::Cow::Borrowed("ACCESS_TOKEN"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "SERVICE_AGENT_AUTH_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::SERVICE_AGENT_AUTH_UNSPECIFIED)
+                    }
+                    "NONE" => std::option::Option::Some(Self::NONE),
+                    "ID_TOKEN" => std::option::Option::Some(Self::ID_TOKEN),
+                    "ACCESS_TOKEN" => std::option::Option::Some(Self::ACCESS_TOKEN),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for ServiceAgentAuth {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for ServiceAgentAuth {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for ServiceAgentAuth {
             fn default() -> Self {
-                service_agent_auth::SERVICE_AGENT_AUTH_UNSPECIFIED
+                Self::new(0)
             }
         }
 
         /// Represents the type of webhook configuration.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct WebhookType(std::borrow::Cow<'static, str>);
+        pub struct WebhookType(i32);
 
         impl WebhookType {
+            /// Default value. This value is unused.
+            pub const WEBHOOK_TYPE_UNSPECIFIED: WebhookType = WebhookType::new(0);
+
+            /// Represents a standard webhook.
+            pub const STANDARD: WebhookType = WebhookType::new(1);
+
+            /// Represents a flexible webhook.
+            pub const FLEXIBLE: WebhookType = WebhookType::new(2);
+
             /// Creates a new WebhookType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("WEBHOOK_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("STANDARD"),
+                    2 => std::borrow::Cow::Borrowed("FLEXIBLE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "WEBHOOK_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::WEBHOOK_TYPE_UNSPECIFIED)
+                    }
+                    "STANDARD" => std::option::Option::Some(Self::STANDARD),
+                    "FLEXIBLE" => std::option::Option::Some(Self::FLEXIBLE),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [WebhookType](WebhookType)
-        pub mod webhook_type {
-            use super::WebhookType;
-
-            /// Default value. This value is unused.
-            pub const WEBHOOK_TYPE_UNSPECIFIED: WebhookType =
-                WebhookType::new("WEBHOOK_TYPE_UNSPECIFIED");
-
-            /// Represents a standard webhook.
-            pub const STANDARD: WebhookType = WebhookType::new("STANDARD");
-
-            /// Represents a flexible webhook.
-            pub const FLEXIBLE: WebhookType = WebhookType::new("FLEXIBLE");
-        }
-
-        impl std::convert::From<std::string::String> for WebhookType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for WebhookType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for WebhookType {
             fn default() -> Self {
-                webhook_type::WEBHOOK_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
 
         /// HTTP method to use when calling webhooks.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct HttpMethod(std::borrow::Cow<'static, str>);
+        pub struct HttpMethod(i32);
 
         impl HttpMethod {
+            /// HTTP method not specified.
+            pub const HTTP_METHOD_UNSPECIFIED: HttpMethod = HttpMethod::new(0);
+
+            /// HTTP POST Method.
+            pub const POST: HttpMethod = HttpMethod::new(1);
+
+            /// HTTP GET Method.
+            pub const GET: HttpMethod = HttpMethod::new(2);
+
+            /// HTTP HEAD Method.
+            pub const HEAD: HttpMethod = HttpMethod::new(3);
+
+            /// HTTP PUT Method.
+            pub const PUT: HttpMethod = HttpMethod::new(4);
+
+            /// HTTP DELETE Method.
+            pub const DELETE: HttpMethod = HttpMethod::new(5);
+
+            /// HTTP PATCH Method.
+            pub const PATCH: HttpMethod = HttpMethod::new(6);
+
+            /// HTTP OPTIONS Method.
+            pub const OPTIONS: HttpMethod = HttpMethod::new(7);
+
             /// Creates a new HttpMethod instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("HTTP_METHOD_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("POST"),
+                    2 => std::borrow::Cow::Borrowed("GET"),
+                    3 => std::borrow::Cow::Borrowed("HEAD"),
+                    4 => std::borrow::Cow::Borrowed("PUT"),
+                    5 => std::borrow::Cow::Borrowed("DELETE"),
+                    6 => std::borrow::Cow::Borrowed("PATCH"),
+                    7 => std::borrow::Cow::Borrowed("OPTIONS"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "HTTP_METHOD_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::HTTP_METHOD_UNSPECIFIED)
+                    }
+                    "POST" => std::option::Option::Some(Self::POST),
+                    "GET" => std::option::Option::Some(Self::GET),
+                    "HEAD" => std::option::Option::Some(Self::HEAD),
+                    "PUT" => std::option::Option::Some(Self::PUT),
+                    "DELETE" => std::option::Option::Some(Self::DELETE),
+                    "PATCH" => std::option::Option::Some(Self::PATCH),
+                    "OPTIONS" => std::option::Option::Some(Self::OPTIONS),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [HttpMethod](HttpMethod)
-        pub mod http_method {
-            use super::HttpMethod;
-
-            /// HTTP method not specified.
-            pub const HTTP_METHOD_UNSPECIFIED: HttpMethod =
-                HttpMethod::new("HTTP_METHOD_UNSPECIFIED");
-
-            /// HTTP POST Method.
-            pub const POST: HttpMethod = HttpMethod::new("POST");
-
-            /// HTTP GET Method.
-            pub const GET: HttpMethod = HttpMethod::new("GET");
-
-            /// HTTP HEAD Method.
-            pub const HEAD: HttpMethod = HttpMethod::new("HEAD");
-
-            /// HTTP PUT Method.
-            pub const PUT: HttpMethod = HttpMethod::new("PUT");
-
-            /// HTTP DELETE Method.
-            pub const DELETE: HttpMethod = HttpMethod::new("DELETE");
-
-            /// HTTP PATCH Method.
-            pub const PATCH: HttpMethod = HttpMethod::new("PATCH");
-
-            /// HTTP OPTIONS Method.
-            pub const OPTIONS: HttpMethod = HttpMethod::new("OPTIONS");
-        }
-
-        impl std::convert::From<std::string::String> for HttpMethod {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for HttpMethod {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for HttpMethod {
             fn default() -> Self {
-                http_method::HTTP_METHOD_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -26310,46 +27106,62 @@ pub mod webhook_response {
 
         /// Defines merge behavior for `messages`.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct MergeBehavior(std::borrow::Cow<'static, str>);
+        pub struct MergeBehavior(i32);
 
         impl MergeBehavior {
-            /// Creates a new MergeBehavior instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [MergeBehavior](MergeBehavior)
-        pub mod merge_behavior {
-            use super::MergeBehavior;
-
             /// Not specified. `APPEND` will be used.
-            pub const MERGE_BEHAVIOR_UNSPECIFIED: MergeBehavior =
-                MergeBehavior::new("MERGE_BEHAVIOR_UNSPECIFIED");
+            pub const MERGE_BEHAVIOR_UNSPECIFIED: MergeBehavior = MergeBehavior::new(0);
 
             /// `messages` will be appended to the list of messages waiting to be sent
             /// to the user.
-            pub const APPEND: MergeBehavior = MergeBehavior::new("APPEND");
+            pub const APPEND: MergeBehavior = MergeBehavior::new(1);
 
             /// `messages` will replace the list of messages waiting to be sent to the
             /// user.
-            pub const REPLACE: MergeBehavior = MergeBehavior::new("REPLACE");
+            pub const REPLACE: MergeBehavior = MergeBehavior::new(2);
+
+            /// Creates a new MergeBehavior instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("MERGE_BEHAVIOR_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("APPEND"),
+                    2 => std::borrow::Cow::Borrowed("REPLACE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "MERGE_BEHAVIOR_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::MERGE_BEHAVIOR_UNSPECIFIED)
+                    }
+                    "APPEND" => std::option::Option::Some(Self::APPEND),
+                    "REPLACE" => std::option::Option::Some(Self::REPLACE),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for MergeBehavior {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for MergeBehavior {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for MergeBehavior {
             fn default() -> Self {
-                merge_behavior::MERGE_BEHAVIOR_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -26623,49 +27435,67 @@ pub mod page_info {
 
             /// Represents the state of a parameter.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct ParameterState(std::borrow::Cow<'static, str>);
+            pub struct ParameterState(i32);
 
             impl ParameterState {
-                /// Creates a new ParameterState instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [ParameterState](ParameterState)
-            pub mod parameter_state {
-                use super::ParameterState;
-
                 /// Not specified. This value should be never used.
-                pub const PARAMETER_STATE_UNSPECIFIED: ParameterState =
-                    ParameterState::new("PARAMETER_STATE_UNSPECIFIED");
+                pub const PARAMETER_STATE_UNSPECIFIED: ParameterState = ParameterState::new(0);
 
                 /// Indicates that the parameter does not have a value.
-                pub const EMPTY: ParameterState = ParameterState::new("EMPTY");
+                pub const EMPTY: ParameterState = ParameterState::new(1);
 
                 /// Indicates that the parameter value is invalid. This field can be used
                 /// by the webhook to invalidate the parameter and ask the server to
                 /// collect it from the user again.
-                pub const INVALID: ParameterState = ParameterState::new("INVALID");
+                pub const INVALID: ParameterState = ParameterState::new(2);
 
                 /// Indicates that the parameter has a value.
-                pub const FILLED: ParameterState = ParameterState::new("FILLED");
+                pub const FILLED: ParameterState = ParameterState::new(3);
+
+                /// Creates a new ParameterState instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("PARAMETER_STATE_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("EMPTY"),
+                        2 => std::borrow::Cow::Borrowed("INVALID"),
+                        3 => std::borrow::Cow::Borrowed("FILLED"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "PARAMETER_STATE_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::PARAMETER_STATE_UNSPECIFIED)
+                        }
+                        "EMPTY" => std::option::Option::Some(Self::EMPTY),
+                        "INVALID" => std::option::Option::Some(Self::INVALID),
+                        "FILLED" => std::option::Option::Some(Self::FILLED),
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for ParameterState {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for ParameterState {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for ParameterState {
                 fn default() -> Self {
-                    parameter_state::PARAMETER_STATE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -26805,53 +27635,35 @@ impl wkt::message::Message for LanguageInfo {
 /// documentation](https://cloud.google.com/speech-to-text/docs/basics) for more
 /// details.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AudioEncoding(std::borrow::Cow<'static, str>);
+pub struct AudioEncoding(i32);
 
 impl AudioEncoding {
-    /// Creates a new AudioEncoding instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [AudioEncoding](AudioEncoding)
-pub mod audio_encoding {
-    use super::AudioEncoding;
-
     /// Not specified.
-    pub const AUDIO_ENCODING_UNSPECIFIED: AudioEncoding =
-        AudioEncoding::new("AUDIO_ENCODING_UNSPECIFIED");
+    pub const AUDIO_ENCODING_UNSPECIFIED: AudioEncoding = AudioEncoding::new(0);
 
     /// Uncompressed 16-bit signed little-endian samples (Linear PCM).
-    pub const AUDIO_ENCODING_LINEAR_16: AudioEncoding =
-        AudioEncoding::new("AUDIO_ENCODING_LINEAR_16");
+    pub const AUDIO_ENCODING_LINEAR_16: AudioEncoding = AudioEncoding::new(1);
 
     /// [`FLAC`](https://xiph.org/flac/documentation.html) (Free Lossless Audio
     /// Codec) is the recommended encoding because it is lossless (therefore
     /// recognition is not compromised) and requires only about half the
     /// bandwidth of `LINEAR16`. `FLAC` stream encoding supports 16-bit and
     /// 24-bit samples, however, not all fields in `STREAMINFO` are supported.
-    pub const AUDIO_ENCODING_FLAC: AudioEncoding = AudioEncoding::new("AUDIO_ENCODING_FLAC");
+    pub const AUDIO_ENCODING_FLAC: AudioEncoding = AudioEncoding::new(2);
 
     /// 8-bit samples that compand 14-bit audio samples using G.711 PCMU/mu-law.
-    pub const AUDIO_ENCODING_MULAW: AudioEncoding = AudioEncoding::new("AUDIO_ENCODING_MULAW");
+    pub const AUDIO_ENCODING_MULAW: AudioEncoding = AudioEncoding::new(3);
 
     /// Adaptive Multi-Rate Narrowband codec. `sample_rate_hertz` must be 8000.
-    pub const AUDIO_ENCODING_AMR: AudioEncoding = AudioEncoding::new("AUDIO_ENCODING_AMR");
+    pub const AUDIO_ENCODING_AMR: AudioEncoding = AudioEncoding::new(4);
 
     /// Adaptive Multi-Rate Wideband codec. `sample_rate_hertz` must be 16000.
-    pub const AUDIO_ENCODING_AMR_WB: AudioEncoding = AudioEncoding::new("AUDIO_ENCODING_AMR_WB");
+    pub const AUDIO_ENCODING_AMR_WB: AudioEncoding = AudioEncoding::new(5);
 
     /// Opus encoded audio frames in Ogg container
     /// ([OggOpus](https://wiki.xiph.org/OggOpus)).
     /// `sample_rate_hertz` must be 16000.
-    pub const AUDIO_ENCODING_OGG_OPUS: AudioEncoding =
-        AudioEncoding::new("AUDIO_ENCODING_OGG_OPUS");
+    pub const AUDIO_ENCODING_OGG_OPUS: AudioEncoding = AudioEncoding::new(6);
 
     /// Although the use of lossy encodings is not recommended, if a very low
     /// bitrate encoding is required, `OGG_OPUS` is highly preferred over
@@ -26866,22 +27678,67 @@ pub mod audio_encoding {
     /// bytes (octets) as specified in RFC 5574. In other words, each RTP header
     /// is replaced with a single byte containing the block length. Only Speex
     /// wideband is supported. `sample_rate_hertz` must be 16000.
-    pub const AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE: AudioEncoding =
-        AudioEncoding::new("AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE");
+    pub const AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE: AudioEncoding = AudioEncoding::new(7);
 
     /// 8-bit samples that compand 13-bit audio samples using G.711 PCMU/a-law.
-    pub const AUDIO_ENCODING_ALAW: AudioEncoding = AudioEncoding::new("AUDIO_ENCODING_ALAW");
+    pub const AUDIO_ENCODING_ALAW: AudioEncoding = AudioEncoding::new(8);
+
+    /// Creates a new AudioEncoding instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_LINEAR_16"),
+            2 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_FLAC"),
+            3 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_MULAW"),
+            4 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_AMR"),
+            5 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_AMR_WB"),
+            6 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_OGG_OPUS"),
+            7 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE"),
+            8 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_ALAW"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "AUDIO_ENCODING_UNSPECIFIED" => {
+                std::option::Option::Some(Self::AUDIO_ENCODING_UNSPECIFIED)
+            }
+            "AUDIO_ENCODING_LINEAR_16" => std::option::Option::Some(Self::AUDIO_ENCODING_LINEAR_16),
+            "AUDIO_ENCODING_FLAC" => std::option::Option::Some(Self::AUDIO_ENCODING_FLAC),
+            "AUDIO_ENCODING_MULAW" => std::option::Option::Some(Self::AUDIO_ENCODING_MULAW),
+            "AUDIO_ENCODING_AMR" => std::option::Option::Some(Self::AUDIO_ENCODING_AMR),
+            "AUDIO_ENCODING_AMR_WB" => std::option::Option::Some(Self::AUDIO_ENCODING_AMR_WB),
+            "AUDIO_ENCODING_OGG_OPUS" => std::option::Option::Some(Self::AUDIO_ENCODING_OGG_OPUS),
+            "AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE" => {
+                std::option::Option::Some(Self::AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE)
+            }
+            "AUDIO_ENCODING_ALAW" => std::option::Option::Some(Self::AUDIO_ENCODING_ALAW),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for AudioEncoding {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for AudioEncoding {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for AudioEncoding {
     fn default() -> Self {
-        audio_encoding::AUDIO_ENCODING_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -26896,41 +27753,24 @@ impl std::default::Default for AudioEncoding {
 ///
 /// [google.cloud.dialogflow.cx.v3.InputAudioConfig.model]: crate::model::InputAudioConfig::model
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SpeechModelVariant(std::borrow::Cow<'static, str>);
+pub struct SpeechModelVariant(i32);
 
 impl SpeechModelVariant {
-    /// Creates a new SpeechModelVariant instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [SpeechModelVariant](SpeechModelVariant)
-pub mod speech_model_variant {
-    use super::SpeechModelVariant;
-
     /// No model variant specified. In this case Dialogflow defaults to
     /// USE_BEST_AVAILABLE.
-    pub const SPEECH_MODEL_VARIANT_UNSPECIFIED: SpeechModelVariant =
-        SpeechModelVariant::new("SPEECH_MODEL_VARIANT_UNSPECIFIED");
+    pub const SPEECH_MODEL_VARIANT_UNSPECIFIED: SpeechModelVariant = SpeechModelVariant::new(0);
 
     /// Use the best available variant of the [Speech
     /// model][InputAudioConfig.model] that the caller is eligible for.
     ///
     /// [InputAudioConfig.model]: crate::model::InputAudioConfig::model
-    pub const USE_BEST_AVAILABLE: SpeechModelVariant =
-        SpeechModelVariant::new("USE_BEST_AVAILABLE");
+    pub const USE_BEST_AVAILABLE: SpeechModelVariant = SpeechModelVariant::new(1);
 
     /// Use standard model variant even if an enhanced model is available.  See the
     /// [Cloud Speech
     /// documentation](https://cloud.google.com/speech-to-text/docs/enhanced-models)
     /// for details about enhanced models.
-    pub const USE_STANDARD: SpeechModelVariant = SpeechModelVariant::new("USE_STANDARD");
+    pub const USE_STANDARD: SpeechModelVariant = SpeechModelVariant::new(2);
 
     /// Use an enhanced model variant:
     ///
@@ -26944,227 +27784,343 @@ pub mod speech_model_variant {
     ///
     ///
     /// [google.cloud.dialogflow.cx.v3.InputAudioConfig.model]: crate::model::InputAudioConfig::model
-    pub const USE_ENHANCED: SpeechModelVariant = SpeechModelVariant::new("USE_ENHANCED");
+    pub const USE_ENHANCED: SpeechModelVariant = SpeechModelVariant::new(3);
+
+    /// Creates a new SpeechModelVariant instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SPEECH_MODEL_VARIANT_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("USE_BEST_AVAILABLE"),
+            2 => std::borrow::Cow::Borrowed("USE_STANDARD"),
+            3 => std::borrow::Cow::Borrowed("USE_ENHANCED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SPEECH_MODEL_VARIANT_UNSPECIFIED" => {
+                std::option::Option::Some(Self::SPEECH_MODEL_VARIANT_UNSPECIFIED)
+            }
+            "USE_BEST_AVAILABLE" => std::option::Option::Some(Self::USE_BEST_AVAILABLE),
+            "USE_STANDARD" => std::option::Option::Some(Self::USE_STANDARD),
+            "USE_ENHANCED" => std::option::Option::Some(Self::USE_ENHANCED),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for SpeechModelVariant {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SpeechModelVariant {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SpeechModelVariant {
     fn default() -> Self {
-        speech_model_variant::SPEECH_MODEL_VARIANT_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Gender of the voice as described in
 /// [SSML voice element](https://www.w3.org/TR/speech-synthesis11/#edef_voice).
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SsmlVoiceGender(std::borrow::Cow<'static, str>);
+pub struct SsmlVoiceGender(i32);
 
 impl SsmlVoiceGender {
+    /// An unspecified gender, which means that the client doesn't care which
+    /// gender the selected voice will have.
+    pub const SSML_VOICE_GENDER_UNSPECIFIED: SsmlVoiceGender = SsmlVoiceGender::new(0);
+
+    /// A male voice.
+    pub const SSML_VOICE_GENDER_MALE: SsmlVoiceGender = SsmlVoiceGender::new(1);
+
+    /// A female voice.
+    pub const SSML_VOICE_GENDER_FEMALE: SsmlVoiceGender = SsmlVoiceGender::new(2);
+
+    /// A gender-neutral voice.
+    pub const SSML_VOICE_GENDER_NEUTRAL: SsmlVoiceGender = SsmlVoiceGender::new(3);
+
     /// Creates a new SsmlVoiceGender instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SSML_VOICE_GENDER_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SSML_VOICE_GENDER_MALE"),
+            2 => std::borrow::Cow::Borrowed("SSML_VOICE_GENDER_FEMALE"),
+            3 => std::borrow::Cow::Borrowed("SSML_VOICE_GENDER_NEUTRAL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SSML_VOICE_GENDER_UNSPECIFIED" => {
+                std::option::Option::Some(Self::SSML_VOICE_GENDER_UNSPECIFIED)
+            }
+            "SSML_VOICE_GENDER_MALE" => std::option::Option::Some(Self::SSML_VOICE_GENDER_MALE),
+            "SSML_VOICE_GENDER_FEMALE" => std::option::Option::Some(Self::SSML_VOICE_GENDER_FEMALE),
+            "SSML_VOICE_GENDER_NEUTRAL" => {
+                std::option::Option::Some(Self::SSML_VOICE_GENDER_NEUTRAL)
+            }
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [SsmlVoiceGender](SsmlVoiceGender)
-pub mod ssml_voice_gender {
-    use super::SsmlVoiceGender;
-
-    /// An unspecified gender, which means that the client doesn't care which
-    /// gender the selected voice will have.
-    pub const SSML_VOICE_GENDER_UNSPECIFIED: SsmlVoiceGender =
-        SsmlVoiceGender::new("SSML_VOICE_GENDER_UNSPECIFIED");
-
-    /// A male voice.
-    pub const SSML_VOICE_GENDER_MALE: SsmlVoiceGender =
-        SsmlVoiceGender::new("SSML_VOICE_GENDER_MALE");
-
-    /// A female voice.
-    pub const SSML_VOICE_GENDER_FEMALE: SsmlVoiceGender =
-        SsmlVoiceGender::new("SSML_VOICE_GENDER_FEMALE");
-
-    /// A gender-neutral voice.
-    pub const SSML_VOICE_GENDER_NEUTRAL: SsmlVoiceGender =
-        SsmlVoiceGender::new("SSML_VOICE_GENDER_NEUTRAL");
-}
-
-impl std::convert::From<std::string::String> for SsmlVoiceGender {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SsmlVoiceGender {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SsmlVoiceGender {
     fn default() -> Self {
-        ssml_voice_gender::SSML_VOICE_GENDER_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Audio encoding of the output audio format in Text-To-Speech.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OutputAudioEncoding(std::borrow::Cow<'static, str>);
+pub struct OutputAudioEncoding(i32);
 
 impl OutputAudioEncoding {
-    /// Creates a new OutputAudioEncoding instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [OutputAudioEncoding](OutputAudioEncoding)
-pub mod output_audio_encoding {
-    use super::OutputAudioEncoding;
-
     /// Not specified.
-    pub const OUTPUT_AUDIO_ENCODING_UNSPECIFIED: OutputAudioEncoding =
-        OutputAudioEncoding::new("OUTPUT_AUDIO_ENCODING_UNSPECIFIED");
+    pub const OUTPUT_AUDIO_ENCODING_UNSPECIFIED: OutputAudioEncoding = OutputAudioEncoding::new(0);
 
     /// Uncompressed 16-bit signed little-endian samples (Linear PCM).
     /// Audio content returned as LINEAR16 also contains a WAV header.
-    pub const OUTPUT_AUDIO_ENCODING_LINEAR_16: OutputAudioEncoding =
-        OutputAudioEncoding::new("OUTPUT_AUDIO_ENCODING_LINEAR_16");
+    pub const OUTPUT_AUDIO_ENCODING_LINEAR_16: OutputAudioEncoding = OutputAudioEncoding::new(1);
 
     /// MP3 audio at 32kbps.
-    pub const OUTPUT_AUDIO_ENCODING_MP3: OutputAudioEncoding =
-        OutputAudioEncoding::new("OUTPUT_AUDIO_ENCODING_MP3");
+    pub const OUTPUT_AUDIO_ENCODING_MP3: OutputAudioEncoding = OutputAudioEncoding::new(2);
 
     /// MP3 audio at 64kbps.
-    pub const OUTPUT_AUDIO_ENCODING_MP3_64_KBPS: OutputAudioEncoding =
-        OutputAudioEncoding::new("OUTPUT_AUDIO_ENCODING_MP3_64_KBPS");
+    pub const OUTPUT_AUDIO_ENCODING_MP3_64_KBPS: OutputAudioEncoding = OutputAudioEncoding::new(4);
 
     /// Opus encoded audio wrapped in an ogg container. The result will be a
     /// file which can be played natively on Android, and in browsers (at least
     /// Chrome and Firefox). The quality of the encoding is considerably higher
     /// than MP3 while using approximately the same bitrate.
-    pub const OUTPUT_AUDIO_ENCODING_OGG_OPUS: OutputAudioEncoding =
-        OutputAudioEncoding::new("OUTPUT_AUDIO_ENCODING_OGG_OPUS");
+    pub const OUTPUT_AUDIO_ENCODING_OGG_OPUS: OutputAudioEncoding = OutputAudioEncoding::new(3);
 
     /// 8-bit samples that compand 14-bit audio samples using G.711 PCMU/mu-law.
-    pub const OUTPUT_AUDIO_ENCODING_MULAW: OutputAudioEncoding =
-        OutputAudioEncoding::new("OUTPUT_AUDIO_ENCODING_MULAW");
+    pub const OUTPUT_AUDIO_ENCODING_MULAW: OutputAudioEncoding = OutputAudioEncoding::new(5);
 
     /// 8-bit samples that compand 13-bit audio samples using G.711 PCMU/a-law.
-    pub const OUTPUT_AUDIO_ENCODING_ALAW: OutputAudioEncoding =
-        OutputAudioEncoding::new("OUTPUT_AUDIO_ENCODING_ALAW");
+    pub const OUTPUT_AUDIO_ENCODING_ALAW: OutputAudioEncoding = OutputAudioEncoding::new(6);
+
+    /// Creates a new OutputAudioEncoding instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_LINEAR_16"),
+            2 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_MP3"),
+            3 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_OGG_OPUS"),
+            4 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_MP3_64_KBPS"),
+            5 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_MULAW"),
+            6 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_ALAW"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "OUTPUT_AUDIO_ENCODING_UNSPECIFIED" => {
+                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_UNSPECIFIED)
+            }
+            "OUTPUT_AUDIO_ENCODING_LINEAR_16" => {
+                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_LINEAR_16)
+            }
+            "OUTPUT_AUDIO_ENCODING_MP3" => {
+                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_MP3)
+            }
+            "OUTPUT_AUDIO_ENCODING_MP3_64_KBPS" => {
+                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_MP3_64_KBPS)
+            }
+            "OUTPUT_AUDIO_ENCODING_OGG_OPUS" => {
+                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_OGG_OPUS)
+            }
+            "OUTPUT_AUDIO_ENCODING_MULAW" => {
+                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_MULAW)
+            }
+            "OUTPUT_AUDIO_ENCODING_ALAW" => {
+                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_ALAW)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for OutputAudioEncoding {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for OutputAudioEncoding {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for OutputAudioEncoding {
     fn default() -> Self {
-        output_audio_encoding::OUTPUT_AUDIO_ENCODING_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Type of a data store.
 /// Determines how search is performed in the data store.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DataStoreType(std::borrow::Cow<'static, str>);
+pub struct DataStoreType(i32);
 
 impl DataStoreType {
+    /// Not specified. This value indicates that the data store type is not
+    /// specified, so it will not be used during search.
+    pub const DATA_STORE_TYPE_UNSPECIFIED: DataStoreType = DataStoreType::new(0);
+
+    /// A data store that contains public web content.
+    pub const PUBLIC_WEB: DataStoreType = DataStoreType::new(1);
+
+    /// A data store that contains unstructured private data.
+    pub const UNSTRUCTURED: DataStoreType = DataStoreType::new(2);
+
+    /// A data store that contains structured data (for example FAQ).
+    pub const STRUCTURED: DataStoreType = DataStoreType::new(3);
+
     /// Creates a new DataStoreType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DATA_STORE_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PUBLIC_WEB"),
+            2 => std::borrow::Cow::Borrowed("UNSTRUCTURED"),
+            3 => std::borrow::Cow::Borrowed("STRUCTURED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DATA_STORE_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::DATA_STORE_TYPE_UNSPECIFIED)
+            }
+            "PUBLIC_WEB" => std::option::Option::Some(Self::PUBLIC_WEB),
+            "UNSTRUCTURED" => std::option::Option::Some(Self::UNSTRUCTURED),
+            "STRUCTURED" => std::option::Option::Some(Self::STRUCTURED),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [DataStoreType](DataStoreType)
-pub mod data_store_type {
-    use super::DataStoreType;
-
-    /// Not specified. This value indicates that the data store type is not
-    /// specified, so it will not be used during search.
-    pub const DATA_STORE_TYPE_UNSPECIFIED: DataStoreType =
-        DataStoreType::new("DATA_STORE_TYPE_UNSPECIFIED");
-
-    /// A data store that contains public web content.
-    pub const PUBLIC_WEB: DataStoreType = DataStoreType::new("PUBLIC_WEB");
-
-    /// A data store that contains unstructured private data.
-    pub const UNSTRUCTURED: DataStoreType = DataStoreType::new("UNSTRUCTURED");
-
-    /// A data store that contains structured data (for example FAQ).
-    pub const STRUCTURED: DataStoreType = DataStoreType::new("STRUCTURED");
-}
-
-impl std::convert::From<std::string::String> for DataStoreType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DataStoreType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DataStoreType {
     fn default() -> Self {
-        data_store_type::DATA_STORE_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The document processing mode of the data store.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DocumentProcessingMode(std::borrow::Cow<'static, str>);
+pub struct DocumentProcessingMode(i32);
 
 impl DocumentProcessingMode {
-    /// Creates a new DocumentProcessingMode instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [DocumentProcessingMode](DocumentProcessingMode)
-pub mod document_processing_mode {
-    use super::DocumentProcessingMode;
-
     /// Not specified. This should be set for STRUCTURED type data stores. Due to
     /// legacy reasons this is considered as DOCUMENTS for STRUCTURED and
     /// PUBLIC_WEB data stores.
     pub const DOCUMENT_PROCESSING_MODE_UNSPECIFIED: DocumentProcessingMode =
-        DocumentProcessingMode::new("DOCUMENT_PROCESSING_MODE_UNSPECIFIED");
+        DocumentProcessingMode::new(0);
 
     /// Documents are processed as documents.
-    pub const DOCUMENTS: DocumentProcessingMode = DocumentProcessingMode::new("DOCUMENTS");
+    pub const DOCUMENTS: DocumentProcessingMode = DocumentProcessingMode::new(1);
 
     /// Documents are converted to chunks.
-    pub const CHUNKS: DocumentProcessingMode = DocumentProcessingMode::new("CHUNKS");
+    pub const CHUNKS: DocumentProcessingMode = DocumentProcessingMode::new(2);
+
+    /// Creates a new DocumentProcessingMode instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DOCUMENT_PROCESSING_MODE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("DOCUMENTS"),
+            2 => std::borrow::Cow::Borrowed("CHUNKS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DOCUMENT_PROCESSING_MODE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::DOCUMENT_PROCESSING_MODE_UNSPECIFIED)
+            }
+            "DOCUMENTS" => std::option::Option::Some(Self::DOCUMENTS),
+            "CHUNKS" => std::option::Option::Some(Self::CHUNKS),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for DocumentProcessingMode {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DocumentProcessingMode {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DocumentProcessingMode {
     fn default() -> Self {
-        document_processing_mode::DOCUMENT_PROCESSING_MODE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -27172,59 +28128,82 @@ impl std::default::Default for DocumentProcessingMode {
 /// entities, and webhooks) with identical display names during import
 /// operations.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ImportStrategy(std::borrow::Cow<'static, str>);
+pub struct ImportStrategy(i32);
 
 impl ImportStrategy {
-    /// Creates a new ImportStrategy instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ImportStrategy](ImportStrategy)
-pub mod import_strategy {
-    use super::ImportStrategy;
-
     /// Unspecified. Treated as 'CREATE_NEW'.
-    pub const IMPORT_STRATEGY_UNSPECIFIED: ImportStrategy =
-        ImportStrategy::new("IMPORT_STRATEGY_UNSPECIFIED");
+    pub const IMPORT_STRATEGY_UNSPECIFIED: ImportStrategy = ImportStrategy::new(0);
 
     /// Create a new resource with a numeric suffix appended to the end of the
     /// existing display name.
-    pub const IMPORT_STRATEGY_CREATE_NEW: ImportStrategy =
-        ImportStrategy::new("IMPORT_STRATEGY_CREATE_NEW");
+    pub const IMPORT_STRATEGY_CREATE_NEW: ImportStrategy = ImportStrategy::new(1);
 
     /// Replace existing resource with incoming resource in the content to be
     /// imported.
-    pub const IMPORT_STRATEGY_REPLACE: ImportStrategy =
-        ImportStrategy::new("IMPORT_STRATEGY_REPLACE");
+    pub const IMPORT_STRATEGY_REPLACE: ImportStrategy = ImportStrategy::new(2);
 
     /// Keep existing resource and discard incoming resource in the content to be
     /// imported.
-    pub const IMPORT_STRATEGY_KEEP: ImportStrategy = ImportStrategy::new("IMPORT_STRATEGY_KEEP");
+    pub const IMPORT_STRATEGY_KEEP: ImportStrategy = ImportStrategy::new(3);
 
     /// Combine existing and incoming resources when a conflict is encountered.
-    pub const IMPORT_STRATEGY_MERGE: ImportStrategy = ImportStrategy::new("IMPORT_STRATEGY_MERGE");
+    pub const IMPORT_STRATEGY_MERGE: ImportStrategy = ImportStrategy::new(4);
 
     /// Throw error if a conflict is encountered.
-    pub const IMPORT_STRATEGY_THROW_ERROR: ImportStrategy =
-        ImportStrategy::new("IMPORT_STRATEGY_THROW_ERROR");
+    pub const IMPORT_STRATEGY_THROW_ERROR: ImportStrategy = ImportStrategy::new(5);
+
+    /// Creates a new ImportStrategy instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("IMPORT_STRATEGY_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("IMPORT_STRATEGY_CREATE_NEW"),
+            2 => std::borrow::Cow::Borrowed("IMPORT_STRATEGY_REPLACE"),
+            3 => std::borrow::Cow::Borrowed("IMPORT_STRATEGY_KEEP"),
+            4 => std::borrow::Cow::Borrowed("IMPORT_STRATEGY_MERGE"),
+            5 => std::borrow::Cow::Borrowed("IMPORT_STRATEGY_THROW_ERROR"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "IMPORT_STRATEGY_UNSPECIFIED" => {
+                std::option::Option::Some(Self::IMPORT_STRATEGY_UNSPECIFIED)
+            }
+            "IMPORT_STRATEGY_CREATE_NEW" => {
+                std::option::Option::Some(Self::IMPORT_STRATEGY_CREATE_NEW)
+            }
+            "IMPORT_STRATEGY_REPLACE" => std::option::Option::Some(Self::IMPORT_STRATEGY_REPLACE),
+            "IMPORT_STRATEGY_KEEP" => std::option::Option::Some(Self::IMPORT_STRATEGY_KEEP),
+            "IMPORT_STRATEGY_MERGE" => std::option::Option::Some(Self::IMPORT_STRATEGY_MERGE),
+            "IMPORT_STRATEGY_THROW_ERROR" => {
+                std::option::Option::Some(Self::IMPORT_STRATEGY_THROW_ERROR)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ImportStrategy {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ImportStrategy {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ImportStrategy {
     fn default() -> Self {
-        import_strategy::IMPORT_STRATEGY_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -27232,84 +28211,114 @@ impl std::default::Default for ImportStrategy {
 /// An intent can be a sizable object. Therefore, we provide a resource view that
 /// does not return training phrases in the response.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct IntentView(std::borrow::Cow<'static, str>);
+pub struct IntentView(i32);
 
 impl IntentView {
+    /// Not specified. Treated as INTENT_VIEW_FULL.
+    pub const INTENT_VIEW_UNSPECIFIED: IntentView = IntentView::new(0);
+
+    /// Training phrases field is not populated in the response.
+    pub const INTENT_VIEW_PARTIAL: IntentView = IntentView::new(1);
+
+    /// All fields are populated.
+    pub const INTENT_VIEW_FULL: IntentView = IntentView::new(2);
+
     /// Creates a new IntentView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("INTENT_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("INTENT_VIEW_PARTIAL"),
+            2 => std::borrow::Cow::Borrowed("INTENT_VIEW_FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "INTENT_VIEW_UNSPECIFIED" => std::option::Option::Some(Self::INTENT_VIEW_UNSPECIFIED),
+            "INTENT_VIEW_PARTIAL" => std::option::Option::Some(Self::INTENT_VIEW_PARTIAL),
+            "INTENT_VIEW_FULL" => std::option::Option::Some(Self::INTENT_VIEW_FULL),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [IntentView](IntentView)
-pub mod intent_view {
-    use super::IntentView;
-
-    /// Not specified. Treated as INTENT_VIEW_FULL.
-    pub const INTENT_VIEW_UNSPECIFIED: IntentView = IntentView::new("INTENT_VIEW_UNSPECIFIED");
-
-    /// Training phrases field is not populated in the response.
-    pub const INTENT_VIEW_PARTIAL: IntentView = IntentView::new("INTENT_VIEW_PARTIAL");
-
-    /// All fields are populated.
-    pub const INTENT_VIEW_FULL: IntentView = IntentView::new("INTENT_VIEW_FULL");
-}
-
-impl std::convert::From<std::string::String> for IntentView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for IntentView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for IntentView {
     fn default() -> Self {
-        intent_view::INTENT_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The test result for a test case and an agent environment.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TestResult(std::borrow::Cow<'static, str>);
+pub struct TestResult(i32);
 
 impl TestResult {
+    /// Not specified. Should never be used.
+    pub const TEST_RESULT_UNSPECIFIED: TestResult = TestResult::new(0);
+
+    /// The test passed.
+    pub const PASSED: TestResult = TestResult::new(1);
+
+    /// The test did not pass.
+    pub const FAILED: TestResult = TestResult::new(2);
+
     /// Creates a new TestResult instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("TEST_RESULT_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PASSED"),
+            2 => std::borrow::Cow::Borrowed("FAILED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "TEST_RESULT_UNSPECIFIED" => std::option::Option::Some(Self::TEST_RESULT_UNSPECIFIED),
+            "PASSED" => std::option::Option::Some(Self::PASSED),
+            "FAILED" => std::option::Option::Some(Self::FAILED),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [TestResult](TestResult)
-pub mod test_result {
-    use super::TestResult;
-
-    /// Not specified. Should never be used.
-    pub const TEST_RESULT_UNSPECIFIED: TestResult = TestResult::new("TEST_RESULT_UNSPECIFIED");
-
-    /// The test passed.
-    pub const PASSED: TestResult = TestResult::new("PASSED");
-
-    /// The test did not pass.
-    pub const FAILED: TestResult = TestResult::new("FAILED");
-}
-
-impl std::convert::From<std::string::String> for TestResult {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for TestResult {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for TestResult {
     fn default() -> Self {
-        test_result::TEST_RESULT_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/dialogflow/cx/v3/src/transport.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::Agents for Agents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/agents", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -70,7 +70,7 @@ impl crate::stubs::Agents for Agents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -89,7 +89,7 @@ impl crate::stubs::Agents for Agents {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}/agents", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -115,7 +115,7 @@ impl crate::stubs::Agents for Agents {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -142,7 +142,7 @@ impl crate::stubs::Agents for Agents {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -161,7 +161,7 @@ impl crate::stubs::Agents for Agents {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:export", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -178,7 +178,7 @@ impl crate::stubs::Agents for Agents {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:restore", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -195,7 +195,7 @@ impl crate::stubs::Agents for Agents {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:validate", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -212,7 +212,7 @@ impl crate::stubs::Agents for Agents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -232,7 +232,7 @@ impl crate::stubs::Agents for Agents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -261,7 +261,7 @@ impl crate::stubs::Agents for Agents {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -290,7 +290,7 @@ impl crate::stubs::Agents for Agents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -312,7 +312,7 @@ impl crate::stubs::Agents for Agents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -331,7 +331,7 @@ impl crate::stubs::Agents for Agents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -353,7 +353,7 @@ impl crate::stubs::Agents for Agents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -372,7 +372,7 @@ impl crate::stubs::Agents for Agents {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -431,7 +431,7 @@ impl crate::stubs::Changelogs for Changelogs {
                 reqwest::Method::GET,
                 format!("/v3/{}/changelogs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -453,7 +453,7 @@ impl crate::stubs::Changelogs for Changelogs {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -472,7 +472,7 @@ impl crate::stubs::Changelogs for Changelogs {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -494,7 +494,7 @@ impl crate::stubs::Changelogs for Changelogs {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -513,7 +513,7 @@ impl crate::stubs::Changelogs for Changelogs {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -535,7 +535,7 @@ impl crate::stubs::Changelogs for Changelogs {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -554,7 +554,7 @@ impl crate::stubs::Changelogs for Changelogs {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -599,7 +599,7 @@ impl crate::stubs::Deployments for Deployments {
                 reqwest::Method::GET,
                 format!("/v3/{}/deployments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -620,7 +620,7 @@ impl crate::stubs::Deployments for Deployments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -639,7 +639,7 @@ impl crate::stubs::Deployments for Deployments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -661,7 +661,7 @@ impl crate::stubs::Deployments for Deployments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -680,7 +680,7 @@ impl crate::stubs::Deployments for Deployments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -702,7 +702,7 @@ impl crate::stubs::Deployments for Deployments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -721,7 +721,7 @@ impl crate::stubs::Deployments for Deployments {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -763,7 +763,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -786,7 +786,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
                 reqwest::Method::POST,
                 format!("/v3/{}/entityTypes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -815,7 +815,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -845,7 +845,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -868,7 +868,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
                 reqwest::Method::GET,
                 format!("/v3/{}/entityTypes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -893,7 +893,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
                 reqwest::Method::POST,
                 format!("/v3/{}/entityTypes:export", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -913,7 +913,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
                 reqwest::Method::POST,
                 format!("/v3/{}/entityTypes:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -930,7 +930,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -952,7 +952,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -971,7 +971,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -993,7 +993,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1012,7 +1012,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1071,7 +1071,7 @@ impl crate::stubs::Environments for Environments {
                 reqwest::Method::GET,
                 format!("/v3/{}/environments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1092,7 +1092,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1114,7 +1114,7 @@ impl crate::stubs::Environments for Environments {
                 reqwest::Method::POST,
                 format!("/v3/{}/environments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1142,7 +1142,7 @@ impl crate::stubs::Environments for Environments {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1171,7 +1171,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1193,7 +1193,7 @@ impl crate::stubs::Environments for Environments {
                 reqwest::Method::GET,
                 format!("/v3/{}:lookupEnvironmentHistory", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1217,7 +1217,7 @@ impl crate::stubs::Environments for Environments {
                 reqwest::Method::POST,
                 format!("/v3/{}:runContinuousTest", req.environment),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1237,7 +1237,7 @@ impl crate::stubs::Environments for Environments {
                 reqwest::Method::GET,
                 format!("/v3/{}/continuousTestResults", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1261,7 +1261,7 @@ impl crate::stubs::Environments for Environments {
                 reqwest::Method::POST,
                 format!("/v3/{}:deployFlow", req.environment),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1278,7 +1278,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1300,7 +1300,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1319,7 +1319,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1341,7 +1341,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1360,7 +1360,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1419,7 +1419,7 @@ impl crate::stubs::Experiments for Experiments {
                 reqwest::Method::GET,
                 format!("/v3/{}/experiments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1440,7 +1440,7 @@ impl crate::stubs::Experiments for Experiments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1462,7 +1462,7 @@ impl crate::stubs::Experiments for Experiments {
                 reqwest::Method::POST,
                 format!("/v3/{}/experiments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1490,7 +1490,7 @@ impl crate::stubs::Experiments for Experiments {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1519,7 +1519,7 @@ impl crate::stubs::Experiments for Experiments {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1538,7 +1538,7 @@ impl crate::stubs::Experiments for Experiments {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:start", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1555,7 +1555,7 @@ impl crate::stubs::Experiments for Experiments {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:stop", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1572,7 +1572,7 @@ impl crate::stubs::Experiments for Experiments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1594,7 +1594,7 @@ impl crate::stubs::Experiments for Experiments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1613,7 +1613,7 @@ impl crate::stubs::Experiments for Experiments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1635,7 +1635,7 @@ impl crate::stubs::Experiments for Experiments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1654,7 +1654,7 @@ impl crate::stubs::Experiments for Experiments {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1694,7 +1694,7 @@ impl crate::stubs::Flows for Flows {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}/flows", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1712,7 +1712,7 @@ impl crate::stubs::Flows for Flows {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1732,7 +1732,7 @@ impl crate::stubs::Flows for Flows {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/flows", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1754,7 +1754,7 @@ impl crate::stubs::Flows for Flows {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1783,7 +1783,7 @@ impl crate::stubs::Flows for Flows {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1811,7 +1811,7 @@ impl crate::stubs::Flows for Flows {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:train", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1828,7 +1828,7 @@ impl crate::stubs::Flows for Flows {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:validate", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1845,7 +1845,7 @@ impl crate::stubs::Flows for Flows {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1868,7 +1868,7 @@ impl crate::stubs::Flows for Flows {
                 reqwest::Method::POST,
                 format!("/v3/{}/flows:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1885,7 +1885,7 @@ impl crate::stubs::Flows for Flows {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:export", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1902,7 +1902,7 @@ impl crate::stubs::Flows for Flows {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1924,7 +1924,7 @@ impl crate::stubs::Flows for Flows {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1943,7 +1943,7 @@ impl crate::stubs::Flows for Flows {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1965,7 +1965,7 @@ impl crate::stubs::Flows for Flows {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1984,7 +1984,7 @@ impl crate::stubs::Flows for Flows {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2043,7 +2043,7 @@ impl crate::stubs::Generators for Generators {
                 reqwest::Method::GET,
                 format!("/v3/{}/generators", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2065,7 +2065,7 @@ impl crate::stubs::Generators for Generators {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2088,7 +2088,7 @@ impl crate::stubs::Generators for Generators {
                 reqwest::Method::POST,
                 format!("/v3/{}/generators", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2117,7 +2117,7 @@ impl crate::stubs::Generators for Generators {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2147,7 +2147,7 @@ impl crate::stubs::Generators for Generators {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2167,7 +2167,7 @@ impl crate::stubs::Generators for Generators {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2189,7 +2189,7 @@ impl crate::stubs::Generators for Generators {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2208,7 +2208,7 @@ impl crate::stubs::Generators for Generators {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2230,7 +2230,7 @@ impl crate::stubs::Generators for Generators {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2249,7 +2249,7 @@ impl crate::stubs::Generators for Generators {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2291,7 +2291,7 @@ impl crate::stubs::Intents for Intents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/intents", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2314,7 +2314,7 @@ impl crate::stubs::Intents for Intents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2334,7 +2334,7 @@ impl crate::stubs::Intents for Intents {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}/intents", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2361,7 +2361,7 @@ impl crate::stubs::Intents for Intents {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2389,7 +2389,7 @@ impl crate::stubs::Intents for Intents {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2411,7 +2411,7 @@ impl crate::stubs::Intents for Intents {
                 reqwest::Method::POST,
                 format!("/v3/{}/intents:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2431,7 +2431,7 @@ impl crate::stubs::Intents for Intents {
                 reqwest::Method::POST,
                 format!("/v3/{}/intents:export", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2448,7 +2448,7 @@ impl crate::stubs::Intents for Intents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2470,7 +2470,7 @@ impl crate::stubs::Intents for Intents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2489,7 +2489,7 @@ impl crate::stubs::Intents for Intents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2511,7 +2511,7 @@ impl crate::stubs::Intents for Intents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2530,7 +2530,7 @@ impl crate::stubs::Intents for Intents {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2584,7 +2584,7 @@ impl crate::stubs::Pages for Pages {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/pages", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2606,7 +2606,7 @@ impl crate::stubs::Pages for Pages {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2626,7 +2626,7 @@ impl crate::stubs::Pages for Pages {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}/pages", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2653,7 +2653,7 @@ impl crate::stubs::Pages for Pages {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2681,7 +2681,7 @@ impl crate::stubs::Pages for Pages {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2701,7 +2701,7 @@ impl crate::stubs::Pages for Pages {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2723,7 +2723,7 @@ impl crate::stubs::Pages for Pages {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2742,7 +2742,7 @@ impl crate::stubs::Pages for Pages {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2764,7 +2764,7 @@ impl crate::stubs::Pages for Pages {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2783,7 +2783,7 @@ impl crate::stubs::Pages for Pages {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2828,7 +2828,7 @@ impl crate::stubs::SecuritySettingsService for SecuritySettingsService {
                 reqwest::Method::POST,
                 format!("/v3/{}/securitySettings", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2847,7 +2847,7 @@ impl crate::stubs::SecuritySettingsService for SecuritySettingsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2875,7 +2875,7 @@ impl crate::stubs::SecuritySettingsService for SecuritySettingsService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2907,7 +2907,7 @@ impl crate::stubs::SecuritySettingsService for SecuritySettingsService {
                 reqwest::Method::GET,
                 format!("/v3/{}/securitySettings", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2928,7 +2928,7 @@ impl crate::stubs::SecuritySettingsService for SecuritySettingsService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2947,7 +2947,7 @@ impl crate::stubs::SecuritySettingsService for SecuritySettingsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2969,7 +2969,7 @@ impl crate::stubs::SecuritySettingsService for SecuritySettingsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2988,7 +2988,7 @@ impl crate::stubs::SecuritySettingsService for SecuritySettingsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3010,7 +3010,7 @@ impl crate::stubs::SecuritySettingsService for SecuritySettingsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3029,7 +3029,7 @@ impl crate::stubs::SecuritySettingsService for SecuritySettingsService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3074,7 +3074,7 @@ impl crate::stubs::Sessions for Sessions {
                 reqwest::Method::POST,
                 format!("/v3/{}:detectIntent", req.session),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3094,7 +3094,7 @@ impl crate::stubs::Sessions for Sessions {
                 reqwest::Method::POST,
                 format!("/v3/{}:matchIntent", req.session),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3120,7 +3120,7 @@ impl crate::stubs::Sessions for Sessions {
                         .session
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3140,7 +3140,7 @@ impl crate::stubs::Sessions for Sessions {
                 reqwest::Method::POST,
                 format!("/v3/{}:submitAnswerFeedback", req.session),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3157,7 +3157,7 @@ impl crate::stubs::Sessions for Sessions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3179,7 +3179,7 @@ impl crate::stubs::Sessions for Sessions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3198,7 +3198,7 @@ impl crate::stubs::Sessions for Sessions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3220,7 +3220,7 @@ impl crate::stubs::Sessions for Sessions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3239,7 +3239,7 @@ impl crate::stubs::Sessions for Sessions {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3284,7 +3284,7 @@ impl crate::stubs::SessionEntityTypes for SessionEntityTypes {
                 reqwest::Method::GET,
                 format!("/v3/{}/entityTypes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3305,7 +3305,7 @@ impl crate::stubs::SessionEntityTypes for SessionEntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3327,7 +3327,7 @@ impl crate::stubs::SessionEntityTypes for SessionEntityTypes {
                 reqwest::Method::POST,
                 format!("/v3/{}/entityTypes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3355,7 +3355,7 @@ impl crate::stubs::SessionEntityTypes for SessionEntityTypes {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3384,7 +3384,7 @@ impl crate::stubs::SessionEntityTypes for SessionEntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3403,7 +3403,7 @@ impl crate::stubs::SessionEntityTypes for SessionEntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3425,7 +3425,7 @@ impl crate::stubs::SessionEntityTypes for SessionEntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3444,7 +3444,7 @@ impl crate::stubs::SessionEntityTypes for SessionEntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3466,7 +3466,7 @@ impl crate::stubs::SessionEntityTypes for SessionEntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3485,7 +3485,7 @@ impl crate::stubs::SessionEntityTypes for SessionEntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3530,7 +3530,7 @@ impl crate::stubs::TestCases for TestCases {
                 reqwest::Method::GET,
                 format!("/v3/{}/testCases", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3555,7 +3555,7 @@ impl crate::stubs::TestCases for TestCases {
                 reqwest::Method::POST,
                 format!("/v3/{}/testCases:batchDelete", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3572,7 +3572,7 @@ impl crate::stubs::TestCases for TestCases {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3594,7 +3594,7 @@ impl crate::stubs::TestCases for TestCases {
                 reqwest::Method::POST,
                 format!("/v3/{}/testCases", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3622,7 +3622,7 @@ impl crate::stubs::TestCases for TestCases {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3651,7 +3651,7 @@ impl crate::stubs::TestCases for TestCases {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:run", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3671,7 +3671,7 @@ impl crate::stubs::TestCases for TestCases {
                 reqwest::Method::POST,
                 format!("/v3/{}/testCases:batchRun", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3691,7 +3691,7 @@ impl crate::stubs::TestCases for TestCases {
                 reqwest::Method::GET,
                 format!("/v3/{}/testCases:calculateCoverage", req.agent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3714,7 +3714,7 @@ impl crate::stubs::TestCases for TestCases {
                 reqwest::Method::POST,
                 format!("/v3/{}/testCases:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3734,7 +3734,7 @@ impl crate::stubs::TestCases for TestCases {
                 reqwest::Method::POST,
                 format!("/v3/{}/testCases:export", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3751,7 +3751,7 @@ impl crate::stubs::TestCases for TestCases {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/results", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3773,7 +3773,7 @@ impl crate::stubs::TestCases for TestCases {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3792,7 +3792,7 @@ impl crate::stubs::TestCases for TestCases {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3814,7 +3814,7 @@ impl crate::stubs::TestCases for TestCases {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3833,7 +3833,7 @@ impl crate::stubs::TestCases for TestCases {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3855,7 +3855,7 @@ impl crate::stubs::TestCases for TestCases {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3874,7 +3874,7 @@ impl crate::stubs::TestCases for TestCases {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3933,7 +3933,7 @@ impl crate::stubs::TransitionRouteGroups for TransitionRouteGroups {
                 reqwest::Method::GET,
                 format!("/v3/{}/transitionRouteGroups", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3955,7 +3955,7 @@ impl crate::stubs::TransitionRouteGroups for TransitionRouteGroups {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3978,7 +3978,7 @@ impl crate::stubs::TransitionRouteGroups for TransitionRouteGroups {
                 reqwest::Method::POST,
                 format!("/v3/{}/transitionRouteGroups", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4007,7 +4007,7 @@ impl crate::stubs::TransitionRouteGroups for TransitionRouteGroups {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4037,7 +4037,7 @@ impl crate::stubs::TransitionRouteGroups for TransitionRouteGroups {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4057,7 +4057,7 @@ impl crate::stubs::TransitionRouteGroups for TransitionRouteGroups {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4079,7 +4079,7 @@ impl crate::stubs::TransitionRouteGroups for TransitionRouteGroups {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4098,7 +4098,7 @@ impl crate::stubs::TransitionRouteGroups for TransitionRouteGroups {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4120,7 +4120,7 @@ impl crate::stubs::TransitionRouteGroups for TransitionRouteGroups {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4139,7 +4139,7 @@ impl crate::stubs::TransitionRouteGroups for TransitionRouteGroups {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4181,7 +4181,7 @@ impl crate::stubs::Versions for Versions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/versions", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4202,7 +4202,7 @@ impl crate::stubs::Versions for Versions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4224,7 +4224,7 @@ impl crate::stubs::Versions for Versions {
                 reqwest::Method::POST,
                 format!("/v3/{}/versions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4252,7 +4252,7 @@ impl crate::stubs::Versions for Versions {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4281,7 +4281,7 @@ impl crate::stubs::Versions for Versions {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4300,7 +4300,7 @@ impl crate::stubs::Versions for Versions {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:load", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4320,7 +4320,7 @@ impl crate::stubs::Versions for Versions {
                 reqwest::Method::POST,
                 format!("/v3/{}:compareVersions", req.base_version),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4337,7 +4337,7 @@ impl crate::stubs::Versions for Versions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4359,7 +4359,7 @@ impl crate::stubs::Versions for Versions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4378,7 +4378,7 @@ impl crate::stubs::Versions for Versions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4400,7 +4400,7 @@ impl crate::stubs::Versions for Versions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4419,7 +4419,7 @@ impl crate::stubs::Versions for Versions {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4475,7 +4475,7 @@ impl crate::stubs::Webhooks for Webhooks {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/webhooks", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4496,7 +4496,7 @@ impl crate::stubs::Webhooks for Webhooks {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4518,7 +4518,7 @@ impl crate::stubs::Webhooks for Webhooks {
                 reqwest::Method::POST,
                 format!("/v3/{}/webhooks", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4546,7 +4546,7 @@ impl crate::stubs::Webhooks for Webhooks {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4575,7 +4575,7 @@ impl crate::stubs::Webhooks for Webhooks {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4595,7 +4595,7 @@ impl crate::stubs::Webhooks for Webhooks {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4617,7 +4617,7 @@ impl crate::stubs::Webhooks for Webhooks {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4636,7 +4636,7 @@ impl crate::stubs::Webhooks for Webhooks {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4658,7 +4658,7 @@ impl crate::stubs::Webhooks for Webhooks {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4677,7 +4677,7 @@ impl crate::stubs::Webhooks for Webhooks {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/dialogflow/v2/src/model.rs
+++ b/src/generated/cloud/dialogflow/v2/src/model.rs
@@ -219,136 +219,187 @@ pub mod agent {
 
     /// Match mode determines how intents are detected from user queries.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MatchMode(std::borrow::Cow<'static, str>);
+    pub struct MatchMode(i32);
 
     impl MatchMode {
-        /// Creates a new MatchMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [MatchMode](MatchMode)
-    pub mod match_mode {
-        use super::MatchMode;
-
         /// Not specified.
-        pub const MATCH_MODE_UNSPECIFIED: MatchMode = MatchMode::new("MATCH_MODE_UNSPECIFIED");
+        pub const MATCH_MODE_UNSPECIFIED: MatchMode = MatchMode::new(0);
 
         /// Best for agents with a small number of examples in intents and/or wide
         /// use of templates syntax and composite entities.
-        pub const MATCH_MODE_HYBRID: MatchMode = MatchMode::new("MATCH_MODE_HYBRID");
+        pub const MATCH_MODE_HYBRID: MatchMode = MatchMode::new(1);
 
         /// Can be used for agents with a large number of examples in intents,
         /// especially the ones using @sys.any or very large custom entities.
-        pub const MATCH_MODE_ML_ONLY: MatchMode = MatchMode::new("MATCH_MODE_ML_ONLY");
+        pub const MATCH_MODE_ML_ONLY: MatchMode = MatchMode::new(2);
+
+        /// Creates a new MatchMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MATCH_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MATCH_MODE_HYBRID"),
+                2 => std::borrow::Cow::Borrowed("MATCH_MODE_ML_ONLY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MATCH_MODE_UNSPECIFIED" => std::option::Option::Some(Self::MATCH_MODE_UNSPECIFIED),
+                "MATCH_MODE_HYBRID" => std::option::Option::Some(Self::MATCH_MODE_HYBRID),
+                "MATCH_MODE_ML_ONLY" => std::option::Option::Some(Self::MATCH_MODE_ML_ONLY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for MatchMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MatchMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MatchMode {
         fn default() -> Self {
-            match_mode::MATCH_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// API version for the agent.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ApiVersion(std::borrow::Cow<'static, str>);
+    pub struct ApiVersion(i32);
 
     impl ApiVersion {
+        /// Not specified.
+        pub const API_VERSION_UNSPECIFIED: ApiVersion = ApiVersion::new(0);
+
+        /// Legacy V1 API.
+        pub const API_VERSION_V1: ApiVersion = ApiVersion::new(1);
+
+        /// V2 API.
+        pub const API_VERSION_V2: ApiVersion = ApiVersion::new(2);
+
+        /// V2beta1 API.
+        pub const API_VERSION_V2_BETA_1: ApiVersion = ApiVersion::new(3);
+
         /// Creates a new ApiVersion instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("API_VERSION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("API_VERSION_V1"),
+                2 => std::borrow::Cow::Borrowed("API_VERSION_V2"),
+                3 => std::borrow::Cow::Borrowed("API_VERSION_V2_BETA_1"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "API_VERSION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::API_VERSION_UNSPECIFIED)
+                }
+                "API_VERSION_V1" => std::option::Option::Some(Self::API_VERSION_V1),
+                "API_VERSION_V2" => std::option::Option::Some(Self::API_VERSION_V2),
+                "API_VERSION_V2_BETA_1" => std::option::Option::Some(Self::API_VERSION_V2_BETA_1),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ApiVersion](ApiVersion)
-    pub mod api_version {
-        use super::ApiVersion;
-
-        /// Not specified.
-        pub const API_VERSION_UNSPECIFIED: ApiVersion = ApiVersion::new("API_VERSION_UNSPECIFIED");
-
-        /// Legacy V1 API.
-        pub const API_VERSION_V1: ApiVersion = ApiVersion::new("API_VERSION_V1");
-
-        /// V2 API.
-        pub const API_VERSION_V2: ApiVersion = ApiVersion::new("API_VERSION_V2");
-
-        /// V2beta1 API.
-        pub const API_VERSION_V2_BETA_1: ApiVersion = ApiVersion::new("API_VERSION_V2_BETA_1");
-    }
-
-    impl std::convert::From<std::string::String> for ApiVersion {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ApiVersion {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ApiVersion {
         fn default() -> Self {
-            api_version::API_VERSION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Represents the agent tier.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Tier(std::borrow::Cow<'static, str>);
+    pub struct Tier(i32);
 
     impl Tier {
-        /// Creates a new Tier instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Tier](Tier)
-    pub mod tier {
-        use super::Tier;
-
         /// Not specified. This value should never be used.
-        pub const TIER_UNSPECIFIED: Tier = Tier::new("TIER_UNSPECIFIED");
+        pub const TIER_UNSPECIFIED: Tier = Tier::new(0);
 
         /// Trial Edition, previously known as Standard Edition.
-        pub const TIER_STANDARD: Tier = Tier::new("TIER_STANDARD");
+        pub const TIER_STANDARD: Tier = Tier::new(1);
 
         /// Essentials Edition, previously known as Enterprise Essential Edition.
-        pub const TIER_ENTERPRISE: Tier = Tier::new("TIER_ENTERPRISE");
+        pub const TIER_ENTERPRISE: Tier = Tier::new(2);
 
         /// Essentials Edition (same as TIER_ENTERPRISE), previously known as
         /// Enterprise Plus Edition.
-        pub const TIER_ENTERPRISE_PLUS: Tier = Tier::new("TIER_ENTERPRISE_PLUS");
+        pub const TIER_ENTERPRISE_PLUS: Tier = Tier::new(3);
+
+        /// Creates a new Tier instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TIER_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TIER_STANDARD"),
+                2 => std::borrow::Cow::Borrowed("TIER_ENTERPRISE"),
+                3 => std::borrow::Cow::Borrowed("TIER_ENTERPRISE_PLUS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TIER_UNSPECIFIED" => std::option::Option::Some(Self::TIER_UNSPECIFIED),
+                "TIER_STANDARD" => std::option::Option::Some(Self::TIER_STANDARD),
+                "TIER_ENTERPRISE" => std::option::Option::Some(Self::TIER_ENTERPRISE),
+                "TIER_ENTERPRISE_PLUS" => std::option::Option::Some(Self::TIER_ENTERPRISE_PLUS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Tier {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Tier {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Tier {
         fn default() -> Self {
-            tier::TIER_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1541,47 +1592,65 @@ pub mod answer_feedback {
 
     /// The correctness level of an answer.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CorrectnessLevel(std::borrow::Cow<'static, str>);
+    pub struct CorrectnessLevel(i32);
 
     impl CorrectnessLevel {
+        /// Correctness level unspecified.
+        pub const CORRECTNESS_LEVEL_UNSPECIFIED: CorrectnessLevel = CorrectnessLevel::new(0);
+
+        /// Answer is totally wrong.
+        pub const NOT_CORRECT: CorrectnessLevel = CorrectnessLevel::new(1);
+
+        /// Answer is partially correct.
+        pub const PARTIALLY_CORRECT: CorrectnessLevel = CorrectnessLevel::new(2);
+
+        /// Answer is fully correct.
+        pub const FULLY_CORRECT: CorrectnessLevel = CorrectnessLevel::new(3);
+
         /// Creates a new CorrectnessLevel instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CORRECTNESS_LEVEL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NOT_CORRECT"),
+                2 => std::borrow::Cow::Borrowed("PARTIALLY_CORRECT"),
+                3 => std::borrow::Cow::Borrowed("FULLY_CORRECT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CORRECTNESS_LEVEL_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CORRECTNESS_LEVEL_UNSPECIFIED)
+                }
+                "NOT_CORRECT" => std::option::Option::Some(Self::NOT_CORRECT),
+                "PARTIALLY_CORRECT" => std::option::Option::Some(Self::PARTIALLY_CORRECT),
+                "FULLY_CORRECT" => std::option::Option::Some(Self::FULLY_CORRECT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [CorrectnessLevel](CorrectnessLevel)
-    pub mod correctness_level {
-        use super::CorrectnessLevel;
-
-        /// Correctness level unspecified.
-        pub const CORRECTNESS_LEVEL_UNSPECIFIED: CorrectnessLevel =
-            CorrectnessLevel::new("CORRECTNESS_LEVEL_UNSPECIFIED");
-
-        /// Answer is totally wrong.
-        pub const NOT_CORRECT: CorrectnessLevel = CorrectnessLevel::new("NOT_CORRECT");
-
-        /// Answer is partially correct.
-        pub const PARTIALLY_CORRECT: CorrectnessLevel = CorrectnessLevel::new("PARTIALLY_CORRECT");
-
-        /// Answer is fully correct.
-        pub const FULLY_CORRECT: CorrectnessLevel = CorrectnessLevel::new("FULLY_CORRECT");
-    }
-
-    impl std::convert::From<std::string::String> for CorrectnessLevel {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CorrectnessLevel {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CorrectnessLevel {
         fn default() -> Self {
-            correctness_level::CORRECTNESS_LEVEL_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1929,130 +1998,179 @@ pub mod agent_assistant_feedback {
 
     /// Relevance of an answer.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AnswerRelevance(std::borrow::Cow<'static, str>);
+    pub struct AnswerRelevance(i32);
 
     impl AnswerRelevance {
+        /// Answer relevance unspecified.
+        pub const ANSWER_RELEVANCE_UNSPECIFIED: AnswerRelevance = AnswerRelevance::new(0);
+
+        /// Answer is irrelevant to query.
+        pub const IRRELEVANT: AnswerRelevance = AnswerRelevance::new(1);
+
+        /// Answer is relevant to query.
+        pub const RELEVANT: AnswerRelevance = AnswerRelevance::new(2);
+
         /// Creates a new AnswerRelevance instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ANSWER_RELEVANCE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IRRELEVANT"),
+                2 => std::borrow::Cow::Borrowed("RELEVANT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ANSWER_RELEVANCE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ANSWER_RELEVANCE_UNSPECIFIED)
+                }
+                "IRRELEVANT" => std::option::Option::Some(Self::IRRELEVANT),
+                "RELEVANT" => std::option::Option::Some(Self::RELEVANT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AnswerRelevance](AnswerRelevance)
-    pub mod answer_relevance {
-        use super::AnswerRelevance;
-
-        /// Answer relevance unspecified.
-        pub const ANSWER_RELEVANCE_UNSPECIFIED: AnswerRelevance =
-            AnswerRelevance::new("ANSWER_RELEVANCE_UNSPECIFIED");
-
-        /// Answer is irrelevant to query.
-        pub const IRRELEVANT: AnswerRelevance = AnswerRelevance::new("IRRELEVANT");
-
-        /// Answer is relevant to query.
-        pub const RELEVANT: AnswerRelevance = AnswerRelevance::new("RELEVANT");
-    }
-
-    impl std::convert::From<std::string::String> for AnswerRelevance {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AnswerRelevance {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AnswerRelevance {
         fn default() -> Self {
-            answer_relevance::ANSWER_RELEVANCE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Correctness of document.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DocumentCorrectness(std::borrow::Cow<'static, str>);
+    pub struct DocumentCorrectness(i32);
 
     impl DocumentCorrectness {
+        /// Document correctness unspecified.
+        pub const DOCUMENT_CORRECTNESS_UNSPECIFIED: DocumentCorrectness =
+            DocumentCorrectness::new(0);
+
+        /// Information in document is incorrect.
+        pub const INCORRECT: DocumentCorrectness = DocumentCorrectness::new(1);
+
+        /// Information in document is correct.
+        pub const CORRECT: DocumentCorrectness = DocumentCorrectness::new(2);
+
         /// Creates a new DocumentCorrectness instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DOCUMENT_CORRECTNESS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INCORRECT"),
+                2 => std::borrow::Cow::Borrowed("CORRECT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DOCUMENT_CORRECTNESS_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DOCUMENT_CORRECTNESS_UNSPECIFIED)
+                }
+                "INCORRECT" => std::option::Option::Some(Self::INCORRECT),
+                "CORRECT" => std::option::Option::Some(Self::CORRECT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DocumentCorrectness](DocumentCorrectness)
-    pub mod document_correctness {
-        use super::DocumentCorrectness;
-
-        /// Document correctness unspecified.
-        pub const DOCUMENT_CORRECTNESS_UNSPECIFIED: DocumentCorrectness =
-            DocumentCorrectness::new("DOCUMENT_CORRECTNESS_UNSPECIFIED");
-
-        /// Information in document is incorrect.
-        pub const INCORRECT: DocumentCorrectness = DocumentCorrectness::new("INCORRECT");
-
-        /// Information in document is correct.
-        pub const CORRECT: DocumentCorrectness = DocumentCorrectness::new("CORRECT");
-    }
-
-    impl std::convert::From<std::string::String> for DocumentCorrectness {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DocumentCorrectness {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DocumentCorrectness {
         fn default() -> Self {
-            document_correctness::DOCUMENT_CORRECTNESS_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Efficiency of document.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DocumentEfficiency(std::borrow::Cow<'static, str>);
+    pub struct DocumentEfficiency(i32);
 
     impl DocumentEfficiency {
+        /// Document efficiency unspecified.
+        pub const DOCUMENT_EFFICIENCY_UNSPECIFIED: DocumentEfficiency = DocumentEfficiency::new(0);
+
+        /// Document is inefficient.
+        pub const INEFFICIENT: DocumentEfficiency = DocumentEfficiency::new(1);
+
+        /// Document is efficient.
+        pub const EFFICIENT: DocumentEfficiency = DocumentEfficiency::new(2);
+
         /// Creates a new DocumentEfficiency instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DOCUMENT_EFFICIENCY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INEFFICIENT"),
+                2 => std::borrow::Cow::Borrowed("EFFICIENT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DOCUMENT_EFFICIENCY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DOCUMENT_EFFICIENCY_UNSPECIFIED)
+                }
+                "INEFFICIENT" => std::option::Option::Some(Self::INEFFICIENT),
+                "EFFICIENT" => std::option::Option::Some(Self::EFFICIENT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DocumentEfficiency](DocumentEfficiency)
-    pub mod document_efficiency {
-        use super::DocumentEfficiency;
-
-        /// Document efficiency unspecified.
-        pub const DOCUMENT_EFFICIENCY_UNSPECIFIED: DocumentEfficiency =
-            DocumentEfficiency::new("DOCUMENT_EFFICIENCY_UNSPECIFIED");
-
-        /// Document is inefficient.
-        pub const INEFFICIENT: DocumentEfficiency = DocumentEfficiency::new("INEFFICIENT");
-
-        /// Document is efficient.
-        pub const EFFICIENT: DocumentEfficiency = DocumentEfficiency::new("EFFICIENT");
-    }
-
-    impl std::convert::From<std::string::String> for DocumentEfficiency {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DocumentEfficiency {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DocumentEfficiency {
         fn default() -> Self {
-            document_efficiency::DOCUMENT_EFFICIENCY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3877,132 +3995,180 @@ pub mod conversation {
 
             /// Represents the format of the ingested string.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct ContentFormat(std::borrow::Cow<'static, str>);
+            pub struct ContentFormat(i32);
 
             impl ContentFormat {
+                /// Unspecified content format.
+                pub const CONTENT_FORMAT_UNSPECIFIED: ContentFormat = ContentFormat::new(0);
+
+                /// Content was provided in JSON format.
+                pub const JSON: ContentFormat = ContentFormat::new(1);
+
+                /// Content was provided as plain text.
+                pub const PLAIN_TEXT: ContentFormat = ContentFormat::new(2);
+
                 /// Creates a new ContentFormat instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
                 }
 
                 /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("CONTENT_FORMAT_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("JSON"),
+                        2 => std::borrow::Cow::Borrowed("PLAIN_TEXT"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "CONTENT_FORMAT_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::CONTENT_FORMAT_UNSPECIFIED)
+                        }
+                        "JSON" => std::option::Option::Some(Self::JSON),
+                        "PLAIN_TEXT" => std::option::Option::Some(Self::PLAIN_TEXT),
+                        _ => std::option::Option::None,
+                    }
                 }
             }
 
-            /// Useful constants to work with [ContentFormat](ContentFormat)
-            pub mod content_format {
-                use super::ContentFormat;
-
-                /// Unspecified content format.
-                pub const CONTENT_FORMAT_UNSPECIFIED: ContentFormat =
-                    ContentFormat::new("CONTENT_FORMAT_UNSPECIFIED");
-
-                /// Content was provided in JSON format.
-                pub const JSON: ContentFormat = ContentFormat::new("JSON");
-
-                /// Content was provided as plain text.
-                pub const PLAIN_TEXT: ContentFormat = ContentFormat::new("PLAIN_TEXT");
-            }
-
-            impl std::convert::From<std::string::String> for ContentFormat {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for ContentFormat {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for ContentFormat {
                 fn default() -> Self {
-                    content_format::CONTENT_FORMAT_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
 
         /// Represents the mode in which context reference contents are updated.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct UpdateMode(std::borrow::Cow<'static, str>);
+        pub struct UpdateMode(i32);
 
         impl UpdateMode {
+            /// Unspecified update mode.
+            pub const UPDATE_MODE_UNSPECIFIED: UpdateMode = UpdateMode::new(0);
+
+            /// Context content updates are applied in append mode.
+            pub const APPEND: UpdateMode = UpdateMode::new(1);
+
+            /// Context content updates are applied in overwrite mode.
+            pub const OVERWRITE: UpdateMode = UpdateMode::new(2);
+
             /// Creates a new UpdateMode instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("UPDATE_MODE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("APPEND"),
+                    2 => std::borrow::Cow::Borrowed("OVERWRITE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "UPDATE_MODE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::UPDATE_MODE_UNSPECIFIED)
+                    }
+                    "APPEND" => std::option::Option::Some(Self::APPEND),
+                    "OVERWRITE" => std::option::Option::Some(Self::OVERWRITE),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [UpdateMode](UpdateMode)
-        pub mod update_mode {
-            use super::UpdateMode;
-
-            /// Unspecified update mode.
-            pub const UPDATE_MODE_UNSPECIFIED: UpdateMode =
-                UpdateMode::new("UPDATE_MODE_UNSPECIFIED");
-
-            /// Context content updates are applied in append mode.
-            pub const APPEND: UpdateMode = UpdateMode::new("APPEND");
-
-            /// Context content updates are applied in overwrite mode.
-            pub const OVERWRITE: UpdateMode = UpdateMode::new("OVERWRITE");
-        }
-
-        impl std::convert::From<std::string::String> for UpdateMode {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for UpdateMode {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for UpdateMode {
             fn default() -> Self {
-                update_mode::UPDATE_MODE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// Enumeration of the completion status of the conversation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LifecycleState(std::borrow::Cow<'static, str>);
+    pub struct LifecycleState(i32);
 
     impl LifecycleState {
+        /// Unknown.
+        pub const LIFECYCLE_STATE_UNSPECIFIED: LifecycleState = LifecycleState::new(0);
+
+        /// Conversation is currently open for media analysis.
+        pub const IN_PROGRESS: LifecycleState = LifecycleState::new(1);
+
+        /// Conversation has been completed.
+        pub const COMPLETED: LifecycleState = LifecycleState::new(2);
+
         /// Creates a new LifecycleState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LIFECYCLE_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                2 => std::borrow::Cow::Borrowed("COMPLETED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LIFECYCLE_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::LIFECYCLE_STATE_UNSPECIFIED)
+                }
+                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                "COMPLETED" => std::option::Option::Some(Self::COMPLETED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [LifecycleState](LifecycleState)
-    pub mod lifecycle_state {
-        use super::LifecycleState;
-
-        /// Unknown.
-        pub const LIFECYCLE_STATE_UNSPECIFIED: LifecycleState =
-            LifecycleState::new("LIFECYCLE_STATE_UNSPECIFIED");
-
-        /// Conversation is currently open for media analysis.
-        pub const IN_PROGRESS: LifecycleState = LifecycleState::new("IN_PROGRESS");
-
-        /// Conversation has been completed.
-        pub const COMPLETED: LifecycleState = LifecycleState::new("COMPLETED");
-    }
-
-    impl std::convert::From<std::string::String> for LifecycleState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LifecycleState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LifecycleState {
         fn default() -> Self {
-            lifecycle_state::LIFECYCLE_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -4010,49 +4176,63 @@ pub mod conversation {
     /// Reference:
     /// <https://cloud.google.com/agent-assist/docs/basics#conversation_stages>
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConversationStage(std::borrow::Cow<'static, str>);
+    pub struct ConversationStage(i32);
 
     impl ConversationStage {
-        /// Creates a new ConversationStage instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ConversationStage](ConversationStage)
-    pub mod conversation_stage {
-        use super::ConversationStage;
-
         /// Unknown. Should never be used after a conversation is successfully
         /// created.
-        pub const CONVERSATION_STAGE_UNSPECIFIED: ConversationStage =
-            ConversationStage::new("CONVERSATION_STAGE_UNSPECIFIED");
+        pub const CONVERSATION_STAGE_UNSPECIFIED: ConversationStage = ConversationStage::new(0);
 
         /// The conversation should return virtual agent responses into the
         /// conversation.
-        pub const VIRTUAL_AGENT_STAGE: ConversationStage =
-            ConversationStage::new("VIRTUAL_AGENT_STAGE");
+        pub const VIRTUAL_AGENT_STAGE: ConversationStage = ConversationStage::new(1);
 
         /// The conversation should not provide responses, just listen and provide
         /// suggestions.
-        pub const HUMAN_ASSIST_STAGE: ConversationStage =
-            ConversationStage::new("HUMAN_ASSIST_STAGE");
+        pub const HUMAN_ASSIST_STAGE: ConversationStage = ConversationStage::new(2);
+
+        /// Creates a new ConversationStage instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CONVERSATION_STAGE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("VIRTUAL_AGENT_STAGE"),
+                2 => std::borrow::Cow::Borrowed("HUMAN_ASSIST_STAGE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CONVERSATION_STAGE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CONVERSATION_STAGE_UNSPECIFIED)
+                }
+                "VIRTUAL_AGENT_STAGE" => std::option::Option::Some(Self::VIRTUAL_AGENT_STAGE),
+                "HUMAN_ASSIST_STAGE" => std::option::Option::Some(Self::HUMAN_ASSIST_STAGE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ConversationStage {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ConversationStage {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ConversationStage {
         fn default() -> Self {
-            conversation_stage::CONVERSATION_STAGE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5891,33 +6071,18 @@ pub mod search_knowledge_request {
                         /// The attribute(or function) for which the custom ranking is to be
                         /// applied.
                         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                        pub struct AttributeType(std::borrow::Cow<'static, str>);
+                        pub struct AttributeType(i32);
 
                         impl AttributeType {
-                            /// Creates a new AttributeType instance.
-                            pub const fn new(v: &'static str) -> Self {
-                                Self(std::borrow::Cow::Borrowed(v))
-                            }
-
-                            /// Gets the enum value.
-                            pub fn value(&self) -> &str {
-                                &self.0
-                            }
-                        }
-
-                        /// Useful constants to work with [AttributeType](AttributeType)
-                        pub mod attribute_type {
-                            use super::AttributeType;
-
                             /// Unspecified AttributeType.
                             pub const ATTRIBUTE_TYPE_UNSPECIFIED: AttributeType =
-                                AttributeType::new("ATTRIBUTE_TYPE_UNSPECIFIED");
+                                AttributeType::new(0);
 
                             /// The value of the numerical field will be used to dynamically
                             /// update the boost amount. In this case, the attribute_value (the
                             /// x value) of the control point will be the actual value of the
                             /// numerical field for which the boost_amount is specified.
-                            pub const NUMERICAL: AttributeType = AttributeType::new("NUMERICAL");
+                            pub const NUMERICAL: AttributeType = AttributeType::new(1);
 
                             /// For the freshness use case the attribute value will be the
                             /// duration between the current time and the date in the datetime
@@ -5925,60 +6090,115 @@ pub mod search_knowledge_request {
                             /// `dayTimeDuration` value (a restricted subset of an ISO 8601
                             /// duration value). The pattern for this is:
                             /// `[nD][T[nH][nM][nS]]`. E.g. `5D`, `3DT12H30M`, `T24H`.
-                            pub const FRESHNESS: AttributeType = AttributeType::new("FRESHNESS");
+                            pub const FRESHNESS: AttributeType = AttributeType::new(2);
+
+                            /// Creates a new AttributeType instance.
+                            pub(crate) const fn new(value: i32) -> Self {
+                                Self(value)
+                            }
+
+                            /// Gets the enum value.
+                            pub fn value(&self) -> i32 {
+                                self.0
+                            }
+
+                            /// Gets the enum value as a string.
+                            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                                match self.0 {
+                                    0 => std::borrow::Cow::Borrowed("ATTRIBUTE_TYPE_UNSPECIFIED"),
+                                    1 => std::borrow::Cow::Borrowed("NUMERICAL"),
+                                    2 => std::borrow::Cow::Borrowed("FRESHNESS"),
+                                    _ => std::borrow::Cow::Owned(std::format!(
+                                        "UNKNOWN-VALUE:{}",
+                                        self.0
+                                    )),
+                                }
+                            }
+
+                            /// Creates an enum value from the value name.
+                            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                                match name {
+                                    "ATTRIBUTE_TYPE_UNSPECIFIED" => {
+                                        std::option::Option::Some(Self::ATTRIBUTE_TYPE_UNSPECIFIED)
+                                    }
+                                    "NUMERICAL" => std::option::Option::Some(Self::NUMERICAL),
+                                    "FRESHNESS" => std::option::Option::Some(Self::FRESHNESS),
+                                    _ => std::option::Option::None,
+                                }
+                            }
                         }
 
-                        impl std::convert::From<std::string::String> for AttributeType {
-                            fn from(value: std::string::String) -> Self {
-                                Self(std::borrow::Cow::Owned(value))
+                        impl std::convert::From<i32> for AttributeType {
+                            fn from(value: i32) -> Self {
+                                Self::new(value)
                             }
                         }
 
                         impl std::default::Default for AttributeType {
                             fn default() -> Self {
-                                attribute_type::ATTRIBUTE_TYPE_UNSPECIFIED
+                                Self::new(0)
                             }
                         }
 
                         /// The interpolation type to be applied. Default will be linear
                         /// (Piecewise Linear).
                         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                        pub struct InterpolationType(std::borrow::Cow<'static, str>);
+                        pub struct InterpolationType(i32);
 
                         impl InterpolationType {
-                            /// Creates a new InterpolationType instance.
-                            pub const fn new(v: &'static str) -> Self {
-                                Self(std::borrow::Cow::Borrowed(v))
-                            }
-
-                            /// Gets the enum value.
-                            pub fn value(&self) -> &str {
-                                &self.0
-                            }
-                        }
-
-                        /// Useful constants to work with [InterpolationType](InterpolationType)
-                        pub mod interpolation_type {
-                            use super::InterpolationType;
-
                             /// Interpolation type is unspecified. In this case, it defaults to
                             /// Linear.
                             pub const INTERPOLATION_TYPE_UNSPECIFIED: InterpolationType =
-                                InterpolationType::new("INTERPOLATION_TYPE_UNSPECIFIED");
+                                InterpolationType::new(0);
 
                             /// Piecewise linear interpolation will be applied.
-                            pub const LINEAR: InterpolationType = InterpolationType::new("LINEAR");
+                            pub const LINEAR: InterpolationType = InterpolationType::new(1);
+
+                            /// Creates a new InterpolationType instance.
+                            pub(crate) const fn new(value: i32) -> Self {
+                                Self(value)
+                            }
+
+                            /// Gets the enum value.
+                            pub fn value(&self) -> i32 {
+                                self.0
+                            }
+
+                            /// Gets the enum value as a string.
+                            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                                match self.0 {
+                                    0 => {
+                                        std::borrow::Cow::Borrowed("INTERPOLATION_TYPE_UNSPECIFIED")
+                                    }
+                                    1 => std::borrow::Cow::Borrowed("LINEAR"),
+                                    _ => std::borrow::Cow::Owned(std::format!(
+                                        "UNKNOWN-VALUE:{}",
+                                        self.0
+                                    )),
+                                }
+                            }
+
+                            /// Creates an enum value from the value name.
+                            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                                match name {
+                                    "INTERPOLATION_TYPE_UNSPECIFIED" => std::option::Option::Some(
+                                        Self::INTERPOLATION_TYPE_UNSPECIFIED,
+                                    ),
+                                    "LINEAR" => std::option::Option::Some(Self::LINEAR),
+                                    _ => std::option::Option::None,
+                                }
+                            }
                         }
 
-                        impl std::convert::From<std::string::String> for InterpolationType {
-                            fn from(value: std::string::String) -> Self {
-                                Self(std::borrow::Cow::Owned(value))
+                        impl std::convert::From<i32> for InterpolationType {
+                            fn from(value: i32) -> Self {
+                                Self::new(value)
                             }
                         }
 
                         impl std::default::Default for InterpolationType {
                             fn default() -> Self {
-                                interpolation_type::INTERPOLATION_TYPE_UNSPECIFIED
+                                Self::new(0)
                             }
                         }
                     }
@@ -6044,47 +6264,63 @@ pub mod search_knowledge_request {
     ///
     /// [google.cloud.dialogflow.v2.Participants.SuggestKnowledgeAssist]: crate::client::Participants::suggest_knowledge_assist
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct QuerySource(std::borrow::Cow<'static, str>);
+    pub struct QuerySource(i32);
 
     impl QuerySource {
-        /// Creates a new QuerySource instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [QuerySource](QuerySource)
-    pub mod query_source {
-        use super::QuerySource;
-
         /// Unknown query source.
-        pub const QUERY_SOURCE_UNSPECIFIED: QuerySource =
-            QuerySource::new("QUERY_SOURCE_UNSPECIFIED");
+        pub const QUERY_SOURCE_UNSPECIFIED: QuerySource = QuerySource::new(0);
 
         /// The query is from agents.
-        pub const AGENT_QUERY: QuerySource = QuerySource::new("AGENT_QUERY");
+        pub const AGENT_QUERY: QuerySource = QuerySource::new(1);
 
         /// The query is a suggested query from
         /// [Participants.SuggestKnowledgeAssist][google.cloud.dialogflow.v2.Participants.SuggestKnowledgeAssist].
         ///
         /// [google.cloud.dialogflow.v2.Participants.SuggestKnowledgeAssist]: crate::client::Participants::suggest_knowledge_assist
-        pub const SUGGESTED_QUERY: QuerySource = QuerySource::new("SUGGESTED_QUERY");
+        pub const SUGGESTED_QUERY: QuerySource = QuerySource::new(2);
+
+        /// Creates a new QuerySource instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("QUERY_SOURCE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AGENT_QUERY"),
+                2 => std::borrow::Cow::Borrowed("SUGGESTED_QUERY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "QUERY_SOURCE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::QUERY_SOURCE_UNSPECIFIED)
+                }
+                "AGENT_QUERY" => std::option::Option::Some(Self::AGENT_QUERY),
+                "SUGGESTED_QUERY" => std::option::Option::Some(Self::SUGGESTED_QUERY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for QuerySource {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for QuerySource {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for QuerySource {
         fn default() -> Self {
-            query_source::QUERY_SOURCE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6277,46 +6513,65 @@ pub mod search_knowledge_answer {
 
     /// The type of the answer.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AnswerType(std::borrow::Cow<'static, str>);
+    pub struct AnswerType(i32);
 
     impl AnswerType {
+        /// The answer has a unspecified type.
+        pub const ANSWER_TYPE_UNSPECIFIED: AnswerType = AnswerType::new(0);
+
+        /// The answer is from FAQ documents.
+        pub const FAQ: AnswerType = AnswerType::new(1);
+
+        /// The answer is from generative model.
+        pub const GENERATIVE: AnswerType = AnswerType::new(2);
+
+        /// The answer is from intent matching.
+        pub const INTENT: AnswerType = AnswerType::new(3);
+
         /// Creates a new AnswerType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ANSWER_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FAQ"),
+                2 => std::borrow::Cow::Borrowed("GENERATIVE"),
+                3 => std::borrow::Cow::Borrowed("INTENT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ANSWER_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ANSWER_TYPE_UNSPECIFIED)
+                }
+                "FAQ" => std::option::Option::Some(Self::FAQ),
+                "GENERATIVE" => std::option::Option::Some(Self::GENERATIVE),
+                "INTENT" => std::option::Option::Some(Self::INTENT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AnswerType](AnswerType)
-    pub mod answer_type {
-        use super::AnswerType;
-
-        /// The answer has a unspecified type.
-        pub const ANSWER_TYPE_UNSPECIFIED: AnswerType = AnswerType::new("ANSWER_TYPE_UNSPECIFIED");
-
-        /// The answer is from FAQ documents.
-        pub const FAQ: AnswerType = AnswerType::new("FAQ");
-
-        /// The answer is from generative model.
-        pub const GENERATIVE: AnswerType = AnswerType::new("GENERATIVE");
-
-        /// The answer is from intent matching.
-        pub const INTENT: AnswerType = AnswerType::new("INTENT");
-    }
-
-    impl std::convert::From<std::string::String> for AnswerType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AnswerType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AnswerType {
         fn default() -> Self {
-            answer_type::ANSWER_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7224,51 +7479,36 @@ pub mod conversation_event {
 
     /// Enumeration of the types of events available.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// Type not set.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// A new conversation has been opened. This is fired when a telephone call
         /// is answered, or a conversation is created via the API.
-        pub const CONVERSATION_STARTED: Type = Type::new("CONVERSATION_STARTED");
+        pub const CONVERSATION_STARTED: Type = Type::new(1);
 
         /// An existing conversation has closed. This is fired when a telephone call
         /// is terminated, or a conversation is closed via the API.
-        pub const CONVERSATION_FINISHED: Type = Type::new("CONVERSATION_FINISHED");
+        pub const CONVERSATION_FINISHED: Type = Type::new(2);
 
         /// An existing conversation has received notification from Dialogflow that
         /// human intervention is required.
-        pub const HUMAN_INTERVENTION_NEEDED: Type = Type::new("HUMAN_INTERVENTION_NEEDED");
+        pub const HUMAN_INTERVENTION_NEEDED: Type = Type::new(3);
 
         /// An existing conversation has received a new message, either from API or
         /// telephony. It is configured in
         /// [ConversationProfile.new_message_event_notification_config][google.cloud.dialogflow.v2.ConversationProfile.new_message_event_notification_config]
         ///
         /// [google.cloud.dialogflow.v2.ConversationProfile.new_message_event_notification_config]: crate::model::ConversationProfile::new_message_event_notification_config
-        pub const NEW_MESSAGE: Type = Type::new("NEW_MESSAGE");
+        pub const NEW_MESSAGE: Type = Type::new(5);
 
         /// An existing conversation has received a new speech recognition result.
         /// This is mainly for delivering intermediate transcripts. The notification
         /// is configured in
         /// [ConversationProfile.new_recognition_event_notification_config][].
-        pub const NEW_RECOGNITION_RESULT: Type = Type::new("NEW_RECOGNITION_RESULT");
+        pub const NEW_RECOGNITION_RESULT: Type = Type::new(7);
 
         /// Unrecoverable error during a telephone call.
         ///
@@ -7280,18 +7520,58 @@ pub mod conversation_event {
         ///
         /// * in an API call because we can directly return the error, or,
         /// * when we can recover from an error.
-        pub const UNRECOVERABLE_ERROR: Type = Type::new("UNRECOVERABLE_ERROR");
+        pub const UNRECOVERABLE_ERROR: Type = Type::new(4);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CONVERSATION_STARTED"),
+                2 => std::borrow::Cow::Borrowed("CONVERSATION_FINISHED"),
+                3 => std::borrow::Cow::Borrowed("HUMAN_INTERVENTION_NEEDED"),
+                4 => std::borrow::Cow::Borrowed("UNRECOVERABLE_ERROR"),
+                5 => std::borrow::Cow::Borrowed("NEW_MESSAGE"),
+                7 => std::borrow::Cow::Borrowed("NEW_RECOGNITION_RESULT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "CONVERSATION_STARTED" => std::option::Option::Some(Self::CONVERSATION_STARTED),
+                "CONVERSATION_FINISHED" => std::option::Option::Some(Self::CONVERSATION_FINISHED),
+                "HUMAN_INTERVENTION_NEEDED" => {
+                    std::option::Option::Some(Self::HUMAN_INTERVENTION_NEEDED)
+                }
+                "NEW_MESSAGE" => std::option::Option::Some(Self::NEW_MESSAGE),
+                "NEW_RECOGNITION_RESULT" => std::option::Option::Some(Self::NEW_RECOGNITION_RESULT),
+                "UNRECOVERABLE_ERROR" => std::option::Option::Some(Self::UNRECOVERABLE_ERROR),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -7520,106 +7800,149 @@ pub mod conversation_model {
 
     /// State of the model.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Should not be used, an un-set enum has this value by default.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Model being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// Model is not deployed but ready to deploy.
-        pub const UNDEPLOYED: State = State::new("UNDEPLOYED");
+        pub const UNDEPLOYED: State = State::new(2);
 
         /// Model is deploying.
-        pub const DEPLOYING: State = State::new("DEPLOYING");
+        pub const DEPLOYING: State = State::new(3);
 
         /// Model is deployed and ready to use.
-        pub const DEPLOYED: State = State::new("DEPLOYED");
+        pub const DEPLOYED: State = State::new(4);
 
         /// Model is undeploying.
-        pub const UNDEPLOYING: State = State::new("UNDEPLOYING");
+        pub const UNDEPLOYING: State = State::new(5);
 
         /// Model is deleting.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(6);
 
         /// Model is in error state. Not ready to deploy and use.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(7);
 
         /// Model is being created but the training has not started,
         /// The model may remain in this state until there is enough capacity to
         /// start training.
-        pub const PENDING: State = State::new("PENDING");
+        pub const PENDING: State = State::new(8);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("UNDEPLOYED"),
+                3 => std::borrow::Cow::Borrowed("DEPLOYING"),
+                4 => std::borrow::Cow::Borrowed("DEPLOYED"),
+                5 => std::borrow::Cow::Borrowed("UNDEPLOYING"),
+                6 => std::borrow::Cow::Borrowed("DELETING"),
+                7 => std::borrow::Cow::Borrowed("FAILED"),
+                8 => std::borrow::Cow::Borrowed("PENDING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "UNDEPLOYED" => std::option::Option::Some(Self::UNDEPLOYED),
+                "DEPLOYING" => std::option::Option::Some(Self::DEPLOYING),
+                "DEPLOYED" => std::option::Option::Some(Self::DEPLOYED),
+                "UNDEPLOYING" => std::option::Option::Some(Self::UNDEPLOYING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Model type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ModelType(std::borrow::Cow<'static, str>);
+    pub struct ModelType(i32);
 
     impl ModelType {
+        /// ModelType unspecified.
+        pub const MODEL_TYPE_UNSPECIFIED: ModelType = ModelType::new(0);
+
+        /// ModelType smart reply dual encoder model.
+        pub const SMART_REPLY_DUAL_ENCODER_MODEL: ModelType = ModelType::new(2);
+
+        /// ModelType smart reply bert model.
+        pub const SMART_REPLY_BERT_MODEL: ModelType = ModelType::new(6);
+
         /// Creates a new ModelType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MODEL_TYPE_UNSPECIFIED"),
+                2 => std::borrow::Cow::Borrowed("SMART_REPLY_DUAL_ENCODER_MODEL"),
+                6 => std::borrow::Cow::Borrowed("SMART_REPLY_BERT_MODEL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MODEL_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::MODEL_TYPE_UNSPECIFIED),
+                "SMART_REPLY_DUAL_ENCODER_MODEL" => {
+                    std::option::Option::Some(Self::SMART_REPLY_DUAL_ENCODER_MODEL)
+                }
+                "SMART_REPLY_BERT_MODEL" => std::option::Option::Some(Self::SMART_REPLY_BERT_MODEL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ModelType](ModelType)
-    pub mod model_type {
-        use super::ModelType;
-
-        /// ModelType unspecified.
-        pub const MODEL_TYPE_UNSPECIFIED: ModelType = ModelType::new("MODEL_TYPE_UNSPECIFIED");
-
-        /// ModelType smart reply dual encoder model.
-        pub const SMART_REPLY_DUAL_ENCODER_MODEL: ModelType =
-            ModelType::new("SMART_REPLY_DUAL_ENCODER_MODEL");
-
-        /// ModelType smart reply bert model.
-        pub const SMART_REPLY_BERT_MODEL: ModelType = ModelType::new("SMART_REPLY_BERT_MODEL");
-    }
-
-    impl std::convert::From<std::string::String> for ModelType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ModelType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ModelType {
         fn default() -> Self {
-            model_type::MODEL_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -8793,57 +9116,80 @@ pub mod create_conversation_model_operation_metadata {
 
     /// State of CreateConversationModel operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Invalid.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Request is submitted, but training has not started yet.
         /// The model may remain in this state until there is enough capacity to
         /// start training.
-        pub const PENDING: State = State::new("PENDING");
+        pub const PENDING: State = State::new(1);
 
         /// The training has succeeded.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
+        pub const SUCCEEDED: State = State::new(2);
 
         /// The training has succeeded.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(3);
 
         /// The training has been cancelled.
-        pub const CANCELLED: State = State::new("CANCELLED");
+        pub const CANCELLED: State = State::new(4);
 
         /// The training is in cancelling state.
-        pub const CANCELLING: State = State::new("CANCELLING");
+        pub const CANCELLING: State = State::new(5);
 
         /// Custom model is training.
-        pub const TRAINING: State = State::new("TRAINING");
+        pub const TRAINING: State = State::new(6);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                4 => std::borrow::Cow::Borrowed("CANCELLED"),
+                5 => std::borrow::Cow::Borrowed("CANCELLING"),
+                6 => std::borrow::Cow::Borrowed("TRAINING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
+                "TRAINING" => std::option::Option::Some(Self::TRAINING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -9091,52 +9437,73 @@ pub mod create_conversation_model_evaluation_operation_metadata {
 
     /// State of CreateConversationModel operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Operation status not specified.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The operation is being prepared.
+        pub const INITIALIZING: State = State::new(1);
+
+        /// The operation is running.
+        pub const RUNNING: State = State::new(2);
+
+        /// The operation is cancelled.
+        pub const CANCELLED: State = State::new(3);
+
+        /// The operation has succeeded.
+        pub const SUCCEEDED: State = State::new(4);
+
+        /// The operation has failed.
+        pub const FAILED: State = State::new(5);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INITIALIZING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("CANCELLED"),
+                4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                5 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "INITIALIZING" => std::option::Option::Some(Self::INITIALIZING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Operation status not specified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The operation is being prepared.
-        pub const INITIALIZING: State = State::new("INITIALIZING");
-
-        /// The operation is running.
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// The operation is cancelled.
-        pub const CANCELLED: State = State::new("CANCELLED");
-
-        /// The operation has succeeded.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-        /// The operation has failed.
-        pub const FAILED: State = State::new("FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -10621,68 +10988,94 @@ pub mod human_agent_assistant_config {
             /// Selectable sections to return when requesting a summary of a
             /// conversation.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct SectionType(std::borrow::Cow<'static, str>);
+            pub struct SectionType(i32);
 
             impl SectionType {
-                /// Creates a new SectionType instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [SectionType](SectionType)
-            pub mod section_type {
-                use super::SectionType;
-
                 /// Undefined section type, does not return anything.
-                pub const SECTION_TYPE_UNSPECIFIED: SectionType =
-                    SectionType::new("SECTION_TYPE_UNSPECIFIED");
+                pub const SECTION_TYPE_UNSPECIFIED: SectionType = SectionType::new(0);
 
                 /// What the customer needs help with or has question about.
                 /// Section name: "situation".
-                pub const SITUATION: SectionType = SectionType::new("SITUATION");
+                pub const SITUATION: SectionType = SectionType::new(1);
 
                 /// What the agent does to help the customer.
                 /// Section name: "action".
-                pub const ACTION: SectionType = SectionType::new("ACTION");
+                pub const ACTION: SectionType = SectionType::new(2);
 
                 /// Result of the customer service. A single word describing the result
                 /// of the conversation.
                 /// Section name: "resolution".
-                pub const RESOLUTION: SectionType = SectionType::new("RESOLUTION");
+                pub const RESOLUTION: SectionType = SectionType::new(3);
 
                 /// Reason for cancellation if the customer requests for a cancellation.
                 /// "N/A" otherwise.
                 /// Section name: "reason_for_cancellation".
-                pub const REASON_FOR_CANCELLATION: SectionType =
-                    SectionType::new("REASON_FOR_CANCELLATION");
+                pub const REASON_FOR_CANCELLATION: SectionType = SectionType::new(4);
 
                 /// "Unsatisfied" or "Satisfied" depending on the customer's feelings at
                 /// the end of the conversation.
                 /// Section name: "customer_satisfaction".
-                pub const CUSTOMER_SATISFACTION: SectionType =
-                    SectionType::new("CUSTOMER_SATISFACTION");
+                pub const CUSTOMER_SATISFACTION: SectionType = SectionType::new(5);
 
                 /// Key entities extracted from the conversation, such as ticket number,
                 /// order number, dollar amount, etc.
                 /// Section names are prefixed by "entities/".
-                pub const ENTITIES: SectionType = SectionType::new("ENTITIES");
+                pub const ENTITIES: SectionType = SectionType::new(6);
+
+                /// Creates a new SectionType instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("SECTION_TYPE_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("SITUATION"),
+                        2 => std::borrow::Cow::Borrowed("ACTION"),
+                        3 => std::borrow::Cow::Borrowed("RESOLUTION"),
+                        4 => std::borrow::Cow::Borrowed("REASON_FOR_CANCELLATION"),
+                        5 => std::borrow::Cow::Borrowed("CUSTOMER_SATISFACTION"),
+                        6 => std::borrow::Cow::Borrowed("ENTITIES"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "SECTION_TYPE_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::SECTION_TYPE_UNSPECIFIED)
+                        }
+                        "SITUATION" => std::option::Option::Some(Self::SITUATION),
+                        "ACTION" => std::option::Option::Some(Self::ACTION),
+                        "RESOLUTION" => std::option::Option::Some(Self::RESOLUTION),
+                        "REASON_FOR_CANCELLATION" => {
+                            std::option::Option::Some(Self::REASON_FOR_CANCELLATION)
+                        }
+                        "CUSTOMER_SATISFACTION" => {
+                            std::option::Option::Some(Self::CUSTOMER_SATISFACTION)
+                        }
+                        "ENTITIES" => std::option::Option::Some(Self::ENTITIES),
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for SectionType {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for SectionType {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for SectionType {
                 fn default() -> Self {
-                    section_type::SECTION_TYPE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -11163,44 +11556,60 @@ pub mod notification_config {
 
     /// Format of cloud pub/sub message.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MessageFormat(std::borrow::Cow<'static, str>);
+    pub struct MessageFormat(i32);
 
     impl MessageFormat {
+        /// If it is unspecified, PROTO will be used.
+        pub const MESSAGE_FORMAT_UNSPECIFIED: MessageFormat = MessageFormat::new(0);
+
+        /// Pub/Sub message will be serialized proto.
+        pub const PROTO: MessageFormat = MessageFormat::new(1);
+
+        /// Pub/Sub message will be json.
+        pub const JSON: MessageFormat = MessageFormat::new(2);
+
         /// Creates a new MessageFormat instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MESSAGE_FORMAT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROTO"),
+                2 => std::borrow::Cow::Borrowed("JSON"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MESSAGE_FORMAT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MESSAGE_FORMAT_UNSPECIFIED)
+                }
+                "PROTO" => std::option::Option::Some(Self::PROTO),
+                "JSON" => std::option::Option::Some(Self::JSON),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [MessageFormat](MessageFormat)
-    pub mod message_format {
-        use super::MessageFormat;
-
-        /// If it is unspecified, PROTO will be used.
-        pub const MESSAGE_FORMAT_UNSPECIFIED: MessageFormat =
-            MessageFormat::new("MESSAGE_FORMAT_UNSPECIFIED");
-
-        /// Pub/Sub message will be serialized proto.
-        pub const PROTO: MessageFormat = MessageFormat::new("PROTO");
-
-        /// Pub/Sub message will be json.
-        pub const JSON: MessageFormat = MessageFormat::new("JSON");
-    }
-
-    impl std::convert::From<std::string::String> for MessageFormat {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MessageFormat {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MessageFormat {
         fn default() -> Self {
-            message_format::MESSAGE_FORMAT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -11280,55 +11689,80 @@ pub mod suggestion_feature {
 
     /// Defines the type of Human Agent Assistant feature.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Unspecified feature type.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// Run article suggestion model for chat.
+        pub const ARTICLE_SUGGESTION: Type = Type::new(1);
+
+        /// Run FAQ model for chat.
+        pub const FAQ: Type = Type::new(2);
+
+        /// Run smart reply model for chat.
+        pub const SMART_REPLY: Type = Type::new(3);
+
+        /// Run conversation summarization model for chat.
+        pub const CONVERSATION_SUMMARIZATION: Type = Type::new(8);
+
+        /// Run knowledge search with text input from agent or text generated query.
+        pub const KNOWLEDGE_SEARCH: Type = Type::new(14);
+
+        /// Run knowledge assist with automatic query generation.
+        pub const KNOWLEDGE_ASSIST: Type = Type::new(15);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ARTICLE_SUGGESTION"),
+                2 => std::borrow::Cow::Borrowed("FAQ"),
+                3 => std::borrow::Cow::Borrowed("SMART_REPLY"),
+                8 => std::borrow::Cow::Borrowed("CONVERSATION_SUMMARIZATION"),
+                14 => std::borrow::Cow::Borrowed("KNOWLEDGE_SEARCH"),
+                15 => std::borrow::Cow::Borrowed("KNOWLEDGE_ASSIST"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "ARTICLE_SUGGESTION" => std::option::Option::Some(Self::ARTICLE_SUGGESTION),
+                "FAQ" => std::option::Option::Some(Self::FAQ),
+                "SMART_REPLY" => std::option::Option::Some(Self::SMART_REPLY),
+                "CONVERSATION_SUMMARIZATION" => {
+                    std::option::Option::Some(Self::CONVERSATION_SUMMARIZATION)
+                }
+                "KNOWLEDGE_SEARCH" => std::option::Option::Some(Self::KNOWLEDGE_SEARCH),
+                "KNOWLEDGE_ASSIST" => std::option::Option::Some(Self::KNOWLEDGE_ASSIST),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Unspecified feature type.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// Run article suggestion model for chat.
-        pub const ARTICLE_SUGGESTION: Type = Type::new("ARTICLE_SUGGESTION");
-
-        /// Run FAQ model for chat.
-        pub const FAQ: Type = Type::new("FAQ");
-
-        /// Run smart reply model for chat.
-        pub const SMART_REPLY: Type = Type::new("SMART_REPLY");
-
-        /// Run conversation summarization model for chat.
-        pub const CONVERSATION_SUMMARIZATION: Type = Type::new("CONVERSATION_SUMMARIZATION");
-
-        /// Run knowledge search with text input from agent or text generated query.
-        pub const KNOWLEDGE_SEARCH: Type = Type::new("KNOWLEDGE_SEARCH");
-
-        /// Run knowledge assist with automatic query generation.
-        pub const KNOWLEDGE_ASSIST: Type = Type::new("KNOWLEDGE_ASSIST");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -11882,27 +12316,11 @@ pub mod document {
 
     /// The knowledge type of document content.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct KnowledgeType(std::borrow::Cow<'static, str>);
+    pub struct KnowledgeType(i32);
 
     impl KnowledgeType {
-        /// Creates a new KnowledgeType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [KnowledgeType](KnowledgeType)
-    pub mod knowledge_type {
-        use super::KnowledgeType;
-
         /// The type is unspecified or arbitrary.
-        pub const KNOWLEDGE_TYPE_UNSPECIFIED: KnowledgeType =
-            KnowledgeType::new("KNOWLEDGE_TYPE_UNSPECIFIED");
+        pub const KNOWLEDGE_TYPE_UNSPECIFIED: KnowledgeType = KnowledgeType::new(0);
 
         /// The document content contains question and answer pairs as either HTML or
         /// CSV. Typical FAQ HTML formats are parsed accurately, but unusual formats
@@ -11911,81 +12329,139 @@ pub mod document {
         /// CSV must have questions in the first column and answers in the second,
         /// with no header. Because of this explicit format, they are always parsed
         /// accurately.
-        pub const FAQ: KnowledgeType = KnowledgeType::new("FAQ");
+        pub const FAQ: KnowledgeType = KnowledgeType::new(1);
 
         /// Documents for which unstructured text is extracted and used for
         /// question answering.
-        pub const EXTRACTIVE_QA: KnowledgeType = KnowledgeType::new("EXTRACTIVE_QA");
+        pub const EXTRACTIVE_QA: KnowledgeType = KnowledgeType::new(2);
 
         /// The entire document content as a whole can be used for query results.
         /// Only for Contact Center Solutions on Dialogflow.
-        pub const ARTICLE_SUGGESTION: KnowledgeType = KnowledgeType::new("ARTICLE_SUGGESTION");
+        pub const ARTICLE_SUGGESTION: KnowledgeType = KnowledgeType::new(3);
 
         /// The document contains agent-facing Smart Reply entries.
-        pub const AGENT_FACING_SMART_REPLY: KnowledgeType =
-            KnowledgeType::new("AGENT_FACING_SMART_REPLY");
+        pub const AGENT_FACING_SMART_REPLY: KnowledgeType = KnowledgeType::new(4);
+
+        /// Creates a new KnowledgeType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("KNOWLEDGE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FAQ"),
+                2 => std::borrow::Cow::Borrowed("EXTRACTIVE_QA"),
+                3 => std::borrow::Cow::Borrowed("ARTICLE_SUGGESTION"),
+                4 => std::borrow::Cow::Borrowed("AGENT_FACING_SMART_REPLY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "KNOWLEDGE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::KNOWLEDGE_TYPE_UNSPECIFIED)
+                }
+                "FAQ" => std::option::Option::Some(Self::FAQ),
+                "EXTRACTIVE_QA" => std::option::Option::Some(Self::EXTRACTIVE_QA),
+                "ARTICLE_SUGGESTION" => std::option::Option::Some(Self::ARTICLE_SUGGESTION),
+                "AGENT_FACING_SMART_REPLY" => {
+                    std::option::Option::Some(Self::AGENT_FACING_SMART_REPLY)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for KnowledgeType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for KnowledgeType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for KnowledgeType {
         fn default() -> Self {
-            knowledge_type::KNOWLEDGE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Possible states of the document
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The document state is unspecified.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The document creation is in progress.
+        pub const CREATING: State = State::new(1);
+
+        /// The document is active and ready to use.
+        pub const ACTIVE: State = State::new(2);
+
+        /// The document updation is in progress.
+        pub const UPDATING: State = State::new(3);
+
+        /// The document is reloading.
+        pub const RELOADING: State = State::new(4);
+
+        /// The document deletion is in progress.
+        pub const DELETING: State = State::new(5);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("RELOADING"),
+                5 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "RELOADING" => std::option::Option::Some(Self::RELOADING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The document state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The document creation is in progress.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The document is active and ready to use.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The document updation is in progress.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// The document is reloading.
-        pub const RELOADING: State = State::new("RELOADING");
-
-        /// The document deletion is in progress.
-        pub const DELETING: State = State::new("DELETING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -12933,46 +13409,63 @@ pub mod knowledge_operation_metadata {
 
     /// States of the operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State unspecified.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The operation has been created.
+        pub const PENDING: State = State::new(1);
+
+        /// The operation is currently running.
+        pub const RUNNING: State = State::new(2);
+
+        /// The operation is done, either cancelled or completed.
+        pub const DONE: State = State::new(3);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("DONE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "DONE" => std::option::Option::Some(Self::DONE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The operation has been created.
-        pub const PENDING: State = State::new("PENDING");
-
-        /// The operation is currently running.
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// The operation is done, either cancelled or completed.
-        pub const DONE: State = State::new("DONE");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -13329,50 +13822,67 @@ pub mod entity_type {
 
     /// Represents kinds of entities.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Kind(std::borrow::Cow<'static, str>);
+    pub struct Kind(i32);
 
     impl Kind {
-        /// Creates a new Kind instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Kind](Kind)
-    pub mod kind {
-        use super::Kind;
-
         /// Not specified. This value should be never used.
-        pub const KIND_UNSPECIFIED: Kind = Kind::new("KIND_UNSPECIFIED");
+        pub const KIND_UNSPECIFIED: Kind = Kind::new(0);
 
         /// Map entity types allow mapping of a group of synonyms to a reference
         /// value.
-        pub const KIND_MAP: Kind = Kind::new("KIND_MAP");
+        pub const KIND_MAP: Kind = Kind::new(1);
 
         /// List entity types contain a set of entries that do not map to reference
         /// values. However, list entity types can contain references to other entity
         /// types (with or without aliases).
-        pub const KIND_LIST: Kind = Kind::new("KIND_LIST");
+        pub const KIND_LIST: Kind = Kind::new(2);
 
         /// Regexp entity types allow to specify regular expressions in entries
         /// values.
-        pub const KIND_REGEXP: Kind = Kind::new("KIND_REGEXP");
+        pub const KIND_REGEXP: Kind = Kind::new(3);
+
+        /// Creates a new Kind instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("KIND_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("KIND_MAP"),
+                2 => std::borrow::Cow::Borrowed("KIND_LIST"),
+                3 => std::borrow::Cow::Borrowed("KIND_REGEXP"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "KIND_UNSPECIFIED" => std::option::Option::Some(Self::KIND_UNSPECIFIED),
+                "KIND_MAP" => std::option::Option::Some(Self::KIND_MAP),
+                "KIND_LIST" => std::option::Option::Some(Self::KIND_LIST),
+                "KIND_REGEXP" => std::option::Option::Some(Self::KIND_REGEXP),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Kind {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Kind {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Kind {
         fn default() -> Self {
-            kind::KIND_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -13380,43 +13890,58 @@ pub mod entity_type {
     /// allows an agent to recognize values that have not been explicitly listed in
     /// the entity (for example, new kinds of shopping list items).
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AutoExpansionMode(std::borrow::Cow<'static, str>);
+    pub struct AutoExpansionMode(i32);
 
     impl AutoExpansionMode {
-        /// Creates a new AutoExpansionMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [AutoExpansionMode](AutoExpansionMode)
-    pub mod auto_expansion_mode {
-        use super::AutoExpansionMode;
-
         /// Auto expansion disabled for the entity.
-        pub const AUTO_EXPANSION_MODE_UNSPECIFIED: AutoExpansionMode =
-            AutoExpansionMode::new("AUTO_EXPANSION_MODE_UNSPECIFIED");
+        pub const AUTO_EXPANSION_MODE_UNSPECIFIED: AutoExpansionMode = AutoExpansionMode::new(0);
 
         /// Allows an agent to recognize values that have not been explicitly
         /// listed in the entity.
-        pub const AUTO_EXPANSION_MODE_DEFAULT: AutoExpansionMode =
-            AutoExpansionMode::new("AUTO_EXPANSION_MODE_DEFAULT");
+        pub const AUTO_EXPANSION_MODE_DEFAULT: AutoExpansionMode = AutoExpansionMode::new(1);
+
+        /// Creates a new AutoExpansionMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("AUTO_EXPANSION_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AUTO_EXPANSION_MODE_DEFAULT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "AUTO_EXPANSION_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::AUTO_EXPANSION_MODE_UNSPECIFIED)
+                }
+                "AUTO_EXPANSION_MODE_DEFAULT" => {
+                    std::option::Option::Some(Self::AUTO_EXPANSION_MODE_DEFAULT)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for AutoExpansionMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AutoExpansionMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AutoExpansionMode {
         fn default() -> Self {
-            auto_expansion_mode::AUTO_EXPANSION_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -14388,46 +14913,63 @@ pub mod environment {
     /// the agent. After the new agent version is done loading, the environment is
     /// set back to the `RUNNING` state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Not specified. This value is not used.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Stopped.
+        pub const STOPPED: State = State::new(1);
+
+        /// Loading.
+        pub const LOADING: State = State::new(2);
+
+        /// Running.
+        pub const RUNNING: State = State::new(3);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STOPPED"),
+                2 => std::borrow::Cow::Borrowed("LOADING"),
+                3 => std::borrow::Cow::Borrowed("RUNNING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "STOPPED" => std::option::Option::Some(Self::STOPPED),
+                "LOADING" => std::option::Option::Some(Self::LOADING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Not specified. This value is not used.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Stopped.
-        pub const STOPPED: State = State::new("STOPPED");
-
-        /// Loading.
-        pub const LOADING: State = State::new("LOADING");
-
-        /// Running.
-        pub const RUNNING: State = State::new("RUNNING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -15286,40 +15828,53 @@ pub mod fulfillment {
 
         /// The type of the feature.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(std::borrow::Cow<'static, str>);
+        pub struct Type(i32);
 
         impl Type {
+            /// Feature type not specified.
+            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+            /// Fulfillment is enabled for SmallTalk.
+            pub const SMALLTALK: Type = Type::new(1);
+
             /// Creates a new Type instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("SMALLTALK"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                    "SMALLTALK" => std::option::Option::Some(Self::SMALLTALK),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Type](Type)
-        pub mod r#type {
-            use super::Type;
-
-            /// Feature type not specified.
-            pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-            /// Fulfillment is enabled for SmallTalk.
-            pub const SMALLTALK: Type = Type::new("SMALLTALK");
-        }
-
-        impl std::convert::From<std::string::String> for Type {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                r#type::TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -15837,47 +16392,64 @@ pub mod message_entry {
 
     /// Enumeration of the roles a participant can play in a conversation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Role(std::borrow::Cow<'static, str>);
+    pub struct Role(i32);
 
     impl Role {
-        /// Creates a new Role instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Role](Role)
-    pub mod role {
-        use super::Role;
-
         /// Participant role not set.
-        pub const ROLE_UNSPECIFIED: Role = Role::new("ROLE_UNSPECIFIED");
+        pub const ROLE_UNSPECIFIED: Role = Role::new(0);
 
         /// Participant is a human agent.
-        pub const HUMAN_AGENT: Role = Role::new("HUMAN_AGENT");
+        pub const HUMAN_AGENT: Role = Role::new(1);
 
         /// Participant is an automated agent, such as a Dialogflow agent.
-        pub const AUTOMATED_AGENT: Role = Role::new("AUTOMATED_AGENT");
+        pub const AUTOMATED_AGENT: Role = Role::new(2);
 
         /// Participant is an end user that has called or chatted with
         /// Dialogflow services.
-        pub const END_USER: Role = Role::new("END_USER");
+        pub const END_USER: Role = Role::new(3);
+
+        /// Creates a new Role instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ROLE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("HUMAN_AGENT"),
+                2 => std::borrow::Cow::Borrowed("AUTOMATED_AGENT"),
+                3 => std::borrow::Cow::Borrowed("END_USER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ROLE_UNSPECIFIED" => std::option::Option::Some(Self::ROLE_UNSPECIFIED),
+                "HUMAN_AGENT" => std::option::Option::Some(Self::HUMAN_AGENT),
+                "AUTOMATED_AGENT" => std::option::Option::Some(Self::AUTOMATED_AGENT),
+                "END_USER" => std::option::Option::Some(Self::END_USER),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Role {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Role {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Role {
         fn default() -> Self {
-            role::ROLE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -16222,76 +16794,107 @@ pub mod summarization_section {
 
     /// Type enum of the summarization sections.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// Undefined section type, does not return anything.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// What the customer needs help with or has question about.
         /// Section name: "situation".
-        pub const SITUATION: Type = Type::new("SITUATION");
+        pub const SITUATION: Type = Type::new(1);
 
         /// What the agent does to help the customer.
         /// Section name: "action".
-        pub const ACTION: Type = Type::new("ACTION");
+        pub const ACTION: Type = Type::new(2);
 
         /// Result of the customer service. A single word describing the result
         /// of the conversation.
         /// Section name: "resolution".
-        pub const RESOLUTION: Type = Type::new("RESOLUTION");
+        pub const RESOLUTION: Type = Type::new(3);
 
         /// Reason for cancellation if the customer requests for a cancellation.
         /// "N/A" otherwise.
         /// Section name: "reason_for_cancellation".
-        pub const REASON_FOR_CANCELLATION: Type = Type::new("REASON_FOR_CANCELLATION");
+        pub const REASON_FOR_CANCELLATION: Type = Type::new(4);
 
         /// "Unsatisfied" or "Satisfied" depending on the customer's feelings at
         /// the end of the conversation.
         /// Section name: "customer_satisfaction".
-        pub const CUSTOMER_SATISFACTION: Type = Type::new("CUSTOMER_SATISFACTION");
+        pub const CUSTOMER_SATISFACTION: Type = Type::new(5);
 
         /// Key entities extracted from the conversation, such as ticket number,
         /// order number, dollar amount, etc.
         /// Section names are prefixed by "entities/".
-        pub const ENTITIES: Type = Type::new("ENTITIES");
+        pub const ENTITIES: Type = Type::new(6);
 
         /// Customer defined sections.
-        pub const CUSTOMER_DEFINED: Type = Type::new("CUSTOMER_DEFINED");
+        pub const CUSTOMER_DEFINED: Type = Type::new(7);
 
         /// Concise version of the situation section. This type is only available if
         /// type SITUATION is not selected.
-        pub const SITUATION_CONCISE: Type = Type::new("SITUATION_CONCISE");
+        pub const SITUATION_CONCISE: Type = Type::new(9);
 
         /// Concise version of the action section. This type is only available if
         /// type ACTION is not selected.
-        pub const ACTION_CONCISE: Type = Type::new("ACTION_CONCISE");
+        pub const ACTION_CONCISE: Type = Type::new(10);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SITUATION"),
+                2 => std::borrow::Cow::Borrowed("ACTION"),
+                3 => std::borrow::Cow::Borrowed("RESOLUTION"),
+                4 => std::borrow::Cow::Borrowed("REASON_FOR_CANCELLATION"),
+                5 => std::borrow::Cow::Borrowed("CUSTOMER_SATISFACTION"),
+                6 => std::borrow::Cow::Borrowed("ENTITIES"),
+                7 => std::borrow::Cow::Borrowed("CUSTOMER_DEFINED"),
+                9 => std::borrow::Cow::Borrowed("SITUATION_CONCISE"),
+                10 => std::borrow::Cow::Borrowed("ACTION_CONCISE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "SITUATION" => std::option::Option::Some(Self::SITUATION),
+                "ACTION" => std::option::Option::Some(Self::ACTION),
+                "RESOLUTION" => std::option::Option::Some(Self::RESOLUTION),
+                "REASON_FOR_CANCELLATION" => {
+                    std::option::Option::Some(Self::REASON_FOR_CANCELLATION)
+                }
+                "CUSTOMER_SATISFACTION" => std::option::Option::Some(Self::CUSTOMER_SATISFACTION),
+                "ENTITIES" => std::option::Option::Some(Self::ENTITIES),
+                "CUSTOMER_DEFINED" => std::option::Option::Some(Self::CUSTOMER_DEFINED),
+                "SITUATION_CONCISE" => std::option::Option::Some(Self::SITUATION_CONCISE),
+                "ACTION_CONCISE" => std::option::Option::Some(Self::ACTION_CONCISE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -17420,30 +18023,15 @@ pub mod intent {
 
         /// Represents different types of training phrases.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(std::borrow::Cow<'static, str>);
+        pub struct Type(i32);
 
         impl Type {
-            /// Creates a new Type instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [Type](Type)
-        pub mod r#type {
-            use super::Type;
-
             /// Not specified. This value should never be used.
-            pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
             /// Examples do not contain @-prefixed entity type names, but example parts
             /// can be annotated with entity types.
-            pub const EXAMPLE: Type = Type::new("EXAMPLE");
+            pub const EXAMPLE: Type = Type::new(1);
 
             /// Templates are not annotated with entity types, but they can contain
             /// @-prefixed entity type names as substrings.
@@ -17451,18 +18039,48 @@ pub mod intent {
             /// way to create new training phrases. If you have existing training
             /// phrases that you've created in template mode, those will continue to
             /// work.
-            pub const TEMPLATE: Type = Type::new("TEMPLATE");
+            pub const TEMPLATE: Type = Type::new(2);
+
+            /// Creates a new Type instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("EXAMPLE"),
+                    2 => std::borrow::Cow::Borrowed("TEMPLATE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                    "EXAMPLE" => std::option::Option::Some(Self::EXAMPLE),
+                    "TEMPLATE" => std::option::Option::Some(Self::TEMPLATE),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for Type {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                r#type::TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -19239,41 +19857,56 @@ pub mod intent {
 
             /// Format of response media type.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct ResponseMediaType(std::borrow::Cow<'static, str>);
+            pub struct ResponseMediaType(i32);
 
             impl ResponseMediaType {
+                /// Unspecified.
+                pub const RESPONSE_MEDIA_TYPE_UNSPECIFIED: ResponseMediaType =
+                    ResponseMediaType::new(0);
+
+                /// Response media type is audio.
+                pub const AUDIO: ResponseMediaType = ResponseMediaType::new(1);
+
                 /// Creates a new ResponseMediaType instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
                 }
 
                 /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("RESPONSE_MEDIA_TYPE_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("AUDIO"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "RESPONSE_MEDIA_TYPE_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::RESPONSE_MEDIA_TYPE_UNSPECIFIED)
+                        }
+                        "AUDIO" => std::option::Option::Some(Self::AUDIO),
+                        _ => std::option::Option::None,
+                    }
                 }
             }
 
-            /// Useful constants to work with [ResponseMediaType](ResponseMediaType)
-            pub mod response_media_type {
-                use super::ResponseMediaType;
-
-                /// Unspecified.
-                pub const RESPONSE_MEDIA_TYPE_UNSPECIFIED: ResponseMediaType =
-                    ResponseMediaType::new("RESPONSE_MEDIA_TYPE_UNSPECIFIED");
-
-                /// Response media type is audio.
-                pub const AUDIO: ResponseMediaType = ResponseMediaType::new("AUDIO");
-            }
-
-            impl std::convert::From<std::string::String> for ResponseMediaType {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for ResponseMediaType {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for ResponseMediaType {
                 fn default() -> Self {
-                    response_media_type::RESPONSE_MEDIA_TYPE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -19486,45 +20119,64 @@ pub mod intent {
 
                     /// Type of the URI.
                     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                    pub struct UrlTypeHint(std::borrow::Cow<'static, str>);
+                    pub struct UrlTypeHint(i32);
 
                     impl UrlTypeHint {
-                        /// Creates a new UrlTypeHint instance.
-                        pub const fn new(v: &'static str) -> Self {
-                            Self(std::borrow::Cow::Borrowed(v))
-                        }
-
-                        /// Gets the enum value.
-                        pub fn value(&self) -> &str {
-                            &self.0
-                        }
-                    }
-
-                    /// Useful constants to work with [UrlTypeHint](UrlTypeHint)
-                    pub mod url_type_hint {
-                        use super::UrlTypeHint;
-
                         /// Unspecified
-                        pub const URL_TYPE_HINT_UNSPECIFIED: UrlTypeHint =
-                            UrlTypeHint::new("URL_TYPE_HINT_UNSPECIFIED");
+                        pub const URL_TYPE_HINT_UNSPECIFIED: UrlTypeHint = UrlTypeHint::new(0);
 
                         /// Url would be an amp action
-                        pub const AMP_ACTION: UrlTypeHint = UrlTypeHint::new("AMP_ACTION");
+                        pub const AMP_ACTION: UrlTypeHint = UrlTypeHint::new(1);
 
                         /// URL that points directly to AMP content, or to a canonical URL
                         /// which refers to AMP content via \<link rel="amphtml"\>.
-                        pub const AMP_CONTENT: UrlTypeHint = UrlTypeHint::new("AMP_CONTENT");
+                        pub const AMP_CONTENT: UrlTypeHint = UrlTypeHint::new(2);
+
+                        /// Creates a new UrlTypeHint instance.
+                        pub(crate) const fn new(value: i32) -> Self {
+                            Self(value)
+                        }
+
+                        /// Gets the enum value.
+                        pub fn value(&self) -> i32 {
+                            self.0
+                        }
+
+                        /// Gets the enum value as a string.
+                        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                            match self.0 {
+                                0 => std::borrow::Cow::Borrowed("URL_TYPE_HINT_UNSPECIFIED"),
+                                1 => std::borrow::Cow::Borrowed("AMP_ACTION"),
+                                2 => std::borrow::Cow::Borrowed("AMP_CONTENT"),
+                                _ => std::borrow::Cow::Owned(std::format!(
+                                    "UNKNOWN-VALUE:{}",
+                                    self.0
+                                )),
+                            }
+                        }
+
+                        /// Creates an enum value from the value name.
+                        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                            match name {
+                                "URL_TYPE_HINT_UNSPECIFIED" => {
+                                    std::option::Option::Some(Self::URL_TYPE_HINT_UNSPECIFIED)
+                                }
+                                "AMP_ACTION" => std::option::Option::Some(Self::AMP_ACTION),
+                                "AMP_CONTENT" => std::option::Option::Some(Self::AMP_CONTENT),
+                                _ => std::option::Option::None,
+                            }
+                        }
                     }
 
-                    impl std::convert::From<std::string::String> for UrlTypeHint {
-                        fn from(value: std::string::String) -> Self {
-                            Self(std::borrow::Cow::Owned(value))
+                    impl std::convert::From<i32> for UrlTypeHint {
+                        fn from(value: i32) -> Self {
+                            Self::new(value)
                         }
                     }
 
                     impl std::default::Default for UrlTypeHint {
                         fn default() -> Self {
-                            url_type_hint::URL_TYPE_HINT_UNSPECIFIED
+                            Self::new(0)
                         }
                     }
                 }
@@ -19534,36 +20186,21 @@ pub mod intent {
             /// when the image's aspect ratio does not match the image container's
             /// aspect ratio.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct ImageDisplayOptions(std::borrow::Cow<'static, str>);
+            pub struct ImageDisplayOptions(i32);
 
             impl ImageDisplayOptions {
-                /// Creates a new ImageDisplayOptions instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [ImageDisplayOptions](ImageDisplayOptions)
-            pub mod image_display_options {
-                use super::ImageDisplayOptions;
-
                 /// Fill the gaps between the image and the image container with gray
                 /// bars.
                 pub const IMAGE_DISPLAY_OPTIONS_UNSPECIFIED: ImageDisplayOptions =
-                    ImageDisplayOptions::new("IMAGE_DISPLAY_OPTIONS_UNSPECIFIED");
+                    ImageDisplayOptions::new(0);
 
                 /// Fill the gaps between the image and the image container with gray
                 /// bars.
-                pub const GRAY: ImageDisplayOptions = ImageDisplayOptions::new("GRAY");
+                pub const GRAY: ImageDisplayOptions = ImageDisplayOptions::new(1);
 
                 /// Fill the gaps between the image and the image container with white
                 /// bars.
-                pub const WHITE: ImageDisplayOptions = ImageDisplayOptions::new("WHITE");
+                pub const WHITE: ImageDisplayOptions = ImageDisplayOptions::new(2);
 
                 /// Image is scaled such that the image width and height match or exceed
                 /// the container dimensions. This may crop the top and bottom of the
@@ -19571,23 +20208,58 @@ pub mod intent {
                 /// height, or crop the left and right of the image if the scaled image
                 /// width is greater than the container width. This is similar to "Zoom
                 /// Mode" on a widescreen TV when playing a 4:3 video.
-                pub const CROPPED: ImageDisplayOptions = ImageDisplayOptions::new("CROPPED");
+                pub const CROPPED: ImageDisplayOptions = ImageDisplayOptions::new(3);
 
                 /// Pad the gaps between image and image frame with a blurred copy of the
                 /// same image.
-                pub const BLURRED_BACKGROUND: ImageDisplayOptions =
-                    ImageDisplayOptions::new("BLURRED_BACKGROUND");
+                pub const BLURRED_BACKGROUND: ImageDisplayOptions = ImageDisplayOptions::new(4);
+
+                /// Creates a new ImageDisplayOptions instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("IMAGE_DISPLAY_OPTIONS_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("GRAY"),
+                        2 => std::borrow::Cow::Borrowed("WHITE"),
+                        3 => std::borrow::Cow::Borrowed("CROPPED"),
+                        4 => std::borrow::Cow::Borrowed("BLURRED_BACKGROUND"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "IMAGE_DISPLAY_OPTIONS_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::IMAGE_DISPLAY_OPTIONS_UNSPECIFIED)
+                        }
+                        "GRAY" => std::option::Option::Some(Self::GRAY),
+                        "WHITE" => std::option::Option::Some(Self::WHITE),
+                        "CROPPED" => std::option::Option::Some(Self::CROPPED),
+                        "BLURRED_BACKGROUND" => std::option::Option::Some(Self::BLURRED_BACKGROUND),
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for ImageDisplayOptions {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for ImageDisplayOptions {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for ImageDisplayOptions {
                 fn default() -> Self {
-                    image_display_options::IMAGE_DISPLAY_OPTIONS_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -19750,47 +20422,66 @@ pub mod intent {
 
             /// Text alignments within a cell.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct HorizontalAlignment(std::borrow::Cow<'static, str>);
+            pub struct HorizontalAlignment(i32);
 
             impl HorizontalAlignment {
+                /// Text is aligned to the leading edge of the column.
+                pub const HORIZONTAL_ALIGNMENT_UNSPECIFIED: HorizontalAlignment =
+                    HorizontalAlignment::new(0);
+
+                /// Text is aligned to the leading edge of the column.
+                pub const LEADING: HorizontalAlignment = HorizontalAlignment::new(1);
+
+                /// Text is centered in the column.
+                pub const CENTER: HorizontalAlignment = HorizontalAlignment::new(2);
+
+                /// Text is aligned to the trailing edge of the column.
+                pub const TRAILING: HorizontalAlignment = HorizontalAlignment::new(3);
+
                 /// Creates a new HorizontalAlignment instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
                 }
 
                 /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("HORIZONTAL_ALIGNMENT_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("LEADING"),
+                        2 => std::borrow::Cow::Borrowed("CENTER"),
+                        3 => std::borrow::Cow::Borrowed("TRAILING"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "HORIZONTAL_ALIGNMENT_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::HORIZONTAL_ALIGNMENT_UNSPECIFIED)
+                        }
+                        "LEADING" => std::option::Option::Some(Self::LEADING),
+                        "CENTER" => std::option::Option::Some(Self::CENTER),
+                        "TRAILING" => std::option::Option::Some(Self::TRAILING),
+                        _ => std::option::Option::None,
+                    }
                 }
             }
 
-            /// Useful constants to work with [HorizontalAlignment](HorizontalAlignment)
-            pub mod horizontal_alignment {
-                use super::HorizontalAlignment;
-
-                /// Text is aligned to the leading edge of the column.
-                pub const HORIZONTAL_ALIGNMENT_UNSPECIFIED: HorizontalAlignment =
-                    HorizontalAlignment::new("HORIZONTAL_ALIGNMENT_UNSPECIFIED");
-
-                /// Text is aligned to the leading edge of the column.
-                pub const LEADING: HorizontalAlignment = HorizontalAlignment::new("LEADING");
-
-                /// Text is centered in the column.
-                pub const CENTER: HorizontalAlignment = HorizontalAlignment::new("CENTER");
-
-                /// Text is aligned to the trailing edge of the column.
-                pub const TRAILING: HorizontalAlignment = HorizontalAlignment::new("TRAILING");
-            }
-
-            impl std::convert::From<std::string::String> for HorizontalAlignment {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for HorizontalAlignment {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for HorizontalAlignment {
                 fn default() -> Self {
-                    horizontal_alignment::HORIZONTAL_ALIGNMENT_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -19875,66 +20566,95 @@ pub mod intent {
         /// The rich response message integration platform. See
         /// [Integrations](https://cloud.google.com/dialogflow/docs/integrations).
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Platform(std::borrow::Cow<'static, str>);
+        pub struct Platform(i32);
 
         impl Platform {
-            /// Creates a new Platform instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [Platform](Platform)
-        pub mod platform {
-            use super::Platform;
-
             /// Default platform.
-            pub const PLATFORM_UNSPECIFIED: Platform = Platform::new("PLATFORM_UNSPECIFIED");
+            pub const PLATFORM_UNSPECIFIED: Platform = Platform::new(0);
 
             /// Facebook.
-            pub const FACEBOOK: Platform = Platform::new("FACEBOOK");
+            pub const FACEBOOK: Platform = Platform::new(1);
 
             /// Slack.
-            pub const SLACK: Platform = Platform::new("SLACK");
+            pub const SLACK: Platform = Platform::new(2);
 
             /// Telegram.
-            pub const TELEGRAM: Platform = Platform::new("TELEGRAM");
+            pub const TELEGRAM: Platform = Platform::new(3);
 
             /// Kik.
-            pub const KIK: Platform = Platform::new("KIK");
+            pub const KIK: Platform = Platform::new(4);
 
             /// Skype.
-            pub const SKYPE: Platform = Platform::new("SKYPE");
+            pub const SKYPE: Platform = Platform::new(5);
 
             /// Line.
-            pub const LINE: Platform = Platform::new("LINE");
+            pub const LINE: Platform = Platform::new(6);
 
             /// Viber.
-            pub const VIBER: Platform = Platform::new("VIBER");
+            pub const VIBER: Platform = Platform::new(7);
 
             /// Google Assistant
             /// See [Dialogflow webhook
             /// format](https://developers.google.com/assistant/actions/build/json/dialogflow-webhook-json)
-            pub const ACTIONS_ON_GOOGLE: Platform = Platform::new("ACTIONS_ON_GOOGLE");
+            pub const ACTIONS_ON_GOOGLE: Platform = Platform::new(8);
 
             /// Google Hangouts.
-            pub const GOOGLE_HANGOUTS: Platform = Platform::new("GOOGLE_HANGOUTS");
+            pub const GOOGLE_HANGOUTS: Platform = Platform::new(11);
+
+            /// Creates a new Platform instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("PLATFORM_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("FACEBOOK"),
+                    2 => std::borrow::Cow::Borrowed("SLACK"),
+                    3 => std::borrow::Cow::Borrowed("TELEGRAM"),
+                    4 => std::borrow::Cow::Borrowed("KIK"),
+                    5 => std::borrow::Cow::Borrowed("SKYPE"),
+                    6 => std::borrow::Cow::Borrowed("LINE"),
+                    7 => std::borrow::Cow::Borrowed("VIBER"),
+                    8 => std::borrow::Cow::Borrowed("ACTIONS_ON_GOOGLE"),
+                    11 => std::borrow::Cow::Borrowed("GOOGLE_HANGOUTS"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "PLATFORM_UNSPECIFIED" => std::option::Option::Some(Self::PLATFORM_UNSPECIFIED),
+                    "FACEBOOK" => std::option::Option::Some(Self::FACEBOOK),
+                    "SLACK" => std::option::Option::Some(Self::SLACK),
+                    "TELEGRAM" => std::option::Option::Some(Self::TELEGRAM),
+                    "KIK" => std::option::Option::Some(Self::KIK),
+                    "SKYPE" => std::option::Option::Some(Self::SKYPE),
+                    "LINE" => std::option::Option::Some(Self::LINE),
+                    "VIBER" => std::option::Option::Some(Self::VIBER),
+                    "ACTIONS_ON_GOOGLE" => std::option::Option::Some(Self::ACTIONS_ON_GOOGLE),
+                    "GOOGLE_HANGOUTS" => std::option::Option::Some(Self::GOOGLE_HANGOUTS),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for Platform {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Platform {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Platform {
             fn default() -> Self {
-                platform::PLATFORM_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -20023,46 +20743,63 @@ pub mod intent {
 
     /// Represents the different states that webhooks can be in.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct WebhookState(std::borrow::Cow<'static, str>);
+    pub struct WebhookState(i32);
 
     impl WebhookState {
-        /// Creates a new WebhookState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [WebhookState](WebhookState)
-    pub mod webhook_state {
-        use super::WebhookState;
-
         /// Webhook is disabled in the agent and in the intent.
-        pub const WEBHOOK_STATE_UNSPECIFIED: WebhookState =
-            WebhookState::new("WEBHOOK_STATE_UNSPECIFIED");
+        pub const WEBHOOK_STATE_UNSPECIFIED: WebhookState = WebhookState::new(0);
 
         /// Webhook is enabled in the agent and in the intent.
-        pub const WEBHOOK_STATE_ENABLED: WebhookState = WebhookState::new("WEBHOOK_STATE_ENABLED");
+        pub const WEBHOOK_STATE_ENABLED: WebhookState = WebhookState::new(1);
 
         /// Webhook is enabled in the agent and in the intent. Also, each slot
         /// filling prompt is forwarded to the webhook.
-        pub const WEBHOOK_STATE_ENABLED_FOR_SLOT_FILLING: WebhookState =
-            WebhookState::new("WEBHOOK_STATE_ENABLED_FOR_SLOT_FILLING");
+        pub const WEBHOOK_STATE_ENABLED_FOR_SLOT_FILLING: WebhookState = WebhookState::new(2);
+
+        /// Creates a new WebhookState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("WEBHOOK_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("WEBHOOK_STATE_ENABLED"),
+                2 => std::borrow::Cow::Borrowed("WEBHOOK_STATE_ENABLED_FOR_SLOT_FILLING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "WEBHOOK_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::WEBHOOK_STATE_UNSPECIFIED)
+                }
+                "WEBHOOK_STATE_ENABLED" => std::option::Option::Some(Self::WEBHOOK_STATE_ENABLED),
+                "WEBHOOK_STATE_ENABLED_FOR_SLOT_FILLING" => {
+                    std::option::Option::Some(Self::WEBHOOK_STATE_ENABLED_FOR_SLOT_FILLING)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for WebhookState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for WebhookState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for WebhookState {
         fn default() -> Self {
-            webhook_state::WEBHOOK_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -21286,47 +22023,64 @@ pub mod participant {
 
     /// Enumeration of the roles a participant can play in a conversation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Role(std::borrow::Cow<'static, str>);
+    pub struct Role(i32);
 
     impl Role {
-        /// Creates a new Role instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Role](Role)
-    pub mod role {
-        use super::Role;
-
         /// Participant role not set.
-        pub const ROLE_UNSPECIFIED: Role = Role::new("ROLE_UNSPECIFIED");
+        pub const ROLE_UNSPECIFIED: Role = Role::new(0);
 
         /// Participant is a human agent.
-        pub const HUMAN_AGENT: Role = Role::new("HUMAN_AGENT");
+        pub const HUMAN_AGENT: Role = Role::new(1);
 
         /// Participant is an automated agent, such as a Dialogflow agent.
-        pub const AUTOMATED_AGENT: Role = Role::new("AUTOMATED_AGENT");
+        pub const AUTOMATED_AGENT: Role = Role::new(2);
 
         /// Participant is an end user that has called or chatted with
         /// Dialogflow services.
-        pub const END_USER: Role = Role::new("END_USER");
+        pub const END_USER: Role = Role::new(3);
+
+        /// Creates a new Role instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ROLE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("HUMAN_AGENT"),
+                2 => std::borrow::Cow::Borrowed("AUTOMATED_AGENT"),
+                3 => std::borrow::Cow::Borrowed("END_USER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ROLE_UNSPECIFIED" => std::option::Option::Some(Self::ROLE_UNSPECIFIED),
+                "HUMAN_AGENT" => std::option::Option::Some(Self::HUMAN_AGENT),
+                "AUTOMATED_AGENT" => std::option::Option::Some(Self::AUTOMATED_AGENT),
+                "END_USER" => std::option::Option::Some(Self::END_USER),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Role {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Role {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Role {
         fn default() -> Self {
-            role::ROLE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -23534,46 +24288,63 @@ pub mod automated_agent_reply {
 
     /// Represents different automated agent reply types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AutomatedAgentReplyType(std::borrow::Cow<'static, str>);
+    pub struct AutomatedAgentReplyType(i32);
 
     impl AutomatedAgentReplyType {
-        /// Creates a new AutomatedAgentReplyType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [AutomatedAgentReplyType](AutomatedAgentReplyType)
-    pub mod automated_agent_reply_type {
-        use super::AutomatedAgentReplyType;
-
         /// Not specified. This should never happen.
         pub const AUTOMATED_AGENT_REPLY_TYPE_UNSPECIFIED: AutomatedAgentReplyType =
-            AutomatedAgentReplyType::new("AUTOMATED_AGENT_REPLY_TYPE_UNSPECIFIED");
+            AutomatedAgentReplyType::new(0);
 
         /// Partial reply. e.g. Aggregated responses in a `Fulfillment` that enables
         /// `return_partial_response` can be returned as partial reply.
         /// WARNING: partial reply is not eligible for barge-in.
-        pub const PARTIAL: AutomatedAgentReplyType = AutomatedAgentReplyType::new("PARTIAL");
+        pub const PARTIAL: AutomatedAgentReplyType = AutomatedAgentReplyType::new(1);
 
         /// Final reply.
-        pub const FINAL: AutomatedAgentReplyType = AutomatedAgentReplyType::new("FINAL");
+        pub const FINAL: AutomatedAgentReplyType = AutomatedAgentReplyType::new(2);
+
+        /// Creates a new AutomatedAgentReplyType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("AUTOMATED_AGENT_REPLY_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PARTIAL"),
+                2 => std::borrow::Cow::Borrowed("FINAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "AUTOMATED_AGENT_REPLY_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::AUTOMATED_AGENT_REPLY_TYPE_UNSPECIFIED)
+                }
+                "PARTIAL" => std::option::Option::Some(Self::PARTIAL),
+                "FINAL" => std::option::Option::Some(Self::FINAL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for AutomatedAgentReplyType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AutomatedAgentReplyType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AutomatedAgentReplyType {
         fn default() -> Self {
-            automated_agent_reply_type::AUTOMATED_AGENT_REPLY_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -26631,30 +27402,14 @@ pub mod streaming_recognition_result {
 
     /// Type of the response message.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MessageType(std::borrow::Cow<'static, str>);
+    pub struct MessageType(i32);
 
     impl MessageType {
-        /// Creates a new MessageType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [MessageType](MessageType)
-    pub mod message_type {
-        use super::MessageType;
-
         /// Not specified. Should never be used.
-        pub const MESSAGE_TYPE_UNSPECIFIED: MessageType =
-            MessageType::new("MESSAGE_TYPE_UNSPECIFIED");
+        pub const MESSAGE_TYPE_UNSPECIFIED: MessageType = MessageType::new(0);
 
         /// Message contains a (possibly partial) transcript.
-        pub const TRANSCRIPT: MessageType = MessageType::new("TRANSCRIPT");
+        pub const TRANSCRIPT: MessageType = MessageType::new(1);
 
         /// This event indicates that the server has detected the end of the user's
         /// speech utterance and expects no additional inputs.
@@ -26664,19 +27419,52 @@ pub mod streaming_recognition_result {
         /// additional results until the server closes the gRPC connection. This
         /// message is only sent if `single_utterance` was set to `true`, and is not
         /// used otherwise.
-        pub const END_OF_SINGLE_UTTERANCE: MessageType =
-            MessageType::new("END_OF_SINGLE_UTTERANCE");
+        pub const END_OF_SINGLE_UTTERANCE: MessageType = MessageType::new(2);
+
+        /// Creates a new MessageType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MESSAGE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TRANSCRIPT"),
+                2 => std::borrow::Cow::Borrowed("END_OF_SINGLE_UTTERANCE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MESSAGE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MESSAGE_TYPE_UNSPECIFIED)
+                }
+                "TRANSCRIPT" => std::option::Option::Some(Self::TRANSCRIPT),
+                "END_OF_SINGLE_UTTERANCE" => {
+                    std::option::Option::Some(Self::END_OF_SINGLE_UTTERANCE)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for MessageType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MessageType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MessageType {
         fn default() -> Self {
-            message_type::MESSAGE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -27011,32 +27799,15 @@ pub mod session_entity_type {
 
     /// The types of modifications for a session entity type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EntityOverrideMode(std::borrow::Cow<'static, str>);
+    pub struct EntityOverrideMode(i32);
 
     impl EntityOverrideMode {
-        /// Creates a new EntityOverrideMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [EntityOverrideMode](EntityOverrideMode)
-    pub mod entity_override_mode {
-        use super::EntityOverrideMode;
-
         /// Not specified. This value should be never used.
-        pub const ENTITY_OVERRIDE_MODE_UNSPECIFIED: EntityOverrideMode =
-            EntityOverrideMode::new("ENTITY_OVERRIDE_MODE_UNSPECIFIED");
+        pub const ENTITY_OVERRIDE_MODE_UNSPECIFIED: EntityOverrideMode = EntityOverrideMode::new(0);
 
         /// The collection of session entities overrides the collection of entities
         /// in the corresponding custom entity type.
-        pub const ENTITY_OVERRIDE_MODE_OVERRIDE: EntityOverrideMode =
-            EntityOverrideMode::new("ENTITY_OVERRIDE_MODE_OVERRIDE");
+        pub const ENTITY_OVERRIDE_MODE_OVERRIDE: EntityOverrideMode = EntityOverrideMode::new(1);
 
         /// The collection of session entities extends the collection of entities in
         /// the corresponding custom entity type.
@@ -27050,19 +27821,54 @@ pub mod session_entity_type {
         /// on the custom entity type and merge.
         ///
         /// [google.cloud.dialogflow.v2.EntityTypes.GetEntityType]: crate::client::EntityTypes::get_entity_type
-        pub const ENTITY_OVERRIDE_MODE_SUPPLEMENT: EntityOverrideMode =
-            EntityOverrideMode::new("ENTITY_OVERRIDE_MODE_SUPPLEMENT");
+        pub const ENTITY_OVERRIDE_MODE_SUPPLEMENT: EntityOverrideMode = EntityOverrideMode::new(2);
+
+        /// Creates a new EntityOverrideMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ENTITY_OVERRIDE_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENTITY_OVERRIDE_MODE_OVERRIDE"),
+                2 => std::borrow::Cow::Borrowed("ENTITY_OVERRIDE_MODE_SUPPLEMENT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ENTITY_OVERRIDE_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ENTITY_OVERRIDE_MODE_UNSPECIFIED)
+                }
+                "ENTITY_OVERRIDE_MODE_OVERRIDE" => {
+                    std::option::Option::Some(Self::ENTITY_OVERRIDE_MODE_OVERRIDE)
+                }
+                "ENTITY_OVERRIDE_MODE_SUPPLEMENT" => {
+                    std::option::Option::Some(Self::ENTITY_OVERRIDE_MODE_SUPPLEMENT)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for EntityOverrideMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EntityOverrideMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EntityOverrideMode {
         fn default() -> Self {
-            entity_override_mode::ENTITY_OVERRIDE_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -27440,49 +28246,68 @@ pub mod validation_error {
 
     /// Represents a level of severity.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(std::borrow::Cow<'static, str>);
+    pub struct Severity(i32);
 
     impl Severity {
+        /// Not specified. This value should never be used.
+        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
+
+        /// The agent doesn't follow Dialogflow best practices.
+        pub const INFO: Severity = Severity::new(1);
+
+        /// The agent may not behave as expected.
+        pub const WARNING: Severity = Severity::new(2);
+
+        /// The agent may experience partial failures.
+        pub const ERROR: Severity = Severity::new(3);
+
+        /// The agent may completely fail.
+        pub const CRITICAL: Severity = Severity::new(4);
+
         /// Creates a new Severity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INFO"),
+                2 => std::borrow::Cow::Borrowed("WARNING"),
+                3 => std::borrow::Cow::Borrowed("ERROR"),
+                4 => std::borrow::Cow::Borrowed("CRITICAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
+                "INFO" => std::option::Option::Some(Self::INFO),
+                "WARNING" => std::option::Option::Some(Self::WARNING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Severity](Severity)
-    pub mod severity {
-        use super::Severity;
-
-        /// Not specified. This value should never be used.
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new("SEVERITY_UNSPECIFIED");
-
-        /// The agent doesn't follow Dialogflow best practices.
-        pub const INFO: Severity = Severity::new("INFO");
-
-        /// The agent may not behave as expected.
-        pub const WARNING: Severity = Severity::new("WARNING");
-
-        /// The agent may experience partial failures.
-        pub const ERROR: Severity = Severity::new("ERROR");
-
-        /// The agent may completely fail.
-        pub const CRITICAL: Severity = Severity::new("CRITICAL");
-    }
-
-    impl std::convert::From<std::string::String> for Severity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            severity::SEVERITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -27626,47 +28451,65 @@ pub mod version {
 
     /// The status of a version.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VersionStatus(std::borrow::Cow<'static, str>);
+    pub struct VersionStatus(i32);
 
     impl VersionStatus {
+        /// Not specified. This value is not used.
+        pub const VERSION_STATUS_UNSPECIFIED: VersionStatus = VersionStatus::new(0);
+
+        /// Version is not ready to serve (e.g. training is in progress).
+        pub const IN_PROGRESS: VersionStatus = VersionStatus::new(1);
+
+        /// Version is ready to serve.
+        pub const READY: VersionStatus = VersionStatus::new(2);
+
+        /// Version training failed.
+        pub const FAILED: VersionStatus = VersionStatus::new(3);
+
         /// Creates a new VersionStatus instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VERSION_STATUS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VERSION_STATUS_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::VERSION_STATUS_UNSPECIFIED)
+                }
+                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                "READY" => std::option::Option::Some(Self::READY),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [VersionStatus](VersionStatus)
-    pub mod version_status {
-        use super::VersionStatus;
-
-        /// Not specified. This value is not used.
-        pub const VERSION_STATUS_UNSPECIFIED: VersionStatus =
-            VersionStatus::new("VERSION_STATUS_UNSPECIFIED");
-
-        /// Version is not ready to serve (e.g. training is in progress).
-        pub const IN_PROGRESS: VersionStatus = VersionStatus::new("IN_PROGRESS");
-
-        /// Version is ready to serve.
-        pub const READY: VersionStatus = VersionStatus::new("READY");
-
-        /// Version training failed.
-        pub const FAILED: VersionStatus = VersionStatus::new("FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for VersionStatus {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for VersionStatus {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for VersionStatus {
         fn default() -> Self {
-            version_status::VERSION_STATUS_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -28284,86 +29127,130 @@ impl wkt::message::Message for OriginalDetectIntentRequest {
 /// [DTMF](https://en.wikipedia.org/wiki/Dual-tone_multi-frequency_signaling)
 /// digit in Telephony Gateway.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TelephonyDtmf(std::borrow::Cow<'static, str>);
+pub struct TelephonyDtmf(i32);
 
 impl TelephonyDtmf {
+    /// Not specified. This value may be used to indicate an absent digit.
+    pub const TELEPHONY_DTMF_UNSPECIFIED: TelephonyDtmf = TelephonyDtmf::new(0);
+
+    /// Number: '1'.
+    pub const DTMF_ONE: TelephonyDtmf = TelephonyDtmf::new(1);
+
+    /// Number: '2'.
+    pub const DTMF_TWO: TelephonyDtmf = TelephonyDtmf::new(2);
+
+    /// Number: '3'.
+    pub const DTMF_THREE: TelephonyDtmf = TelephonyDtmf::new(3);
+
+    /// Number: '4'.
+    pub const DTMF_FOUR: TelephonyDtmf = TelephonyDtmf::new(4);
+
+    /// Number: '5'.
+    pub const DTMF_FIVE: TelephonyDtmf = TelephonyDtmf::new(5);
+
+    /// Number: '6'.
+    pub const DTMF_SIX: TelephonyDtmf = TelephonyDtmf::new(6);
+
+    /// Number: '7'.
+    pub const DTMF_SEVEN: TelephonyDtmf = TelephonyDtmf::new(7);
+
+    /// Number: '8'.
+    pub const DTMF_EIGHT: TelephonyDtmf = TelephonyDtmf::new(8);
+
+    /// Number: '9'.
+    pub const DTMF_NINE: TelephonyDtmf = TelephonyDtmf::new(9);
+
+    /// Number: '0'.
+    pub const DTMF_ZERO: TelephonyDtmf = TelephonyDtmf::new(10);
+
+    /// Letter: 'A'.
+    pub const DTMF_A: TelephonyDtmf = TelephonyDtmf::new(11);
+
+    /// Letter: 'B'.
+    pub const DTMF_B: TelephonyDtmf = TelephonyDtmf::new(12);
+
+    /// Letter: 'C'.
+    pub const DTMF_C: TelephonyDtmf = TelephonyDtmf::new(13);
+
+    /// Letter: 'D'.
+    pub const DTMF_D: TelephonyDtmf = TelephonyDtmf::new(14);
+
+    /// Asterisk/star: '*'.
+    pub const DTMF_STAR: TelephonyDtmf = TelephonyDtmf::new(15);
+
+    /// Pound/diamond/hash/square/gate/octothorpe: '#'.
+    pub const DTMF_POUND: TelephonyDtmf = TelephonyDtmf::new(16);
+
     /// Creates a new TelephonyDtmf instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("TELEPHONY_DTMF_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("DTMF_ONE"),
+            2 => std::borrow::Cow::Borrowed("DTMF_TWO"),
+            3 => std::borrow::Cow::Borrowed("DTMF_THREE"),
+            4 => std::borrow::Cow::Borrowed("DTMF_FOUR"),
+            5 => std::borrow::Cow::Borrowed("DTMF_FIVE"),
+            6 => std::borrow::Cow::Borrowed("DTMF_SIX"),
+            7 => std::borrow::Cow::Borrowed("DTMF_SEVEN"),
+            8 => std::borrow::Cow::Borrowed("DTMF_EIGHT"),
+            9 => std::borrow::Cow::Borrowed("DTMF_NINE"),
+            10 => std::borrow::Cow::Borrowed("DTMF_ZERO"),
+            11 => std::borrow::Cow::Borrowed("DTMF_A"),
+            12 => std::borrow::Cow::Borrowed("DTMF_B"),
+            13 => std::borrow::Cow::Borrowed("DTMF_C"),
+            14 => std::borrow::Cow::Borrowed("DTMF_D"),
+            15 => std::borrow::Cow::Borrowed("DTMF_STAR"),
+            16 => std::borrow::Cow::Borrowed("DTMF_POUND"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "TELEPHONY_DTMF_UNSPECIFIED" => {
+                std::option::Option::Some(Self::TELEPHONY_DTMF_UNSPECIFIED)
+            }
+            "DTMF_ONE" => std::option::Option::Some(Self::DTMF_ONE),
+            "DTMF_TWO" => std::option::Option::Some(Self::DTMF_TWO),
+            "DTMF_THREE" => std::option::Option::Some(Self::DTMF_THREE),
+            "DTMF_FOUR" => std::option::Option::Some(Self::DTMF_FOUR),
+            "DTMF_FIVE" => std::option::Option::Some(Self::DTMF_FIVE),
+            "DTMF_SIX" => std::option::Option::Some(Self::DTMF_SIX),
+            "DTMF_SEVEN" => std::option::Option::Some(Self::DTMF_SEVEN),
+            "DTMF_EIGHT" => std::option::Option::Some(Self::DTMF_EIGHT),
+            "DTMF_NINE" => std::option::Option::Some(Self::DTMF_NINE),
+            "DTMF_ZERO" => std::option::Option::Some(Self::DTMF_ZERO),
+            "DTMF_A" => std::option::Option::Some(Self::DTMF_A),
+            "DTMF_B" => std::option::Option::Some(Self::DTMF_B),
+            "DTMF_C" => std::option::Option::Some(Self::DTMF_C),
+            "DTMF_D" => std::option::Option::Some(Self::DTMF_D),
+            "DTMF_STAR" => std::option::Option::Some(Self::DTMF_STAR),
+            "DTMF_POUND" => std::option::Option::Some(Self::DTMF_POUND),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [TelephonyDtmf](TelephonyDtmf)
-pub mod telephony_dtmf {
-    use super::TelephonyDtmf;
-
-    /// Not specified. This value may be used to indicate an absent digit.
-    pub const TELEPHONY_DTMF_UNSPECIFIED: TelephonyDtmf =
-        TelephonyDtmf::new("TELEPHONY_DTMF_UNSPECIFIED");
-
-    /// Number: '1'.
-    pub const DTMF_ONE: TelephonyDtmf = TelephonyDtmf::new("DTMF_ONE");
-
-    /// Number: '2'.
-    pub const DTMF_TWO: TelephonyDtmf = TelephonyDtmf::new("DTMF_TWO");
-
-    /// Number: '3'.
-    pub const DTMF_THREE: TelephonyDtmf = TelephonyDtmf::new("DTMF_THREE");
-
-    /// Number: '4'.
-    pub const DTMF_FOUR: TelephonyDtmf = TelephonyDtmf::new("DTMF_FOUR");
-
-    /// Number: '5'.
-    pub const DTMF_FIVE: TelephonyDtmf = TelephonyDtmf::new("DTMF_FIVE");
-
-    /// Number: '6'.
-    pub const DTMF_SIX: TelephonyDtmf = TelephonyDtmf::new("DTMF_SIX");
-
-    /// Number: '7'.
-    pub const DTMF_SEVEN: TelephonyDtmf = TelephonyDtmf::new("DTMF_SEVEN");
-
-    /// Number: '8'.
-    pub const DTMF_EIGHT: TelephonyDtmf = TelephonyDtmf::new("DTMF_EIGHT");
-
-    /// Number: '9'.
-    pub const DTMF_NINE: TelephonyDtmf = TelephonyDtmf::new("DTMF_NINE");
-
-    /// Number: '0'.
-    pub const DTMF_ZERO: TelephonyDtmf = TelephonyDtmf::new("DTMF_ZERO");
-
-    /// Letter: 'A'.
-    pub const DTMF_A: TelephonyDtmf = TelephonyDtmf::new("DTMF_A");
-
-    /// Letter: 'B'.
-    pub const DTMF_B: TelephonyDtmf = TelephonyDtmf::new("DTMF_B");
-
-    /// Letter: 'C'.
-    pub const DTMF_C: TelephonyDtmf = TelephonyDtmf::new("DTMF_C");
-
-    /// Letter: 'D'.
-    pub const DTMF_D: TelephonyDtmf = TelephonyDtmf::new("DTMF_D");
-
-    /// Asterisk/star: '*'.
-    pub const DTMF_STAR: TelephonyDtmf = TelephonyDtmf::new("DTMF_STAR");
-
-    /// Pound/diamond/hash/square/gate/octothorpe: '#'.
-    pub const DTMF_POUND: TelephonyDtmf = TelephonyDtmf::new("DTMF_POUND");
-}
-
-impl std::convert::From<std::string::String> for TelephonyDtmf {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for TelephonyDtmf {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for TelephonyDtmf {
     fn default() -> Self {
-        telephony_dtmf::TELEPHONY_DTMF_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -28373,53 +29260,35 @@ impl std::default::Default for TelephonyDtmf {
 /// documentation](https://cloud.google.com/speech-to-text/docs/basics) for more
 /// details.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AudioEncoding(std::borrow::Cow<'static, str>);
+pub struct AudioEncoding(i32);
 
 impl AudioEncoding {
-    /// Creates a new AudioEncoding instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [AudioEncoding](AudioEncoding)
-pub mod audio_encoding {
-    use super::AudioEncoding;
-
     /// Not specified.
-    pub const AUDIO_ENCODING_UNSPECIFIED: AudioEncoding =
-        AudioEncoding::new("AUDIO_ENCODING_UNSPECIFIED");
+    pub const AUDIO_ENCODING_UNSPECIFIED: AudioEncoding = AudioEncoding::new(0);
 
     /// Uncompressed 16-bit signed little-endian samples (Linear PCM).
-    pub const AUDIO_ENCODING_LINEAR_16: AudioEncoding =
-        AudioEncoding::new("AUDIO_ENCODING_LINEAR_16");
+    pub const AUDIO_ENCODING_LINEAR_16: AudioEncoding = AudioEncoding::new(1);
 
     /// [`FLAC`](https://xiph.org/flac/documentation.html) (Free Lossless Audio
     /// Codec) is the recommended encoding because it is lossless (therefore
     /// recognition is not compromised) and requires only about half the
     /// bandwidth of `LINEAR16`. `FLAC` stream encoding supports 16-bit and
     /// 24-bit samples, however, not all fields in `STREAMINFO` are supported.
-    pub const AUDIO_ENCODING_FLAC: AudioEncoding = AudioEncoding::new("AUDIO_ENCODING_FLAC");
+    pub const AUDIO_ENCODING_FLAC: AudioEncoding = AudioEncoding::new(2);
 
     /// 8-bit samples that compand 14-bit audio samples using G.711 PCMU/mu-law.
-    pub const AUDIO_ENCODING_MULAW: AudioEncoding = AudioEncoding::new("AUDIO_ENCODING_MULAW");
+    pub const AUDIO_ENCODING_MULAW: AudioEncoding = AudioEncoding::new(3);
 
     /// Adaptive Multi-Rate Narrowband codec. `sample_rate_hertz` must be 8000.
-    pub const AUDIO_ENCODING_AMR: AudioEncoding = AudioEncoding::new("AUDIO_ENCODING_AMR");
+    pub const AUDIO_ENCODING_AMR: AudioEncoding = AudioEncoding::new(4);
 
     /// Adaptive Multi-Rate Wideband codec. `sample_rate_hertz` must be 16000.
-    pub const AUDIO_ENCODING_AMR_WB: AudioEncoding = AudioEncoding::new("AUDIO_ENCODING_AMR_WB");
+    pub const AUDIO_ENCODING_AMR_WB: AudioEncoding = AudioEncoding::new(5);
 
     /// Opus encoded audio frames in Ogg container
     /// ([OggOpus](https://wiki.xiph.org/OggOpus)).
     /// `sample_rate_hertz` must be 16000.
-    pub const AUDIO_ENCODING_OGG_OPUS: AudioEncoding =
-        AudioEncoding::new("AUDIO_ENCODING_OGG_OPUS");
+    pub const AUDIO_ENCODING_OGG_OPUS: AudioEncoding = AudioEncoding::new(6);
 
     /// Although the use of lossy encodings is not recommended, if a very low
     /// bitrate encoding is required, `OGG_OPUS` is highly preferred over
@@ -28434,22 +29303,67 @@ pub mod audio_encoding {
     /// bytes (octets) as specified in RFC 5574. In other words, each RTP header
     /// is replaced with a single byte containing the block length. Only Speex
     /// wideband is supported. `sample_rate_hertz` must be 16000.
-    pub const AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE: AudioEncoding =
-        AudioEncoding::new("AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE");
+    pub const AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE: AudioEncoding = AudioEncoding::new(7);
 
     /// 8-bit samples that compand 13-bit audio samples using G.711 PCMU/a-law.
-    pub const AUDIO_ENCODING_ALAW: AudioEncoding = AudioEncoding::new("AUDIO_ENCODING_ALAW");
+    pub const AUDIO_ENCODING_ALAW: AudioEncoding = AudioEncoding::new(8);
+
+    /// Creates a new AudioEncoding instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_LINEAR_16"),
+            2 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_FLAC"),
+            3 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_MULAW"),
+            4 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_AMR"),
+            5 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_AMR_WB"),
+            6 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_OGG_OPUS"),
+            7 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE"),
+            8 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_ALAW"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "AUDIO_ENCODING_UNSPECIFIED" => {
+                std::option::Option::Some(Self::AUDIO_ENCODING_UNSPECIFIED)
+            }
+            "AUDIO_ENCODING_LINEAR_16" => std::option::Option::Some(Self::AUDIO_ENCODING_LINEAR_16),
+            "AUDIO_ENCODING_FLAC" => std::option::Option::Some(Self::AUDIO_ENCODING_FLAC),
+            "AUDIO_ENCODING_MULAW" => std::option::Option::Some(Self::AUDIO_ENCODING_MULAW),
+            "AUDIO_ENCODING_AMR" => std::option::Option::Some(Self::AUDIO_ENCODING_AMR),
+            "AUDIO_ENCODING_AMR_WB" => std::option::Option::Some(Self::AUDIO_ENCODING_AMR_WB),
+            "AUDIO_ENCODING_OGG_OPUS" => std::option::Option::Some(Self::AUDIO_ENCODING_OGG_OPUS),
+            "AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE" => {
+                std::option::Option::Some(Self::AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE)
+            }
+            "AUDIO_ENCODING_ALAW" => std::option::Option::Some(Self::AUDIO_ENCODING_ALAW),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for AudioEncoding {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for AudioEncoding {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for AudioEncoding {
     fn default() -> Self {
-        audio_encoding::AUDIO_ENCODING_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -28464,28 +29378,12 @@ impl std::default::Default for AudioEncoding {
 ///
 /// [google.cloud.dialogflow.v2.InputAudioConfig.model]: crate::model::InputAudioConfig::model
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SpeechModelVariant(std::borrow::Cow<'static, str>);
+pub struct SpeechModelVariant(i32);
 
 impl SpeechModelVariant {
-    /// Creates a new SpeechModelVariant instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [SpeechModelVariant](SpeechModelVariant)
-pub mod speech_model_variant {
-    use super::SpeechModelVariant;
-
     /// No model variant specified. In this case Dialogflow defaults to
     /// USE_BEST_AVAILABLE.
-    pub const SPEECH_MODEL_VARIANT_UNSPECIFIED: SpeechModelVariant =
-        SpeechModelVariant::new("SPEECH_MODEL_VARIANT_UNSPECIFIED");
+    pub const SPEECH_MODEL_VARIANT_UNSPECIFIED: SpeechModelVariant = SpeechModelVariant::new(0);
 
     /// Use the best available variant of the [Speech model][model] that the caller
     /// is eligible for.
@@ -28493,14 +29391,13 @@ pub mod speech_model_variant {
     /// Please see the [Dialogflow
     /// docs](https://cloud.google.com/dialogflow/docs/data-logging) for
     /// how to make your project eligible for enhanced models.
-    pub const USE_BEST_AVAILABLE: SpeechModelVariant =
-        SpeechModelVariant::new("USE_BEST_AVAILABLE");
+    pub const USE_BEST_AVAILABLE: SpeechModelVariant = SpeechModelVariant::new(1);
 
     /// Use standard model variant even if an enhanced model is available.  See the
     /// [Cloud Speech
     /// documentation](https://cloud.google.com/speech-to-text/docs/enhanced-models)
     /// for details about enhanced models.
-    pub const USE_STANDARD: SpeechModelVariant = SpeechModelVariant::new("USE_STANDARD");
+    pub const USE_STANDARD: SpeechModelVariant = SpeechModelVariant::new(2);
 
     /// Use an enhanced model variant:
     ///
@@ -28519,185 +29416,286 @@ pub mod speech_model_variant {
     ///
     ///
     /// [google.cloud.dialogflow.v2.InputAudioConfig.model]: crate::model::InputAudioConfig::model
-    pub const USE_ENHANCED: SpeechModelVariant = SpeechModelVariant::new("USE_ENHANCED");
+    pub const USE_ENHANCED: SpeechModelVariant = SpeechModelVariant::new(3);
+
+    /// Creates a new SpeechModelVariant instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SPEECH_MODEL_VARIANT_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("USE_BEST_AVAILABLE"),
+            2 => std::borrow::Cow::Borrowed("USE_STANDARD"),
+            3 => std::borrow::Cow::Borrowed("USE_ENHANCED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SPEECH_MODEL_VARIANT_UNSPECIFIED" => {
+                std::option::Option::Some(Self::SPEECH_MODEL_VARIANT_UNSPECIFIED)
+            }
+            "USE_BEST_AVAILABLE" => std::option::Option::Some(Self::USE_BEST_AVAILABLE),
+            "USE_STANDARD" => std::option::Option::Some(Self::USE_STANDARD),
+            "USE_ENHANCED" => std::option::Option::Some(Self::USE_ENHANCED),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for SpeechModelVariant {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SpeechModelVariant {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SpeechModelVariant {
     fn default() -> Self {
-        speech_model_variant::SPEECH_MODEL_VARIANT_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Gender of the voice as described in
 /// [SSML voice element](https://www.w3.org/TR/speech-synthesis11/#edef_voice).
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SsmlVoiceGender(std::borrow::Cow<'static, str>);
+pub struct SsmlVoiceGender(i32);
 
 impl SsmlVoiceGender {
+    /// An unspecified gender, which means that the client doesn't care which
+    /// gender the selected voice will have.
+    pub const SSML_VOICE_GENDER_UNSPECIFIED: SsmlVoiceGender = SsmlVoiceGender::new(0);
+
+    /// A male voice.
+    pub const SSML_VOICE_GENDER_MALE: SsmlVoiceGender = SsmlVoiceGender::new(1);
+
+    /// A female voice.
+    pub const SSML_VOICE_GENDER_FEMALE: SsmlVoiceGender = SsmlVoiceGender::new(2);
+
+    /// A gender-neutral voice.
+    pub const SSML_VOICE_GENDER_NEUTRAL: SsmlVoiceGender = SsmlVoiceGender::new(3);
+
     /// Creates a new SsmlVoiceGender instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SSML_VOICE_GENDER_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SSML_VOICE_GENDER_MALE"),
+            2 => std::borrow::Cow::Borrowed("SSML_VOICE_GENDER_FEMALE"),
+            3 => std::borrow::Cow::Borrowed("SSML_VOICE_GENDER_NEUTRAL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SSML_VOICE_GENDER_UNSPECIFIED" => {
+                std::option::Option::Some(Self::SSML_VOICE_GENDER_UNSPECIFIED)
+            }
+            "SSML_VOICE_GENDER_MALE" => std::option::Option::Some(Self::SSML_VOICE_GENDER_MALE),
+            "SSML_VOICE_GENDER_FEMALE" => std::option::Option::Some(Self::SSML_VOICE_GENDER_FEMALE),
+            "SSML_VOICE_GENDER_NEUTRAL" => {
+                std::option::Option::Some(Self::SSML_VOICE_GENDER_NEUTRAL)
+            }
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [SsmlVoiceGender](SsmlVoiceGender)
-pub mod ssml_voice_gender {
-    use super::SsmlVoiceGender;
-
-    /// An unspecified gender, which means that the client doesn't care which
-    /// gender the selected voice will have.
-    pub const SSML_VOICE_GENDER_UNSPECIFIED: SsmlVoiceGender =
-        SsmlVoiceGender::new("SSML_VOICE_GENDER_UNSPECIFIED");
-
-    /// A male voice.
-    pub const SSML_VOICE_GENDER_MALE: SsmlVoiceGender =
-        SsmlVoiceGender::new("SSML_VOICE_GENDER_MALE");
-
-    /// A female voice.
-    pub const SSML_VOICE_GENDER_FEMALE: SsmlVoiceGender =
-        SsmlVoiceGender::new("SSML_VOICE_GENDER_FEMALE");
-
-    /// A gender-neutral voice.
-    pub const SSML_VOICE_GENDER_NEUTRAL: SsmlVoiceGender =
-        SsmlVoiceGender::new("SSML_VOICE_GENDER_NEUTRAL");
-}
-
-impl std::convert::From<std::string::String> for SsmlVoiceGender {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SsmlVoiceGender {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SsmlVoiceGender {
     fn default() -> Self {
-        ssml_voice_gender::SSML_VOICE_GENDER_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Audio encoding of the output audio format in Text-To-Speech.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OutputAudioEncoding(std::borrow::Cow<'static, str>);
+pub struct OutputAudioEncoding(i32);
 
 impl OutputAudioEncoding {
-    /// Creates a new OutputAudioEncoding instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [OutputAudioEncoding](OutputAudioEncoding)
-pub mod output_audio_encoding {
-    use super::OutputAudioEncoding;
-
     /// Not specified.
-    pub const OUTPUT_AUDIO_ENCODING_UNSPECIFIED: OutputAudioEncoding =
-        OutputAudioEncoding::new("OUTPUT_AUDIO_ENCODING_UNSPECIFIED");
+    pub const OUTPUT_AUDIO_ENCODING_UNSPECIFIED: OutputAudioEncoding = OutputAudioEncoding::new(0);
 
     /// Uncompressed 16-bit signed little-endian samples (Linear PCM).
     /// Audio content returned as LINEAR16 also contains a WAV header.
-    pub const OUTPUT_AUDIO_ENCODING_LINEAR_16: OutputAudioEncoding =
-        OutputAudioEncoding::new("OUTPUT_AUDIO_ENCODING_LINEAR_16");
+    pub const OUTPUT_AUDIO_ENCODING_LINEAR_16: OutputAudioEncoding = OutputAudioEncoding::new(1);
 
     /// MP3 audio at 32kbps.
-    pub const OUTPUT_AUDIO_ENCODING_MP3: OutputAudioEncoding =
-        OutputAudioEncoding::new("OUTPUT_AUDIO_ENCODING_MP3");
+    pub const OUTPUT_AUDIO_ENCODING_MP3: OutputAudioEncoding = OutputAudioEncoding::new(2);
 
     /// MP3 audio at 64kbps.
-    pub const OUTPUT_AUDIO_ENCODING_MP3_64_KBPS: OutputAudioEncoding =
-        OutputAudioEncoding::new("OUTPUT_AUDIO_ENCODING_MP3_64_KBPS");
+    pub const OUTPUT_AUDIO_ENCODING_MP3_64_KBPS: OutputAudioEncoding = OutputAudioEncoding::new(4);
 
     /// Opus encoded audio wrapped in an ogg container. The result will be a
     /// file which can be played natively on Android, and in browsers (at least
     /// Chrome and Firefox). The quality of the encoding is considerably higher
     /// than MP3 while using approximately the same bitrate.
-    pub const OUTPUT_AUDIO_ENCODING_OGG_OPUS: OutputAudioEncoding =
-        OutputAudioEncoding::new("OUTPUT_AUDIO_ENCODING_OGG_OPUS");
+    pub const OUTPUT_AUDIO_ENCODING_OGG_OPUS: OutputAudioEncoding = OutputAudioEncoding::new(3);
 
     /// 8-bit samples that compand 14-bit audio samples using G.711 PCMU/mu-law.
-    pub const OUTPUT_AUDIO_ENCODING_MULAW: OutputAudioEncoding =
-        OutputAudioEncoding::new("OUTPUT_AUDIO_ENCODING_MULAW");
+    pub const OUTPUT_AUDIO_ENCODING_MULAW: OutputAudioEncoding = OutputAudioEncoding::new(5);
 
     /// 8-bit samples that compand 13-bit audio samples using G.711 PCMU/a-law.
-    pub const OUTPUT_AUDIO_ENCODING_ALAW: OutputAudioEncoding =
-        OutputAudioEncoding::new("OUTPUT_AUDIO_ENCODING_ALAW");
+    pub const OUTPUT_AUDIO_ENCODING_ALAW: OutputAudioEncoding = OutputAudioEncoding::new(6);
+
+    /// Creates a new OutputAudioEncoding instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_LINEAR_16"),
+            2 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_MP3"),
+            3 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_OGG_OPUS"),
+            4 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_MP3_64_KBPS"),
+            5 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_MULAW"),
+            6 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_ALAW"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "OUTPUT_AUDIO_ENCODING_UNSPECIFIED" => {
+                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_UNSPECIFIED)
+            }
+            "OUTPUT_AUDIO_ENCODING_LINEAR_16" => {
+                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_LINEAR_16)
+            }
+            "OUTPUT_AUDIO_ENCODING_MP3" => {
+                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_MP3)
+            }
+            "OUTPUT_AUDIO_ENCODING_MP3_64_KBPS" => {
+                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_MP3_64_KBPS)
+            }
+            "OUTPUT_AUDIO_ENCODING_OGG_OPUS" => {
+                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_OGG_OPUS)
+            }
+            "OUTPUT_AUDIO_ENCODING_MULAW" => {
+                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_MULAW)
+            }
+            "OUTPUT_AUDIO_ENCODING_ALAW" => {
+                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_ALAW)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for OutputAudioEncoding {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for OutputAudioEncoding {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for OutputAudioEncoding {
     fn default() -> Self {
-        output_audio_encoding::OUTPUT_AUDIO_ENCODING_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The event that triggers the generator and LLM execution.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TriggerEvent(std::borrow::Cow<'static, str>);
+pub struct TriggerEvent(i32);
 
 impl TriggerEvent {
-    /// Creates a new TriggerEvent instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [TriggerEvent](TriggerEvent)
-pub mod trigger_event {
-    use super::TriggerEvent;
-
     /// Default value for TriggerEvent.
-    pub const TRIGGER_EVENT_UNSPECIFIED: TriggerEvent =
-        TriggerEvent::new("TRIGGER_EVENT_UNSPECIFIED");
+    pub const TRIGGER_EVENT_UNSPECIFIED: TriggerEvent = TriggerEvent::new(0);
 
     /// Triggers when each chat message or voice utterance ends.
-    pub const END_OF_UTTERANCE: TriggerEvent = TriggerEvent::new("END_OF_UTTERANCE");
+    pub const END_OF_UTTERANCE: TriggerEvent = TriggerEvent::new(1);
 
     /// Triggers on the conversation manually by API calls, such as
     /// Conversations.GenerateStatelessSuggestion and
     /// Conversations.GenerateSuggestions.
-    pub const MANUAL_CALL: TriggerEvent = TriggerEvent::new("MANUAL_CALL");
+    pub const MANUAL_CALL: TriggerEvent = TriggerEvent::new(2);
 
     /// Triggers after each customer message only.
-    pub const CUSTOMER_MESSAGE: TriggerEvent = TriggerEvent::new("CUSTOMER_MESSAGE");
+    pub const CUSTOMER_MESSAGE: TriggerEvent = TriggerEvent::new(3);
 
     /// Triggers after each agent message only.
-    pub const AGENT_MESSAGE: TriggerEvent = TriggerEvent::new("AGENT_MESSAGE");
+    pub const AGENT_MESSAGE: TriggerEvent = TriggerEvent::new(4);
+
+    /// Creates a new TriggerEvent instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("TRIGGER_EVENT_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("END_OF_UTTERANCE"),
+            2 => std::borrow::Cow::Borrowed("MANUAL_CALL"),
+            3 => std::borrow::Cow::Borrowed("CUSTOMER_MESSAGE"),
+            4 => std::borrow::Cow::Borrowed("AGENT_MESSAGE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "TRIGGER_EVENT_UNSPECIFIED" => {
+                std::option::Option::Some(Self::TRIGGER_EVENT_UNSPECIFIED)
+            }
+            "END_OF_UTTERANCE" => std::option::Option::Some(Self::END_OF_UTTERANCE),
+            "MANUAL_CALL" => std::option::Option::Some(Self::MANUAL_CALL),
+            "CUSTOMER_MESSAGE" => std::option::Option::Some(Self::CUSTOMER_MESSAGE),
+            "AGENT_MESSAGE" => std::option::Option::Some(Self::AGENT_MESSAGE),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for TriggerEvent {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for TriggerEvent {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for TriggerEvent {
     fn default() -> Self {
-        trigger_event::TRIGGER_EVENT_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -28705,39 +29703,52 @@ impl std::default::Default for TriggerEvent {
 /// An intent can be a sizable object. Therefore, we provide a resource view that
 /// does not return training phrases in the response by default.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct IntentView(std::borrow::Cow<'static, str>);
+pub struct IntentView(i32);
 
 impl IntentView {
+    /// Training phrases field is not populated in the response.
+    pub const INTENT_VIEW_UNSPECIFIED: IntentView = IntentView::new(0);
+
+    /// All fields are populated.
+    pub const INTENT_VIEW_FULL: IntentView = IntentView::new(1);
+
     /// Creates a new IntentView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("INTENT_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("INTENT_VIEW_FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "INTENT_VIEW_UNSPECIFIED" => std::option::Option::Some(Self::INTENT_VIEW_UNSPECIFIED),
+            "INTENT_VIEW_FULL" => std::option::Option::Some(Self::INTENT_VIEW_FULL),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [IntentView](IntentView)
-pub mod intent_view {
-    use super::IntentView;
-
-    /// Training phrases field is not populated in the response.
-    pub const INTENT_VIEW_UNSPECIFIED: IntentView = IntentView::new("INTENT_VIEW_UNSPECIFIED");
-
-    /// All fields are populated.
-    pub const INTENT_VIEW_FULL: IntentView = IntentView::new("INTENT_VIEW_FULL");
-}
-
-impl std::convert::From<std::string::String> for IntentView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for IntentView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for IntentView {
     fn default() -> Self {
-        intent_view::INTENT_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/dialogflow/v2/src/transport.rs
+++ b/src/generated/cloud/dialogflow/v2/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::Agents for Agents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/agent", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -77,7 +77,7 @@ impl crate::stubs::Agents for Agents {
                         .parent
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -104,7 +104,7 @@ impl crate::stubs::Agents for Agents {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}/agent", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -126,7 +126,7 @@ impl crate::stubs::Agents for Agents {
                 reqwest::Method::GET,
                 format!("/v2/{}/agent:search", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -150,7 +150,7 @@ impl crate::stubs::Agents for Agents {
                 reqwest::Method::POST,
                 format!("/v2/{}/agent:train", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -170,7 +170,7 @@ impl crate::stubs::Agents for Agents {
                 reqwest::Method::POST,
                 format!("/v2/{}/agent:export", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -190,7 +190,7 @@ impl crate::stubs::Agents for Agents {
                 reqwest::Method::POST,
                 format!("/v2/{}/agent:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -210,7 +210,7 @@ impl crate::stubs::Agents for Agents {
                 reqwest::Method::POST,
                 format!("/v2/{}/agent:restore", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -230,7 +230,7 @@ impl crate::stubs::Agents for Agents {
                 reqwest::Method::GET,
                 format!("/v2/{}/agent/validationResult", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -250,7 +250,7 @@ impl crate::stubs::Agents for Agents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -272,7 +272,7 @@ impl crate::stubs::Agents for Agents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -291,7 +291,7 @@ impl crate::stubs::Agents for Agents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -313,7 +313,7 @@ impl crate::stubs::Agents for Agents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -332,7 +332,7 @@ impl crate::stubs::Agents for Agents {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -391,7 +391,7 @@ impl crate::stubs::AnswerRecords for AnswerRecords {
                 reqwest::Method::GET,
                 format!("/v2/{}/answerRecords", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -422,7 +422,7 @@ impl crate::stubs::AnswerRecords for AnswerRecords {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -451,7 +451,7 @@ impl crate::stubs::AnswerRecords for AnswerRecords {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -473,7 +473,7 @@ impl crate::stubs::AnswerRecords for AnswerRecords {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -492,7 +492,7 @@ impl crate::stubs::AnswerRecords for AnswerRecords {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -514,7 +514,7 @@ impl crate::stubs::AnswerRecords for AnswerRecords {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -533,7 +533,7 @@ impl crate::stubs::AnswerRecords for AnswerRecords {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -575,7 +575,7 @@ impl crate::stubs::Contexts for Contexts {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/contexts", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -596,7 +596,7 @@ impl crate::stubs::Contexts for Contexts {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -618,7 +618,7 @@ impl crate::stubs::Contexts for Contexts {
                 reqwest::Method::POST,
                 format!("/v2/{}/contexts", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -646,7 +646,7 @@ impl crate::stubs::Contexts for Contexts {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -675,7 +675,7 @@ impl crate::stubs::Contexts for Contexts {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -697,7 +697,7 @@ impl crate::stubs::Contexts for Contexts {
                 reqwest::Method::DELETE,
                 format!("/v2/{}/contexts", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -716,7 +716,7 @@ impl crate::stubs::Contexts for Contexts {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -738,7 +738,7 @@ impl crate::stubs::Contexts for Contexts {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -757,7 +757,7 @@ impl crate::stubs::Contexts for Contexts {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -779,7 +779,7 @@ impl crate::stubs::Contexts for Contexts {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -798,7 +798,7 @@ impl crate::stubs::Contexts for Contexts {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -843,7 +843,7 @@ impl crate::stubs::Conversations for Conversations {
                 reqwest::Method::POST,
                 format!("/v2/{}/conversations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -866,7 +866,7 @@ impl crate::stubs::Conversations for Conversations {
                 reqwest::Method::GET,
                 format!("/v2/{}/conversations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -888,7 +888,7 @@ impl crate::stubs::Conversations for Conversations {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -907,7 +907,7 @@ impl crate::stubs::Conversations for Conversations {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:complete", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -927,7 +927,7 @@ impl crate::stubs::Conversations for Conversations {
                 reqwest::Method::POST,
                 format!("/v2/{}:ingestContextReferences", req.conversation),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -944,7 +944,7 @@ impl crate::stubs::Conversations for Conversations {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/messages", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -972,7 +972,7 @@ impl crate::stubs::Conversations for Conversations {
                     req.conversation
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -998,7 +998,7 @@ impl crate::stubs::Conversations for Conversations {
                         .parent
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1018,7 +1018,7 @@ impl crate::stubs::Conversations for Conversations {
                 reqwest::Method::POST,
                 format!("/v2/{}/statelessSuggestion:generate", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1038,7 +1038,7 @@ impl crate::stubs::Conversations for Conversations {
                 reqwest::Method::POST,
                 format!("/v2/{}/suggestions:searchKnowledge", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1058,7 +1058,7 @@ impl crate::stubs::Conversations for Conversations {
                 reqwest::Method::POST,
                 format!("/v2/{}/suggestions:generate", req.conversation),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1075,7 +1075,7 @@ impl crate::stubs::Conversations for Conversations {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1097,7 +1097,7 @@ impl crate::stubs::Conversations for Conversations {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1116,7 +1116,7 @@ impl crate::stubs::Conversations for Conversations {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1138,7 +1138,7 @@ impl crate::stubs::Conversations for Conversations {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1157,7 +1157,7 @@ impl crate::stubs::Conversations for Conversations {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1202,7 +1202,7 @@ impl crate::stubs::ConversationDatasets for ConversationDatasets {
                 reqwest::Method::POST,
                 format!("/v2/{}/conversationDatasets", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1221,7 +1221,7 @@ impl crate::stubs::ConversationDatasets for ConversationDatasets {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1243,7 +1243,7 @@ impl crate::stubs::ConversationDatasets for ConversationDatasets {
                 reqwest::Method::GET,
                 format!("/v2/{}/conversationDatasets", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1264,7 +1264,7 @@ impl crate::stubs::ConversationDatasets for ConversationDatasets {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1286,7 +1286,7 @@ impl crate::stubs::ConversationDatasets for ConversationDatasets {
                 reqwest::Method::POST,
                 format!("/v2/{}:importConversationData", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1303,7 +1303,7 @@ impl crate::stubs::ConversationDatasets for ConversationDatasets {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1325,7 +1325,7 @@ impl crate::stubs::ConversationDatasets for ConversationDatasets {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1344,7 +1344,7 @@ impl crate::stubs::ConversationDatasets for ConversationDatasets {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1366,7 +1366,7 @@ impl crate::stubs::ConversationDatasets for ConversationDatasets {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1385,7 +1385,7 @@ impl crate::stubs::ConversationDatasets for ConversationDatasets {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1444,7 +1444,7 @@ impl crate::stubs::ConversationModels for ConversationModels {
                 reqwest::Method::POST,
                 format!("/v2/{}/conversationModels", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1463,7 +1463,7 @@ impl crate::stubs::ConversationModels for ConversationModels {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1485,7 +1485,7 @@ impl crate::stubs::ConversationModels for ConversationModels {
                 reqwest::Method::GET,
                 format!("/v2/{}/conversationModels", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1506,7 +1506,7 @@ impl crate::stubs::ConversationModels for ConversationModels {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1525,7 +1525,7 @@ impl crate::stubs::ConversationModels for ConversationModels {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:deploy", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1542,7 +1542,7 @@ impl crate::stubs::ConversationModels for ConversationModels {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:undeploy", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1559,7 +1559,7 @@ impl crate::stubs::ConversationModels for ConversationModels {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1581,7 +1581,7 @@ impl crate::stubs::ConversationModels for ConversationModels {
                 reqwest::Method::GET,
                 format!("/v2/{}/evaluations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1605,7 +1605,7 @@ impl crate::stubs::ConversationModels for ConversationModels {
                 reqwest::Method::POST,
                 format!("/v2/{}/evaluations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1622,7 +1622,7 @@ impl crate::stubs::ConversationModels for ConversationModels {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1644,7 +1644,7 @@ impl crate::stubs::ConversationModels for ConversationModels {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1663,7 +1663,7 @@ impl crate::stubs::ConversationModels for ConversationModels {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1685,7 +1685,7 @@ impl crate::stubs::ConversationModels for ConversationModels {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1704,7 +1704,7 @@ impl crate::stubs::ConversationModels for ConversationModels {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1763,7 +1763,7 @@ impl crate::stubs::ConversationProfiles for ConversationProfiles {
                 reqwest::Method::GET,
                 format!("/v2/{}/conversationProfiles", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1784,7 +1784,7 @@ impl crate::stubs::ConversationProfiles for ConversationProfiles {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1806,7 +1806,7 @@ impl crate::stubs::ConversationProfiles for ConversationProfiles {
                 reqwest::Method::POST,
                 format!("/v2/{}/conversationProfiles", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1834,7 +1834,7 @@ impl crate::stubs::ConversationProfiles for ConversationProfiles {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1863,7 +1863,7 @@ impl crate::stubs::ConversationProfiles for ConversationProfiles {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1888,7 +1888,7 @@ impl crate::stubs::ConversationProfiles for ConversationProfiles {
                     req.conversation_profile
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1911,7 +1911,7 @@ impl crate::stubs::ConversationProfiles for ConversationProfiles {
                     req.conversation_profile
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1928,7 +1928,7 @@ impl crate::stubs::ConversationProfiles for ConversationProfiles {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1950,7 +1950,7 @@ impl crate::stubs::ConversationProfiles for ConversationProfiles {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1969,7 +1969,7 @@ impl crate::stubs::ConversationProfiles for ConversationProfiles {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1991,7 +1991,7 @@ impl crate::stubs::ConversationProfiles for ConversationProfiles {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2010,7 +2010,7 @@ impl crate::stubs::ConversationProfiles for ConversationProfiles {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2069,7 +2069,7 @@ impl crate::stubs::Documents for Documents {
                 reqwest::Method::GET,
                 format!("/v2/{}/documents", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2091,7 +2091,7 @@ impl crate::stubs::Documents for Documents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2113,7 +2113,7 @@ impl crate::stubs::Documents for Documents {
                 reqwest::Method::POST,
                 format!("/v2/{}/documents", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2135,7 +2135,7 @@ impl crate::stubs::Documents for Documents {
                 reqwest::Method::POST,
                 format!("/v2/{}/documents:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2152,7 +2152,7 @@ impl crate::stubs::Documents for Documents {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2180,7 +2180,7 @@ impl crate::stubs::Documents for Documents {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2209,7 +2209,7 @@ impl crate::stubs::Documents for Documents {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:reload", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2226,7 +2226,7 @@ impl crate::stubs::Documents for Documents {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:export", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2243,7 +2243,7 @@ impl crate::stubs::Documents for Documents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2265,7 +2265,7 @@ impl crate::stubs::Documents for Documents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2284,7 +2284,7 @@ impl crate::stubs::Documents for Documents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2306,7 +2306,7 @@ impl crate::stubs::Documents for Documents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2325,7 +2325,7 @@ impl crate::stubs::Documents for Documents {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2381,7 +2381,7 @@ impl crate::stubs::EncryptionSpecService for EncryptionSpecService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2409,7 +2409,7 @@ impl crate::stubs::EncryptionSpecService for EncryptionSpecService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2426,7 +2426,7 @@ impl crate::stubs::EncryptionSpecService for EncryptionSpecService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2448,7 +2448,7 @@ impl crate::stubs::EncryptionSpecService for EncryptionSpecService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2467,7 +2467,7 @@ impl crate::stubs::EncryptionSpecService for EncryptionSpecService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2489,7 +2489,7 @@ impl crate::stubs::EncryptionSpecService for EncryptionSpecService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2508,7 +2508,7 @@ impl crate::stubs::EncryptionSpecService for EncryptionSpecService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2567,7 +2567,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
                 reqwest::Method::GET,
                 format!("/v2/{}/entityTypes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2589,7 +2589,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2612,7 +2612,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
                 reqwest::Method::POST,
                 format!("/v2/{}/entityTypes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2641,7 +2641,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2671,7 +2671,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2693,7 +2693,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
                 reqwest::Method::POST,
                 format!("/v2/{}/entityTypes:batchUpdate", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2713,7 +2713,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
                 reqwest::Method::POST,
                 format!("/v2/{}/entityTypes:batchDelete", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2733,7 +2733,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
                 reqwest::Method::POST,
                 format!("/v2/{}/entities:batchCreate", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2753,7 +2753,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
                 reqwest::Method::POST,
                 format!("/v2/{}/entities:batchUpdate", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2773,7 +2773,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
                 reqwest::Method::POST,
                 format!("/v2/{}/entities:batchDelete", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2790,7 +2790,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2812,7 +2812,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2831,7 +2831,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2853,7 +2853,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2872,7 +2872,7 @@ impl crate::stubs::EntityTypes for EntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2931,7 +2931,7 @@ impl crate::stubs::Environments for Environments {
                 reqwest::Method::GET,
                 format!("/v2/{}/environments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2952,7 +2952,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2974,7 +2974,7 @@ impl crate::stubs::Environments for Environments {
                 reqwest::Method::POST,
                 format!("/v2/{}/environments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3003,7 +3003,7 @@ impl crate::stubs::Environments for Environments {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3036,7 +3036,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3055,7 +3055,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/history", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3076,7 +3076,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3098,7 +3098,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3117,7 +3117,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3139,7 +3139,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3158,7 +3158,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3200,7 +3200,7 @@ impl crate::stubs::Fulfillments for Fulfillments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3228,7 +3228,7 @@ impl crate::stubs::Fulfillments for Fulfillments {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3257,7 +3257,7 @@ impl crate::stubs::Fulfillments for Fulfillments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3279,7 +3279,7 @@ impl crate::stubs::Fulfillments for Fulfillments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3298,7 +3298,7 @@ impl crate::stubs::Fulfillments for Fulfillments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3320,7 +3320,7 @@ impl crate::stubs::Fulfillments for Fulfillments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3339,7 +3339,7 @@ impl crate::stubs::Fulfillments for Fulfillments {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3384,7 +3384,7 @@ impl crate::stubs::Generators for Generators {
                 reqwest::Method::POST,
                 format!("/v2/{}/generators", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3404,7 +3404,7 @@ impl crate::stubs::Generators for Generators {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3426,7 +3426,7 @@ impl crate::stubs::Generators for Generators {
                 reqwest::Method::GET,
                 format!("/v2/{}/generators", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3447,7 +3447,7 @@ impl crate::stubs::Generators for Generators {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3475,7 +3475,7 @@ impl crate::stubs::Generators for Generators {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3504,7 +3504,7 @@ impl crate::stubs::Generators for Generators {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3526,7 +3526,7 @@ impl crate::stubs::Generators for Generators {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3545,7 +3545,7 @@ impl crate::stubs::Generators for Generators {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3567,7 +3567,7 @@ impl crate::stubs::Generators for Generators {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3586,7 +3586,7 @@ impl crate::stubs::Generators for Generators {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3628,7 +3628,7 @@ impl crate::stubs::Intents for Intents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/intents", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3651,7 +3651,7 @@ impl crate::stubs::Intents for Intents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3672,7 +3672,7 @@ impl crate::stubs::Intents for Intents {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}/intents", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3700,7 +3700,7 @@ impl crate::stubs::Intents for Intents {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3729,7 +3729,7 @@ impl crate::stubs::Intents for Intents {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3751,7 +3751,7 @@ impl crate::stubs::Intents for Intents {
                 reqwest::Method::POST,
                 format!("/v2/{}/intents:batchUpdate", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3771,7 +3771,7 @@ impl crate::stubs::Intents for Intents {
                 reqwest::Method::POST,
                 format!("/v2/{}/intents:batchDelete", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3788,7 +3788,7 @@ impl crate::stubs::Intents for Intents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3810,7 +3810,7 @@ impl crate::stubs::Intents for Intents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3829,7 +3829,7 @@ impl crate::stubs::Intents for Intents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3851,7 +3851,7 @@ impl crate::stubs::Intents for Intents {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3870,7 +3870,7 @@ impl crate::stubs::Intents for Intents {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3929,7 +3929,7 @@ impl crate::stubs::KnowledgeBases for KnowledgeBases {
                 reqwest::Method::GET,
                 format!("/v2/{}/knowledgeBases", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3951,7 +3951,7 @@ impl crate::stubs::KnowledgeBases for KnowledgeBases {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3973,7 +3973,7 @@ impl crate::stubs::KnowledgeBases for KnowledgeBases {
                 reqwest::Method::POST,
                 format!("/v2/{}/knowledgeBases", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -3992,7 +3992,7 @@ impl crate::stubs::KnowledgeBases for KnowledgeBases {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4021,7 +4021,7 @@ impl crate::stubs::KnowledgeBases for KnowledgeBases {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4050,7 +4050,7 @@ impl crate::stubs::KnowledgeBases for KnowledgeBases {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4072,7 +4072,7 @@ impl crate::stubs::KnowledgeBases for KnowledgeBases {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4091,7 +4091,7 @@ impl crate::stubs::KnowledgeBases for KnowledgeBases {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4113,7 +4113,7 @@ impl crate::stubs::KnowledgeBases for KnowledgeBases {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4132,7 +4132,7 @@ impl crate::stubs::KnowledgeBases for KnowledgeBases {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4177,7 +4177,7 @@ impl crate::stubs::Participants for Participants {
                 reqwest::Method::POST,
                 format!("/v2/{}/participants", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4196,7 +4196,7 @@ impl crate::stubs::Participants for Participants {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4218,7 +4218,7 @@ impl crate::stubs::Participants for Participants {
                 reqwest::Method::GET,
                 format!("/v2/{}/participants", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4248,7 +4248,7 @@ impl crate::stubs::Participants for Participants {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4280,7 +4280,7 @@ impl crate::stubs::Participants for Participants {
                 reqwest::Method::POST,
                 format!("/v2/{}:analyzeContent", req.participant),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4300,7 +4300,7 @@ impl crate::stubs::Participants for Participants {
                 reqwest::Method::POST,
                 format!("/v2/{}/suggestions:suggestArticles", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4320,7 +4320,7 @@ impl crate::stubs::Participants for Participants {
                 reqwest::Method::POST,
                 format!("/v2/{}/suggestions:suggestFaqAnswers", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4340,7 +4340,7 @@ impl crate::stubs::Participants for Participants {
                 reqwest::Method::POST,
                 format!("/v2/{}/suggestions:suggestSmartReplies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4360,7 +4360,7 @@ impl crate::stubs::Participants for Participants {
                 reqwest::Method::POST,
                 format!("/v2/{}/suggestions:suggestKnowledgeAssist", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4377,7 +4377,7 @@ impl crate::stubs::Participants for Participants {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4399,7 +4399,7 @@ impl crate::stubs::Participants for Participants {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4418,7 +4418,7 @@ impl crate::stubs::Participants for Participants {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4440,7 +4440,7 @@ impl crate::stubs::Participants for Participants {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4459,7 +4459,7 @@ impl crate::stubs::Participants for Participants {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4504,7 +4504,7 @@ impl crate::stubs::Sessions for Sessions {
                 reqwest::Method::POST,
                 format!("/v2/{}:detectIntent", req.session),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4521,7 +4521,7 @@ impl crate::stubs::Sessions for Sessions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4543,7 +4543,7 @@ impl crate::stubs::Sessions for Sessions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4562,7 +4562,7 @@ impl crate::stubs::Sessions for Sessions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4584,7 +4584,7 @@ impl crate::stubs::Sessions for Sessions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4603,7 +4603,7 @@ impl crate::stubs::Sessions for Sessions {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4648,7 +4648,7 @@ impl crate::stubs::SessionEntityTypes for SessionEntityTypes {
                 reqwest::Method::GET,
                 format!("/v2/{}/entityTypes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4669,7 +4669,7 @@ impl crate::stubs::SessionEntityTypes for SessionEntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4691,7 +4691,7 @@ impl crate::stubs::SessionEntityTypes for SessionEntityTypes {
                 reqwest::Method::POST,
                 format!("/v2/{}/entityTypes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4719,7 +4719,7 @@ impl crate::stubs::SessionEntityTypes for SessionEntityTypes {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4748,7 +4748,7 @@ impl crate::stubs::SessionEntityTypes for SessionEntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4767,7 +4767,7 @@ impl crate::stubs::SessionEntityTypes for SessionEntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4789,7 +4789,7 @@ impl crate::stubs::SessionEntityTypes for SessionEntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4808,7 +4808,7 @@ impl crate::stubs::SessionEntityTypes for SessionEntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4830,7 +4830,7 @@ impl crate::stubs::SessionEntityTypes for SessionEntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4849,7 +4849,7 @@ impl crate::stubs::SessionEntityTypes for SessionEntityTypes {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4891,7 +4891,7 @@ impl crate::stubs::Versions for Versions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/versions", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4912,7 +4912,7 @@ impl crate::stubs::Versions for Versions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4934,7 +4934,7 @@ impl crate::stubs::Versions for Versions {
                 reqwest::Method::POST,
                 format!("/v2/{}/versions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4962,7 +4962,7 @@ impl crate::stubs::Versions for Versions {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -4991,7 +4991,7 @@ impl crate::stubs::Versions for Versions {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5010,7 +5010,7 @@ impl crate::stubs::Versions for Versions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5032,7 +5032,7 @@ impl crate::stubs::Versions for Versions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5051,7 +5051,7 @@ impl crate::stubs::Versions for Versions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5073,7 +5073,7 @@ impl crate::stubs::Versions for Versions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -5092,7 +5092,7 @@ impl crate::stubs::Versions for Versions {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/discoveryengine/v1/src/model.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/model.rs
@@ -1299,46 +1299,63 @@ pub mod answer {
 
         /// Enumeration of the state of the step.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(std::borrow::Cow<'static, str>);
+        pub struct State(i32);
 
         impl State {
+            /// Unknown.
+            pub const STATE_UNSPECIFIED: State = State::new(0);
+
+            /// Step is currently in progress.
+            pub const IN_PROGRESS: State = State::new(1);
+
+            /// Step currently failed.
+            pub const FAILED: State = State::new(2);
+
+            /// Step has succeeded.
+            pub const SUCCEEDED: State = State::new(3);
+
             /// Creates a new State instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                    2 => std::borrow::Cow::Borrowed("FAILED"),
+                    3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                    "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                    "FAILED" => std::option::Option::Some(Self::FAILED),
+                    "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [State](State)
-        pub mod state {
-            use super::State;
-
-            /// Unknown.
-            pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-            /// Step is currently in progress.
-            pub const IN_PROGRESS: State = State::new("IN_PROGRESS");
-
-            /// Step currently failed.
-            pub const FAILED: State = State::new("FAILED");
-
-            /// Step has succeeded.
-            pub const SUCCEEDED: State = State::new("SUCCEEDED");
-        }
-
-        impl std::convert::From<std::string::String> for State {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                state::STATE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -1438,50 +1455,74 @@ pub mod answer {
 
             /// Query classification types.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct Type(std::borrow::Cow<'static, str>);
+            pub struct Type(i32);
 
             impl Type {
+                /// Unspecified query classification type.
+                pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+                /// Adversarial query classification type.
+                pub const ADVERSARIAL_QUERY: Type = Type::new(1);
+
+                /// Non-answer-seeking query classification type, for chit chat.
+                pub const NON_ANSWER_SEEKING_QUERY: Type = Type::new(2);
+
+                /// Jail-breaking query classification type.
+                pub const JAIL_BREAKING_QUERY: Type = Type::new(3);
+
+                /// Non-answer-seeking query classification type, for no clear intent.
+                pub const NON_ANSWER_SEEKING_QUERY_V2: Type = Type::new(4);
+
                 /// Creates a new Type instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
                 }
 
                 /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("ADVERSARIAL_QUERY"),
+                        2 => std::borrow::Cow::Borrowed("NON_ANSWER_SEEKING_QUERY"),
+                        3 => std::borrow::Cow::Borrowed("JAIL_BREAKING_QUERY"),
+                        4 => std::borrow::Cow::Borrowed("NON_ANSWER_SEEKING_QUERY_V2"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                        "ADVERSARIAL_QUERY" => std::option::Option::Some(Self::ADVERSARIAL_QUERY),
+                        "NON_ANSWER_SEEKING_QUERY" => {
+                            std::option::Option::Some(Self::NON_ANSWER_SEEKING_QUERY)
+                        }
+                        "JAIL_BREAKING_QUERY" => {
+                            std::option::Option::Some(Self::JAIL_BREAKING_QUERY)
+                        }
+                        "NON_ANSWER_SEEKING_QUERY_V2" => {
+                            std::option::Option::Some(Self::NON_ANSWER_SEEKING_QUERY_V2)
+                        }
+                        _ => std::option::Option::None,
+                    }
                 }
             }
 
-            /// Useful constants to work with [Type](Type)
-            pub mod r#type {
-                use super::Type;
-
-                /// Unspecified query classification type.
-                pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-                /// Adversarial query classification type.
-                pub const ADVERSARIAL_QUERY: Type = Type::new("ADVERSARIAL_QUERY");
-
-                /// Non-answer-seeking query classification type, for chit chat.
-                pub const NON_ANSWER_SEEKING_QUERY: Type = Type::new("NON_ANSWER_SEEKING_QUERY");
-
-                /// Jail-breaking query classification type.
-                pub const JAIL_BREAKING_QUERY: Type = Type::new("JAIL_BREAKING_QUERY");
-
-                /// Non-answer-seeking query classification type, for no clear intent.
-                pub const NON_ANSWER_SEEKING_QUERY_V2: Type =
-                    Type::new("NON_ANSWER_SEEKING_QUERY_V2");
-            }
-
-            impl std::convert::From<std::string::String> for Type {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for Type {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for Type {
                 fn default() -> Self {
-                    r#type::TYPE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -1489,141 +1530,196 @@ pub mod answer {
 
     /// Enumeration of the state of the answer generation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unknown.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Answer generation is currently in progress.
+        pub const IN_PROGRESS: State = State::new(1);
+
+        /// Answer generation currently failed.
+        pub const FAILED: State = State::new(2);
+
+        /// Answer generation has succeeded.
+        pub const SUCCEEDED: State = State::new(3);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                2 => std::borrow::Cow::Borrowed("FAILED"),
+                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unknown.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Answer generation is currently in progress.
-        pub const IN_PROGRESS: State = State::new("IN_PROGRESS");
-
-        /// Answer generation currently failed.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// Answer generation has succeeded.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// An enum for answer skipped reasons.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AnswerSkippedReason(std::borrow::Cow<'static, str>);
+    pub struct AnswerSkippedReason(i32);
 
     impl AnswerSkippedReason {
-        /// Creates a new AnswerSkippedReason instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [AnswerSkippedReason](AnswerSkippedReason)
-    pub mod answer_skipped_reason {
-        use super::AnswerSkippedReason;
-
         /// Default value. The answer skipped reason is not specified.
         pub const ANSWER_SKIPPED_REASON_UNSPECIFIED: AnswerSkippedReason =
-            AnswerSkippedReason::new("ANSWER_SKIPPED_REASON_UNSPECIFIED");
+            AnswerSkippedReason::new(0);
 
         /// The adversarial query ignored case.
-        pub const ADVERSARIAL_QUERY_IGNORED: AnswerSkippedReason =
-            AnswerSkippedReason::new("ADVERSARIAL_QUERY_IGNORED");
+        pub const ADVERSARIAL_QUERY_IGNORED: AnswerSkippedReason = AnswerSkippedReason::new(1);
 
         /// The non-answer seeking query ignored case
         ///
         /// Google skips the answer if the query is chit chat.
         pub const NON_ANSWER_SEEKING_QUERY_IGNORED: AnswerSkippedReason =
-            AnswerSkippedReason::new("NON_ANSWER_SEEKING_QUERY_IGNORED");
+            AnswerSkippedReason::new(2);
 
         /// The out-of-domain query ignored case.
         ///
         /// Google skips the answer if there are no high-relevance search results.
-        pub const OUT_OF_DOMAIN_QUERY_IGNORED: AnswerSkippedReason =
-            AnswerSkippedReason::new("OUT_OF_DOMAIN_QUERY_IGNORED");
+        pub const OUT_OF_DOMAIN_QUERY_IGNORED: AnswerSkippedReason = AnswerSkippedReason::new(3);
 
         /// The potential policy violation case.
         ///
         /// Google skips the answer if there is a potential policy violation
         /// detected. This includes content that may be violent or toxic.
-        pub const POTENTIAL_POLICY_VIOLATION: AnswerSkippedReason =
-            AnswerSkippedReason::new("POTENTIAL_POLICY_VIOLATION");
+        pub const POTENTIAL_POLICY_VIOLATION: AnswerSkippedReason = AnswerSkippedReason::new(4);
 
         /// The no relevant content case.
         ///
         /// Google skips the answer if there is no relevant content in the
         /// retrieved search results.
-        pub const NO_RELEVANT_CONTENT: AnswerSkippedReason =
-            AnswerSkippedReason::new("NO_RELEVANT_CONTENT");
+        pub const NO_RELEVANT_CONTENT: AnswerSkippedReason = AnswerSkippedReason::new(5);
 
         /// The jail-breaking query ignored case.
         ///
         /// For example, "Reply in the tone of a competing company's CEO".
         /// Google skips the answer if the query is classified as a jail-breaking
         /// query.
-        pub const JAIL_BREAKING_QUERY_IGNORED: AnswerSkippedReason =
-            AnswerSkippedReason::new("JAIL_BREAKING_QUERY_IGNORED");
+        pub const JAIL_BREAKING_QUERY_IGNORED: AnswerSkippedReason = AnswerSkippedReason::new(6);
 
         /// The customer policy violation case.
         ///
         /// Google skips the summary if there is a customer policy violation
         /// detected. The policy is defined by the customer.
-        pub const CUSTOMER_POLICY_VIOLATION: AnswerSkippedReason =
-            AnswerSkippedReason::new("CUSTOMER_POLICY_VIOLATION");
+        pub const CUSTOMER_POLICY_VIOLATION: AnswerSkippedReason = AnswerSkippedReason::new(7);
 
         /// The non-answer seeking query ignored case.
         ///
         /// Google skips the answer if the query doesn't have clear intent.
         pub const NON_ANSWER_SEEKING_QUERY_IGNORED_V2: AnswerSkippedReason =
-            AnswerSkippedReason::new("NON_ANSWER_SEEKING_QUERY_IGNORED_V2");
+            AnswerSkippedReason::new(8);
 
         /// The low-grounded answer case.
         ///
         /// Google skips the answer if a well grounded answer was unable to be
         /// generated.
-        pub const LOW_GROUNDED_ANSWER: AnswerSkippedReason =
-            AnswerSkippedReason::new("LOW_GROUNDED_ANSWER");
+        pub const LOW_GROUNDED_ANSWER: AnswerSkippedReason = AnswerSkippedReason::new(9);
+
+        /// Creates a new AnswerSkippedReason instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ANSWER_SKIPPED_REASON_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ADVERSARIAL_QUERY_IGNORED"),
+                2 => std::borrow::Cow::Borrowed("NON_ANSWER_SEEKING_QUERY_IGNORED"),
+                3 => std::borrow::Cow::Borrowed("OUT_OF_DOMAIN_QUERY_IGNORED"),
+                4 => std::borrow::Cow::Borrowed("POTENTIAL_POLICY_VIOLATION"),
+                5 => std::borrow::Cow::Borrowed("NO_RELEVANT_CONTENT"),
+                6 => std::borrow::Cow::Borrowed("JAIL_BREAKING_QUERY_IGNORED"),
+                7 => std::borrow::Cow::Borrowed("CUSTOMER_POLICY_VIOLATION"),
+                8 => std::borrow::Cow::Borrowed("NON_ANSWER_SEEKING_QUERY_IGNORED_V2"),
+                9 => std::borrow::Cow::Borrowed("LOW_GROUNDED_ANSWER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ANSWER_SKIPPED_REASON_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ANSWER_SKIPPED_REASON_UNSPECIFIED)
+                }
+                "ADVERSARIAL_QUERY_IGNORED" => {
+                    std::option::Option::Some(Self::ADVERSARIAL_QUERY_IGNORED)
+                }
+                "NON_ANSWER_SEEKING_QUERY_IGNORED" => {
+                    std::option::Option::Some(Self::NON_ANSWER_SEEKING_QUERY_IGNORED)
+                }
+                "OUT_OF_DOMAIN_QUERY_IGNORED" => {
+                    std::option::Option::Some(Self::OUT_OF_DOMAIN_QUERY_IGNORED)
+                }
+                "POTENTIAL_POLICY_VIOLATION" => {
+                    std::option::Option::Some(Self::POTENTIAL_POLICY_VIOLATION)
+                }
+                "NO_RELEVANT_CONTENT" => std::option::Option::Some(Self::NO_RELEVANT_CONTENT),
+                "JAIL_BREAKING_QUERY_IGNORED" => {
+                    std::option::Option::Some(Self::JAIL_BREAKING_QUERY_IGNORED)
+                }
+                "CUSTOMER_POLICY_VIOLATION" => {
+                    std::option::Option::Some(Self::CUSTOMER_POLICY_VIOLATION)
+                }
+                "NON_ANSWER_SEEKING_QUERY_IGNORED_V2" => {
+                    std::option::Option::Some(Self::NON_ANSWER_SEEKING_QUERY_IGNORED_V2)
+                }
+                "LOW_GROUNDED_ANSWER" => std::option::Option::Some(Self::LOW_GROUNDED_ANSWER),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for AnswerSkippedReason {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AnswerSkippedReason {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AnswerSkippedReason {
         fn default() -> Self {
-            answer_skipped_reason::ANSWER_SKIPPED_REASON_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2293,44 +2389,60 @@ pub mod suggestion_deny_list_entry {
 
     /// Operator for matching with the generated suggestions.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MatchOperator(std::borrow::Cow<'static, str>);
+    pub struct MatchOperator(i32);
 
     impl MatchOperator {
+        /// Default value. Should not be used
+        pub const MATCH_OPERATOR_UNSPECIFIED: MatchOperator = MatchOperator::new(0);
+
+        /// If the suggestion is an exact match to the block_phrase, then block it.
+        pub const EXACT_MATCH: MatchOperator = MatchOperator::new(1);
+
+        /// If the suggestion contains the block_phrase, then block it.
+        pub const CONTAINS: MatchOperator = MatchOperator::new(2);
+
         /// Creates a new MatchOperator instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MATCH_OPERATOR_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("EXACT_MATCH"),
+                2 => std::borrow::Cow::Borrowed("CONTAINS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MATCH_OPERATOR_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MATCH_OPERATOR_UNSPECIFIED)
+                }
+                "EXACT_MATCH" => std::option::Option::Some(Self::EXACT_MATCH),
+                "CONTAINS" => std::option::Option::Some(Self::CONTAINS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [MatchOperator](MatchOperator)
-    pub mod match_operator {
-        use super::MatchOperator;
-
-        /// Default value. Should not be used
-        pub const MATCH_OPERATOR_UNSPECIFIED: MatchOperator =
-            MatchOperator::new("MATCH_OPERATOR_UNSPECIFIED");
-
-        /// If the suggestion is an exact match to the block_phrase, then block it.
-        pub const EXACT_MATCH: MatchOperator = MatchOperator::new("EXACT_MATCH");
-
-        /// If the suggestion contains the block_phrase, then block it.
-        pub const CONTAINS: MatchOperator = MatchOperator::new("CONTAINS");
-    }
-
-    impl std::convert::From<std::string::String> for MatchOperator {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MatchOperator {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MatchOperator {
         fn default() -> Self {
-            match_operator::MATCH_OPERATOR_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3742,43 +3854,58 @@ pub mod conversation {
 
     /// Enumeration of the state of the conversation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unknown.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Conversation is currently open.
+        pub const IN_PROGRESS: State = State::new(1);
+
+        /// Conversation has been completed.
+        pub const COMPLETED: State = State::new(2);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                2 => std::borrow::Cow::Borrowed("COMPLETED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                "COMPLETED" => std::option::Option::Some(Self::COMPLETED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unknown.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Conversation is currently open.
-        pub const IN_PROGRESS: State = State::new("IN_PROGRESS");
-
-        /// Conversation has been completed.
-        pub const COMPLETED: State = State::new("COMPLETED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5953,50 +6080,74 @@ pub mod answer_query_request {
 
             /// Query classification types.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct Type(std::borrow::Cow<'static, str>);
+            pub struct Type(i32);
 
             impl Type {
+                /// Unspecified query classification type.
+                pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+                /// Adversarial query classification type.
+                pub const ADVERSARIAL_QUERY: Type = Type::new(1);
+
+                /// Non-answer-seeking query classification type, for chit chat.
+                pub const NON_ANSWER_SEEKING_QUERY: Type = Type::new(2);
+
+                /// Jail-breaking query classification type.
+                pub const JAIL_BREAKING_QUERY: Type = Type::new(3);
+
+                /// Non-answer-seeking query classification type, for no clear intent.
+                pub const NON_ANSWER_SEEKING_QUERY_V2: Type = Type::new(4);
+
                 /// Creates a new Type instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
                 }
 
                 /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("ADVERSARIAL_QUERY"),
+                        2 => std::borrow::Cow::Borrowed("NON_ANSWER_SEEKING_QUERY"),
+                        3 => std::borrow::Cow::Borrowed("JAIL_BREAKING_QUERY"),
+                        4 => std::borrow::Cow::Borrowed("NON_ANSWER_SEEKING_QUERY_V2"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                        "ADVERSARIAL_QUERY" => std::option::Option::Some(Self::ADVERSARIAL_QUERY),
+                        "NON_ANSWER_SEEKING_QUERY" => {
+                            std::option::Option::Some(Self::NON_ANSWER_SEEKING_QUERY)
+                        }
+                        "JAIL_BREAKING_QUERY" => {
+                            std::option::Option::Some(Self::JAIL_BREAKING_QUERY)
+                        }
+                        "NON_ANSWER_SEEKING_QUERY_V2" => {
+                            std::option::Option::Some(Self::NON_ANSWER_SEEKING_QUERY_V2)
+                        }
+                        _ => std::option::Option::None,
+                    }
                 }
             }
 
-            /// Useful constants to work with [Type](Type)
-            pub mod r#type {
-                use super::Type;
-
-                /// Unspecified query classification type.
-                pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-                /// Adversarial query classification type.
-                pub const ADVERSARIAL_QUERY: Type = Type::new("ADVERSARIAL_QUERY");
-
-                /// Non-answer-seeking query classification type, for chit chat.
-                pub const NON_ANSWER_SEEKING_QUERY: Type = Type::new("NON_ANSWER_SEEKING_QUERY");
-
-                /// Jail-breaking query classification type.
-                pub const JAIL_BREAKING_QUERY: Type = Type::new("JAIL_BREAKING_QUERY");
-
-                /// Non-answer-seeking query classification type, for no clear intent.
-                pub const NON_ANSWER_SEEKING_QUERY_V2: Type =
-                    Type::new("NON_ANSWER_SEEKING_QUERY_V2");
-            }
-
-            impl std::convert::From<std::string::String> for Type {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for Type {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for Type {
                 fn default() -> Self {
-                    r#type::TYPE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -6575,58 +6726,87 @@ pub mod custom_tuning_model {
 
     /// The state of the model.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ModelState(std::borrow::Cow<'static, str>);
+    pub struct ModelState(i32);
 
     impl ModelState {
+        /// Default value.
+        pub const MODEL_STATE_UNSPECIFIED: ModelState = ModelState::new(0);
+
+        /// The model is in a paused training state.
+        pub const TRAINING_PAUSED: ModelState = ModelState::new(1);
+
+        /// The model is currently training.
+        pub const TRAINING: ModelState = ModelState::new(2);
+
+        /// The model has successfully completed training.
+        pub const TRAINING_COMPLETE: ModelState = ModelState::new(3);
+
+        /// The model is ready for serving.
+        pub const READY_FOR_SERVING: ModelState = ModelState::new(4);
+
+        /// The model training failed.
+        pub const TRAINING_FAILED: ModelState = ModelState::new(5);
+
+        /// The model training finished successfully but metrics did not improve.
+        pub const NO_IMPROVEMENT: ModelState = ModelState::new(6);
+
+        /// Input data validation failed. Model training didn't start.
+        pub const INPUT_VALIDATION_FAILED: ModelState = ModelState::new(7);
+
         /// Creates a new ModelState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MODEL_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TRAINING_PAUSED"),
+                2 => std::borrow::Cow::Borrowed("TRAINING"),
+                3 => std::borrow::Cow::Borrowed("TRAINING_COMPLETE"),
+                4 => std::borrow::Cow::Borrowed("READY_FOR_SERVING"),
+                5 => std::borrow::Cow::Borrowed("TRAINING_FAILED"),
+                6 => std::borrow::Cow::Borrowed("NO_IMPROVEMENT"),
+                7 => std::borrow::Cow::Borrowed("INPUT_VALIDATION_FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MODEL_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MODEL_STATE_UNSPECIFIED)
+                }
+                "TRAINING_PAUSED" => std::option::Option::Some(Self::TRAINING_PAUSED),
+                "TRAINING" => std::option::Option::Some(Self::TRAINING),
+                "TRAINING_COMPLETE" => std::option::Option::Some(Self::TRAINING_COMPLETE),
+                "READY_FOR_SERVING" => std::option::Option::Some(Self::READY_FOR_SERVING),
+                "TRAINING_FAILED" => std::option::Option::Some(Self::TRAINING_FAILED),
+                "NO_IMPROVEMENT" => std::option::Option::Some(Self::NO_IMPROVEMENT),
+                "INPUT_VALIDATION_FAILED" => {
+                    std::option::Option::Some(Self::INPUT_VALIDATION_FAILED)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ModelState](ModelState)
-    pub mod model_state {
-        use super::ModelState;
-
-        /// Default value.
-        pub const MODEL_STATE_UNSPECIFIED: ModelState = ModelState::new("MODEL_STATE_UNSPECIFIED");
-
-        /// The model is in a paused training state.
-        pub const TRAINING_PAUSED: ModelState = ModelState::new("TRAINING_PAUSED");
-
-        /// The model is currently training.
-        pub const TRAINING: ModelState = ModelState::new("TRAINING");
-
-        /// The model has successfully completed training.
-        pub const TRAINING_COMPLETE: ModelState = ModelState::new("TRAINING_COMPLETE");
-
-        /// The model is ready for serving.
-        pub const READY_FOR_SERVING: ModelState = ModelState::new("READY_FOR_SERVING");
-
-        /// The model training failed.
-        pub const TRAINING_FAILED: ModelState = ModelState::new("TRAINING_FAILED");
-
-        /// The model training finished successfully but metrics did not improve.
-        pub const NO_IMPROVEMENT: ModelState = ModelState::new("NO_IMPROVEMENT");
-
-        /// Input data validation failed. Model training didn't start.
-        pub const INPUT_VALIDATION_FAILED: ModelState = ModelState::new("INPUT_VALIDATION_FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for ModelState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ModelState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ModelState {
         fn default() -> Self {
-            model_state::MODEL_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6943,60 +7123,80 @@ pub mod data_store {
 
     /// Content config of the data store.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ContentConfig(std::borrow::Cow<'static, str>);
+    pub struct ContentConfig(i32);
 
     impl ContentConfig {
-        /// Creates a new ContentConfig instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ContentConfig](ContentConfig)
-    pub mod content_config {
-        use super::ContentConfig;
-
         /// Default value.
-        pub const CONTENT_CONFIG_UNSPECIFIED: ContentConfig =
-            ContentConfig::new("CONTENT_CONFIG_UNSPECIFIED");
+        pub const CONTENT_CONFIG_UNSPECIFIED: ContentConfig = ContentConfig::new(0);
 
         /// Only contains documents without any
         /// [Document.content][google.cloud.discoveryengine.v1.Document.content].
         ///
         /// [google.cloud.discoveryengine.v1.Document.content]: crate::model::Document::content
-        pub const NO_CONTENT: ContentConfig = ContentConfig::new("NO_CONTENT");
+        pub const NO_CONTENT: ContentConfig = ContentConfig::new(1);
 
         /// Only contains documents with
         /// [Document.content][google.cloud.discoveryengine.v1.Document.content].
         ///
         /// [google.cloud.discoveryengine.v1.Document.content]: crate::model::Document::content
-        pub const CONTENT_REQUIRED: ContentConfig = ContentConfig::new("CONTENT_REQUIRED");
+        pub const CONTENT_REQUIRED: ContentConfig = ContentConfig::new(2);
 
         /// The data store is used for public website search.
-        pub const PUBLIC_WEBSITE: ContentConfig = ContentConfig::new("PUBLIC_WEBSITE");
+        pub const PUBLIC_WEBSITE: ContentConfig = ContentConfig::new(3);
 
         /// The data store is used for workspace search. Details of workspace
         /// data store are specified in the
         /// [WorkspaceConfig][google.cloud.discoveryengine.v1.WorkspaceConfig].
         ///
         /// [google.cloud.discoveryengine.v1.WorkspaceConfig]: crate::model::WorkspaceConfig
-        pub const GOOGLE_WORKSPACE: ContentConfig = ContentConfig::new("GOOGLE_WORKSPACE");
+        pub const GOOGLE_WORKSPACE: ContentConfig = ContentConfig::new(4);
+
+        /// Creates a new ContentConfig instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CONTENT_CONFIG_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NO_CONTENT"),
+                2 => std::borrow::Cow::Borrowed("CONTENT_REQUIRED"),
+                3 => std::borrow::Cow::Borrowed("PUBLIC_WEBSITE"),
+                4 => std::borrow::Cow::Borrowed("GOOGLE_WORKSPACE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CONTENT_CONFIG_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CONTENT_CONFIG_UNSPECIFIED)
+                }
+                "NO_CONTENT" => std::option::Option::Some(Self::NO_CONTENT),
+                "CONTENT_REQUIRED" => std::option::Option::Some(Self::CONTENT_REQUIRED),
+                "PUBLIC_WEBSITE" => std::option::Option::Some(Self::PUBLIC_WEBSITE),
+                "GOOGLE_WORKSPACE" => std::option::Option::Some(Self::GOOGLE_WORKSPACE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ContentConfig {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ContentConfig {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ContentConfig {
         fn default() -> Self {
-            content_config::CONTENT_CONFIG_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7083,58 +7283,83 @@ pub mod workspace_config {
 
     /// Specifies the type of Workspace App supported by this DataStore
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Defaults to an unspecified Workspace type.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// Workspace Data Store contains Drive data
+        pub const GOOGLE_DRIVE: Type = Type::new(1);
+
+        /// Workspace Data Store contains Mail data
+        pub const GOOGLE_MAIL: Type = Type::new(2);
+
+        /// Workspace Data Store contains Sites data
+        pub const GOOGLE_SITES: Type = Type::new(3);
+
+        /// Workspace Data Store contains Calendar data
+        pub const GOOGLE_CALENDAR: Type = Type::new(4);
+
+        /// Workspace Data Store contains Chat data
+        pub const GOOGLE_CHAT: Type = Type::new(5);
+
+        /// Workspace Data Store contains Groups data
+        pub const GOOGLE_GROUPS: Type = Type::new(6);
+
+        /// Workspace Data Store contains Keep data
+        pub const GOOGLE_KEEP: Type = Type::new(7);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GOOGLE_DRIVE"),
+                2 => std::borrow::Cow::Borrowed("GOOGLE_MAIL"),
+                3 => std::borrow::Cow::Borrowed("GOOGLE_SITES"),
+                4 => std::borrow::Cow::Borrowed("GOOGLE_CALENDAR"),
+                5 => std::borrow::Cow::Borrowed("GOOGLE_CHAT"),
+                6 => std::borrow::Cow::Borrowed("GOOGLE_GROUPS"),
+                7 => std::borrow::Cow::Borrowed("GOOGLE_KEEP"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "GOOGLE_DRIVE" => std::option::Option::Some(Self::GOOGLE_DRIVE),
+                "GOOGLE_MAIL" => std::option::Option::Some(Self::GOOGLE_MAIL),
+                "GOOGLE_SITES" => std::option::Option::Some(Self::GOOGLE_SITES),
+                "GOOGLE_CALENDAR" => std::option::Option::Some(Self::GOOGLE_CALENDAR),
+                "GOOGLE_CHAT" => std::option::Option::Some(Self::GOOGLE_CHAT),
+                "GOOGLE_GROUPS" => std::option::Option::Some(Self::GOOGLE_GROUPS),
+                "GOOGLE_KEEP" => std::option::Option::Some(Self::GOOGLE_KEEP),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Defaults to an unspecified Workspace type.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// Workspace Data Store contains Drive data
-        pub const GOOGLE_DRIVE: Type = Type::new("GOOGLE_DRIVE");
-
-        /// Workspace Data Store contains Mail data
-        pub const GOOGLE_MAIL: Type = Type::new("GOOGLE_MAIL");
-
-        /// Workspace Data Store contains Sites data
-        pub const GOOGLE_SITES: Type = Type::new("GOOGLE_SITES");
-
-        /// Workspace Data Store contains Calendar data
-        pub const GOOGLE_CALENDAR: Type = Type::new("GOOGLE_CALENDAR");
-
-        /// Workspace Data Store contains Chat data
-        pub const GOOGLE_CHAT: Type = Type::new("GOOGLE_CHAT");
-
-        /// Workspace Data Store contains Groups data
-        pub const GOOGLE_GROUPS: Type = Type::new("GOOGLE_GROUPS");
-
-        /// Workspace Data Store contains Keep data
-        pub const GOOGLE_KEEP: Type = Type::new("GOOGLE_KEEP");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -9505,31 +9730,16 @@ pub mod batch_get_documents_metadata_response {
     ///
     /// [google.cloud.discoveryengine.v1.Document]: crate::model::Document
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Should never be set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The [Document][google.cloud.discoveryengine.v1.Document] is indexed.
         ///
         /// [google.cloud.discoveryengine.v1.Document]: crate::model::Document
-        pub const INDEXED: State = State::new("INDEXED");
+        pub const INDEXED: State = State::new(1);
 
         /// The [Document][google.cloud.discoveryengine.v1.Document] is not indexed
         /// because its URI is not in the
@@ -9537,23 +9747,55 @@ pub mod batch_get_documents_metadata_response {
         ///
         /// [google.cloud.discoveryengine.v1.Document]: crate::model::Document
         /// [google.cloud.discoveryengine.v1.TargetSite]: crate::model::TargetSite
-        pub const NOT_IN_TARGET_SITE: State = State::new("NOT_IN_TARGET_SITE");
+        pub const NOT_IN_TARGET_SITE: State = State::new(2);
 
         /// The [Document][google.cloud.discoveryengine.v1.Document] is not indexed.
         ///
         /// [google.cloud.discoveryengine.v1.Document]: crate::model::Document
-        pub const NOT_IN_INDEX: State = State::new("NOT_IN_INDEX");
+        pub const NOT_IN_INDEX: State = State::new(3);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INDEXED"),
+                2 => std::borrow::Cow::Borrowed("NOT_IN_TARGET_SITE"),
+                3 => std::borrow::Cow::Borrowed("NOT_IN_INDEX"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "INDEXED" => std::option::Option::Some(Self::INDEXED),
+                "NOT_IN_TARGET_SITE" => std::option::Option::Some(Self::NOT_IN_TARGET_SITE),
+                "NOT_IN_INDEX" => std::option::Option::Some(Self::NOT_IN_INDEX),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -11110,40 +11352,55 @@ pub mod generate_grounded_content_request {
 
             /// The version of the predictor to be used in dynamic retrieval.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct Version(std::borrow::Cow<'static, str>);
+            pub struct Version(i32);
 
             impl Version {
+                /// Automatically choose the best version of the retrieval predictor.
+                pub const VERSION_UNSPECIFIED: Version = Version::new(0);
+
+                /// The V1 model which is evaluating each source independently.
+                pub const V1_INDEPENDENT: Version = Version::new(1);
+
                 /// Creates a new Version instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
                 }
 
                 /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("VERSION_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("V1_INDEPENDENT"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "VERSION_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::VERSION_UNSPECIFIED)
+                        }
+                        "V1_INDEPENDENT" => std::option::Option::Some(Self::V1_INDEPENDENT),
+                        _ => std::option::Option::None,
+                    }
                 }
             }
 
-            /// Useful constants to work with [Version](Version)
-            pub mod version {
-                use super::Version;
-
-                /// Automatically choose the best version of the retrieval predictor.
-                pub const VERSION_UNSPECIFIED: Version = Version::new("VERSION_UNSPECIFIED");
-
-                /// The V1 model which is evaluating each source independently.
-                pub const V1_INDEPENDENT: Version = Version::new("V1_INDEPENDENT");
-            }
-
-            impl std::convert::From<std::string::String> for Version {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for Version {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for Version {
                 fn default() -> Self {
-                    version::VERSION_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -11771,49 +12028,70 @@ pub mod generate_grounded_content_response {
 
                 /// Describes the source to which the metadata is associated to.
                 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                pub struct Source(std::borrow::Cow<'static, str>);
+                pub struct Source(i32);
 
                 impl Source {
+                    /// Unspecified source.
+                    pub const SOURCE_UNSPECIFIED: Source = Source::new(0);
+
+                    /// Vertex AI search.
+                    pub const VERTEX_AI_SEARCH: Source = Source::new(1);
+
+                    /// Google Search.
+                    pub const GOOGLE_SEARCH: Source = Source::new(3);
+
+                    /// User inline provided content.
+                    pub const INLINE_CONTENT: Source = Source::new(2);
+
+                    /// Google Maps.
+                    pub const GOOGLE_MAPS: Source = Source::new(4);
+
                     /// Creates a new Source instance.
-                    pub const fn new(v: &'static str) -> Self {
-                        Self(std::borrow::Cow::Borrowed(v))
+                    pub(crate) const fn new(value: i32) -> Self {
+                        Self(value)
                     }
 
                     /// Gets the enum value.
-                    pub fn value(&self) -> &str {
-                        &self.0
+                    pub fn value(&self) -> i32 {
+                        self.0
+                    }
+
+                    /// Gets the enum value as a string.
+                    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                        match self.0 {
+                            0 => std::borrow::Cow::Borrowed("SOURCE_UNSPECIFIED"),
+                            1 => std::borrow::Cow::Borrowed("VERTEX_AI_SEARCH"),
+                            2 => std::borrow::Cow::Borrowed("INLINE_CONTENT"),
+                            3 => std::borrow::Cow::Borrowed("GOOGLE_SEARCH"),
+                            4 => std::borrow::Cow::Borrowed("GOOGLE_MAPS"),
+                            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                        }
+                    }
+
+                    /// Creates an enum value from the value name.
+                    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                        match name {
+                            "SOURCE_UNSPECIFIED" => {
+                                std::option::Option::Some(Self::SOURCE_UNSPECIFIED)
+                            }
+                            "VERTEX_AI_SEARCH" => std::option::Option::Some(Self::VERTEX_AI_SEARCH),
+                            "GOOGLE_SEARCH" => std::option::Option::Some(Self::GOOGLE_SEARCH),
+                            "INLINE_CONTENT" => std::option::Option::Some(Self::INLINE_CONTENT),
+                            "GOOGLE_MAPS" => std::option::Option::Some(Self::GOOGLE_MAPS),
+                            _ => std::option::Option::None,
+                        }
                     }
                 }
 
-                /// Useful constants to work with [Source](Source)
-                pub mod source {
-                    use super::Source;
-
-                    /// Unspecified source.
-                    pub const SOURCE_UNSPECIFIED: Source = Source::new("SOURCE_UNSPECIFIED");
-
-                    /// Vertex AI search.
-                    pub const VERTEX_AI_SEARCH: Source = Source::new("VERTEX_AI_SEARCH");
-
-                    /// Google Search.
-                    pub const GOOGLE_SEARCH: Source = Source::new("GOOGLE_SEARCH");
-
-                    /// User inline provided content.
-                    pub const INLINE_CONTENT: Source = Source::new("INLINE_CONTENT");
-
-                    /// Google Maps.
-                    pub const GOOGLE_MAPS: Source = Source::new("GOOGLE_MAPS");
-                }
-
-                impl std::convert::From<std::string::String> for Source {
-                    fn from(value: std::string::String) -> Self {
-                        Self(std::borrow::Cow::Owned(value))
+                impl std::convert::From<i32> for Source {
+                    fn from(value: i32) -> Self {
+                        Self::new(value)
                     }
                 }
 
                 impl std::default::Default for Source {
                     fn default() -> Self {
-                        source::SOURCE_UNSPECIFIED
+                        Self::new(0)
                     }
                 }
             }
@@ -11901,40 +12179,55 @@ pub mod generate_grounded_content_response {
 
                 /// The version of the predictor which was used in dynamic retrieval.
                 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                pub struct Version(std::borrow::Cow<'static, str>);
+                pub struct Version(i32);
 
                 impl Version {
+                    /// Unspecified version, should never be used.
+                    pub const VERSION_UNSPECIFIED: Version = Version::new(0);
+
+                    /// The V1 model which is evaluating each source independently.
+                    pub const V1_INDEPENDENT: Version = Version::new(1);
+
                     /// Creates a new Version instance.
-                    pub const fn new(v: &'static str) -> Self {
-                        Self(std::borrow::Cow::Borrowed(v))
+                    pub(crate) const fn new(value: i32) -> Self {
+                        Self(value)
                     }
 
                     /// Gets the enum value.
-                    pub fn value(&self) -> &str {
-                        &self.0
+                    pub fn value(&self) -> i32 {
+                        self.0
+                    }
+
+                    /// Gets the enum value as a string.
+                    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                        match self.0 {
+                            0 => std::borrow::Cow::Borrowed("VERSION_UNSPECIFIED"),
+                            1 => std::borrow::Cow::Borrowed("V1_INDEPENDENT"),
+                            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                        }
+                    }
+
+                    /// Creates an enum value from the value name.
+                    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                        match name {
+                            "VERSION_UNSPECIFIED" => {
+                                std::option::Option::Some(Self::VERSION_UNSPECIFIED)
+                            }
+                            "V1_INDEPENDENT" => std::option::Option::Some(Self::V1_INDEPENDENT),
+                            _ => std::option::Option::None,
+                        }
                     }
                 }
 
-                /// Useful constants to work with [Version](Version)
-                pub mod version {
-                    use super::Version;
-
-                    /// Unspecified version, should never be used.
-                    pub const VERSION_UNSPECIFIED: Version = Version::new("VERSION_UNSPECIFIED");
-
-                    /// The V1 model which is evaluating each source independently.
-                    pub const V1_INDEPENDENT: Version = Version::new("V1_INDEPENDENT");
-                }
-
-                impl std::convert::From<std::string::String> for Version {
-                    fn from(value: std::string::String) -> Self {
-                        Self(std::borrow::Cow::Owned(value))
+                impl std::convert::From<i32> for Version {
+                    fn from(value: i32) -> Self {
+                        Self::new(value)
                     }
                 }
 
                 impl std::default::Default for Version {
                     fn default() -> Self {
-                        version::VERSION_UNSPECIFIED
+                        Self::new(0)
                     }
                 }
             }
@@ -13024,100 +13317,140 @@ pub mod bigtable_options {
     /// Bytes.toBytes](https://hbase.apache.org/apidocs/org/apache/hadoop/hbase/util/Bytes.html)
     /// function when the encoding value is set to `BINARY`.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// The type is unspecified.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// String type.
+        pub const STRING: Type = Type::new(1);
+
+        /// Numerical type.
+        pub const NUMBER: Type = Type::new(2);
+
+        /// Integer type.
+        pub const INTEGER: Type = Type::new(3);
+
+        /// Variable length integer type.
+        pub const VAR_INTEGER: Type = Type::new(4);
+
+        /// BigDecimal type.
+        pub const BIG_NUMERIC: Type = Type::new(5);
+
+        /// Boolean type.
+        pub const BOOLEAN: Type = Type::new(6);
+
+        /// JSON type.
+        pub const JSON: Type = Type::new(7);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STRING"),
+                2 => std::borrow::Cow::Borrowed("NUMBER"),
+                3 => std::borrow::Cow::Borrowed("INTEGER"),
+                4 => std::borrow::Cow::Borrowed("VAR_INTEGER"),
+                5 => std::borrow::Cow::Borrowed("BIG_NUMERIC"),
+                6 => std::borrow::Cow::Borrowed("BOOLEAN"),
+                7 => std::borrow::Cow::Borrowed("JSON"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "STRING" => std::option::Option::Some(Self::STRING),
+                "NUMBER" => std::option::Option::Some(Self::NUMBER),
+                "INTEGER" => std::option::Option::Some(Self::INTEGER),
+                "VAR_INTEGER" => std::option::Option::Some(Self::VAR_INTEGER),
+                "BIG_NUMERIC" => std::option::Option::Some(Self::BIG_NUMERIC),
+                "BOOLEAN" => std::option::Option::Some(Self::BOOLEAN),
+                "JSON" => std::option::Option::Some(Self::JSON),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// The type is unspecified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// String type.
-        pub const STRING: Type = Type::new("STRING");
-
-        /// Numerical type.
-        pub const NUMBER: Type = Type::new("NUMBER");
-
-        /// Integer type.
-        pub const INTEGER: Type = Type::new("INTEGER");
-
-        /// Variable length integer type.
-        pub const VAR_INTEGER: Type = Type::new("VAR_INTEGER");
-
-        /// BigDecimal type.
-        pub const BIG_NUMERIC: Type = Type::new("BIG_NUMERIC");
-
-        /// Boolean type.
-        pub const BOOLEAN: Type = Type::new("BOOLEAN");
-
-        /// JSON type.
-        pub const JSON: Type = Type::new("JSON");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The encoding mode of a Bigtable column or column family.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Encoding(std::borrow::Cow<'static, str>);
+    pub struct Encoding(i32);
 
     impl Encoding {
+        /// The encoding is unspecified.
+        pub const ENCODING_UNSPECIFIED: Encoding = Encoding::new(0);
+
+        /// Text encoding.
+        pub const TEXT: Encoding = Encoding::new(1);
+
+        /// Binary encoding.
+        pub const BINARY: Encoding = Encoding::new(2);
+
         /// Creates a new Encoding instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ENCODING_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TEXT"),
+                2 => std::borrow::Cow::Borrowed("BINARY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ENCODING_UNSPECIFIED" => std::option::Option::Some(Self::ENCODING_UNSPECIFIED),
+                "TEXT" => std::option::Option::Some(Self::TEXT),
+                "BINARY" => std::option::Option::Some(Self::BINARY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Encoding](Encoding)
-    pub mod encoding {
-        use super::Encoding;
-
-        /// The encoding is unspecified.
-        pub const ENCODING_UNSPECIFIED: Encoding = Encoding::new("ENCODING_UNSPECIFIED");
-
-        /// Text encoding.
-        pub const TEXT: Encoding = Encoding::new("TEXT");
-
-        /// Binary encoding.
-        pub const BINARY: Encoding = Encoding::new("BINARY");
-    }
-
-    impl std::convert::From<std::string::String> for Encoding {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Encoding {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Encoding {
         fn default() -> Self {
-            encoding::ENCODING_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -14522,45 +14855,61 @@ pub mod import_documents_request {
     /// Indicates how imported documents are reconciled with the existing documents
     /// created or imported before.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ReconciliationMode(std::borrow::Cow<'static, str>);
+    pub struct ReconciliationMode(i32);
 
     impl ReconciliationMode {
-        /// Creates a new ReconciliationMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ReconciliationMode](ReconciliationMode)
-    pub mod reconciliation_mode {
-        use super::ReconciliationMode;
-
         /// Defaults to `INCREMENTAL`.
-        pub const RECONCILIATION_MODE_UNSPECIFIED: ReconciliationMode =
-            ReconciliationMode::new("RECONCILIATION_MODE_UNSPECIFIED");
+        pub const RECONCILIATION_MODE_UNSPECIFIED: ReconciliationMode = ReconciliationMode::new(0);
 
         /// Inserts new documents or updates existing documents.
-        pub const INCREMENTAL: ReconciliationMode = ReconciliationMode::new("INCREMENTAL");
+        pub const INCREMENTAL: ReconciliationMode = ReconciliationMode::new(1);
 
         /// Calculates diff and replaces the entire document dataset. Existing
         /// documents may be deleted if they are not present in the source location.
-        pub const FULL: ReconciliationMode = ReconciliationMode::new("FULL");
+        pub const FULL: ReconciliationMode = ReconciliationMode::new(2);
+
+        /// Creates a new ReconciliationMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RECONCILIATION_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INCREMENTAL"),
+                2 => std::borrow::Cow::Borrowed("FULL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RECONCILIATION_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RECONCILIATION_MODE_UNSPECIFIED)
+                }
+                "INCREMENTAL" => std::option::Option::Some(Self::INCREMENTAL),
+                "FULL" => std::option::Option::Some(Self::FULL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ReconciliationMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ReconciliationMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ReconciliationMode {
         fn default() -> Self {
-            reconciliation_mode::RECONCILIATION_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -15468,46 +15817,63 @@ pub mod project {
 
         /// The agreement states this terms of service.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(std::borrow::Cow<'static, str>);
+        pub struct State(i32);
 
         impl State {
+            /// The default value of the enum. This value is not actually used.
+            pub const STATE_UNSPECIFIED: State = State::new(0);
+
+            /// The project has given consent to the terms of service.
+            pub const TERMS_ACCEPTED: State = State::new(1);
+
+            /// The project is pending to review and accept the terms of service.
+            pub const TERMS_PENDING: State = State::new(2);
+
+            /// The project has declined or revoked the agreement to terms of service.
+            pub const TERMS_DECLINED: State = State::new(3);
+
             /// Creates a new State instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("TERMS_ACCEPTED"),
+                    2 => std::borrow::Cow::Borrowed("TERMS_PENDING"),
+                    3 => std::borrow::Cow::Borrowed("TERMS_DECLINED"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                    "TERMS_ACCEPTED" => std::option::Option::Some(Self::TERMS_ACCEPTED),
+                    "TERMS_PENDING" => std::option::Option::Some(Self::TERMS_PENDING),
+                    "TERMS_DECLINED" => std::option::Option::Some(Self::TERMS_DECLINED),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [State](State)
-        pub mod state {
-            use super::State;
-
-            /// The default value of the enum. This value is not actually used.
-            pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-            /// The project has given consent to the terms of service.
-            pub const TERMS_ACCEPTED: State = State::new("TERMS_ACCEPTED");
-
-            /// The project is pending to review and accept the terms of service.
-            pub const TERMS_PENDING: State = State::new("TERMS_PENDING");
-
-            /// The project has declined or revoked the agreement to terms of service.
-            pub const TERMS_DECLINED: State = State::new("TERMS_DECLINED");
-        }
-
-        impl std::convert::From<std::string::String> for State {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                state::STATE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -18856,33 +19222,17 @@ pub mod search_request {
                 /// The attribute(or function) for which the custom ranking is to be
                 /// applied.
                 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                pub struct AttributeType(std::borrow::Cow<'static, str>);
+                pub struct AttributeType(i32);
 
                 impl AttributeType {
-                    /// Creates a new AttributeType instance.
-                    pub const fn new(v: &'static str) -> Self {
-                        Self(std::borrow::Cow::Borrowed(v))
-                    }
-
-                    /// Gets the enum value.
-                    pub fn value(&self) -> &str {
-                        &self.0
-                    }
-                }
-
-                /// Useful constants to work with [AttributeType](AttributeType)
-                pub mod attribute_type {
-                    use super::AttributeType;
-
                     /// Unspecified AttributeType.
-                    pub const ATTRIBUTE_TYPE_UNSPECIFIED: AttributeType =
-                        AttributeType::new("ATTRIBUTE_TYPE_UNSPECIFIED");
+                    pub const ATTRIBUTE_TYPE_UNSPECIFIED: AttributeType = AttributeType::new(0);
 
                     /// The value of the numerical field will be used to dynamically update
                     /// the boost amount. In this case, the attribute_value (the x value)
                     /// of the control point will be the actual value of the numerical
                     /// field for which the boost_amount is specified.
-                    pub const NUMERICAL: AttributeType = AttributeType::new("NUMERICAL");
+                    pub const NUMERICAL: AttributeType = AttributeType::new(1);
 
                     /// For the freshness use case the attribute value will be the duration
                     /// between the current time and the date in the datetime field
@@ -18890,60 +19240,107 @@ pub mod search_request {
                     /// value (a restricted subset of an ISO 8601 duration value). The
                     /// pattern for this is: `[nD][T[nH][nM][nS]]`.
                     /// For example, `5D`, `3DT12H30M`, `T24H`.
-                    pub const FRESHNESS: AttributeType = AttributeType::new("FRESHNESS");
+                    pub const FRESHNESS: AttributeType = AttributeType::new(2);
+
+                    /// Creates a new AttributeType instance.
+                    pub(crate) const fn new(value: i32) -> Self {
+                        Self(value)
+                    }
+
+                    /// Gets the enum value.
+                    pub fn value(&self) -> i32 {
+                        self.0
+                    }
+
+                    /// Gets the enum value as a string.
+                    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                        match self.0 {
+                            0 => std::borrow::Cow::Borrowed("ATTRIBUTE_TYPE_UNSPECIFIED"),
+                            1 => std::borrow::Cow::Borrowed("NUMERICAL"),
+                            2 => std::borrow::Cow::Borrowed("FRESHNESS"),
+                            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                        }
+                    }
+
+                    /// Creates an enum value from the value name.
+                    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                        match name {
+                            "ATTRIBUTE_TYPE_UNSPECIFIED" => {
+                                std::option::Option::Some(Self::ATTRIBUTE_TYPE_UNSPECIFIED)
+                            }
+                            "NUMERICAL" => std::option::Option::Some(Self::NUMERICAL),
+                            "FRESHNESS" => std::option::Option::Some(Self::FRESHNESS),
+                            _ => std::option::Option::None,
+                        }
+                    }
                 }
 
-                impl std::convert::From<std::string::String> for AttributeType {
-                    fn from(value: std::string::String) -> Self {
-                        Self(std::borrow::Cow::Owned(value))
+                impl std::convert::From<i32> for AttributeType {
+                    fn from(value: i32) -> Self {
+                        Self::new(value)
                     }
                 }
 
                 impl std::default::Default for AttributeType {
                     fn default() -> Self {
-                        attribute_type::ATTRIBUTE_TYPE_UNSPECIFIED
+                        Self::new(0)
                     }
                 }
 
                 /// The interpolation type to be applied. Default will be linear
                 /// (Piecewise Linear).
                 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                pub struct InterpolationType(std::borrow::Cow<'static, str>);
+                pub struct InterpolationType(i32);
 
                 impl InterpolationType {
-                    /// Creates a new InterpolationType instance.
-                    pub const fn new(v: &'static str) -> Self {
-                        Self(std::borrow::Cow::Borrowed(v))
-                    }
-
-                    /// Gets the enum value.
-                    pub fn value(&self) -> &str {
-                        &self.0
-                    }
-                }
-
-                /// Useful constants to work with [InterpolationType](InterpolationType)
-                pub mod interpolation_type {
-                    use super::InterpolationType;
-
                     /// Interpolation type is unspecified. In this case, it defaults to
                     /// Linear.
                     pub const INTERPOLATION_TYPE_UNSPECIFIED: InterpolationType =
-                        InterpolationType::new("INTERPOLATION_TYPE_UNSPECIFIED");
+                        InterpolationType::new(0);
 
                     /// Piecewise linear interpolation will be applied.
-                    pub const LINEAR: InterpolationType = InterpolationType::new("LINEAR");
+                    pub const LINEAR: InterpolationType = InterpolationType::new(1);
+
+                    /// Creates a new InterpolationType instance.
+                    pub(crate) const fn new(value: i32) -> Self {
+                        Self(value)
+                    }
+
+                    /// Gets the enum value.
+                    pub fn value(&self) -> i32 {
+                        self.0
+                    }
+
+                    /// Gets the enum value as a string.
+                    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                        match self.0 {
+                            0 => std::borrow::Cow::Borrowed("INTERPOLATION_TYPE_UNSPECIFIED"),
+                            1 => std::borrow::Cow::Borrowed("LINEAR"),
+                            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                        }
+                    }
+
+                    /// Creates an enum value from the value name.
+                    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                        match name {
+                            "INTERPOLATION_TYPE_UNSPECIFIED" => {
+                                std::option::Option::Some(Self::INTERPOLATION_TYPE_UNSPECIFIED)
+                            }
+                            "LINEAR" => std::option::Option::Some(Self::LINEAR),
+                            _ => std::option::Option::None,
+                        }
+                    }
                 }
 
-                impl std::convert::From<std::string::String> for InterpolationType {
-                    fn from(value: std::string::String) -> Self {
-                        Self(std::borrow::Cow::Owned(value))
+                impl std::convert::From<i32> for InterpolationType {
+                    fn from(value: i32) -> Self {
+                        Self::new(value)
                     }
                 }
 
                 impl std::default::Default for InterpolationType {
                     fn default() -> Self {
-                        interpolation_type::INTERPOLATION_TYPE_UNSPECIFIED
+                        Self::new(0)
                     }
                 }
             }
@@ -19005,51 +19402,68 @@ pub mod search_request {
 
         /// Enum describing under which condition query expansion should occur.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Condition(std::borrow::Cow<'static, str>);
+        pub struct Condition(i32);
 
         impl Condition {
-            /// Creates a new Condition instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [Condition](Condition)
-        pub mod condition {
-            use super::Condition;
-
             /// Unspecified query expansion condition. In this case, server behavior
             /// defaults to
             /// [Condition.DISABLED][google.cloud.discoveryengine.v1.SearchRequest.QueryExpansionSpec.Condition.DISABLED].
             ///
             /// [google.cloud.discoveryengine.v1.SearchRequest.QueryExpansionSpec.Condition.DISABLED]: crate::model::search_request::query_expansion_spec::condition::DISABLED
-            pub const CONDITION_UNSPECIFIED: Condition = Condition::new("CONDITION_UNSPECIFIED");
+            pub const CONDITION_UNSPECIFIED: Condition = Condition::new(0);
 
             /// Disabled query expansion. Only the exact search query is used, even if
             /// [SearchResponse.total_size][google.cloud.discoveryengine.v1.SearchResponse.total_size]
             /// is zero.
             ///
             /// [google.cloud.discoveryengine.v1.SearchResponse.total_size]: crate::model::SearchResponse::total_size
-            pub const DISABLED: Condition = Condition::new("DISABLED");
+            pub const DISABLED: Condition = Condition::new(1);
 
             /// Automatic query expansion built by the Search API.
-            pub const AUTO: Condition = Condition::new("AUTO");
+            pub const AUTO: Condition = Condition::new(2);
+
+            /// Creates a new Condition instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("CONDITION_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("DISABLED"),
+                    2 => std::borrow::Cow::Borrowed("AUTO"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "CONDITION_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::CONDITION_UNSPECIFIED)
+                    }
+                    "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                    "AUTO" => std::option::Option::Some(Self::AUTO),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for Condition {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Condition {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Condition {
             fn default() -> Self {
-                condition::CONDITION_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -19098,30 +19512,15 @@ pub mod search_request {
 
         /// Enum describing under which mode spell correction should occur.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Mode(std::borrow::Cow<'static, str>);
+        pub struct Mode(i32);
 
         impl Mode {
-            /// Creates a new Mode instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [Mode](Mode)
-        pub mod mode {
-            use super::Mode;
-
             /// Unspecified spell correction mode. In this case, server behavior
             /// defaults to
             /// [Mode.AUTO][google.cloud.discoveryengine.v1.SearchRequest.SpellCorrectionSpec.Mode.AUTO].
             ///
             /// [google.cloud.discoveryengine.v1.SearchRequest.SpellCorrectionSpec.Mode.AUTO]: crate::model::search_request::spell_correction_spec::mode::AUTO
-            pub const MODE_UNSPECIFIED: Mode = Mode::new("MODE_UNSPECIFIED");
+            pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
 
             /// Search API tries to find a spelling suggestion. If a suggestion is
             /// found, it is put in the
@@ -19129,22 +19528,52 @@ pub mod search_request {
             /// The spelling suggestion won't be used as the search query.
             ///
             /// [google.cloud.discoveryengine.v1.SearchResponse.corrected_query]: crate::model::SearchResponse::corrected_query
-            pub const SUGGESTION_ONLY: Mode = Mode::new("SUGGESTION_ONLY");
+            pub const SUGGESTION_ONLY: Mode = Mode::new(1);
 
             /// Automatic spell correction built by the Search API. Search will
             /// be based on the corrected query if found.
-            pub const AUTO: Mode = Mode::new("AUTO");
+            pub const AUTO: Mode = Mode::new(2);
+
+            /// Creates a new Mode instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("SUGGESTION_ONLY"),
+                    2 => std::borrow::Cow::Borrowed("AUTO"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
+                    "SUGGESTION_ONLY" => std::option::Option::Some(Self::SUGGESTION_ONLY),
+                    "AUTO" => std::option::Option::Some(Self::AUTO),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for Mode {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Mode {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Mode {
             fn default() -> Self {
-                mode::MODE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -19784,45 +20213,61 @@ pub mod search_request {
         /// Specifies the search result mode. If unspecified, the
         /// search result mode defaults to `DOCUMENTS`.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SearchResultMode(std::borrow::Cow<'static, str>);
+        pub struct SearchResultMode(i32);
 
         impl SearchResultMode {
-            /// Creates a new SearchResultMode instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [SearchResultMode](SearchResultMode)
-        pub mod search_result_mode {
-            use super::SearchResultMode;
-
             /// Default value.
-            pub const SEARCH_RESULT_MODE_UNSPECIFIED: SearchResultMode =
-                SearchResultMode::new("SEARCH_RESULT_MODE_UNSPECIFIED");
+            pub const SEARCH_RESULT_MODE_UNSPECIFIED: SearchResultMode = SearchResultMode::new(0);
 
             /// Returns documents in the search result.
-            pub const DOCUMENTS: SearchResultMode = SearchResultMode::new("DOCUMENTS");
+            pub const DOCUMENTS: SearchResultMode = SearchResultMode::new(1);
 
             /// Returns chunks in the search result. Only available if the
             /// [DataStore.DocumentProcessingConfig.chunking_config][] is specified.
-            pub const CHUNKS: SearchResultMode = SearchResultMode::new("CHUNKS");
+            pub const CHUNKS: SearchResultMode = SearchResultMode::new(2);
+
+            /// Creates a new SearchResultMode instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("SEARCH_RESULT_MODE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("DOCUMENTS"),
+                    2 => std::borrow::Cow::Borrowed("CHUNKS"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "SEARCH_RESULT_MODE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::SEARCH_RESULT_MODE_UNSPECIFIED)
+                    }
+                    "DOCUMENTS" => std::option::Option::Some(Self::DOCUMENTS),
+                    "CHUNKS" => std::option::Option::Some(Self::CHUNKS),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for SearchResultMode {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for SearchResultMode {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for SearchResultMode {
             fn default() -> Self {
-                search_result_mode::SEARCH_RESULT_MODE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -19871,46 +20316,63 @@ pub mod search_request {
 
         /// Enum describing under which condition search as you type should occur.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Condition(std::borrow::Cow<'static, str>);
+        pub struct Condition(i32);
 
         impl Condition {
-            /// Creates a new Condition instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [Condition](Condition)
-        pub mod condition {
-            use super::Condition;
-
             /// Server behavior defaults to
             /// [Condition.DISABLED][google.cloud.discoveryengine.v1.SearchRequest.SearchAsYouTypeSpec.Condition.DISABLED].
             ///
             /// [google.cloud.discoveryengine.v1.SearchRequest.SearchAsYouTypeSpec.Condition.DISABLED]: crate::model::search_request::search_as_you_type_spec::condition::DISABLED
-            pub const CONDITION_UNSPECIFIED: Condition = Condition::new("CONDITION_UNSPECIFIED");
+            pub const CONDITION_UNSPECIFIED: Condition = Condition::new(0);
 
             /// Disables Search As You Type.
-            pub const DISABLED: Condition = Condition::new("DISABLED");
+            pub const DISABLED: Condition = Condition::new(1);
 
             /// Enables Search As You Type.
-            pub const ENABLED: Condition = Condition::new("ENABLED");
+            pub const ENABLED: Condition = Condition::new(2);
+
+            /// Creates a new Condition instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("CONDITION_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("DISABLED"),
+                    2 => std::borrow::Cow::Borrowed("ENABLED"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "CONDITION_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::CONDITION_UNSPECIFIED)
+                    }
+                    "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                    "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for Condition {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Condition {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Condition {
             fn default() -> Self {
-                condition::CONDITION_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -20910,27 +21372,12 @@ pub mod search_response {
 
         /// An Enum for summary-skipped reasons.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SummarySkippedReason(std::borrow::Cow<'static, str>);
+        pub struct SummarySkippedReason(i32);
 
         impl SummarySkippedReason {
-            /// Creates a new SummarySkippedReason instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [SummarySkippedReason](SummarySkippedReason)
-        pub mod summary_skipped_reason {
-            use super::SummarySkippedReason;
-
             /// Default value. The summary skipped reason is not specified.
             pub const SUMMARY_SKIPPED_REASON_UNSPECIFIED: SummarySkippedReason =
-                SummarySkippedReason::new("SUMMARY_SKIPPED_REASON_UNSPECIFIED");
+                SummarySkippedReason::new(0);
 
             /// The adversarial query ignored case.
             ///
@@ -20940,7 +21387,7 @@ pub mod search_response {
             ///
             /// [google.cloud.discoveryengine.v1.SearchRequest.ContentSearchSpec.SummarySpec.ignore_adversarial_query]: crate::model::search_request::content_search_spec::SummarySpec::ignore_adversarial_query
             pub const ADVERSARIAL_QUERY_IGNORED: SummarySkippedReason =
-                SummarySkippedReason::new("ADVERSARIAL_QUERY_IGNORED");
+                SummarySkippedReason::new(1);
 
             /// The non-summary seeking query ignored case.
             ///
@@ -20951,7 +21398,7 @@ pub mod search_response {
             ///
             /// [google.cloud.discoveryengine.v1.SearchRequest.ContentSearchSpec.SummarySpec.ignore_non_summary_seeking_query]: crate::model::search_request::content_search_spec::SummarySpec::ignore_non_summary_seeking_query
             pub const NON_SUMMARY_SEEKING_QUERY_IGNORED: SummarySkippedReason =
-                SummarySkippedReason::new("NON_SUMMARY_SEEKING_QUERY_IGNORED");
+                SummarySkippedReason::new(2);
 
             /// The out-of-domain query ignored case.
             ///
@@ -20959,27 +21406,25 @@ pub mod search_response {
             /// For example, the data store contains facts about company A but the
             /// user query is asking questions about company B.
             pub const OUT_OF_DOMAIN_QUERY_IGNORED: SummarySkippedReason =
-                SummarySkippedReason::new("OUT_OF_DOMAIN_QUERY_IGNORED");
+                SummarySkippedReason::new(3);
 
             /// The potential policy violation case.
             ///
             /// Google skips the summary if there is a potential policy violation
             /// detected. This includes content that may be violent or toxic.
             pub const POTENTIAL_POLICY_VIOLATION: SummarySkippedReason =
-                SummarySkippedReason::new("POTENTIAL_POLICY_VIOLATION");
+                SummarySkippedReason::new(4);
 
             /// The LLM addon not enabled case.
             ///
             /// Google skips the summary if the LLM addon is not enabled.
-            pub const LLM_ADDON_NOT_ENABLED: SummarySkippedReason =
-                SummarySkippedReason::new("LLM_ADDON_NOT_ENABLED");
+            pub const LLM_ADDON_NOT_ENABLED: SummarySkippedReason = SummarySkippedReason::new(5);
 
             /// The no relevant content case.
             ///
             /// Google skips the summary if there is no relevant content in the
             /// retrieved search results.
-            pub const NO_RELEVANT_CONTENT: SummarySkippedReason =
-                SummarySkippedReason::new("NO_RELEVANT_CONTENT");
+            pub const NO_RELEVANT_CONTENT: SummarySkippedReason = SummarySkippedReason::new(6);
 
             /// The jail-breaking query ignored case.
             ///
@@ -20988,14 +21433,14 @@ pub mod search_response {
             /// [SearchRequest.ContentSearchSpec.SummarySpec.ignore_jail_breaking_query]
             /// is set to `true`.
             pub const JAIL_BREAKING_QUERY_IGNORED: SummarySkippedReason =
-                SummarySkippedReason::new("JAIL_BREAKING_QUERY_IGNORED");
+                SummarySkippedReason::new(7);
 
             /// The customer policy violation case.
             ///
             /// Google skips the summary if there is a customer policy violation
             /// detected. The policy is defined by the customer.
             pub const CUSTOMER_POLICY_VIOLATION: SummarySkippedReason =
-                SummarySkippedReason::new("CUSTOMER_POLICY_VIOLATION");
+                SummarySkippedReason::new(8);
 
             /// The non-answer seeking query ignored case.
             ///
@@ -21004,18 +21449,80 @@ pub mod search_response {
             /// [SearchRequest.ContentSearchSpec.SummarySpec.ignore_non_answer_seeking_query]
             /// is set to `true`.
             pub const NON_SUMMARY_SEEKING_QUERY_IGNORED_V2: SummarySkippedReason =
-                SummarySkippedReason::new("NON_SUMMARY_SEEKING_QUERY_IGNORED_V2");
+                SummarySkippedReason::new(9);
+
+            /// Creates a new SummarySkippedReason instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("SUMMARY_SKIPPED_REASON_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("ADVERSARIAL_QUERY_IGNORED"),
+                    2 => std::borrow::Cow::Borrowed("NON_SUMMARY_SEEKING_QUERY_IGNORED"),
+                    3 => std::borrow::Cow::Borrowed("OUT_OF_DOMAIN_QUERY_IGNORED"),
+                    4 => std::borrow::Cow::Borrowed("POTENTIAL_POLICY_VIOLATION"),
+                    5 => std::borrow::Cow::Borrowed("LLM_ADDON_NOT_ENABLED"),
+                    6 => std::borrow::Cow::Borrowed("NO_RELEVANT_CONTENT"),
+                    7 => std::borrow::Cow::Borrowed("JAIL_BREAKING_QUERY_IGNORED"),
+                    8 => std::borrow::Cow::Borrowed("CUSTOMER_POLICY_VIOLATION"),
+                    9 => std::borrow::Cow::Borrowed("NON_SUMMARY_SEEKING_QUERY_IGNORED_V2"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "SUMMARY_SKIPPED_REASON_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::SUMMARY_SKIPPED_REASON_UNSPECIFIED)
+                    }
+                    "ADVERSARIAL_QUERY_IGNORED" => {
+                        std::option::Option::Some(Self::ADVERSARIAL_QUERY_IGNORED)
+                    }
+                    "NON_SUMMARY_SEEKING_QUERY_IGNORED" => {
+                        std::option::Option::Some(Self::NON_SUMMARY_SEEKING_QUERY_IGNORED)
+                    }
+                    "OUT_OF_DOMAIN_QUERY_IGNORED" => {
+                        std::option::Option::Some(Self::OUT_OF_DOMAIN_QUERY_IGNORED)
+                    }
+                    "POTENTIAL_POLICY_VIOLATION" => {
+                        std::option::Option::Some(Self::POTENTIAL_POLICY_VIOLATION)
+                    }
+                    "LLM_ADDON_NOT_ENABLED" => {
+                        std::option::Option::Some(Self::LLM_ADDON_NOT_ENABLED)
+                    }
+                    "NO_RELEVANT_CONTENT" => std::option::Option::Some(Self::NO_RELEVANT_CONTENT),
+                    "JAIL_BREAKING_QUERY_IGNORED" => {
+                        std::option::Option::Some(Self::JAIL_BREAKING_QUERY_IGNORED)
+                    }
+                    "CUSTOMER_POLICY_VIOLATION" => {
+                        std::option::Option::Some(Self::CUSTOMER_POLICY_VIOLATION)
+                    }
+                    "NON_SUMMARY_SEEKING_QUERY_IGNORED_V2" => {
+                        std::option::Option::Some(Self::NON_SUMMARY_SEEKING_QUERY_IGNORED_V2)
+                    }
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for SummarySkippedReason {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for SummarySkippedReason {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for SummarySkippedReason {
             fn default() -> Self {
-                summary_skipped_reason::SUMMARY_SKIPPED_REASON_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -21711,40 +22218,53 @@ pub mod session {
 
     /// Enumeration of the state of the session.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State is unspecified.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The session is currently open.
+        pub const IN_PROGRESS: State = State::new(1);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The session is currently open.
-        pub const IN_PROGRESS: State = State::new("IN_PROGRESS");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -22133,100 +22653,135 @@ pub mod target_site {
 
     /// Possible target site types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// This value is unused. In this case, server behavior defaults to
         /// [Type.INCLUDE][google.cloud.discoveryengine.v1.TargetSite.Type.INCLUDE].
         ///
         /// [google.cloud.discoveryengine.v1.TargetSite.Type.INCLUDE]: crate::model::target_site::r#type::INCLUDE
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// Include the target site.
-        pub const INCLUDE: Type = Type::new("INCLUDE");
+        pub const INCLUDE: Type = Type::new(1);
 
         /// Exclude the target site.
-        pub const EXCLUDE: Type = Type::new("EXCLUDE");
+        pub const EXCLUDE: Type = Type::new(2);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INCLUDE"),
+                2 => std::borrow::Cow::Borrowed("EXCLUDE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "INCLUDE" => std::option::Option::Some(Self::INCLUDE),
+                "EXCLUDE" => std::option::Option::Some(Self::EXCLUDE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Target site indexing status enumeration.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IndexingStatus(std::borrow::Cow<'static, str>);
+    pub struct IndexingStatus(i32);
 
     impl IndexingStatus {
-        /// Creates a new IndexingStatus instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [IndexingStatus](IndexingStatus)
-    pub mod indexing_status {
-        use super::IndexingStatus;
-
         /// Defaults to SUCCEEDED.
-        pub const INDEXING_STATUS_UNSPECIFIED: IndexingStatus =
-            IndexingStatus::new("INDEXING_STATUS_UNSPECIFIED");
+        pub const INDEXING_STATUS_UNSPECIFIED: IndexingStatus = IndexingStatus::new(0);
 
         /// The target site is in the update queue and will be picked up by indexing
         /// pipeline.
-        pub const PENDING: IndexingStatus = IndexingStatus::new("PENDING");
+        pub const PENDING: IndexingStatus = IndexingStatus::new(1);
 
         /// The target site fails to be indexed.
-        pub const FAILED: IndexingStatus = IndexingStatus::new("FAILED");
+        pub const FAILED: IndexingStatus = IndexingStatus::new(2);
 
         /// The target site has been indexed.
-        pub const SUCCEEDED: IndexingStatus = IndexingStatus::new("SUCCEEDED");
+        pub const SUCCEEDED: IndexingStatus = IndexingStatus::new(3);
 
         /// The previously indexed target site has been marked to be deleted. This is
         /// a transitioning state which will resulted in either:
         ///
         /// . target site deleted if unindexing is successful;
         /// . state reverts to SUCCEEDED if the unindexing fails.
-        pub const DELETING: IndexingStatus = IndexingStatus::new("DELETING");
+        pub const DELETING: IndexingStatus = IndexingStatus::new(4);
+
+        /// Creates a new IndexingStatus instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("INDEXING_STATUS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("FAILED"),
+                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "INDEXING_STATUS_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::INDEXING_STATUS_UNSPECIFIED)
+                }
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for IndexingStatus {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for IndexingStatus {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for IndexingStatus {
         fn default() -> Self {
-            indexing_status::INDEXING_STATUS_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -22284,47 +22839,66 @@ pub mod site_verification_info {
 
     /// Site verification state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SiteVerificationState(std::borrow::Cow<'static, str>);
+    pub struct SiteVerificationState(i32);
 
     impl SiteVerificationState {
+        /// Defaults to VERIFIED.
+        pub const SITE_VERIFICATION_STATE_UNSPECIFIED: SiteVerificationState =
+            SiteVerificationState::new(0);
+
+        /// Site ownership verified.
+        pub const VERIFIED: SiteVerificationState = SiteVerificationState::new(1);
+
+        /// Site ownership pending verification or verification failed.
+        pub const UNVERIFIED: SiteVerificationState = SiteVerificationState::new(2);
+
+        /// Site exempt from verification, e.g., a public website that opens to all.
+        pub const EXEMPTED: SiteVerificationState = SiteVerificationState::new(3);
+
         /// Creates a new SiteVerificationState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SITE_VERIFICATION_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("VERIFIED"),
+                2 => std::borrow::Cow::Borrowed("UNVERIFIED"),
+                3 => std::borrow::Cow::Borrowed("EXEMPTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SITE_VERIFICATION_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SITE_VERIFICATION_STATE_UNSPECIFIED)
+                }
+                "VERIFIED" => std::option::Option::Some(Self::VERIFIED),
+                "UNVERIFIED" => std::option::Option::Some(Self::UNVERIFIED),
+                "EXEMPTED" => std::option::Option::Some(Self::EXEMPTED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SiteVerificationState](SiteVerificationState)
-    pub mod site_verification_state {
-        use super::SiteVerificationState;
-
-        /// Defaults to VERIFIED.
-        pub const SITE_VERIFICATION_STATE_UNSPECIFIED: SiteVerificationState =
-            SiteVerificationState::new("SITE_VERIFICATION_STATE_UNSPECIFIED");
-
-        /// Site ownership verified.
-        pub const VERIFIED: SiteVerificationState = SiteVerificationState::new("VERIFIED");
-
-        /// Site ownership pending verification or verification failed.
-        pub const UNVERIFIED: SiteVerificationState = SiteVerificationState::new("UNVERIFIED");
-
-        /// Site exempt from verification, e.g., a public website that opens to all.
-        pub const EXEMPTED: SiteVerificationState = SiteVerificationState::new("EXEMPTED");
-    }
-
-    impl std::convert::From<std::string::String> for SiteVerificationState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SiteVerificationState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SiteVerificationState {
         fn default() -> Self {
-            site_verification_state::SITE_VERIFICATION_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -23458,44 +24032,60 @@ pub mod recrawl_uris_response {
 
             /// CorpusType for the failed crawling operation.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct CorpusType(std::borrow::Cow<'static, str>);
+            pub struct CorpusType(i32);
 
             impl CorpusType {
+                /// Default value.
+                pub const CORPUS_TYPE_UNSPECIFIED: CorpusType = CorpusType::new(0);
+
+                /// Denotes a crawling attempt for the desktop version of a page.
+                pub const DESKTOP: CorpusType = CorpusType::new(1);
+
+                /// Denotes a crawling attempt for the mobile version of a page.
+                pub const MOBILE: CorpusType = CorpusType::new(2);
+
                 /// Creates a new CorpusType instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
                 }
 
                 /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("CORPUS_TYPE_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("DESKTOP"),
+                        2 => std::borrow::Cow::Borrowed("MOBILE"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "CORPUS_TYPE_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::CORPUS_TYPE_UNSPECIFIED)
+                        }
+                        "DESKTOP" => std::option::Option::Some(Self::DESKTOP),
+                        "MOBILE" => std::option::Option::Some(Self::MOBILE),
+                        _ => std::option::Option::None,
+                    }
                 }
             }
 
-            /// Useful constants to work with [CorpusType](CorpusType)
-            pub mod corpus_type {
-                use super::CorpusType;
-
-                /// Default value.
-                pub const CORPUS_TYPE_UNSPECIFIED: CorpusType =
-                    CorpusType::new("CORPUS_TYPE_UNSPECIFIED");
-
-                /// Denotes a crawling attempt for the desktop version of a page.
-                pub const DESKTOP: CorpusType = CorpusType::new("DESKTOP");
-
-                /// Denotes a crawling attempt for the mobile version of a page.
-                pub const MOBILE: CorpusType = CorpusType::new("MOBILE");
-            }
-
-            impl std::convert::From<std::string::String> for CorpusType {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for CorpusType {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for CorpusType {
                 fn default() -> Self {
-                    corpus_type::CORPUS_TYPE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -25142,101 +25732,141 @@ impl wkt::message::Message for CollectUserEventRequest {
 ///
 /// [google.cloud.discoveryengine.v1.DataStore]: crate::model::DataStore
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct IndustryVertical(std::borrow::Cow<'static, str>);
+pub struct IndustryVertical(i32);
 
 impl IndustryVertical {
-    /// Creates a new IndustryVertical instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [IndustryVertical](IndustryVertical)
-pub mod industry_vertical {
-    use super::IndustryVertical;
-
     /// Value used when unset.
-    pub const INDUSTRY_VERTICAL_UNSPECIFIED: IndustryVertical =
-        IndustryVertical::new("INDUSTRY_VERTICAL_UNSPECIFIED");
+    pub const INDUSTRY_VERTICAL_UNSPECIFIED: IndustryVertical = IndustryVertical::new(0);
 
     /// The generic vertical for documents that are not specific to any industry
     /// vertical.
-    pub const GENERIC: IndustryVertical = IndustryVertical::new("GENERIC");
+    pub const GENERIC: IndustryVertical = IndustryVertical::new(1);
 
     /// The media industry vertical.
-    pub const MEDIA: IndustryVertical = IndustryVertical::new("MEDIA");
+    pub const MEDIA: IndustryVertical = IndustryVertical::new(2);
 
     /// The healthcare FHIR vertical.
-    pub const HEALTHCARE_FHIR: IndustryVertical = IndustryVertical::new("HEALTHCARE_FHIR");
+    pub const HEALTHCARE_FHIR: IndustryVertical = IndustryVertical::new(7);
+
+    /// Creates a new IndustryVertical instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("INDUSTRY_VERTICAL_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("GENERIC"),
+            2 => std::borrow::Cow::Borrowed("MEDIA"),
+            7 => std::borrow::Cow::Borrowed("HEALTHCARE_FHIR"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "INDUSTRY_VERTICAL_UNSPECIFIED" => {
+                std::option::Option::Some(Self::INDUSTRY_VERTICAL_UNSPECIFIED)
+            }
+            "GENERIC" => std::option::Option::Some(Self::GENERIC),
+            "MEDIA" => std::option::Option::Some(Self::MEDIA),
+            "HEALTHCARE_FHIR" => std::option::Option::Some(Self::HEALTHCARE_FHIR),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for IndustryVertical {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for IndustryVertical {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for IndustryVertical {
     fn default() -> Self {
-        industry_vertical::INDUSTRY_VERTICAL_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The type of solution.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SolutionType(std::borrow::Cow<'static, str>);
+pub struct SolutionType(i32);
 
 impl SolutionType {
-    /// Creates a new SolutionType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [SolutionType](SolutionType)
-pub mod solution_type {
-    use super::SolutionType;
-
     /// Default value.
-    pub const SOLUTION_TYPE_UNSPECIFIED: SolutionType =
-        SolutionType::new("SOLUTION_TYPE_UNSPECIFIED");
+    pub const SOLUTION_TYPE_UNSPECIFIED: SolutionType = SolutionType::new(0);
 
     /// Used for Recommendations AI.
-    pub const SOLUTION_TYPE_RECOMMENDATION: SolutionType =
-        SolutionType::new("SOLUTION_TYPE_RECOMMENDATION");
+    pub const SOLUTION_TYPE_RECOMMENDATION: SolutionType = SolutionType::new(1);
 
     /// Used for Discovery Search.
-    pub const SOLUTION_TYPE_SEARCH: SolutionType = SolutionType::new("SOLUTION_TYPE_SEARCH");
+    pub const SOLUTION_TYPE_SEARCH: SolutionType = SolutionType::new(2);
 
     /// Used for use cases related to the Generative AI agent.
-    pub const SOLUTION_TYPE_CHAT: SolutionType = SolutionType::new("SOLUTION_TYPE_CHAT");
+    pub const SOLUTION_TYPE_CHAT: SolutionType = SolutionType::new(3);
 
     /// Used for use cases related to the Generative Chat agent.
     /// It's used for Generative chat engine only, the associated data stores
     /// must enrolled with `SOLUTION_TYPE_CHAT` solution.
-    pub const SOLUTION_TYPE_GENERATIVE_CHAT: SolutionType =
-        SolutionType::new("SOLUTION_TYPE_GENERATIVE_CHAT");
+    pub const SOLUTION_TYPE_GENERATIVE_CHAT: SolutionType = SolutionType::new(4);
+
+    /// Creates a new SolutionType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SOLUTION_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SOLUTION_TYPE_RECOMMENDATION"),
+            2 => std::borrow::Cow::Borrowed("SOLUTION_TYPE_SEARCH"),
+            3 => std::borrow::Cow::Borrowed("SOLUTION_TYPE_CHAT"),
+            4 => std::borrow::Cow::Borrowed("SOLUTION_TYPE_GENERATIVE_CHAT"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SOLUTION_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::SOLUTION_TYPE_UNSPECIFIED)
+            }
+            "SOLUTION_TYPE_RECOMMENDATION" => {
+                std::option::Option::Some(Self::SOLUTION_TYPE_RECOMMENDATION)
+            }
+            "SOLUTION_TYPE_SEARCH" => std::option::Option::Some(Self::SOLUTION_TYPE_SEARCH),
+            "SOLUTION_TYPE_CHAT" => std::option::Option::Some(Self::SOLUTION_TYPE_CHAT),
+            "SOLUTION_TYPE_GENERATIVE_CHAT" => {
+                std::option::Option::Some(Self::SOLUTION_TYPE_GENERATIVE_CHAT)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for SolutionType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SolutionType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SolutionType {
     fn default() -> Self {
-        solution_type::SOLUTION_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -25246,132 +25876,177 @@ impl std::default::Default for SolutionType {
 ///
 /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::solution_type::SOLUTION_TYPE_SEARCH
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SearchUseCase(std::borrow::Cow<'static, str>);
+pub struct SearchUseCase(i32);
 
 impl SearchUseCase {
-    /// Creates a new SearchUseCase instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [SearchUseCase](SearchUseCase)
-pub mod search_use_case {
-    use super::SearchUseCase;
-
     /// Value used when unset. Will not occur in CSS.
-    pub const SEARCH_USE_CASE_UNSPECIFIED: SearchUseCase =
-        SearchUseCase::new("SEARCH_USE_CASE_UNSPECIFIED");
+    pub const SEARCH_USE_CASE_UNSPECIFIED: SearchUseCase = SearchUseCase::new(0);
 
     /// Search use case. Expects the traffic has a non-empty
     /// [query][google.cloud.discoveryengine.v1.SearchRequest.query].
     ///
     /// [google.cloud.discoveryengine.v1.SearchRequest.query]: crate::model::SearchRequest::query
-    pub const SEARCH_USE_CASE_SEARCH: SearchUseCase = SearchUseCase::new("SEARCH_USE_CASE_SEARCH");
+    pub const SEARCH_USE_CASE_SEARCH: SearchUseCase = SearchUseCase::new(1);
 
     /// Browse use case. Expects the traffic has an empty
     /// [query][google.cloud.discoveryengine.v1.SearchRequest.query].
     ///
     /// [google.cloud.discoveryengine.v1.SearchRequest.query]: crate::model::SearchRequest::query
-    pub const SEARCH_USE_CASE_BROWSE: SearchUseCase = SearchUseCase::new("SEARCH_USE_CASE_BROWSE");
+    pub const SEARCH_USE_CASE_BROWSE: SearchUseCase = SearchUseCase::new(2);
+
+    /// Creates a new SearchUseCase instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SEARCH_USE_CASE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SEARCH_USE_CASE_SEARCH"),
+            2 => std::borrow::Cow::Borrowed("SEARCH_USE_CASE_BROWSE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SEARCH_USE_CASE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::SEARCH_USE_CASE_UNSPECIFIED)
+            }
+            "SEARCH_USE_CASE_SEARCH" => std::option::Option::Some(Self::SEARCH_USE_CASE_SEARCH),
+            "SEARCH_USE_CASE_BROWSE" => std::option::Option::Some(Self::SEARCH_USE_CASE_BROWSE),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for SearchUseCase {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SearchUseCase {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SearchUseCase {
     fn default() -> Self {
-        search_use_case::SEARCH_USE_CASE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Tiers of search features. Different tiers might have different
 /// pricing. To learn more, check the pricing documentation.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SearchTier(std::borrow::Cow<'static, str>);
+pub struct SearchTier(i32);
 
 impl SearchTier {
+    /// Default value when the enum is unspecified. This is invalid to use.
+    pub const SEARCH_TIER_UNSPECIFIED: SearchTier = SearchTier::new(0);
+
+    /// Standard tier.
+    pub const SEARCH_TIER_STANDARD: SearchTier = SearchTier::new(1);
+
+    /// Enterprise tier.
+    pub const SEARCH_TIER_ENTERPRISE: SearchTier = SearchTier::new(2);
+
     /// Creates a new SearchTier instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SEARCH_TIER_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SEARCH_TIER_STANDARD"),
+            2 => std::borrow::Cow::Borrowed("SEARCH_TIER_ENTERPRISE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SEARCH_TIER_UNSPECIFIED" => std::option::Option::Some(Self::SEARCH_TIER_UNSPECIFIED),
+            "SEARCH_TIER_STANDARD" => std::option::Option::Some(Self::SEARCH_TIER_STANDARD),
+            "SEARCH_TIER_ENTERPRISE" => std::option::Option::Some(Self::SEARCH_TIER_ENTERPRISE),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [SearchTier](SearchTier)
-pub mod search_tier {
-    use super::SearchTier;
-
-    /// Default value when the enum is unspecified. This is invalid to use.
-    pub const SEARCH_TIER_UNSPECIFIED: SearchTier = SearchTier::new("SEARCH_TIER_UNSPECIFIED");
-
-    /// Standard tier.
-    pub const SEARCH_TIER_STANDARD: SearchTier = SearchTier::new("SEARCH_TIER_STANDARD");
-
-    /// Enterprise tier.
-    pub const SEARCH_TIER_ENTERPRISE: SearchTier = SearchTier::new("SEARCH_TIER_ENTERPRISE");
-}
-
-impl std::convert::From<std::string::String> for SearchTier {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SearchTier {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SearchTier {
     fn default() -> Self {
-        search_tier::SEARCH_TIER_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Add-on that provides additional functionality for search.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SearchAddOn(std::borrow::Cow<'static, str>);
+pub struct SearchAddOn(i32);
 
 impl SearchAddOn {
+    /// Default value when the enum is unspecified. This is invalid to use.
+    pub const SEARCH_ADD_ON_UNSPECIFIED: SearchAddOn = SearchAddOn::new(0);
+
+    /// Large language model add-on.
+    pub const SEARCH_ADD_ON_LLM: SearchAddOn = SearchAddOn::new(1);
+
     /// Creates a new SearchAddOn instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SEARCH_ADD_ON_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SEARCH_ADD_ON_LLM"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SEARCH_ADD_ON_UNSPECIFIED" => {
+                std::option::Option::Some(Self::SEARCH_ADD_ON_UNSPECIFIED)
+            }
+            "SEARCH_ADD_ON_LLM" => std::option::Option::Some(Self::SEARCH_ADD_ON_LLM),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [SearchAddOn](SearchAddOn)
-pub mod search_add_on {
-    use super::SearchAddOn;
-
-    /// Default value when the enum is unspecified. This is invalid to use.
-    pub const SEARCH_ADD_ON_UNSPECIFIED: SearchAddOn =
-        SearchAddOn::new("SEARCH_ADD_ON_UNSPECIFIED");
-
-    /// Large language model add-on.
-    pub const SEARCH_ADD_ON_LLM: SearchAddOn = SearchAddOn::new("SEARCH_ADD_ON_LLM");
-}
-
-impl std::convert::From<std::string::String> for SearchAddOn {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SearchAddOn {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SearchAddOn {
     fn default() -> Self {
-        search_add_on::SEARCH_ADD_ON_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/discoveryengine/v1/src/transport.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::CompletionService for CompletionService {
                 reqwest::Method::GET,
                 format!("/v1/{}:completeQuery", req.data_store),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -78,7 +78,7 @@ impl crate::stubs::CompletionService for CompletionService {
                 reqwest::Method::POST,
                 format!("/v1/{}/suggestionDenyListEntries:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -98,7 +98,7 @@ impl crate::stubs::CompletionService for CompletionService {
                 reqwest::Method::POST,
                 format!("/v1/{}/suggestionDenyListEntries:purge", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -118,7 +118,7 @@ impl crate::stubs::CompletionService for CompletionService {
                 reqwest::Method::POST,
                 format!("/v1/{}/completionSuggestions:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -138,7 +138,7 @@ impl crate::stubs::CompletionService for CompletionService {
                 reqwest::Method::POST,
                 format!("/v1/{}/completionSuggestions:purge", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -155,7 +155,7 @@ impl crate::stubs::CompletionService for CompletionService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -177,7 +177,7 @@ impl crate::stubs::CompletionService for CompletionService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -196,7 +196,7 @@ impl crate::stubs::CompletionService for CompletionService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -253,7 +253,7 @@ impl crate::stubs::ControlService for ControlService {
                 reqwest::Method::POST,
                 format!("/v1/{}/controls", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -273,7 +273,7 @@ impl crate::stubs::ControlService for ControlService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -301,7 +301,7 @@ impl crate::stubs::ControlService for ControlService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -330,7 +330,7 @@ impl crate::stubs::ControlService for ControlService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -349,7 +349,7 @@ impl crate::stubs::ControlService for ControlService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/controls", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -371,7 +371,7 @@ impl crate::stubs::ControlService for ControlService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -393,7 +393,7 @@ impl crate::stubs::ControlService for ControlService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -412,7 +412,7 @@ impl crate::stubs::ControlService for ControlService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -452,7 +452,7 @@ impl crate::stubs::ConversationalSearchService for ConversationalSearchService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:converse", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -472,7 +472,7 @@ impl crate::stubs::ConversationalSearchService for ConversationalSearchService {
                 reqwest::Method::POST,
                 format!("/v1/{}/conversations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -491,7 +491,7 @@ impl crate::stubs::ConversationalSearchService for ConversationalSearchService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -519,7 +519,7 @@ impl crate::stubs::ConversationalSearchService for ConversationalSearchService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -548,7 +548,7 @@ impl crate::stubs::ConversationalSearchService for ConversationalSearchService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -570,7 +570,7 @@ impl crate::stubs::ConversationalSearchService for ConversationalSearchService {
                 reqwest::Method::GET,
                 format!("/v1/{}/conversations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -596,7 +596,7 @@ impl crate::stubs::ConversationalSearchService for ConversationalSearchService {
                 reqwest::Method::POST,
                 format!("/v1/{}:answer", req.serving_config),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -613,7 +613,7 @@ impl crate::stubs::ConversationalSearchService for ConversationalSearchService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -635,7 +635,7 @@ impl crate::stubs::ConversationalSearchService for ConversationalSearchService {
                 reqwest::Method::POST,
                 format!("/v1/{}/sessions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -654,7 +654,7 @@ impl crate::stubs::ConversationalSearchService for ConversationalSearchService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -682,7 +682,7 @@ impl crate::stubs::ConversationalSearchService for ConversationalSearchService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -711,7 +711,7 @@ impl crate::stubs::ConversationalSearchService for ConversationalSearchService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -730,7 +730,7 @@ impl crate::stubs::ConversationalSearchService for ConversationalSearchService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/sessions", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -753,7 +753,7 @@ impl crate::stubs::ConversationalSearchService for ConversationalSearchService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -775,7 +775,7 @@ impl crate::stubs::ConversationalSearchService for ConversationalSearchService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -794,7 +794,7 @@ impl crate::stubs::ConversationalSearchService for ConversationalSearchService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -837,7 +837,7 @@ impl crate::stubs::DataStoreService for DataStoreService {
                 reqwest::Method::POST,
                 format!("/v1/{}/dataStores", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -863,7 +863,7 @@ impl crate::stubs::DataStoreService for DataStoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -885,7 +885,7 @@ impl crate::stubs::DataStoreService for DataStoreService {
                 reqwest::Method::GET,
                 format!("/v1/{}/dataStores", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -907,7 +907,7 @@ impl crate::stubs::DataStoreService for DataStoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -935,7 +935,7 @@ impl crate::stubs::DataStoreService for DataStoreService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -964,7 +964,7 @@ impl crate::stubs::DataStoreService for DataStoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -986,7 +986,7 @@ impl crate::stubs::DataStoreService for DataStoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1005,7 +1005,7 @@ impl crate::stubs::DataStoreService for DataStoreService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1059,7 +1059,7 @@ impl crate::stubs::DocumentService for DocumentService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1081,7 +1081,7 @@ impl crate::stubs::DocumentService for DocumentService {
                 reqwest::Method::GET,
                 format!("/v1/{}/documents", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1105,7 +1105,7 @@ impl crate::stubs::DocumentService for DocumentService {
                 reqwest::Method::POST,
                 format!("/v1/{}/documents", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1134,7 +1134,7 @@ impl crate::stubs::DocumentService for DocumentService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1164,7 +1164,7 @@ impl crate::stubs::DocumentService for DocumentService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1186,7 +1186,7 @@ impl crate::stubs::DocumentService for DocumentService {
                 reqwest::Method::POST,
                 format!("/v1/{}/documents:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1206,7 +1206,7 @@ impl crate::stubs::DocumentService for DocumentService {
                 reqwest::Method::POST,
                 format!("/v1/{}/documents:purge", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1226,7 +1226,7 @@ impl crate::stubs::DocumentService for DocumentService {
                 reqwest::Method::GET,
                 format!("/v1/{}/batchGetDocumentsMetadata", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1255,7 +1255,7 @@ impl crate::stubs::DocumentService for DocumentService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1277,7 +1277,7 @@ impl crate::stubs::DocumentService for DocumentService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1296,7 +1296,7 @@ impl crate::stubs::DocumentService for DocumentService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1350,7 +1350,7 @@ impl crate::stubs::EngineService for EngineService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/engines", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1368,7 +1368,7 @@ impl crate::stubs::EngineService for EngineService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1396,7 +1396,7 @@ impl crate::stubs::EngineService for EngineService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1423,7 +1423,7 @@ impl crate::stubs::EngineService for EngineService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1442,7 +1442,7 @@ impl crate::stubs::EngineService for EngineService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/engines", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1464,7 +1464,7 @@ impl crate::stubs::EngineService for EngineService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1486,7 +1486,7 @@ impl crate::stubs::EngineService for EngineService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1505,7 +1505,7 @@ impl crate::stubs::EngineService for EngineService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1562,7 +1562,7 @@ impl crate::stubs::GroundedGenerationService for GroundedGenerationService {
                 reqwest::Method::POST,
                 format!("/v1/{}:generateGroundedContent", req.location),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1582,7 +1582,7 @@ impl crate::stubs::GroundedGenerationService for GroundedGenerationService {
                 reqwest::Method::POST,
                 format!("/v1/{}:check", req.grounding_config),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1599,7 +1599,7 @@ impl crate::stubs::GroundedGenerationService for GroundedGenerationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1621,7 +1621,7 @@ impl crate::stubs::GroundedGenerationService for GroundedGenerationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1640,7 +1640,7 @@ impl crate::stubs::GroundedGenerationService for GroundedGenerationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1680,7 +1680,7 @@ impl crate::stubs::ProjectService for ProjectService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:provision", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1697,7 +1697,7 @@ impl crate::stubs::ProjectService for ProjectService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1719,7 +1719,7 @@ impl crate::stubs::ProjectService for ProjectService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1738,7 +1738,7 @@ impl crate::stubs::ProjectService for ProjectService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1795,7 +1795,7 @@ impl crate::stubs::RankService for RankService {
                 reqwest::Method::POST,
                 format!("/v1/{}:rank", req.ranking_config),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1812,7 +1812,7 @@ impl crate::stubs::RankService for RankService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1834,7 +1834,7 @@ impl crate::stubs::RankService for RankService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1853,7 +1853,7 @@ impl crate::stubs::RankService for RankService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1896,7 +1896,7 @@ impl crate::stubs::RecommendationService for RecommendationService {
                 reqwest::Method::POST,
                 format!("/v1/{}:recommend", req.serving_config),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1913,7 +1913,7 @@ impl crate::stubs::RecommendationService for RecommendationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1935,7 +1935,7 @@ impl crate::stubs::RecommendationService for RecommendationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1954,7 +1954,7 @@ impl crate::stubs::RecommendationService for RecommendationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1994,7 +1994,7 @@ impl crate::stubs::SchemaService for SchemaService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2013,7 +2013,7 @@ impl crate::stubs::SchemaService for SchemaService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/schemas", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2034,7 +2034,7 @@ impl crate::stubs::SchemaService for SchemaService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/schemas", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2061,7 +2061,7 @@ impl crate::stubs::SchemaService for SchemaService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2079,7 +2079,7 @@ impl crate::stubs::SchemaService for SchemaService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2098,7 +2098,7 @@ impl crate::stubs::SchemaService for SchemaService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2120,7 +2120,7 @@ impl crate::stubs::SchemaService for SchemaService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2139,7 +2139,7 @@ impl crate::stubs::SchemaService for SchemaService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2196,7 +2196,7 @@ impl crate::stubs::SearchService for SearchService {
                 reqwest::Method::POST,
                 format!("/v1/{}:search", req.serving_config),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2216,7 +2216,7 @@ impl crate::stubs::SearchService for SearchService {
                 reqwest::Method::POST,
                 format!("/v1/{}:searchLite", req.serving_config),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2233,7 +2233,7 @@ impl crate::stubs::SearchService for SearchService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2255,7 +2255,7 @@ impl crate::stubs::SearchService for SearchService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2274,7 +2274,7 @@ impl crate::stubs::SearchService for SearchService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2317,7 +2317,7 @@ impl crate::stubs::SearchTuningService for SearchTuningService {
                 reqwest::Method::POST,
                 format!("/v1/{}:trainCustomModel", req.data_store),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2337,7 +2337,7 @@ impl crate::stubs::SearchTuningService for SearchTuningService {
                 reqwest::Method::GET,
                 format!("/v1/{}/customModels", req.data_store),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2356,7 +2356,7 @@ impl crate::stubs::SearchTuningService for SearchTuningService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2378,7 +2378,7 @@ impl crate::stubs::SearchTuningService for SearchTuningService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2397,7 +2397,7 @@ impl crate::stubs::SearchTuningService for SearchTuningService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2451,7 +2451,7 @@ impl crate::stubs::SiteSearchEngineService for SiteSearchEngineService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2473,7 +2473,7 @@ impl crate::stubs::SiteSearchEngineService for SiteSearchEngineService {
                 reqwest::Method::POST,
                 format!("/v1/{}/targetSites", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2495,7 +2495,7 @@ impl crate::stubs::SiteSearchEngineService for SiteSearchEngineService {
                 reqwest::Method::POST,
                 format!("/v1/{}/targetSites:batchCreate", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2512,7 +2512,7 @@ impl crate::stubs::SiteSearchEngineService for SiteSearchEngineService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2540,7 +2540,7 @@ impl crate::stubs::SiteSearchEngineService for SiteSearchEngineService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2559,7 +2559,7 @@ impl crate::stubs::SiteSearchEngineService for SiteSearchEngineService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2581,7 +2581,7 @@ impl crate::stubs::SiteSearchEngineService for SiteSearchEngineService {
                 reqwest::Method::GET,
                 format!("/v1/{}/targetSites", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2605,7 +2605,7 @@ impl crate::stubs::SiteSearchEngineService for SiteSearchEngineService {
                 reqwest::Method::POST,
                 format!("/v1/{}:enableAdvancedSiteSearch", req.site_search_engine),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2625,7 +2625,7 @@ impl crate::stubs::SiteSearchEngineService for SiteSearchEngineService {
                 reqwest::Method::POST,
                 format!("/v1/{}:disableAdvancedSiteSearch", req.site_search_engine),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2645,7 +2645,7 @@ impl crate::stubs::SiteSearchEngineService for SiteSearchEngineService {
                 reqwest::Method::POST,
                 format!("/v1/{}:recrawlUris", req.site_search_engine),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2665,7 +2665,7 @@ impl crate::stubs::SiteSearchEngineService for SiteSearchEngineService {
                 reqwest::Method::POST,
                 format!("/v1/{}:batchVerifyTargetSites", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2688,7 +2688,7 @@ impl crate::stubs::SiteSearchEngineService for SiteSearchEngineService {
                     req.site_search_engine
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2709,7 +2709,7 @@ impl crate::stubs::SiteSearchEngineService for SiteSearchEngineService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2731,7 +2731,7 @@ impl crate::stubs::SiteSearchEngineService for SiteSearchEngineService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2750,7 +2750,7 @@ impl crate::stubs::SiteSearchEngineService for SiteSearchEngineService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2807,7 +2807,7 @@ impl crate::stubs::UserEventService for UserEventService {
                 reqwest::Method::POST,
                 format!("/v1/{}/userEvents:write", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2830,7 +2830,7 @@ impl crate::stubs::UserEventService for UserEventService {
                 reqwest::Method::GET,
                 format!("/v1/{}/userEvents:collect", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2861,7 +2861,7 @@ impl crate::stubs::UserEventService for UserEventService {
                 reqwest::Method::POST,
                 format!("/v1/{}/userEvents:purge", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2881,7 +2881,7 @@ impl crate::stubs::UserEventService for UserEventService {
                 reqwest::Method::POST,
                 format!("/v1/{}/userEvents:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2898,7 +2898,7 @@ impl crate::stubs::UserEventService for UserEventService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2920,7 +2920,7 @@ impl crate::stubs::UserEventService for UserEventService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2939,7 +2939,7 @@ impl crate::stubs::UserEventService for UserEventService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/documentai/v1/src/model.rs
+++ b/src/generated/cloud/documentai/v1/src/model.rs
@@ -1179,53 +1179,73 @@ pub mod document {
 
             /// Detected human reading orientation.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct Orientation(std::borrow::Cow<'static, str>);
+            pub struct Orientation(i32);
 
             impl Orientation {
-                /// Creates a new Orientation instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [Orientation](Orientation)
-            pub mod orientation {
-                use super::Orientation;
-
                 /// Unspecified orientation.
-                pub const ORIENTATION_UNSPECIFIED: Orientation =
-                    Orientation::new("ORIENTATION_UNSPECIFIED");
+                pub const ORIENTATION_UNSPECIFIED: Orientation = Orientation::new(0);
 
                 /// Orientation is aligned with page up.
-                pub const PAGE_UP: Orientation = Orientation::new("PAGE_UP");
+                pub const PAGE_UP: Orientation = Orientation::new(1);
 
                 /// Orientation is aligned with page right.
                 /// Turn the head 90 degrees clockwise from upright to read.
-                pub const PAGE_RIGHT: Orientation = Orientation::new("PAGE_RIGHT");
+                pub const PAGE_RIGHT: Orientation = Orientation::new(2);
 
                 /// Orientation is aligned with page down.
                 /// Turn the head 180 degrees from upright to read.
-                pub const PAGE_DOWN: Orientation = Orientation::new("PAGE_DOWN");
+                pub const PAGE_DOWN: Orientation = Orientation::new(3);
 
                 /// Orientation is aligned with page left.
                 /// Turn the head 90 degrees counterclockwise from upright to read.
-                pub const PAGE_LEFT: Orientation = Orientation::new("PAGE_LEFT");
+                pub const PAGE_LEFT: Orientation = Orientation::new(4);
+
+                /// Creates a new Orientation instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("ORIENTATION_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("PAGE_UP"),
+                        2 => std::borrow::Cow::Borrowed("PAGE_RIGHT"),
+                        3 => std::borrow::Cow::Borrowed("PAGE_DOWN"),
+                        4 => std::borrow::Cow::Borrowed("PAGE_LEFT"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "ORIENTATION_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::ORIENTATION_UNSPECIFIED)
+                        }
+                        "PAGE_UP" => std::option::Option::Some(Self::PAGE_UP),
+                        "PAGE_RIGHT" => std::option::Option::Some(Self::PAGE_RIGHT),
+                        "PAGE_DOWN" => std::option::Option::Some(Self::PAGE_DOWN),
+                        "PAGE_LEFT" => std::option::Option::Some(Self::PAGE_LEFT),
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for Orientation {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for Orientation {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for Orientation {
                 fn default() -> Self {
-                    orientation::ORIENTATION_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -1591,46 +1611,63 @@ pub mod document {
 
                 /// Enum to denote the type of break found.
                 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                pub struct Type(std::borrow::Cow<'static, str>);
+                pub struct Type(i32);
 
                 impl Type {
+                    /// Unspecified break type.
+                    pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+                    /// A single whitespace.
+                    pub const SPACE: Type = Type::new(1);
+
+                    /// A wider whitespace.
+                    pub const WIDE_SPACE: Type = Type::new(2);
+
+                    /// A hyphen that indicates that a token has been split across lines.
+                    pub const HYPHEN: Type = Type::new(3);
+
                     /// Creates a new Type instance.
-                    pub const fn new(v: &'static str) -> Self {
-                        Self(std::borrow::Cow::Borrowed(v))
+                    pub(crate) const fn new(value: i32) -> Self {
+                        Self(value)
                     }
 
                     /// Gets the enum value.
-                    pub fn value(&self) -> &str {
-                        &self.0
+                    pub fn value(&self) -> i32 {
+                        self.0
+                    }
+
+                    /// Gets the enum value as a string.
+                    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                        match self.0 {
+                            0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                            1 => std::borrow::Cow::Borrowed("SPACE"),
+                            2 => std::borrow::Cow::Borrowed("WIDE_SPACE"),
+                            3 => std::borrow::Cow::Borrowed("HYPHEN"),
+                            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                        }
+                    }
+
+                    /// Creates an enum value from the value name.
+                    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                        match name {
+                            "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                            "SPACE" => std::option::Option::Some(Self::SPACE),
+                            "WIDE_SPACE" => std::option::Option::Some(Self::WIDE_SPACE),
+                            "HYPHEN" => std::option::Option::Some(Self::HYPHEN),
+                            _ => std::option::Option::None,
+                        }
                     }
                 }
 
-                /// Useful constants to work with [Type](Type)
-                pub mod r#type {
-                    use super::Type;
-
-                    /// Unspecified break type.
-                    pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-                    /// A single whitespace.
-                    pub const SPACE: Type = Type::new("SPACE");
-
-                    /// A wider whitespace.
-                    pub const WIDE_SPACE: Type = Type::new("WIDE_SPACE");
-
-                    /// A hyphen that indicates that a token has been split across lines.
-                    pub const HYPHEN: Type = Type::new("HYPHEN");
-                }
-
-                impl std::convert::From<std::string::String> for Type {
-                    fn from(value: std::string::String) -> Self {
-                        Self(std::borrow::Cow::Owned(value))
+                impl std::convert::From<i32> for Type {
+                    fn from(value: i32) -> Self {
+                        Self::new(value)
                     }
                 }
 
                 impl std::default::Default for Type {
                     fn default() -> Self {
-                        r#type::TYPE_UNSPECIFIED
+                        Self::new(0)
                     }
                 }
             }
@@ -3290,86 +3327,112 @@ pub mod document {
 
             /// The type of layout that is being referenced.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct LayoutType(std::borrow::Cow<'static, str>);
+            pub struct LayoutType(i32);
 
             impl LayoutType {
-                /// Creates a new LayoutType instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [LayoutType](LayoutType)
-            pub mod layout_type {
-                use super::LayoutType;
-
                 /// Layout Unspecified.
-                pub const LAYOUT_TYPE_UNSPECIFIED: LayoutType =
-                    LayoutType::new("LAYOUT_TYPE_UNSPECIFIED");
+                pub const LAYOUT_TYPE_UNSPECIFIED: LayoutType = LayoutType::new(0);
 
                 /// References a
                 /// [Page.blocks][google.cloud.documentai.v1.Document.Page.blocks]
                 /// element.
                 ///
                 /// [google.cloud.documentai.v1.Document.Page.blocks]: crate::model::document::Page::blocks
-                pub const BLOCK: LayoutType = LayoutType::new("BLOCK");
+                pub const BLOCK: LayoutType = LayoutType::new(1);
 
                 /// References a
                 /// [Page.paragraphs][google.cloud.documentai.v1.Document.Page.paragraphs]
                 /// element.
                 ///
                 /// [google.cloud.documentai.v1.Document.Page.paragraphs]: crate::model::document::Page::paragraphs
-                pub const PARAGRAPH: LayoutType = LayoutType::new("PARAGRAPH");
+                pub const PARAGRAPH: LayoutType = LayoutType::new(2);
 
                 /// References a
                 /// [Page.lines][google.cloud.documentai.v1.Document.Page.lines] element.
                 ///
                 /// [google.cloud.documentai.v1.Document.Page.lines]: crate::model::document::Page::lines
-                pub const LINE: LayoutType = LayoutType::new("LINE");
+                pub const LINE: LayoutType = LayoutType::new(3);
 
                 /// References a
                 /// [Page.tokens][google.cloud.documentai.v1.Document.Page.tokens]
                 /// element.
                 ///
                 /// [google.cloud.documentai.v1.Document.Page.tokens]: crate::model::document::Page::tokens
-                pub const TOKEN: LayoutType = LayoutType::new("TOKEN");
+                pub const TOKEN: LayoutType = LayoutType::new(4);
 
                 /// References a
                 /// [Page.visual_elements][google.cloud.documentai.v1.Document.Page.visual_elements]
                 /// element.
                 ///
                 /// [google.cloud.documentai.v1.Document.Page.visual_elements]: crate::model::document::Page::visual_elements
-                pub const VISUAL_ELEMENT: LayoutType = LayoutType::new("VISUAL_ELEMENT");
+                pub const VISUAL_ELEMENT: LayoutType = LayoutType::new(5);
 
                 /// Refrrences a
                 /// [Page.tables][google.cloud.documentai.v1.Document.Page.tables]
                 /// element.
                 ///
                 /// [google.cloud.documentai.v1.Document.Page.tables]: crate::model::document::Page::tables
-                pub const TABLE: LayoutType = LayoutType::new("TABLE");
+                pub const TABLE: LayoutType = LayoutType::new(6);
 
                 /// References a
                 /// [Page.form_fields][google.cloud.documentai.v1.Document.Page.form_fields]
                 /// element.
                 ///
                 /// [google.cloud.documentai.v1.Document.Page.form_fields]: crate::model::document::Page::form_fields
-                pub const FORM_FIELD: LayoutType = LayoutType::new("FORM_FIELD");
+                pub const FORM_FIELD: LayoutType = LayoutType::new(7);
+
+                /// Creates a new LayoutType instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("LAYOUT_TYPE_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("BLOCK"),
+                        2 => std::borrow::Cow::Borrowed("PARAGRAPH"),
+                        3 => std::borrow::Cow::Borrowed("LINE"),
+                        4 => std::borrow::Cow::Borrowed("TOKEN"),
+                        5 => std::borrow::Cow::Borrowed("VISUAL_ELEMENT"),
+                        6 => std::borrow::Cow::Borrowed("TABLE"),
+                        7 => std::borrow::Cow::Borrowed("FORM_FIELD"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "LAYOUT_TYPE_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::LAYOUT_TYPE_UNSPECIFIED)
+                        }
+                        "BLOCK" => std::option::Option::Some(Self::BLOCK),
+                        "PARAGRAPH" => std::option::Option::Some(Self::PARAGRAPH),
+                        "LINE" => std::option::Option::Some(Self::LINE),
+                        "TOKEN" => std::option::Option::Some(Self::TOKEN),
+                        "VISUAL_ELEMENT" => std::option::Option::Some(Self::VISUAL_ELEMENT),
+                        "TABLE" => std::option::Option::Some(Self::TABLE),
+                        "FORM_FIELD" => std::option::Option::Some(Self::FORM_FIELD),
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for LayoutType {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for LayoutType {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for LayoutType {
                 fn default() -> Self {
-                    layout_type::LAYOUT_TYPE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -3499,65 +3562,91 @@ pub mod document {
 
         /// If a processor or agent does an explicit operation on existing elements.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct OperationType(std::borrow::Cow<'static, str>);
+        pub struct OperationType(i32);
 
         impl OperationType {
-            /// Creates a new OperationType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [OperationType](OperationType)
-        pub mod operation_type {
-            use super::OperationType;
-
             /// Operation type unspecified. If no operation is specified a provenance
             /// entry is simply used to match against a `parent`.
-            pub const OPERATION_TYPE_UNSPECIFIED: OperationType =
-                OperationType::new("OPERATION_TYPE_UNSPECIFIED");
+            pub const OPERATION_TYPE_UNSPECIFIED: OperationType = OperationType::new(0);
 
             /// Add an element.
-            pub const ADD: OperationType = OperationType::new("ADD");
+            pub const ADD: OperationType = OperationType::new(1);
 
             /// Remove an element identified by `parent`.
-            pub const REMOVE: OperationType = OperationType::new("REMOVE");
+            pub const REMOVE: OperationType = OperationType::new(2);
 
             /// Updates any fields within the given provenance scope of the message. It
             /// overwrites the fields rather than replacing them.  Use this when you
             /// want to update a field value of an entity without also updating all the
             /// child properties.
-            pub const UPDATE: OperationType = OperationType::new("UPDATE");
+            pub const UPDATE: OperationType = OperationType::new(7);
 
             /// Currently unused. Replace an element identified by `parent`.
-            pub const REPLACE: OperationType = OperationType::new("REPLACE");
+            pub const REPLACE: OperationType = OperationType::new(3);
 
             /// Deprecated. Request human review for the element identified by
             /// `parent`.
-            pub const EVAL_REQUESTED: OperationType = OperationType::new("EVAL_REQUESTED");
+            pub const EVAL_REQUESTED: OperationType = OperationType::new(4);
 
             /// Deprecated. Element is reviewed and approved at human review,
             /// confidence will be set to 1.0.
-            pub const EVAL_APPROVED: OperationType = OperationType::new("EVAL_APPROVED");
+            pub const EVAL_APPROVED: OperationType = OperationType::new(5);
 
             /// Deprecated. Element is skipped in the validation process.
-            pub const EVAL_SKIPPED: OperationType = OperationType::new("EVAL_SKIPPED");
+            pub const EVAL_SKIPPED: OperationType = OperationType::new(6);
+
+            /// Creates a new OperationType instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("OPERATION_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("ADD"),
+                    2 => std::borrow::Cow::Borrowed("REMOVE"),
+                    3 => std::borrow::Cow::Borrowed("REPLACE"),
+                    4 => std::borrow::Cow::Borrowed("EVAL_REQUESTED"),
+                    5 => std::borrow::Cow::Borrowed("EVAL_APPROVED"),
+                    6 => std::borrow::Cow::Borrowed("EVAL_SKIPPED"),
+                    7 => std::borrow::Cow::Borrowed("UPDATE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "OPERATION_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::OPERATION_TYPE_UNSPECIFIED)
+                    }
+                    "ADD" => std::option::Option::Some(Self::ADD),
+                    "REMOVE" => std::option::Option::Some(Self::REMOVE),
+                    "UPDATE" => std::option::Option::Some(Self::UPDATE),
+                    "REPLACE" => std::option::Option::Some(Self::REPLACE),
+                    "EVAL_REQUESTED" => std::option::Option::Some(Self::EVAL_REQUESTED),
+                    "EVAL_APPROVED" => std::option::Option::Some(Self::EVAL_APPROVED),
+                    "EVAL_SKIPPED" => std::option::Option::Some(Self::EVAL_SKIPPED),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for OperationType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for OperationType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for OperationType {
             fn default() -> Self {
-                operation_type::OPERATION_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -6040,55 +6129,74 @@ pub mod human_review_status {
 
     /// The final state of human review on a processed document.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Human review state is unspecified. Most likely due to an internal error.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Human review is skipped for the document. This can happen because human
         /// review isn't enabled on the processor or the processing request has
         /// been set to skip this document.
-        pub const SKIPPED: State = State::new("SKIPPED");
+        pub const SKIPPED: State = State::new(1);
 
         /// Human review validation is triggered and passed, so no review is needed.
-        pub const VALIDATION_PASSED: State = State::new("VALIDATION_PASSED");
+        pub const VALIDATION_PASSED: State = State::new(2);
 
         /// Human review validation is triggered and the document is under review.
-        pub const IN_PROGRESS: State = State::new("IN_PROGRESS");
+        pub const IN_PROGRESS: State = State::new(3);
 
         /// Some error happened during triggering human review, see the
         /// [state_message][google.cloud.documentai.v1.HumanReviewStatus.state_message]
         /// for details.
         ///
         /// [google.cloud.documentai.v1.HumanReviewStatus.state_message]: crate::model::HumanReviewStatus::state_message
-        pub const ERROR: State = State::new("ERROR");
+        pub const ERROR: State = State::new(4);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SKIPPED"),
+                2 => std::borrow::Cow::Borrowed("VALIDATION_PASSED"),
+                3 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                4 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "SKIPPED" => std::option::Option::Some(Self::SKIPPED),
+                "VALIDATION_PASSED" => std::option::Option::Some(Self::VALIDATION_PASSED),
+                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6466,55 +6574,78 @@ pub mod batch_process_metadata {
 
     /// Possible states of the batch processing operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The default value. This value is used if the state is omitted.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Request operation is waiting for scheduling.
+        pub const WAITING: State = State::new(1);
+
+        /// Request is being processed.
+        pub const RUNNING: State = State::new(2);
+
+        /// The batch processing completed successfully.
+        pub const SUCCEEDED: State = State::new(3);
+
+        /// The batch processing was being cancelled.
+        pub const CANCELLING: State = State::new(4);
+
+        /// The batch processing was cancelled.
+        pub const CANCELLED: State = State::new(5);
+
+        /// The batch processing has failed.
+        pub const FAILED: State = State::new(6);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("WAITING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                4 => std::borrow::Cow::Borrowed("CANCELLING"),
+                5 => std::borrow::Cow::Borrowed("CANCELLED"),
+                6 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "WAITING" => std::option::Option::Some(Self::WAITING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Request operation is waiting for scheduling.
-        pub const WAITING: State = State::new("WAITING");
-
-        /// Request is being processed.
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// The batch processing completed successfully.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-        /// The batch processing was being cancelled.
-        pub const CANCELLING: State = State::new("CANCELLING");
-
-        /// The batch processing was cancelled.
-        pub const CANCELLED: State = State::new("CANCELLED");
-
-        /// The batch processing has failed.
-        pub const FAILED: State = State::new("FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8020,41 +8151,57 @@ pub mod train_processor_version_request {
         /// Training Method for CDE. `TRAINING_METHOD_UNSPECIFIED` will fall back to
         /// `MODEL_BASED`.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct TrainingMethod(std::borrow::Cow<'static, str>);
+        pub struct TrainingMethod(i32);
 
         impl TrainingMethod {
+            pub const TRAINING_METHOD_UNSPECIFIED: TrainingMethod = TrainingMethod::new(0);
+
+            pub const MODEL_BASED: TrainingMethod = TrainingMethod::new(1);
+
+            pub const TEMPLATE_BASED: TrainingMethod = TrainingMethod::new(2);
+
             /// Creates a new TrainingMethod instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("TRAINING_METHOD_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("MODEL_BASED"),
+                    2 => std::borrow::Cow::Borrowed("TEMPLATE_BASED"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "TRAINING_METHOD_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::TRAINING_METHOD_UNSPECIFIED)
+                    }
+                    "MODEL_BASED" => std::option::Option::Some(Self::MODEL_BASED),
+                    "TEMPLATE_BASED" => std::option::Option::Some(Self::TEMPLATE_BASED),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [TrainingMethod](TrainingMethod)
-        pub mod training_method {
-            use super::TrainingMethod;
-
-            pub const TRAINING_METHOD_UNSPECIFIED: TrainingMethod =
-                TrainingMethod::new("TRAINING_METHOD_UNSPECIFIED");
-
-            pub const MODEL_BASED: TrainingMethod = TrainingMethod::new("MODEL_BASED");
-
-            pub const TEMPLATE_BASED: TrainingMethod = TrainingMethod::new("TEMPLATE_BASED");
-        }
-
-        impl std::convert::From<std::string::String> for TrainingMethod {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for TrainingMethod {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for TrainingMethod {
             fn default() -> Self {
-                training_method::TRAINING_METHOD_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -8427,41 +8574,54 @@ pub mod review_document_request {
 
     /// The priority level of the human review task.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Priority(std::borrow::Cow<'static, str>);
+    pub struct Priority(i32);
 
     impl Priority {
-        /// Creates a new Priority instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Priority](Priority)
-    pub mod priority {
-        use super::Priority;
-
         /// The default priority level.
-        pub const DEFAULT: Priority = Priority::new("DEFAULT");
+        pub const DEFAULT: Priority = Priority::new(0);
 
         /// The urgent priority level. The labeling manager should allocate labeler
         /// resource to the urgent task queue to respect this priority level.
-        pub const URGENT: Priority = Priority::new("URGENT");
+        pub const URGENT: Priority = Priority::new(1);
+
+        /// Creates a new Priority instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DEFAULT"),
+                1 => std::borrow::Cow::Borrowed("URGENT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
+                "URGENT" => std::option::Option::Some(Self::URGENT),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Priority {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Priority {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Priority {
         fn default() -> Self {
-            priority::DEFAULT
+            Self::new(0)
         }
     }
 
@@ -8541,43 +8701,58 @@ pub mod review_document_response {
 
     /// Possible states of the review operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The default value. This value is used if the state is omitted.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The review operation is rejected by the reviewer.
+        pub const REJECTED: State = State::new(1);
+
+        /// The review operation is succeeded.
+        pub const SUCCEEDED: State = State::new(2);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REJECTED"),
+                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "REJECTED" => std::option::Option::Some(Self::REJECTED),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The review operation is rejected by the reviewer.
-        pub const REJECTED: State = State::new("REJECTED");
-
-        /// The review operation is succeeded.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -9251,54 +9426,72 @@ pub mod document_schema {
             /// accounts for the customers, the occurrence type is set to
             /// `REQUIRED_MULTIPLE`.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct OccurrenceType(std::borrow::Cow<'static, str>);
+            pub struct OccurrenceType(i32);
 
             impl OccurrenceType {
-                /// Creates a new OccurrenceType instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [OccurrenceType](OccurrenceType)
-            pub mod occurrence_type {
-                use super::OccurrenceType;
-
                 /// Unspecified occurrence type.
-                pub const OCCURRENCE_TYPE_UNSPECIFIED: OccurrenceType =
-                    OccurrenceType::new("OCCURRENCE_TYPE_UNSPECIFIED");
+                pub const OCCURRENCE_TYPE_UNSPECIFIED: OccurrenceType = OccurrenceType::new(0);
 
                 /// There will be zero or one instance of this entity type.  The same
                 /// entity instance may be mentioned multiple times.
-                pub const OPTIONAL_ONCE: OccurrenceType = OccurrenceType::new("OPTIONAL_ONCE");
+                pub const OPTIONAL_ONCE: OccurrenceType = OccurrenceType::new(1);
 
                 /// The entity type will appear zero or multiple times.
-                pub const OPTIONAL_MULTIPLE: OccurrenceType =
-                    OccurrenceType::new("OPTIONAL_MULTIPLE");
+                pub const OPTIONAL_MULTIPLE: OccurrenceType = OccurrenceType::new(2);
 
                 /// The entity type will only appear exactly once.  The same
                 /// entity instance may be mentioned multiple times.
-                pub const REQUIRED_ONCE: OccurrenceType = OccurrenceType::new("REQUIRED_ONCE");
+                pub const REQUIRED_ONCE: OccurrenceType = OccurrenceType::new(3);
 
                 /// The entity type will appear once or more times.
-                pub const REQUIRED_MULTIPLE: OccurrenceType =
-                    OccurrenceType::new("REQUIRED_MULTIPLE");
+                pub const REQUIRED_MULTIPLE: OccurrenceType = OccurrenceType::new(4);
+
+                /// Creates a new OccurrenceType instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("OCCURRENCE_TYPE_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("OPTIONAL_ONCE"),
+                        2 => std::borrow::Cow::Borrowed("OPTIONAL_MULTIPLE"),
+                        3 => std::borrow::Cow::Borrowed("REQUIRED_ONCE"),
+                        4 => std::borrow::Cow::Borrowed("REQUIRED_MULTIPLE"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "OCCURRENCE_TYPE_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::OCCURRENCE_TYPE_UNSPECIFIED)
+                        }
+                        "OPTIONAL_ONCE" => std::option::Option::Some(Self::OPTIONAL_ONCE),
+                        "OPTIONAL_MULTIPLE" => std::option::Option::Some(Self::OPTIONAL_MULTIPLE),
+                        "REQUIRED_ONCE" => std::option::Option::Some(Self::REQUIRED_ONCE),
+                        "REQUIRED_MULTIPLE" => std::option::Option::Some(Self::REQUIRED_MULTIPLE),
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for OccurrenceType {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for OccurrenceType {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for OccurrenceType {
                 fn default() -> Self {
-                    occurrence_type::OCCURRENCE_TYPE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -9909,47 +10102,61 @@ pub mod evaluation {
 
         /// A type that determines how metrics should be interpreted.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct MetricsType(std::borrow::Cow<'static, str>);
+        pub struct MetricsType(i32);
 
         impl MetricsType {
-            /// Creates a new MetricsType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [MetricsType](MetricsType)
-        pub mod metrics_type {
-            use super::MetricsType;
-
             /// The metrics type is unspecified. By default, metrics without a
             /// particular specification are for leaf entity types (i.e., top-level
             /// entity types without child types, or child types which are not
             /// parent types themselves).
-            pub const METRICS_TYPE_UNSPECIFIED: MetricsType =
-                MetricsType::new("METRICS_TYPE_UNSPECIFIED");
+            pub const METRICS_TYPE_UNSPECIFIED: MetricsType = MetricsType::new(0);
 
             /// Indicates whether metrics for this particular label type represent an
             /// aggregate of metrics for other types instead of being based on actual
             /// TP/FP/FN values for the label type. Metrics for parent (i.e., non-leaf)
             /// entity types are an aggregate of metrics for their children.
-            pub const AGGREGATE: MetricsType = MetricsType::new("AGGREGATE");
+            pub const AGGREGATE: MetricsType = MetricsType::new(1);
+
+            /// Creates a new MetricsType instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("METRICS_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("AGGREGATE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "METRICS_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::METRICS_TYPE_UNSPECIFIED)
+                    }
+                    "AGGREGATE" => std::option::Option::Some(Self::AGGREGATE),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for MetricsType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for MetricsType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for MetricsType {
             fn default() -> Self {
-                metrics_type::METRICS_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -10165,52 +10372,73 @@ pub mod common_operation_metadata {
 
     /// State of the longrunning operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Operation is still running.
+        pub const RUNNING: State = State::new(1);
+
+        /// Operation is being cancelled.
+        pub const CANCELLING: State = State::new(2);
+
+        /// Operation succeeded.
+        pub const SUCCEEDED: State = State::new(3);
+
+        /// Operation failed.
+        pub const FAILED: State = State::new(4);
+
+        /// Operation is cancelled.
+        pub const CANCELLED: State = State::new(5);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RUNNING"),
+                2 => std::borrow::Cow::Borrowed("CANCELLING"),
+                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                5 => std::borrow::Cow::Borrowed("CANCELLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Operation is still running.
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// Operation is being cancelled.
-        pub const CANCELLING: State = State::new("CANCELLING");
-
-        /// Operation succeeded.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-        /// Operation failed.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// Operation is cancelled.
-        pub const CANCELLED: State = State::new("CANCELLED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -10672,45 +10900,62 @@ pub mod processor_version {
 
             /// The type of custom model created by the user.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct CustomModelType(std::borrow::Cow<'static, str>);
+            pub struct CustomModelType(i32);
 
             impl CustomModelType {
+                /// The model type is unspecified.
+                pub const CUSTOM_MODEL_TYPE_UNSPECIFIED: CustomModelType = CustomModelType::new(0);
+
+                /// The model is a versioned foundation model.
+                pub const VERSIONED_FOUNDATION: CustomModelType = CustomModelType::new(1);
+
+                /// The model is a finetuned foundation model.
+                pub const FINE_TUNED: CustomModelType = CustomModelType::new(2);
+
                 /// Creates a new CustomModelType instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
                 }
 
                 /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("CUSTOM_MODEL_TYPE_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("VERSIONED_FOUNDATION"),
+                        2 => std::borrow::Cow::Borrowed("FINE_TUNED"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "CUSTOM_MODEL_TYPE_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::CUSTOM_MODEL_TYPE_UNSPECIFIED)
+                        }
+                        "VERSIONED_FOUNDATION" => {
+                            std::option::Option::Some(Self::VERSIONED_FOUNDATION)
+                        }
+                        "FINE_TUNED" => std::option::Option::Some(Self::FINE_TUNED),
+                        _ => std::option::Option::None,
+                    }
                 }
             }
 
-            /// Useful constants to work with [CustomModelType](CustomModelType)
-            pub mod custom_model_type {
-                use super::CustomModelType;
-
-                /// The model type is unspecified.
-                pub const CUSTOM_MODEL_TYPE_UNSPECIFIED: CustomModelType =
-                    CustomModelType::new("CUSTOM_MODEL_TYPE_UNSPECIFIED");
-
-                /// The model is a versioned foundation model.
-                pub const VERSIONED_FOUNDATION: CustomModelType =
-                    CustomModelType::new("VERSIONED_FOUNDATION");
-
-                /// The model is a finetuned foundation model.
-                pub const FINE_TUNED: CustomModelType = CustomModelType::new("FINE_TUNED");
-            }
-
-            impl std::convert::From<std::string::String> for CustomModelType {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for CustomModelType {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for CustomModelType {
                 fn default() -> Self {
-                    custom_model_type::CUSTOM_MODEL_TYPE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -10738,103 +10983,145 @@ pub mod processor_version {
 
     /// The possible states of the processor version.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The processor version is in an unspecified state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The processor version is deployed and can be used for processing.
+        pub const DEPLOYED: State = State::new(1);
+
+        /// The processor version is being deployed.
+        pub const DEPLOYING: State = State::new(2);
+
+        /// The processor version is not deployed and cannot be used for processing.
+        pub const UNDEPLOYED: State = State::new(3);
+
+        /// The processor version is being undeployed.
+        pub const UNDEPLOYING: State = State::new(4);
+
+        /// The processor version is being created.
+        pub const CREATING: State = State::new(5);
+
+        /// The processor version is being deleted.
+        pub const DELETING: State = State::new(6);
+
+        /// The processor version failed and is in an indeterminate state.
+        pub const FAILED: State = State::new(7);
+
+        /// The processor version is being imported.
+        pub const IMPORTING: State = State::new(8);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DEPLOYED"),
+                2 => std::borrow::Cow::Borrowed("DEPLOYING"),
+                3 => std::borrow::Cow::Borrowed("UNDEPLOYED"),
+                4 => std::borrow::Cow::Borrowed("UNDEPLOYING"),
+                5 => std::borrow::Cow::Borrowed("CREATING"),
+                6 => std::borrow::Cow::Borrowed("DELETING"),
+                7 => std::borrow::Cow::Borrowed("FAILED"),
+                8 => std::borrow::Cow::Borrowed("IMPORTING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "DEPLOYED" => std::option::Option::Some(Self::DEPLOYED),
+                "DEPLOYING" => std::option::Option::Some(Self::DEPLOYING),
+                "UNDEPLOYED" => std::option::Option::Some(Self::UNDEPLOYED),
+                "UNDEPLOYING" => std::option::Option::Some(Self::UNDEPLOYING),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "IMPORTING" => std::option::Option::Some(Self::IMPORTING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The processor version is in an unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The processor version is deployed and can be used for processing.
-        pub const DEPLOYED: State = State::new("DEPLOYED");
-
-        /// The processor version is being deployed.
-        pub const DEPLOYING: State = State::new("DEPLOYING");
-
-        /// The processor version is not deployed and cannot be used for processing.
-        pub const UNDEPLOYED: State = State::new("UNDEPLOYED");
-
-        /// The processor version is being undeployed.
-        pub const UNDEPLOYING: State = State::new("UNDEPLOYING");
-
-        /// The processor version is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The processor version is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// The processor version failed and is in an indeterminate state.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// The processor version is being imported.
-        pub const IMPORTING: State = State::new("IMPORTING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The possible model types of the processor version.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ModelType(std::borrow::Cow<'static, str>);
+    pub struct ModelType(i32);
 
     impl ModelType {
+        /// The processor version has unspecified model type.
+        pub const MODEL_TYPE_UNSPECIFIED: ModelType = ModelType::new(0);
+
+        /// The processor version has generative model type.
+        pub const MODEL_TYPE_GENERATIVE: ModelType = ModelType::new(1);
+
+        /// The processor version has custom model type.
+        pub const MODEL_TYPE_CUSTOM: ModelType = ModelType::new(2);
+
         /// Creates a new ModelType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MODEL_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MODEL_TYPE_GENERATIVE"),
+                2 => std::borrow::Cow::Borrowed("MODEL_TYPE_CUSTOM"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MODEL_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::MODEL_TYPE_UNSPECIFIED),
+                "MODEL_TYPE_GENERATIVE" => std::option::Option::Some(Self::MODEL_TYPE_GENERATIVE),
+                "MODEL_TYPE_CUSTOM" => std::option::Option::Some(Self::MODEL_TYPE_CUSTOM),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ModelType](ModelType)
-    pub mod model_type {
-        use super::ModelType;
-
-        /// The processor version has unspecified model type.
-        pub const MODEL_TYPE_UNSPECIFIED: ModelType = ModelType::new("MODEL_TYPE_UNSPECIFIED");
-
-        /// The processor version has generative model type.
-        pub const MODEL_TYPE_GENERATIVE: ModelType = ModelType::new("MODEL_TYPE_GENERATIVE");
-
-        /// The processor version has custom model type.
-        pub const MODEL_TYPE_CUSTOM: ModelType = ModelType::new("MODEL_TYPE_CUSTOM");
-    }
-
-    impl std::convert::From<std::string::String> for ModelType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ModelType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ModelType {
         fn default() -> Self {
-            model_type::MODEL_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -11040,66 +11327,91 @@ pub mod processor {
 
     /// The possible states of the processor.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The processor is in an unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The processor is enabled, i.e., has an enabled version which can
         /// currently serve processing requests and all the feature dependencies have
         /// been successfully initialized.
-        pub const ENABLED: State = State::new("ENABLED");
+        pub const ENABLED: State = State::new(1);
 
         /// The processor is disabled.
-        pub const DISABLED: State = State::new("DISABLED");
+        pub const DISABLED: State = State::new(2);
 
         /// The processor is being enabled, will become `ENABLED` if successful.
-        pub const ENABLING: State = State::new("ENABLING");
+        pub const ENABLING: State = State::new(3);
 
         /// The processor is being disabled, will become `DISABLED` if successful.
-        pub const DISABLING: State = State::new("DISABLING");
+        pub const DISABLING: State = State::new(4);
 
         /// The processor is being created, will become either `ENABLED` (for
         /// successful creation) or `FAILED` (for failed ones).
         /// Once a processor is in this state, it can then be used for document
         /// processing, but the feature dependencies of the processor might not be
         /// fully created yet.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(5);
 
         /// The processor failed during creation or initialization of feature
         /// dependencies. The user should delete the processor and recreate one as
         /// all the functionalities of the processor are disabled.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(6);
 
         /// The processor is being deleted, will be removed if successful.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(7);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENABLED"),
+                2 => std::borrow::Cow::Borrowed("DISABLED"),
+                3 => std::borrow::Cow::Borrowed("ENABLING"),
+                4 => std::borrow::Cow::Borrowed("DISABLING"),
+                5 => std::borrow::Cow::Borrowed("CREATING"),
+                6 => std::borrow::Cow::Borrowed("FAILED"),
+                7 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "ENABLING" => std::option::Option::Some(Self::ENABLING),
+                "DISABLING" => std::option::Option::Some(Self::DISABLING),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/documentai/v1/src/transport.rs
+++ b/src/generated/cloud/documentai/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:process", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -69,7 +69,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
                 reqwest::Method::POST,
                 format!("/v1/{}:batchProcess", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -89,7 +89,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
                 reqwest::Method::GET,
                 format!("/v1/{}:fetchProcessorTypes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -111,7 +111,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
                 reqwest::Method::GET,
                 format!("/v1/{}/processorTypes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -132,7 +132,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -154,7 +154,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
                 reqwest::Method::GET,
                 format!("/v1/{}/processors", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -175,7 +175,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -197,7 +197,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
                 reqwest::Method::POST,
                 format!("/v1/{}/processorVersions:train", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -214,7 +214,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -236,7 +236,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
                 reqwest::Method::GET,
                 format!("/v1/{}/processorVersions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -257,7 +257,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -276,7 +276,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:deploy", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -293,7 +293,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:undeploy", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -313,7 +313,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
                 reqwest::Method::POST,
                 format!("/v1/{}/processors", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -332,7 +332,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -351,7 +351,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:enable", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -368,7 +368,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:disable", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -388,7 +388,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setDefaultProcessorVersion", req.processor),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -408,7 +408,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
                 reqwest::Method::POST,
                 format!("/v1/{}:reviewDocument", req.human_review_config),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -428,7 +428,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
                 reqwest::Method::POST,
                 format!("/v1/{}:evaluateProcessorVersion", req.processor_version),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -445,7 +445,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -467,7 +467,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
                 reqwest::Method::GET,
                 format!("/v1/{}/evaluations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -488,7 +488,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -510,7 +510,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -529,7 +529,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -551,7 +551,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -570,7 +570,7 @@ impl crate::stubs::DocumentProcessorService for DocumentProcessorService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/domains/v1/src/model.rs
+++ b/src/generated/cloud/domains/v1/src/model.rs
@@ -252,95 +252,105 @@ pub mod registration {
 
     /// Possible states of a `Registration`.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The state is undefined.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The domain is being registered.
-        pub const REGISTRATION_PENDING: State = State::new("REGISTRATION_PENDING");
+        pub const REGISTRATION_PENDING: State = State::new(1);
 
         /// The domain registration failed. You can delete resources in this state
         /// to allow registration to be retried.
-        pub const REGISTRATION_FAILED: State = State::new("REGISTRATION_FAILED");
+        pub const REGISTRATION_FAILED: State = State::new(2);
 
         /// The domain is being transferred from another registrar to Cloud Domains.
-        pub const TRANSFER_PENDING: State = State::new("TRANSFER_PENDING");
+        pub const TRANSFER_PENDING: State = State::new(3);
 
         /// The attempt to transfer the domain from another registrar to
         /// Cloud Domains failed. You can delete resources in this state and retry
         /// the transfer.
-        pub const TRANSFER_FAILED: State = State::new("TRANSFER_FAILED");
+        pub const TRANSFER_FAILED: State = State::new(4);
 
         /// The domain is registered and operational. The domain renews automatically
         /// as long as it remains in this state.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(6);
 
         /// The domain is suspended and inoperative. For more details, see the
         /// `issues` field.
-        pub const SUSPENDED: State = State::new("SUSPENDED");
+        pub const SUSPENDED: State = State::new(7);
 
         /// The domain is no longer managed with Cloud Domains. It may have been
         /// transferred to another registrar or exported for management in
         /// [Google Domains](https://domains.google/). You can no longer update it
         /// with this API, and information shown about it may be stale. Domains in
         /// this state are not automatically renewed by Cloud Domains.
-        pub const EXPORTED: State = State::new("EXPORTED");
+        pub const EXPORTED: State = State::new(8);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REGISTRATION_PENDING"),
+                2 => std::borrow::Cow::Borrowed("REGISTRATION_FAILED"),
+                3 => std::borrow::Cow::Borrowed("TRANSFER_PENDING"),
+                4 => std::borrow::Cow::Borrowed("TRANSFER_FAILED"),
+                6 => std::borrow::Cow::Borrowed("ACTIVE"),
+                7 => std::borrow::Cow::Borrowed("SUSPENDED"),
+                8 => std::borrow::Cow::Borrowed("EXPORTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "REGISTRATION_PENDING" => std::option::Option::Some(Self::REGISTRATION_PENDING),
+                "REGISTRATION_FAILED" => std::option::Option::Some(Self::REGISTRATION_FAILED),
+                "TRANSFER_PENDING" => std::option::Option::Some(Self::TRANSFER_PENDING),
+                "TRANSFER_FAILED" => std::option::Option::Some(Self::TRANSFER_FAILED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "SUSPENDED" => std::option::Option::Some(Self::SUSPENDED),
+                "EXPORTED" => std::option::Option::Some(Self::EXPORTED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Possible issues with a `Registration` that require attention.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Issue(std::borrow::Cow<'static, str>);
+    pub struct Issue(i32);
 
     impl Issue {
-        /// Creates a new Issue instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Issue](Issue)
-    pub mod issue {
-        use super::Issue;
-
         /// The issue is undefined.
-        pub const ISSUE_UNSPECIFIED: Issue = Issue::new("ISSUE_UNSPECIFIED");
+        pub const ISSUE_UNSPECIFIED: Issue = Issue::new(0);
 
         /// Contact the Cloud Support team to resolve a problem with this domain.
-        pub const CONTACT_SUPPORT: Issue = Issue::new("CONTACT_SUPPORT");
+        pub const CONTACT_SUPPORT: Issue = Issue::new(1);
 
         /// [ICANN](https://icann.org/) requires verification of the email address
         /// in the `Registration`'s `contact_settings.registrant_contact` field. To
@@ -350,18 +360,48 @@ pub mod registration {
         /// 15 days of registration, the domain is suspended. To resend the
         /// verification email, call ConfigureContactSettings and provide the current
         /// `registrant_contact.email`.
-        pub const UNVERIFIED_EMAIL: Issue = Issue::new("UNVERIFIED_EMAIL");
+        pub const UNVERIFIED_EMAIL: Issue = Issue::new(2);
+
+        /// Creates a new Issue instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ISSUE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CONTACT_SUPPORT"),
+                2 => std::borrow::Cow::Borrowed("UNVERIFIED_EMAIL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ISSUE_UNSPECIFIED" => std::option::Option::Some(Self::ISSUE_UNSPECIFIED),
+                "CONTACT_SUPPORT" => std::option::Option::Some(Self::CONTACT_SUPPORT),
+                "UNVERIFIED_EMAIL" => std::option::Option::Some(Self::UNVERIFIED_EMAIL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Issue {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Issue {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Issue {
         fn default() -> Self {
-            issue::ISSUE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -418,33 +458,17 @@ pub mod management_settings {
 
     /// Defines how the `Registration` is renewed.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RenewalMethod(std::borrow::Cow<'static, str>);
+    pub struct RenewalMethod(i32);
 
     impl RenewalMethod {
-        /// Creates a new RenewalMethod instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RenewalMethod](RenewalMethod)
-    pub mod renewal_method {
-        use super::RenewalMethod;
-
         /// The renewal method is undefined.
-        pub const RENEWAL_METHOD_UNSPECIFIED: RenewalMethod =
-            RenewalMethod::new("RENEWAL_METHOD_UNSPECIFIED");
+        pub const RENEWAL_METHOD_UNSPECIFIED: RenewalMethod = RenewalMethod::new(0);
 
         /// The domain is automatically renewed each year .
         ///
         /// To disable automatic renewals, delete the resource by calling
         /// `DeleteRegistration` or export it by calling `ExportRegistration`.
-        pub const AUTOMATIC_RENEWAL: RenewalMethod = RenewalMethod::new("AUTOMATIC_RENEWAL");
+        pub const AUTOMATIC_RENEWAL: RenewalMethod = RenewalMethod::new(1);
 
         /// The domain must be explicitly renewed each year before its
         /// `expire_time`. This option is only available when the `Registration`
@@ -452,18 +476,50 @@ pub mod management_settings {
         ///
         /// To manage the domain's current billing and
         /// renewal settings, go to [Google Domains](https://domains.google/).
-        pub const MANUAL_RENEWAL: RenewalMethod = RenewalMethod::new("MANUAL_RENEWAL");
+        pub const MANUAL_RENEWAL: RenewalMethod = RenewalMethod::new(2);
+
+        /// Creates a new RenewalMethod instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RENEWAL_METHOD_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AUTOMATIC_RENEWAL"),
+                2 => std::borrow::Cow::Borrowed("MANUAL_RENEWAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RENEWAL_METHOD_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RENEWAL_METHOD_UNSPECIFIED)
+                }
+                "AUTOMATIC_RENEWAL" => std::option::Option::Some(Self::AUTOMATIC_RENEWAL),
+                "MANUAL_RENEWAL" => std::option::Option::Some(Self::MANUAL_RENEWAL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RenewalMethod {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RenewalMethod {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RenewalMethod {
         fn default() -> Self {
-            renewal_method::RENEWAL_METHOD_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -783,138 +839,205 @@ pub mod dns_settings {
         /// List of algorithms used to create a DNSKEY. Certain
         /// algorithms are not supported for particular domains.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Algorithm(std::borrow::Cow<'static, str>);
+        pub struct Algorithm(i32);
 
         impl Algorithm {
+            /// The algorithm is unspecified.
+            pub const ALGORITHM_UNSPECIFIED: Algorithm = Algorithm::new(0);
+
+            /// RSA/MD5. Cannot be used for new deployments.
+            pub const RSAMD5: Algorithm = Algorithm::new(1);
+
+            /// Diffie-Hellman. Cannot be used for new deployments.
+            pub const DH: Algorithm = Algorithm::new(2);
+
+            /// DSA/SHA1. Not recommended for new deployments.
+            pub const DSA: Algorithm = Algorithm::new(3);
+
+            /// ECC. Not recommended for new deployments.
+            pub const ECC: Algorithm = Algorithm::new(4);
+
+            /// RSA/SHA-1. Not recommended for new deployments.
+            pub const RSASHA1: Algorithm = Algorithm::new(5);
+
+            /// DSA-NSEC3-SHA1. Not recommended for new deployments.
+            pub const DSANSEC3SHA1: Algorithm = Algorithm::new(6);
+
+            /// RSA/SHA1-NSEC3-SHA1. Not recommended for new deployments.
+            pub const RSASHA1NSEC3SHA1: Algorithm = Algorithm::new(7);
+
+            /// RSA/SHA-256.
+            pub const RSASHA256: Algorithm = Algorithm::new(8);
+
+            /// RSA/SHA-512.
+            pub const RSASHA512: Algorithm = Algorithm::new(10);
+
+            /// GOST R 34.10-2001.
+            pub const ECCGOST: Algorithm = Algorithm::new(12);
+
+            /// ECDSA Curve P-256 with SHA-256.
+            pub const ECDSAP256SHA256: Algorithm = Algorithm::new(13);
+
+            /// ECDSA Curve P-384 with SHA-384.
+            pub const ECDSAP384SHA384: Algorithm = Algorithm::new(14);
+
+            /// Ed25519.
+            pub const ED25519: Algorithm = Algorithm::new(15);
+
+            /// Ed448.
+            pub const ED448: Algorithm = Algorithm::new(16);
+
+            /// Reserved for Indirect Keys. Cannot be used for new deployments.
+            pub const INDIRECT: Algorithm = Algorithm::new(252);
+
+            /// Private algorithm. Cannot be used for new deployments.
+            pub const PRIVATEDNS: Algorithm = Algorithm::new(253);
+
+            /// Private algorithm OID. Cannot be used for new deployments.
+            pub const PRIVATEOID: Algorithm = Algorithm::new(254);
+
             /// Creates a new Algorithm instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("ALGORITHM_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("RSAMD5"),
+                    2 => std::borrow::Cow::Borrowed("DH"),
+                    3 => std::borrow::Cow::Borrowed("DSA"),
+                    4 => std::borrow::Cow::Borrowed("ECC"),
+                    5 => std::borrow::Cow::Borrowed("RSASHA1"),
+                    6 => std::borrow::Cow::Borrowed("DSANSEC3SHA1"),
+                    7 => std::borrow::Cow::Borrowed("RSASHA1NSEC3SHA1"),
+                    8 => std::borrow::Cow::Borrowed("RSASHA256"),
+                    10 => std::borrow::Cow::Borrowed("RSASHA512"),
+                    12 => std::borrow::Cow::Borrowed("ECCGOST"),
+                    13 => std::borrow::Cow::Borrowed("ECDSAP256SHA256"),
+                    14 => std::borrow::Cow::Borrowed("ECDSAP384SHA384"),
+                    15 => std::borrow::Cow::Borrowed("ED25519"),
+                    16 => std::borrow::Cow::Borrowed("ED448"),
+                    252 => std::borrow::Cow::Borrowed("INDIRECT"),
+                    253 => std::borrow::Cow::Borrowed("PRIVATEDNS"),
+                    254 => std::borrow::Cow::Borrowed("PRIVATEOID"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "ALGORITHM_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::ALGORITHM_UNSPECIFIED)
+                    }
+                    "RSAMD5" => std::option::Option::Some(Self::RSAMD5),
+                    "DH" => std::option::Option::Some(Self::DH),
+                    "DSA" => std::option::Option::Some(Self::DSA),
+                    "ECC" => std::option::Option::Some(Self::ECC),
+                    "RSASHA1" => std::option::Option::Some(Self::RSASHA1),
+                    "DSANSEC3SHA1" => std::option::Option::Some(Self::DSANSEC3SHA1),
+                    "RSASHA1NSEC3SHA1" => std::option::Option::Some(Self::RSASHA1NSEC3SHA1),
+                    "RSASHA256" => std::option::Option::Some(Self::RSASHA256),
+                    "RSASHA512" => std::option::Option::Some(Self::RSASHA512),
+                    "ECCGOST" => std::option::Option::Some(Self::ECCGOST),
+                    "ECDSAP256SHA256" => std::option::Option::Some(Self::ECDSAP256SHA256),
+                    "ECDSAP384SHA384" => std::option::Option::Some(Self::ECDSAP384SHA384),
+                    "ED25519" => std::option::Option::Some(Self::ED25519),
+                    "ED448" => std::option::Option::Some(Self::ED448),
+                    "INDIRECT" => std::option::Option::Some(Self::INDIRECT),
+                    "PRIVATEDNS" => std::option::Option::Some(Self::PRIVATEDNS),
+                    "PRIVATEOID" => std::option::Option::Some(Self::PRIVATEOID),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Algorithm](Algorithm)
-        pub mod algorithm {
-            use super::Algorithm;
-
-            /// The algorithm is unspecified.
-            pub const ALGORITHM_UNSPECIFIED: Algorithm = Algorithm::new("ALGORITHM_UNSPECIFIED");
-
-            /// RSA/MD5. Cannot be used for new deployments.
-            pub const RSAMD5: Algorithm = Algorithm::new("RSAMD5");
-
-            /// Diffie-Hellman. Cannot be used for new deployments.
-            pub const DH: Algorithm = Algorithm::new("DH");
-
-            /// DSA/SHA1. Not recommended for new deployments.
-            pub const DSA: Algorithm = Algorithm::new("DSA");
-
-            /// ECC. Not recommended for new deployments.
-            pub const ECC: Algorithm = Algorithm::new("ECC");
-
-            /// RSA/SHA-1. Not recommended for new deployments.
-            pub const RSASHA1: Algorithm = Algorithm::new("RSASHA1");
-
-            /// DSA-NSEC3-SHA1. Not recommended for new deployments.
-            pub const DSANSEC3SHA1: Algorithm = Algorithm::new("DSANSEC3SHA1");
-
-            /// RSA/SHA1-NSEC3-SHA1. Not recommended for new deployments.
-            pub const RSASHA1NSEC3SHA1: Algorithm = Algorithm::new("RSASHA1NSEC3SHA1");
-
-            /// RSA/SHA-256.
-            pub const RSASHA256: Algorithm = Algorithm::new("RSASHA256");
-
-            /// RSA/SHA-512.
-            pub const RSASHA512: Algorithm = Algorithm::new("RSASHA512");
-
-            /// GOST R 34.10-2001.
-            pub const ECCGOST: Algorithm = Algorithm::new("ECCGOST");
-
-            /// ECDSA Curve P-256 with SHA-256.
-            pub const ECDSAP256SHA256: Algorithm = Algorithm::new("ECDSAP256SHA256");
-
-            /// ECDSA Curve P-384 with SHA-384.
-            pub const ECDSAP384SHA384: Algorithm = Algorithm::new("ECDSAP384SHA384");
-
-            /// Ed25519.
-            pub const ED25519: Algorithm = Algorithm::new("ED25519");
-
-            /// Ed448.
-            pub const ED448: Algorithm = Algorithm::new("ED448");
-
-            /// Reserved for Indirect Keys. Cannot be used for new deployments.
-            pub const INDIRECT: Algorithm = Algorithm::new("INDIRECT");
-
-            /// Private algorithm. Cannot be used for new deployments.
-            pub const PRIVATEDNS: Algorithm = Algorithm::new("PRIVATEDNS");
-
-            /// Private algorithm OID. Cannot be used for new deployments.
-            pub const PRIVATEOID: Algorithm = Algorithm::new("PRIVATEOID");
-        }
-
-        impl std::convert::From<std::string::String> for Algorithm {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Algorithm {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Algorithm {
             fn default() -> Self {
-                algorithm::ALGORITHM_UNSPECIFIED
+                Self::new(0)
             }
         }
 
         /// List of hash functions that may have been used to generate a digest of a
         /// DNSKEY.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct DigestType(std::borrow::Cow<'static, str>);
+        pub struct DigestType(i32);
 
         impl DigestType {
+            /// The DigestType is unspecified.
+            pub const DIGEST_TYPE_UNSPECIFIED: DigestType = DigestType::new(0);
+
+            /// SHA-1. Not recommended for new deployments.
+            pub const SHA1: DigestType = DigestType::new(1);
+
+            /// SHA-256.
+            pub const SHA256: DigestType = DigestType::new(2);
+
+            /// GOST R 34.11-94.
+            pub const GOST3411: DigestType = DigestType::new(3);
+
+            /// SHA-384.
+            pub const SHA384: DigestType = DigestType::new(4);
+
             /// Creates a new DigestType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("DIGEST_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("SHA1"),
+                    2 => std::borrow::Cow::Borrowed("SHA256"),
+                    3 => std::borrow::Cow::Borrowed("GOST3411"),
+                    4 => std::borrow::Cow::Borrowed("SHA384"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "DIGEST_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::DIGEST_TYPE_UNSPECIFIED)
+                    }
+                    "SHA1" => std::option::Option::Some(Self::SHA1),
+                    "SHA256" => std::option::Option::Some(Self::SHA256),
+                    "GOST3411" => std::option::Option::Some(Self::GOST3411),
+                    "SHA384" => std::option::Option::Some(Self::SHA384),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [DigestType](DigestType)
-        pub mod digest_type {
-            use super::DigestType;
-
-            /// The DigestType is unspecified.
-            pub const DIGEST_TYPE_UNSPECIFIED: DigestType =
-                DigestType::new("DIGEST_TYPE_UNSPECIFIED");
-
-            /// SHA-1. Not recommended for new deployments.
-            pub const SHA1: DigestType = DigestType::new("SHA1");
-
-            /// SHA-256.
-            pub const SHA256: DigestType = DigestType::new("SHA256");
-
-            /// GOST R 34.11-94.
-            pub const GOST3411: DigestType = DigestType::new("GOST3411");
-
-            /// SHA-384.
-            pub const SHA384: DigestType = DigestType::new("SHA384");
-        }
-
-        impl std::convert::From<std::string::String> for DigestType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for DigestType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for DigestType {
             fn default() -> Self {
-                digest_type::DIGEST_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -989,47 +1112,62 @@ pub mod dns_settings {
 
     /// The publication state of DS records for a `Registration`.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DsState(std::borrow::Cow<'static, str>);
+    pub struct DsState(i32);
 
     impl DsState {
-        /// Creates a new DsState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DsState](DsState)
-    pub mod ds_state {
-        use super::DsState;
-
         /// DS state is unspecified.
-        pub const DS_STATE_UNSPECIFIED: DsState = DsState::new("DS_STATE_UNSPECIFIED");
+        pub const DS_STATE_UNSPECIFIED: DsState = DsState::new(0);
 
         /// DNSSEC is disabled for this domain. No DS records for this domain are
         /// published in the parent DNS zone.
-        pub const DS_RECORDS_UNPUBLISHED: DsState = DsState::new("DS_RECORDS_UNPUBLISHED");
+        pub const DS_RECORDS_UNPUBLISHED: DsState = DsState::new(1);
 
         /// DNSSEC is enabled for this domain. Appropriate DS records for this domain
         /// are published in the parent DNS zone. This option is valid only if the
         /// DNS zone referenced in the `Registration`'s `dns_provider` field is
         /// already DNSSEC-signed.
-        pub const DS_RECORDS_PUBLISHED: DsState = DsState::new("DS_RECORDS_PUBLISHED");
+        pub const DS_RECORDS_PUBLISHED: DsState = DsState::new(2);
+
+        /// Creates a new DsState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DS_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DS_RECORDS_UNPUBLISHED"),
+                2 => std::borrow::Cow::Borrowed("DS_RECORDS_PUBLISHED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DS_STATE_UNSPECIFIED" => std::option::Option::Some(Self::DS_STATE_UNSPECIFIED),
+                "DS_RECORDS_UNPUBLISHED" => std::option::Option::Some(Self::DS_RECORDS_UNPUBLISHED),
+                "DS_RECORDS_PUBLISHED" => std::option::Option::Some(Self::DS_RECORDS_PUBLISHED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DsState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DsState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DsState {
         fn default() -> Self {
-            ds_state::DS_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -2286,53 +2424,73 @@ pub mod register_parameters {
 
     /// Possible availability states of a domain name.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Availability(std::borrow::Cow<'static, str>);
+    pub struct Availability(i32);
 
     impl Availability {
-        /// Creates a new Availability instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Availability](Availability)
-    pub mod availability {
-        use super::Availability;
-
         /// The availability is unspecified.
-        pub const AVAILABILITY_UNSPECIFIED: Availability =
-            Availability::new("AVAILABILITY_UNSPECIFIED");
+        pub const AVAILABILITY_UNSPECIFIED: Availability = Availability::new(0);
 
         /// The domain is available for registration.
-        pub const AVAILABLE: Availability = Availability::new("AVAILABLE");
+        pub const AVAILABLE: Availability = Availability::new(1);
 
         /// The domain is not available for registration. Generally this means it is
         /// already registered to another party.
-        pub const UNAVAILABLE: Availability = Availability::new("UNAVAILABLE");
+        pub const UNAVAILABLE: Availability = Availability::new(2);
 
         /// The domain is not currently supported by Cloud Domains, but may
         /// be available elsewhere.
-        pub const UNSUPPORTED: Availability = Availability::new("UNSUPPORTED");
+        pub const UNSUPPORTED: Availability = Availability::new(3);
 
         /// Cloud Domains is unable to determine domain availability, generally
         /// due to system maintenance at the domain name registry.
-        pub const UNKNOWN: Availability = Availability::new("UNKNOWN");
+        pub const UNKNOWN: Availability = Availability::new(4);
+
+        /// Creates a new Availability instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("AVAILABILITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AVAILABLE"),
+                2 => std::borrow::Cow::Borrowed("UNAVAILABLE"),
+                3 => std::borrow::Cow::Borrowed("UNSUPPORTED"),
+                4 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "AVAILABILITY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::AVAILABILITY_UNSPECIFIED)
+                }
+                "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
+                "UNAVAILABLE" => std::option::Option::Some(Self::UNAVAILABLE),
+                "UNSUPPORTED" => std::option::Option::Some(Self::UNSUPPORTED),
+                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Availability {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Availability {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Availability {
         fn default() -> Self {
-            availability::AVAILABILITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2558,184 +2716,247 @@ impl wkt::message::Message for OperationMetadata {
 /// each domain name have an entry. Choose from these options to control how much
 /// information in your `ContactSettings` is published.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ContactPrivacy(std::borrow::Cow<'static, str>);
+pub struct ContactPrivacy(i32);
 
 impl ContactPrivacy {
-    /// Creates a new ContactPrivacy instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ContactPrivacy](ContactPrivacy)
-pub mod contact_privacy {
-    use super::ContactPrivacy;
-
     /// The contact privacy settings are undefined.
-    pub const CONTACT_PRIVACY_UNSPECIFIED: ContactPrivacy =
-        ContactPrivacy::new("CONTACT_PRIVACY_UNSPECIFIED");
+    pub const CONTACT_PRIVACY_UNSPECIFIED: ContactPrivacy = ContactPrivacy::new(0);
 
     /// All the data from `ContactSettings` is publicly available. When setting
     /// this option, you must also provide a
     /// `PUBLIC_CONTACT_DATA_ACKNOWLEDGEMENT` in the `contact_notices` field of the
     /// request.
-    pub const PUBLIC_CONTACT_DATA: ContactPrivacy = ContactPrivacy::new("PUBLIC_CONTACT_DATA");
+    pub const PUBLIC_CONTACT_DATA: ContactPrivacy = ContactPrivacy::new(1);
 
     /// None of the data from `ContactSettings` is publicly available. Instead,
     /// proxy contact data is published for your domain. Email sent to the proxy
     /// email address is forwarded to the registrant's email address. Cloud Domains
     /// provides this privacy proxy service at no additional cost.
-    pub const PRIVATE_CONTACT_DATA: ContactPrivacy = ContactPrivacy::new("PRIVATE_CONTACT_DATA");
+    pub const PRIVATE_CONTACT_DATA: ContactPrivacy = ContactPrivacy::new(2);
 
     /// Some data from `ContactSettings` is publicly available. The actual
     /// information redacted depends on the domain. For details, see [the
     /// registration privacy
     /// article](https://support.google.com/domains/answer/3251242).
-    pub const REDACTED_CONTACT_DATA: ContactPrivacy = ContactPrivacy::new("REDACTED_CONTACT_DATA");
+    pub const REDACTED_CONTACT_DATA: ContactPrivacy = ContactPrivacy::new(3);
+
+    /// Creates a new ContactPrivacy instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("CONTACT_PRIVACY_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PUBLIC_CONTACT_DATA"),
+            2 => std::borrow::Cow::Borrowed("PRIVATE_CONTACT_DATA"),
+            3 => std::borrow::Cow::Borrowed("REDACTED_CONTACT_DATA"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "CONTACT_PRIVACY_UNSPECIFIED" => {
+                std::option::Option::Some(Self::CONTACT_PRIVACY_UNSPECIFIED)
+            }
+            "PUBLIC_CONTACT_DATA" => std::option::Option::Some(Self::PUBLIC_CONTACT_DATA),
+            "PRIVATE_CONTACT_DATA" => std::option::Option::Some(Self::PRIVATE_CONTACT_DATA),
+            "REDACTED_CONTACT_DATA" => std::option::Option::Some(Self::REDACTED_CONTACT_DATA),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ContactPrivacy {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ContactPrivacy {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ContactPrivacy {
     fn default() -> Self {
-        contact_privacy::CONTACT_PRIVACY_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Notices about special properties of certain domains.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DomainNotice(std::borrow::Cow<'static, str>);
+pub struct DomainNotice(i32);
 
 impl DomainNotice {
-    /// Creates a new DomainNotice instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [DomainNotice](DomainNotice)
-pub mod domain_notice {
-    use super::DomainNotice;
-
     /// The notice is undefined.
-    pub const DOMAIN_NOTICE_UNSPECIFIED: DomainNotice =
-        DomainNotice::new("DOMAIN_NOTICE_UNSPECIFIED");
+    pub const DOMAIN_NOTICE_UNSPECIFIED: DomainNotice = DomainNotice::new(0);
 
     /// Indicates that the domain is preloaded on the HTTP Strict Transport
     /// Security list in browsers. Serving a website on such domain requires
     /// an SSL certificate. For details, see
     /// [how to get an SSL
     /// certificate](https://support.google.com/domains/answer/7638036).
-    pub const HSTS_PRELOADED: DomainNotice = DomainNotice::new("HSTS_PRELOADED");
+    pub const HSTS_PRELOADED: DomainNotice = DomainNotice::new(1);
+
+    /// Creates a new DomainNotice instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DOMAIN_NOTICE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("HSTS_PRELOADED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DOMAIN_NOTICE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::DOMAIN_NOTICE_UNSPECIFIED)
+            }
+            "HSTS_PRELOADED" => std::option::Option::Some(Self::HSTS_PRELOADED),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for DomainNotice {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DomainNotice {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DomainNotice {
     fn default() -> Self {
-        domain_notice::DOMAIN_NOTICE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Notices related to contact information.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ContactNotice(std::borrow::Cow<'static, str>);
+pub struct ContactNotice(i32);
 
 impl ContactNotice {
-    /// Creates a new ContactNotice instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ContactNotice](ContactNotice)
-pub mod contact_notice {
-    use super::ContactNotice;
-
     /// The notice is undefined.
-    pub const CONTACT_NOTICE_UNSPECIFIED: ContactNotice =
-        ContactNotice::new("CONTACT_NOTICE_UNSPECIFIED");
+    pub const CONTACT_NOTICE_UNSPECIFIED: ContactNotice = ContactNotice::new(0);
 
     /// Required when setting the `privacy` field of `ContactSettings` to
     /// `PUBLIC_CONTACT_DATA`, which exposes contact data publicly.
-    pub const PUBLIC_CONTACT_DATA_ACKNOWLEDGEMENT: ContactNotice =
-        ContactNotice::new("PUBLIC_CONTACT_DATA_ACKNOWLEDGEMENT");
+    pub const PUBLIC_CONTACT_DATA_ACKNOWLEDGEMENT: ContactNotice = ContactNotice::new(1);
+
+    /// Creates a new ContactNotice instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("CONTACT_NOTICE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PUBLIC_CONTACT_DATA_ACKNOWLEDGEMENT"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "CONTACT_NOTICE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::CONTACT_NOTICE_UNSPECIFIED)
+            }
+            "PUBLIC_CONTACT_DATA_ACKNOWLEDGEMENT" => {
+                std::option::Option::Some(Self::PUBLIC_CONTACT_DATA_ACKNOWLEDGEMENT)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ContactNotice {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ContactNotice {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ContactNotice {
     fn default() -> Self {
-        contact_notice::CONTACT_NOTICE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Possible states of a `Registration`'s transfer lock.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TransferLockState(std::borrow::Cow<'static, str>);
+pub struct TransferLockState(i32);
 
 impl TransferLockState {
+    /// The state is unspecified.
+    pub const TRANSFER_LOCK_STATE_UNSPECIFIED: TransferLockState = TransferLockState::new(0);
+
+    /// The domain is unlocked and can be transferred to another registrar.
+    pub const UNLOCKED: TransferLockState = TransferLockState::new(1);
+
+    /// The domain is locked and cannot be transferred to another registrar.
+    pub const LOCKED: TransferLockState = TransferLockState::new(2);
+
     /// Creates a new TransferLockState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("TRANSFER_LOCK_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("UNLOCKED"),
+            2 => std::borrow::Cow::Borrowed("LOCKED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "TRANSFER_LOCK_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::TRANSFER_LOCK_STATE_UNSPECIFIED)
+            }
+            "UNLOCKED" => std::option::Option::Some(Self::UNLOCKED),
+            "LOCKED" => std::option::Option::Some(Self::LOCKED),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [TransferLockState](TransferLockState)
-pub mod transfer_lock_state {
-    use super::TransferLockState;
-
-    /// The state is unspecified.
-    pub const TRANSFER_LOCK_STATE_UNSPECIFIED: TransferLockState =
-        TransferLockState::new("TRANSFER_LOCK_STATE_UNSPECIFIED");
-
-    /// The domain is unlocked and can be transferred to another registrar.
-    pub const UNLOCKED: TransferLockState = TransferLockState::new("UNLOCKED");
-
-    /// The domain is locked and cannot be transferred to another registrar.
-    pub const LOCKED: TransferLockState = TransferLockState::new("LOCKED");
-}
-
-impl std::convert::From<std::string::String> for TransferLockState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for TransferLockState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for TransferLockState {
     fn default() -> Self {
-        transfer_lock_state::TRANSFER_LOCK_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/domains/v1/src/transport.rs
+++ b/src/generated/cloud/domains/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::Domains for Domains {
                 reqwest::Method::GET,
                 format!("/v1/{}/registrations:searchDomains", req.location),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -78,7 +78,7 @@ impl crate::stubs::Domains for Domains {
                     req.location
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -101,7 +101,7 @@ impl crate::stubs::Domains for Domains {
                 reqwest::Method::POST,
                 format!("/v1/{}/registrations:register", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -124,7 +124,7 @@ impl crate::stubs::Domains for Domains {
                     req.location
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -147,7 +147,7 @@ impl crate::stubs::Domains for Domains {
                 reqwest::Method::POST,
                 format!("/v1/{}/registrations:transfer", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -167,7 +167,7 @@ impl crate::stubs::Domains for Domains {
                 reqwest::Method::GET,
                 format!("/v1/{}/registrations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -189,7 +189,7 @@ impl crate::stubs::Domains for Domains {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -217,7 +217,7 @@ impl crate::stubs::Domains for Domains {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -249,7 +249,7 @@ impl crate::stubs::Domains for Domains {
                 reqwest::Method::POST,
                 format!("/v1/{}:configureManagementSettings", req.registration),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -269,7 +269,7 @@ impl crate::stubs::Domains for Domains {
                 reqwest::Method::POST,
                 format!("/v1/{}:configureDnsSettings", req.registration),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -289,7 +289,7 @@ impl crate::stubs::Domains for Domains {
                 reqwest::Method::POST,
                 format!("/v1/{}:configureContactSettings", req.registration),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -306,7 +306,7 @@ impl crate::stubs::Domains for Domains {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:export", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -323,7 +323,7 @@ impl crate::stubs::Domains for Domains {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -345,7 +345,7 @@ impl crate::stubs::Domains for Domains {
                 reqwest::Method::GET,
                 format!("/v1/{}:retrieveAuthorizationCode", req.registration),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -367,7 +367,7 @@ impl crate::stubs::Domains for Domains {
                 reqwest::Method::POST,
                 format!("/v1/{}:resetAuthorizationCode", req.registration),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -384,7 +384,7 @@ impl crate::stubs::Domains for Domains {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -406,7 +406,7 @@ impl crate::stubs::Domains for Domains {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/edgecontainer/v1/src/model.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/model.rs
@@ -619,47 +619,63 @@ pub mod cluster {
         /// Represents the policy configuration about how user applications are
         /// deployed.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SharedDeploymentPolicy(std::borrow::Cow<'static, str>);
+        pub struct SharedDeploymentPolicy(i32);
 
         impl SharedDeploymentPolicy {
-            /// Creates a new SharedDeploymentPolicy instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [SharedDeploymentPolicy](SharedDeploymentPolicy)
-        pub mod shared_deployment_policy {
-            use super::SharedDeploymentPolicy;
-
             /// Unspecified.
             pub const SHARED_DEPLOYMENT_POLICY_UNSPECIFIED: SharedDeploymentPolicy =
-                SharedDeploymentPolicy::new("SHARED_DEPLOYMENT_POLICY_UNSPECIFIED");
+                SharedDeploymentPolicy::new(0);
 
             /// User applications can be deployed both on control plane and worker
             /// nodes.
-            pub const ALLOWED: SharedDeploymentPolicy = SharedDeploymentPolicy::new("ALLOWED");
+            pub const ALLOWED: SharedDeploymentPolicy = SharedDeploymentPolicy::new(1);
 
             /// User applications can not be deployed on control plane nodes and can
             /// only be deployed on worker nodes.
-            pub const DISALLOWED: SharedDeploymentPolicy =
-                SharedDeploymentPolicy::new("DISALLOWED");
+            pub const DISALLOWED: SharedDeploymentPolicy = SharedDeploymentPolicy::new(2);
+
+            /// Creates a new SharedDeploymentPolicy instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("SHARED_DEPLOYMENT_POLICY_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("ALLOWED"),
+                    2 => std::borrow::Cow::Borrowed("DISALLOWED"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "SHARED_DEPLOYMENT_POLICY_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::SHARED_DEPLOYMENT_POLICY_UNSPECIFIED)
+                    }
+                    "ALLOWED" => std::option::Option::Some(Self::ALLOWED),
+                    "DISALLOWED" => std::option::Option::Some(Self::DISALLOWED),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for SharedDeploymentPolicy {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for SharedDeploymentPolicy {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for SharedDeploymentPolicy {
             fn default() -> Self {
-                shared_deployment_policy::SHARED_DEPLOYMENT_POLICY_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -1058,127 +1074,176 @@ pub mod cluster {
 
         /// Indicates the maintenance event type.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(std::borrow::Cow<'static, str>);
+        pub struct Type(i32);
 
         impl Type {
+            /// Unspecified.
+            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+            /// Upgrade initiated by users.
+            pub const USER_INITIATED_UPGRADE: Type = Type::new(1);
+
+            /// Upgrade driven by Google.
+            pub const GOOGLE_DRIVEN_UPGRADE: Type = Type::new(2);
+
             /// Creates a new Type instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("USER_INITIATED_UPGRADE"),
+                    2 => std::borrow::Cow::Borrowed("GOOGLE_DRIVEN_UPGRADE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                    "USER_INITIATED_UPGRADE" => {
+                        std::option::Option::Some(Self::USER_INITIATED_UPGRADE)
+                    }
+                    "GOOGLE_DRIVEN_UPGRADE" => {
+                        std::option::Option::Some(Self::GOOGLE_DRIVEN_UPGRADE)
+                    }
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Type](Type)
-        pub mod r#type {
-            use super::Type;
-
-            /// Unspecified.
-            pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-            /// Upgrade initiated by users.
-            pub const USER_INITIATED_UPGRADE: Type = Type::new("USER_INITIATED_UPGRADE");
-
-            /// Upgrade driven by Google.
-            pub const GOOGLE_DRIVEN_UPGRADE: Type = Type::new("GOOGLE_DRIVEN_UPGRADE");
-        }
-
-        impl std::convert::From<std::string::String> for Type {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                r#type::TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
 
         /// Indicates when the maintenance event should be performed.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Schedule(std::borrow::Cow<'static, str>);
+        pub struct Schedule(i32);
 
         impl Schedule {
+            /// Unspecified.
+            pub const SCHEDULE_UNSPECIFIED: Schedule = Schedule::new(0);
+
+            /// Immediately after receiving the request.
+            pub const IMMEDIATELY: Schedule = Schedule::new(1);
+
             /// Creates a new Schedule instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("SCHEDULE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("IMMEDIATELY"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "SCHEDULE_UNSPECIFIED" => std::option::Option::Some(Self::SCHEDULE_UNSPECIFIED),
+                    "IMMEDIATELY" => std::option::Option::Some(Self::IMMEDIATELY),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Schedule](Schedule)
-        pub mod schedule {
-            use super::Schedule;
-
-            /// Unspecified.
-            pub const SCHEDULE_UNSPECIFIED: Schedule = Schedule::new("SCHEDULE_UNSPECIFIED");
-
-            /// Immediately after receiving the request.
-            pub const IMMEDIATELY: Schedule = Schedule::new("IMMEDIATELY");
-        }
-
-        impl std::convert::From<std::string::String> for Schedule {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Schedule {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Schedule {
             fn default() -> Self {
-                schedule::SCHEDULE_UNSPECIFIED
+                Self::new(0)
             }
         }
 
         /// Indicates the maintenance event state.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(std::borrow::Cow<'static, str>);
+        pub struct State(i32);
 
         impl State {
+            /// Unspecified.
+            pub const STATE_UNSPECIFIED: State = State::new(0);
+
+            /// The maintenance event is ongoing. The cluster might be unusable.
+            pub const RECONCILING: State = State::new(1);
+
+            /// The maintenance event succeeded.
+            pub const SUCCEEDED: State = State::new(2);
+
+            /// The maintenance event failed.
+            pub const FAILED: State = State::new(3);
+
             /// Creates a new State instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("RECONCILING"),
+                    2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                    3 => std::borrow::Cow::Borrowed("FAILED"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                    "RECONCILING" => std::option::Option::Some(Self::RECONCILING),
+                    "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                    "FAILED" => std::option::Option::Some(Self::FAILED),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [State](State)
-        pub mod state {
-            use super::State;
-
-            /// Unspecified.
-            pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-            /// The maintenance event is ongoing. The cluster might be unusable.
-            pub const RECONCILING: State = State::new("RECONCILING");
-
-            /// The maintenance event succeeded.
-            pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-            /// The maintenance event failed.
-            pub const FAILED: State = State::new("FAILED");
-        }
-
-        impl std::convert::From<std::string::String> for State {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                state::STATE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -1270,143 +1335,199 @@ pub mod cluster {
 
         /// The connection state.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(std::borrow::Cow<'static, str>);
+        pub struct State(i32);
 
         impl State {
-            /// Creates a new State instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [State](State)
-        pub mod state {
-            use super::State;
-
             /// Unknown connection state.
-            pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+            pub const STATE_UNSPECIFIED: State = State::new(0);
 
             /// This cluster is currently disconnected from Google.
-            pub const DISCONNECTED: State = State::new("DISCONNECTED");
+            pub const DISCONNECTED: State = State::new(1);
 
             /// This cluster is currently connected to Google.
-            pub const CONNECTED: State = State::new("CONNECTED");
+            pub const CONNECTED: State = State::new(2);
 
             /// This cluster is currently connected to Google, but may have recently
             /// reconnected after a disconnection. It is still syncing back.
-            pub const CONNECTED_AND_SYNCING: State = State::new("CONNECTED_AND_SYNCING");
+            pub const CONNECTED_AND_SYNCING: State = State::new(3);
+
+            /// Creates a new State instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("DISCONNECTED"),
+                    2 => std::borrow::Cow::Borrowed("CONNECTED"),
+                    3 => std::borrow::Cow::Borrowed("CONNECTED_AND_SYNCING"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                    "DISCONNECTED" => std::option::Option::Some(Self::DISCONNECTED),
+                    "CONNECTED" => std::option::Option::Some(Self::CONNECTED),
+                    "CONNECTED_AND_SYNCING" => {
+                        std::option::Option::Some(Self::CONNECTED_AND_SYNCING)
+                    }
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for State {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                state::STATE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// Indicates the status of the cluster.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(std::borrow::Cow<'static, str>);
+    pub struct Status(i32);
 
     impl Status {
-        /// Creates a new Status instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Status](Status)
-    pub mod status {
-        use super::Status;
-
         /// Status unknown.
-        pub const STATUS_UNSPECIFIED: Status = Status::new("STATUS_UNSPECIFIED");
+        pub const STATUS_UNSPECIFIED: Status = Status::new(0);
 
         /// The cluster is being created.
-        pub const PROVISIONING: Status = Status::new("PROVISIONING");
+        pub const PROVISIONING: Status = Status::new(1);
 
         /// The cluster is created and fully usable.
-        pub const RUNNING: Status = Status::new("RUNNING");
+        pub const RUNNING: Status = Status::new(2);
 
         /// The cluster is being deleted.
-        pub const DELETING: Status = Status::new("DELETING");
+        pub const DELETING: Status = Status::new(3);
 
         /// The status indicates that some errors occurred while reconciling/deleting
         /// the cluster.
-        pub const ERROR: Status = Status::new("ERROR");
+        pub const ERROR: Status = Status::new(4);
 
         /// The cluster is undergoing some work such as version upgrades, etc.
-        pub const RECONCILING: Status = Status::new("RECONCILING");
+        pub const RECONCILING: Status = Status::new(5);
+
+        /// Creates a new Status instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATUS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("ERROR"),
+                5 => std::borrow::Cow::Borrowed("RECONCILING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATUS_UNSPECIFIED" => std::option::Option::Some(Self::STATUS_UNSPECIFIED),
+                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "RECONCILING" => std::option::Option::Some(Self::RECONCILING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Status {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            status::STATUS_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The release channel a cluster is subscribed to.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ReleaseChannel(std::borrow::Cow<'static, str>);
+    pub struct ReleaseChannel(i32);
 
     impl ReleaseChannel {
+        /// Unspecified release channel. This will default to the REGULAR channel.
+        pub const RELEASE_CHANNEL_UNSPECIFIED: ReleaseChannel = ReleaseChannel::new(0);
+
+        /// No release channel.
+        pub const NONE: ReleaseChannel = ReleaseChannel::new(1);
+
+        /// Regular release channel.
+        pub const REGULAR: ReleaseChannel = ReleaseChannel::new(2);
+
         /// Creates a new ReleaseChannel instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RELEASE_CHANNEL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NONE"),
+                2 => std::borrow::Cow::Borrowed("REGULAR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RELEASE_CHANNEL_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RELEASE_CHANNEL_UNSPECIFIED)
+                }
+                "NONE" => std::option::Option::Some(Self::NONE),
+                "REGULAR" => std::option::Option::Some(Self::REGULAR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ReleaseChannel](ReleaseChannel)
-    pub mod release_channel {
-        use super::ReleaseChannel;
-
-        /// Unspecified release channel. This will default to the REGULAR channel.
-        pub const RELEASE_CHANNEL_UNSPECIFIED: ReleaseChannel =
-            ReleaseChannel::new("RELEASE_CHANNEL_UNSPECIFIED");
-
-        /// No release channel.
-        pub const NONE: ReleaseChannel = ReleaseChannel::new("NONE");
-
-        /// Regular release channel.
-        pub const REGULAR: ReleaseChannel = ReleaseChannel::new("REGULAR");
-    }
-
-    impl std::convert::From<std::string::String> for ReleaseChannel {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ReleaseChannel {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ReleaseChannel {
         fn default() -> Self {
-            release_channel::RELEASE_CHANNEL_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2346,90 +2467,123 @@ pub mod vpn_connection {
 
         /// The current connection state.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(std::borrow::Cow<'static, str>);
+        pub struct State(i32);
 
         impl State {
+            /// Unknown.
+            pub const STATE_UNSPECIFIED: State = State::new(0);
+
+            /// Connected.
+            pub const STATE_CONNECTED: State = State::new(1);
+
+            /// Still connecting.
+            pub const STATE_CONNECTING: State = State::new(2);
+
+            /// Error occurred.
+            pub const STATE_ERROR: State = State::new(3);
+
             /// Creates a new State instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("STATE_CONNECTED"),
+                    2 => std::borrow::Cow::Borrowed("STATE_CONNECTING"),
+                    3 => std::borrow::Cow::Borrowed("STATE_ERROR"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                    "STATE_CONNECTED" => std::option::Option::Some(Self::STATE_CONNECTED),
+                    "STATE_CONNECTING" => std::option::Option::Some(Self::STATE_CONNECTING),
+                    "STATE_ERROR" => std::option::Option::Some(Self::STATE_ERROR),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [State](State)
-        pub mod state {
-            use super::State;
-
-            /// Unknown.
-            pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-            /// Connected.
-            pub const STATE_CONNECTED: State = State::new("STATE_CONNECTED");
-
-            /// Still connecting.
-            pub const STATE_CONNECTING: State = State::new("STATE_CONNECTING");
-
-            /// Error occurred.
-            pub const STATE_ERROR: State = State::new("STATE_ERROR");
-        }
-
-        impl std::convert::From<std::string::String> for State {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                state::STATE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// Routing mode.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BgpRoutingMode(std::borrow::Cow<'static, str>);
+    pub struct BgpRoutingMode(i32);
 
     impl BgpRoutingMode {
+        /// Unknown.
+        pub const BGP_ROUTING_MODE_UNSPECIFIED: BgpRoutingMode = BgpRoutingMode::new(0);
+
+        /// Regional mode.
+        pub const REGIONAL: BgpRoutingMode = BgpRoutingMode::new(1);
+
+        /// Global mode.
+        pub const GLOBAL: BgpRoutingMode = BgpRoutingMode::new(2);
+
         /// Creates a new BgpRoutingMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("BGP_ROUTING_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REGIONAL"),
+                2 => std::borrow::Cow::Borrowed("GLOBAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "BGP_ROUTING_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::BGP_ROUTING_MODE_UNSPECIFIED)
+                }
+                "REGIONAL" => std::option::Option::Some(Self::REGIONAL),
+                "GLOBAL" => std::option::Option::Some(Self::GLOBAL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [BgpRoutingMode](BgpRoutingMode)
-    pub mod bgp_routing_mode {
-        use super::BgpRoutingMode;
-
-        /// Unknown.
-        pub const BGP_ROUTING_MODE_UNSPECIFIED: BgpRoutingMode =
-            BgpRoutingMode::new("BGP_ROUTING_MODE_UNSPECIFIED");
-
-        /// Regional mode.
-        pub const REGIONAL: BgpRoutingMode = BgpRoutingMode::new("REGIONAL");
-
-        /// Global mode.
-        pub const GLOBAL: BgpRoutingMode = BgpRoutingMode::new("GLOBAL");
-    }
-
-    impl std::convert::From<std::string::String> for BgpRoutingMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for BgpRoutingMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for BgpRoutingMode {
         fn default() -> Self {
-            bgp_routing_mode::BGP_ROUTING_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2544,45 +2698,60 @@ pub mod zone_metadata {
 
     /// Type of the rack.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RackType(std::borrow::Cow<'static, str>);
+    pub struct RackType(i32);
 
     impl RackType {
-        /// Creates a new RackType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RackType](RackType)
-    pub mod rack_type {
-        use super::RackType;
-
         /// Unspecified rack type, single rack also belongs to this type.
-        pub const RACK_TYPE_UNSPECIFIED: RackType = RackType::new("RACK_TYPE_UNSPECIFIED");
+        pub const RACK_TYPE_UNSPECIFIED: RackType = RackType::new(0);
 
         /// Base rack type, a pair of two modified Config-1 racks containing
         /// Aggregation switches.
-        pub const BASE: RackType = RackType::new("BASE");
+        pub const BASE: RackType = RackType::new(1);
 
         /// Expansion rack type, also known as standalone racks,
         /// added by customers on demand.
-        pub const EXPANSION: RackType = RackType::new("EXPANSION");
+        pub const EXPANSION: RackType = RackType::new(2);
+
+        /// Creates a new RackType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RACK_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BASE"),
+                2 => std::borrow::Cow::Borrowed("EXPANSION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RACK_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::RACK_TYPE_UNSPECIFIED),
+                "BASE" => std::option::Option::Some(Self::BASE),
+                "EXPANSION" => std::option::Option::Some(Self::EXPANSION),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RackType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RackType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RackType {
         fn default() -> Self {
-            rack_type::RACK_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3155,41 +3324,55 @@ pub mod operation_metadata {
 
     /// Indicates the reason for the status of the operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StatusReason(std::borrow::Cow<'static, str>);
+    pub struct StatusReason(i32);
 
     impl StatusReason {
+        /// Reason unknown.
+        pub const STATUS_REASON_UNSPECIFIED: StatusReason = StatusReason::new(0);
+
+        /// The cluster upgrade is currently paused.
+        pub const UPGRADE_PAUSED: StatusReason = StatusReason::new(1);
+
         /// Creates a new StatusReason instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATUS_REASON_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("UPGRADE_PAUSED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATUS_REASON_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::STATUS_REASON_UNSPECIFIED)
+                }
+                "UPGRADE_PAUSED" => std::option::Option::Some(Self::UPGRADE_PAUSED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [StatusReason](StatusReason)
-    pub mod status_reason {
-        use super::StatusReason;
-
-        /// Reason unknown.
-        pub const STATUS_REASON_UNSPECIFIED: StatusReason =
-            StatusReason::new("STATUS_REASON_UNSPECIFIED");
-
-        /// The cluster upgrade is currently paused.
-        pub const UPGRADE_PAUSED: StatusReason = StatusReason::new("UPGRADE_PAUSED");
-    }
-
-    impl std::convert::From<std::string::String> for StatusReason {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for StatusReason {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for StatusReason {
         fn default() -> Self {
-            status_reason::STATUS_REASON_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3559,42 +3742,55 @@ pub mod upgrade_cluster_request {
 
     /// Represents the schedule about when the cluster is going to be upgraded.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Schedule(std::borrow::Cow<'static, str>);
+    pub struct Schedule(i32);
 
     impl Schedule {
-        /// Creates a new Schedule instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Schedule](Schedule)
-    pub mod schedule {
-        use super::Schedule;
-
         /// Unspecified. The default is to upgrade the cluster immediately which is
         /// the only option today.
-        pub const SCHEDULE_UNSPECIFIED: Schedule = Schedule::new("SCHEDULE_UNSPECIFIED");
+        pub const SCHEDULE_UNSPECIFIED: Schedule = Schedule::new(0);
 
         /// The cluster is going to be upgraded immediately after receiving the
         /// request.
-        pub const IMMEDIATELY: Schedule = Schedule::new("IMMEDIATELY");
+        pub const IMMEDIATELY: Schedule = Schedule::new(1);
+
+        /// Creates a new Schedule instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SCHEDULE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IMMEDIATELY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SCHEDULE_UNSPECIFIED" => std::option::Option::Some(Self::SCHEDULE_UNSPECIFIED),
+                "IMMEDIATELY" => std::option::Option::Some(Self::IMMEDIATELY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Schedule {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Schedule {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Schedule {
         fn default() -> Self {
-            schedule::SCHEDULE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4622,91 +4818,125 @@ impl wkt::message::Message for GetServerConfigRequest {
 /// Represents the accessibility state of a customer-managed KMS key used for
 /// CMEK integration.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct KmsKeyState(std::borrow::Cow<'static, str>);
+pub struct KmsKeyState(i32);
 
 impl KmsKeyState {
-    /// Creates a new KmsKeyState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [KmsKeyState](KmsKeyState)
-pub mod kms_key_state {
-    use super::KmsKeyState;
-
     /// Unspecified.
-    pub const KMS_KEY_STATE_UNSPECIFIED: KmsKeyState =
-        KmsKeyState::new("KMS_KEY_STATE_UNSPECIFIED");
+    pub const KMS_KEY_STATE_UNSPECIFIED: KmsKeyState = KmsKeyState::new(0);
 
     /// The key is available for use, and dependent resources should be accessible.
-    pub const KMS_KEY_STATE_KEY_AVAILABLE: KmsKeyState =
-        KmsKeyState::new("KMS_KEY_STATE_KEY_AVAILABLE");
+    pub const KMS_KEY_STATE_KEY_AVAILABLE: KmsKeyState = KmsKeyState::new(1);
 
     /// The key is unavailable for an unspecified reason. Dependent resources may
     /// be inaccessible.
-    pub const KMS_KEY_STATE_KEY_UNAVAILABLE: KmsKeyState =
-        KmsKeyState::new("KMS_KEY_STATE_KEY_UNAVAILABLE");
+    pub const KMS_KEY_STATE_KEY_UNAVAILABLE: KmsKeyState = KmsKeyState::new(2);
+
+    /// Creates a new KmsKeyState instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("KMS_KEY_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("KMS_KEY_STATE_KEY_AVAILABLE"),
+            2 => std::borrow::Cow::Borrowed("KMS_KEY_STATE_KEY_UNAVAILABLE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "KMS_KEY_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::KMS_KEY_STATE_UNSPECIFIED)
+            }
+            "KMS_KEY_STATE_KEY_AVAILABLE" => {
+                std::option::Option::Some(Self::KMS_KEY_STATE_KEY_AVAILABLE)
+            }
+            "KMS_KEY_STATE_KEY_UNAVAILABLE" => {
+                std::option::Option::Some(Self::KMS_KEY_STATE_KEY_UNAVAILABLE)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for KmsKeyState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for KmsKeyState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for KmsKeyState {
     fn default() -> Self {
-        kms_key_state::KMS_KEY_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Represents if the resource is in lock down state or pending.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ResourceState(std::borrow::Cow<'static, str>);
+pub struct ResourceState(i32);
 
 impl ResourceState {
+    /// Default value.
+    pub const RESOURCE_STATE_UNSPECIFIED: ResourceState = ResourceState::new(0);
+
+    /// The resource is in LOCK DOWN state.
+    pub const RESOURCE_STATE_LOCK_DOWN: ResourceState = ResourceState::new(1);
+
+    /// The resource is pending lock down.
+    pub const RESOURCE_STATE_LOCK_DOWN_PENDING: ResourceState = ResourceState::new(2);
+
     /// Creates a new ResourceState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("RESOURCE_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("RESOURCE_STATE_LOCK_DOWN"),
+            2 => std::borrow::Cow::Borrowed("RESOURCE_STATE_LOCK_DOWN_PENDING"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "RESOURCE_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::RESOURCE_STATE_UNSPECIFIED)
+            }
+            "RESOURCE_STATE_LOCK_DOWN" => std::option::Option::Some(Self::RESOURCE_STATE_LOCK_DOWN),
+            "RESOURCE_STATE_LOCK_DOWN_PENDING" => {
+                std::option::Option::Some(Self::RESOURCE_STATE_LOCK_DOWN_PENDING)
+            }
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [ResourceState](ResourceState)
-pub mod resource_state {
-    use super::ResourceState;
-
-    /// Default value.
-    pub const RESOURCE_STATE_UNSPECIFIED: ResourceState =
-        ResourceState::new("RESOURCE_STATE_UNSPECIFIED");
-
-    /// The resource is in LOCK DOWN state.
-    pub const RESOURCE_STATE_LOCK_DOWN: ResourceState =
-        ResourceState::new("RESOURCE_STATE_LOCK_DOWN");
-
-    /// The resource is pending lock down.
-    pub const RESOURCE_STATE_LOCK_DOWN_PENDING: ResourceState =
-        ResourceState::new("RESOURCE_STATE_LOCK_DOWN_PENDING");
-}
-
-impl std::convert::From<std::string::String> for ResourceState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ResourceState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ResourceState {
     fn default() -> Self {
-        resource_state::RESOURCE_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/edgecontainer/v1/src/transport.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/clusters", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -94,7 +94,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
                 reqwest::Method::POST,
                 format!("/v1/{}/clusters", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -124,7 +124,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -154,7 +154,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:upgrade", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -171,7 +171,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -194,7 +194,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
                 reqwest::Method::GET,
                 format!("/v1/{}:generateAccessToken", req.cluster),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -216,7 +216,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
                 reqwest::Method::GET,
                 format!("/v1/{}:generateOfflineCredential", req.cluster),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -238,7 +238,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
                 reqwest::Method::GET,
                 format!("/v1/{}/nodePools", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -261,7 +261,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -283,7 +283,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
                 reqwest::Method::POST,
                 format!("/v1/{}/nodePools", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -313,7 +313,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -343,7 +343,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -363,7 +363,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/machines", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -386,7 +386,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -408,7 +408,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
                 reqwest::Method::GET,
                 format!("/v1/{}/vpnConnections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -431,7 +431,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -453,7 +453,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
                 reqwest::Method::POST,
                 format!("/v1/{}/vpnConnections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -474,7 +474,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -497,7 +497,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
                 reqwest::Method::GET,
                 format!("/v1/{}/serverConfig", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -516,7 +516,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -538,7 +538,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -557,7 +557,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -579,7 +579,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -598,7 +598,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -617,7 +617,7 @@ impl crate::stubs::EdgeContainer for EdgeContainer {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/edgenetwork/v1/src/model.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/model.rs
@@ -372,48 +372,64 @@ pub mod subnet {
 
     /// Bonding type in the subnet.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BondingType(std::borrow::Cow<'static, str>);
+    pub struct BondingType(i32);
 
     impl BondingType {
-        /// Creates a new BondingType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [BondingType](BondingType)
-    pub mod bonding_type {
-        use super::BondingType;
-
         /// Unspecified
         /// Bonding type will be unspecified by default and if the user chooses to
         /// not specify a bonding type at time of creating the VLAN. This will be
         /// treated as mixed bonding where the VLAN will have both bonded and
         /// non-bonded connectivity to machines.
-        pub const BONDING_TYPE_UNSPECIFIED: BondingType =
-            BondingType::new("BONDING_TYPE_UNSPECIFIED");
+        pub const BONDING_TYPE_UNSPECIFIED: BondingType = BondingType::new(0);
 
         /// Multi homed.
-        pub const BONDED: BondingType = BondingType::new("BONDED");
+        pub const BONDED: BondingType = BondingType::new(1);
 
         /// Single homed.
-        pub const NON_BONDED: BondingType = BondingType::new("NON_BONDED");
+        pub const NON_BONDED: BondingType = BondingType::new(2);
+
+        /// Creates a new BondingType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("BONDING_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BONDED"),
+                2 => std::borrow::Cow::Borrowed("NON_BONDED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "BONDING_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::BONDING_TYPE_UNSPECIFIED)
+                }
+                "BONDED" => std::option::Option::Some(Self::BONDED),
+                "NON_BONDED" => std::option::Option::Some(Self::NON_BONDED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for BondingType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for BondingType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for BondingType {
         fn default() -> Self {
-            bonding_type::BONDING_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -561,41 +577,55 @@ pub mod interconnect {
 
     /// Type of interconnect.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct InterconnectType(std::borrow::Cow<'static, str>);
+    pub struct InterconnectType(i32);
 
     impl InterconnectType {
+        /// Unspecified.
+        pub const INTERCONNECT_TYPE_UNSPECIFIED: InterconnectType = InterconnectType::new(0);
+
+        /// Dedicated Interconnect.
+        pub const DEDICATED: InterconnectType = InterconnectType::new(1);
+
         /// Creates a new InterconnectType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("INTERCONNECT_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DEDICATED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "INTERCONNECT_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::INTERCONNECT_TYPE_UNSPECIFIED)
+                }
+                "DEDICATED" => std::option::Option::Some(Self::DEDICATED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [InterconnectType](InterconnectType)
-    pub mod interconnect_type {
-        use super::InterconnectType;
-
-        /// Unspecified.
-        pub const INTERCONNECT_TYPE_UNSPECIFIED: InterconnectType =
-            InterconnectType::new("INTERCONNECT_TYPE_UNSPECIFIED");
-
-        /// Dedicated Interconnect.
-        pub const DEDICATED: InterconnectType = InterconnectType::new("DEDICATED");
-    }
-
-    impl std::convert::From<std::string::String> for InterconnectType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for InterconnectType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for InterconnectType {
         fn default() -> Self {
-            interconnect_type::INTERCONNECT_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1568,44 +1598,59 @@ pub mod interconnect_diagnostics {
 
         /// State enum for LACP link.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(std::borrow::Cow<'static, str>);
+        pub struct State(i32);
 
         impl State {
-            /// Creates a new State instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [State](State)
-        pub mod state {
-            use super::State;
-
             /// The default state indicating state is in unknown state.
-            pub const UNKNOWN: State = State::new("UNKNOWN");
+            pub const UNKNOWN: State = State::new(0);
 
             /// The link is configured and active within the bundle.
-            pub const ACTIVE: State = State::new("ACTIVE");
+            pub const ACTIVE: State = State::new(1);
 
             /// The link is not configured within the bundle, this means the rest of
             /// the object should be empty.
-            pub const DETACHED: State = State::new("DETACHED");
+            pub const DETACHED: State = State::new(2);
+
+            /// Creates a new State instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                    1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                    2 => std::borrow::Cow::Borrowed("DETACHED"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                    "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                    "DETACHED" => std::option::Option::Some(Self::DETACHED),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for State {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                state::UNKNOWN
+                Self::new(0)
             }
         }
     }
@@ -1881,43 +1926,58 @@ pub mod router_status {
 
         /// Status of the BGP peer: {UP, DOWN}
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct BgpStatus(std::borrow::Cow<'static, str>);
+        pub struct BgpStatus(i32);
 
         impl BgpStatus {
+            /// The default status indicating BGP session is in unknown state.
+            pub const UNKNOWN: BgpStatus = BgpStatus::new(0);
+
+            /// The UP status indicating BGP session is established.
+            pub const UP: BgpStatus = BgpStatus::new(1);
+
+            /// The DOWN state indicating BGP session is not established yet.
+            pub const DOWN: BgpStatus = BgpStatus::new(2);
+
             /// Creates a new BgpStatus instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                    1 => std::borrow::Cow::Borrowed("UP"),
+                    2 => std::borrow::Cow::Borrowed("DOWN"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                    "UP" => std::option::Option::Some(Self::UP),
+                    "DOWN" => std::option::Option::Some(Self::DOWN),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [BgpStatus](BgpStatus)
-        pub mod bgp_status {
-            use super::BgpStatus;
-
-            /// The default status indicating BGP session is in unknown state.
-            pub const UNKNOWN: BgpStatus = BgpStatus::new("UNKNOWN");
-
-            /// The UP status indicating BGP session is established.
-            pub const UP: BgpStatus = BgpStatus::new("UP");
-
-            /// The DOWN state indicating BGP session is not established yet.
-            pub const DOWN: BgpStatus = BgpStatus::new("DOWN");
-        }
-
-        impl std::convert::From<std::string::String> for BgpStatus {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for BgpStatus {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for BgpStatus {
             fn default() -> Self {
-                bgp_status::UNKNOWN
+                Self::new(0)
             }
         }
     }
@@ -3922,44 +3982,60 @@ pub mod diagnose_network_response {
 
         /// Denotes the status of MACsec sessions for the links of a zone.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct MacsecStatus(std::borrow::Cow<'static, str>);
+        pub struct MacsecStatus(i32);
 
         impl MacsecStatus {
+            /// MACsec status not specified, likely due to missing metrics.
+            pub const MACSEC_STATUS_UNSPECIFIED: MacsecStatus = MacsecStatus::new(0);
+
+            /// All relevant links have at least one MACsec session up.
+            pub const SECURE: MacsecStatus = MacsecStatus::new(1);
+
+            /// At least one relevant link does not have any MACsec sessions up.
+            pub const UNSECURE: MacsecStatus = MacsecStatus::new(2);
+
             /// Creates a new MacsecStatus instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("MACSEC_STATUS_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("SECURE"),
+                    2 => std::borrow::Cow::Borrowed("UNSECURE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "MACSEC_STATUS_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::MACSEC_STATUS_UNSPECIFIED)
+                    }
+                    "SECURE" => std::option::Option::Some(Self::SECURE),
+                    "UNSECURE" => std::option::Option::Some(Self::UNSECURE),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [MacsecStatus](MacsecStatus)
-        pub mod macsec_status {
-            use super::MacsecStatus;
-
-            /// MACsec status not specified, likely due to missing metrics.
-            pub const MACSEC_STATUS_UNSPECIFIED: MacsecStatus =
-                MacsecStatus::new("MACSEC_STATUS_UNSPECIFIED");
-
-            /// All relevant links have at least one MACsec session up.
-            pub const SECURE: MacsecStatus = MacsecStatus::new("SECURE");
-
-            /// At least one relevant link does not have any MACsec sessions up.
-            pub const UNSECURE: MacsecStatus = MacsecStatus::new("UNSECURE");
-        }
-
-        impl std::convert::From<std::string::String> for MacsecStatus {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for MacsecStatus {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for MacsecStatus {
             fn default() -> Self {
-                macsec_status::MACSEC_STATUS_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -4171,51 +4247,72 @@ impl wkt::message::Message for InitializeZoneResponse {
 /// deleted would be: RUNNING -> DELETING. Any failures during processing will
 /// result the resource to be in a SUSPENDED state.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ResourceState(std::borrow::Cow<'static, str>);
+pub struct ResourceState(i32);
 
 impl ResourceState {
+    /// Unspecified state.
+    pub const STATE_UNKNOWN: ResourceState = ResourceState::new(0);
+
+    /// The resource is being prepared to be applied to the rack.
+    pub const STATE_PENDING: ResourceState = ResourceState::new(1);
+
+    /// The resource has started being applied to the rack.
+    pub const STATE_PROVISIONING: ResourceState = ResourceState::new(2);
+
+    /// The resource has been pushed to the rack.
+    pub const STATE_RUNNING: ResourceState = ResourceState::new(3);
+
+    /// The resource failed to push to the rack.
+    pub const STATE_SUSPENDED: ResourceState = ResourceState::new(4);
+
+    /// The resource is under deletion.
+    pub const STATE_DELETING: ResourceState = ResourceState::new(5);
+
     /// Creates a new ResourceState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("STATE_UNKNOWN"),
+            1 => std::borrow::Cow::Borrowed("STATE_PENDING"),
+            2 => std::borrow::Cow::Borrowed("STATE_PROVISIONING"),
+            3 => std::borrow::Cow::Borrowed("STATE_RUNNING"),
+            4 => std::borrow::Cow::Borrowed("STATE_SUSPENDED"),
+            5 => std::borrow::Cow::Borrowed("STATE_DELETING"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "STATE_UNKNOWN" => std::option::Option::Some(Self::STATE_UNKNOWN),
+            "STATE_PENDING" => std::option::Option::Some(Self::STATE_PENDING),
+            "STATE_PROVISIONING" => std::option::Option::Some(Self::STATE_PROVISIONING),
+            "STATE_RUNNING" => std::option::Option::Some(Self::STATE_RUNNING),
+            "STATE_SUSPENDED" => std::option::Option::Some(Self::STATE_SUSPENDED),
+            "STATE_DELETING" => std::option::Option::Some(Self::STATE_DELETING),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [ResourceState](ResourceState)
-pub mod resource_state {
-    use super::ResourceState;
-
-    /// Unspecified state.
-    pub const STATE_UNKNOWN: ResourceState = ResourceState::new("STATE_UNKNOWN");
-
-    /// The resource is being prepared to be applied to the rack.
-    pub const STATE_PENDING: ResourceState = ResourceState::new("STATE_PENDING");
-
-    /// The resource has started being applied to the rack.
-    pub const STATE_PROVISIONING: ResourceState = ResourceState::new("STATE_PROVISIONING");
-
-    /// The resource has been pushed to the rack.
-    pub const STATE_RUNNING: ResourceState = ResourceState::new("STATE_RUNNING");
-
-    /// The resource failed to push to the rack.
-    pub const STATE_SUSPENDED: ResourceState = ResourceState::new("STATE_SUSPENDED");
-
-    /// The resource is under deletion.
-    pub const STATE_DELETING: ResourceState = ResourceState::new("STATE_DELETING");
-}
-
-impl std::convert::From<std::string::String> for ResourceState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ResourceState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ResourceState {
     fn default() -> Self {
-        resource_state::STATE_UNKNOWN
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/edgenetwork/v1/src/transport.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
                 reqwest::Method::POST,
                 format!("/v1/{}:initialize", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -69,7 +69,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/zones", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -92,7 +92,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -111,7 +111,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/networks", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -134,7 +134,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -153,7 +153,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}:diagnose", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -175,7 +175,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
                 reqwest::Method::POST,
                 format!("/v1/{}/networks", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -196,7 +196,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -216,7 +216,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/subnets", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -239,7 +239,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -258,7 +258,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/subnets", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -286,7 +286,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -314,7 +314,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -337,7 +337,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
                 reqwest::Method::GET,
                 format!("/v1/{}/interconnects", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -360,7 +360,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -379,7 +379,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}:diagnose", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -401,7 +401,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
                 reqwest::Method::GET,
                 format!("/v1/{}/interconnectAttachments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -424,7 +424,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -446,7 +446,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
                 reqwest::Method::POST,
                 format!("/v1/{}/interconnectAttachments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -468,7 +468,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -488,7 +488,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/routers", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -511,7 +511,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -530,7 +530,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}:diagnose", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -549,7 +549,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/routers", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -577,7 +577,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -605,7 +605,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -625,7 +625,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -647,7 +647,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -666,7 +666,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -688,7 +688,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -707,7 +707,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -726,7 +726,7 @@ impl crate::stubs::EdgeNetwork for EdgeNetwork {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/essentialcontacts/v1/src/model.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/model.rs
@@ -604,115 +604,159 @@ impl wkt::message::Message for SendTestMessageRequest {
 /// categories. All contacts that are subscribed to that category will receive
 /// the notification.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct NotificationCategory(std::borrow::Cow<'static, str>);
+pub struct NotificationCategory(i32);
 
 impl NotificationCategory {
-    /// Creates a new NotificationCategory instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [NotificationCategory](NotificationCategory)
-pub mod notification_category {
-    use super::NotificationCategory;
-
     /// Notification category is unrecognized or unspecified.
     pub const NOTIFICATION_CATEGORY_UNSPECIFIED: NotificationCategory =
-        NotificationCategory::new("NOTIFICATION_CATEGORY_UNSPECIFIED");
+        NotificationCategory::new(0);
 
     /// All notifications related to the resource, including notifications
     /// pertaining to categories added in the future.
-    pub const ALL: NotificationCategory = NotificationCategory::new("ALL");
+    pub const ALL: NotificationCategory = NotificationCategory::new(2);
 
     /// Notifications related to imminent account suspension.
-    pub const SUSPENSION: NotificationCategory = NotificationCategory::new("SUSPENSION");
+    pub const SUSPENSION: NotificationCategory = NotificationCategory::new(3);
 
     /// Notifications related to security/privacy incidents, notifications, and
     /// vulnerabilities.
-    pub const SECURITY: NotificationCategory = NotificationCategory::new("SECURITY");
+    pub const SECURITY: NotificationCategory = NotificationCategory::new(5);
 
     /// Notifications related to technical events and issues such as outages,
     /// errors, or bugs.
-    pub const TECHNICAL: NotificationCategory = NotificationCategory::new("TECHNICAL");
+    pub const TECHNICAL: NotificationCategory = NotificationCategory::new(6);
 
     /// Notifications related to billing and payments notifications, price updates,
     /// errors, or credits.
-    pub const BILLING: NotificationCategory = NotificationCategory::new("BILLING");
+    pub const BILLING: NotificationCategory = NotificationCategory::new(7);
 
     /// Notifications related to enforcement actions, regulatory compliance, or
     /// government notices.
-    pub const LEGAL: NotificationCategory = NotificationCategory::new("LEGAL");
+    pub const LEGAL: NotificationCategory = NotificationCategory::new(8);
 
     /// Notifications related to new versions, product terms updates, or
     /// deprecations.
-    pub const PRODUCT_UPDATES: NotificationCategory = NotificationCategory::new("PRODUCT_UPDATES");
+    pub const PRODUCT_UPDATES: NotificationCategory = NotificationCategory::new(9);
 
     /// Child category of TECHNICAL. If assigned, technical incident notifications
     /// will go to these contacts instead of TECHNICAL.
-    pub const TECHNICAL_INCIDENTS: NotificationCategory =
-        NotificationCategory::new("TECHNICAL_INCIDENTS");
+    pub const TECHNICAL_INCIDENTS: NotificationCategory = NotificationCategory::new(10);
+
+    /// Creates a new NotificationCategory instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("NOTIFICATION_CATEGORY_UNSPECIFIED"),
+            2 => std::borrow::Cow::Borrowed("ALL"),
+            3 => std::borrow::Cow::Borrowed("SUSPENSION"),
+            5 => std::borrow::Cow::Borrowed("SECURITY"),
+            6 => std::borrow::Cow::Borrowed("TECHNICAL"),
+            7 => std::borrow::Cow::Borrowed("BILLING"),
+            8 => std::borrow::Cow::Borrowed("LEGAL"),
+            9 => std::borrow::Cow::Borrowed("PRODUCT_UPDATES"),
+            10 => std::borrow::Cow::Borrowed("TECHNICAL_INCIDENTS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "NOTIFICATION_CATEGORY_UNSPECIFIED" => {
+                std::option::Option::Some(Self::NOTIFICATION_CATEGORY_UNSPECIFIED)
+            }
+            "ALL" => std::option::Option::Some(Self::ALL),
+            "SUSPENSION" => std::option::Option::Some(Self::SUSPENSION),
+            "SECURITY" => std::option::Option::Some(Self::SECURITY),
+            "TECHNICAL" => std::option::Option::Some(Self::TECHNICAL),
+            "BILLING" => std::option::Option::Some(Self::BILLING),
+            "LEGAL" => std::option::Option::Some(Self::LEGAL),
+            "PRODUCT_UPDATES" => std::option::Option::Some(Self::PRODUCT_UPDATES),
+            "TECHNICAL_INCIDENTS" => std::option::Option::Some(Self::TECHNICAL_INCIDENTS),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for NotificationCategory {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for NotificationCategory {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for NotificationCategory {
     fn default() -> Self {
-        notification_category::NOTIFICATION_CATEGORY_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// A contact's validation state indicates whether or not it is the correct
 /// contact to be receiving notifications for a particular resource.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ValidationState(std::borrow::Cow<'static, str>);
+pub struct ValidationState(i32);
 
 impl ValidationState {
-    /// Creates a new ValidationState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ValidationState](ValidationState)
-pub mod validation_state {
-    use super::ValidationState;
-
     /// The validation state is unknown or unspecified.
-    pub const VALIDATION_STATE_UNSPECIFIED: ValidationState =
-        ValidationState::new("VALIDATION_STATE_UNSPECIFIED");
+    pub const VALIDATION_STATE_UNSPECIFIED: ValidationState = ValidationState::new(0);
 
     /// The contact is marked as valid. This is usually done manually by the
     /// contact admin. All new contacts begin in the valid state.
-    pub const VALID: ValidationState = ValidationState::new("VALID");
+    pub const VALID: ValidationState = ValidationState::new(1);
 
     /// The contact is considered invalid. This may become the state if the
     /// contact's email is found to be unreachable.
-    pub const INVALID: ValidationState = ValidationState::new("INVALID");
+    pub const INVALID: ValidationState = ValidationState::new(2);
+
+    /// Creates a new ValidationState instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("VALIDATION_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("VALID"),
+            2 => std::borrow::Cow::Borrowed("INVALID"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "VALIDATION_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::VALIDATION_STATE_UNSPECIFIED)
+            }
+            "VALID" => std::option::Option::Some(Self::VALID),
+            "INVALID" => std::option::Option::Some(Self::INVALID),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ValidationState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ValidationState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ValidationState {
     fn default() -> Self {
-        validation_state::VALIDATION_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/essentialcontacts/v1/src/transport.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::EssentialContactsService for EssentialContactsService {
                 reqwest::Method::POST,
                 format!("/v1/{}/contacts", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -80,7 +80,7 @@ impl crate::stubs::EssentialContactsService for EssentialContactsService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -109,7 +109,7 @@ impl crate::stubs::EssentialContactsService for EssentialContactsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/contacts", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -130,7 +130,7 @@ impl crate::stubs::EssentialContactsService for EssentialContactsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -149,7 +149,7 @@ impl crate::stubs::EssentialContactsService for EssentialContactsService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -171,7 +171,7 @@ impl crate::stubs::EssentialContactsService for EssentialContactsService {
                 reqwest::Method::GET,
                 format!("/v1/{}/contacts:compute", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -201,7 +201,7 @@ impl crate::stubs::EssentialContactsService for EssentialContactsService {
                 reqwest::Method::POST,
                 format!("/v1/{}/contacts:sendTestMessage", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/eventarc/v1/src/model.rs
+++ b/src/generated/cloud/eventarc/v1/src/model.rs
@@ -209,37 +209,22 @@ pub mod channel {
 
     /// State lists all the possible states of a Channel
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The PENDING state indicates that a Channel has been created successfully
         /// and there is a new activation token available for the subscriber to use
         /// to convey the Channel to the provider in order to create a Connection.
-        pub const PENDING: State = State::new("PENDING");
+        pub const PENDING: State = State::new(1);
 
         /// The ACTIVE state indicates that a Channel has been successfully
         /// connected with the event provider.
         /// An ACTIVE Channel is ready to receive and route events from the
         /// event provider.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(2);
 
         /// The INACTIVE state indicates that the Channel cannot receive events
         /// permanently. There are two possible cases this state can happen:
@@ -250,18 +235,50 @@ pub mod channel {
         ///
         /// To re-establish a Connection with a provider, the subscriber
         /// should create a new Channel and give it to the provider.
-        pub const INACTIVE: State = State::new("INACTIVE");
+        pub const INACTIVE: State = State::new(3);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("INACTIVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -3890,69 +3907,99 @@ pub mod logging_config {
     /// This enum is an exhaustive list of log severities and is FROZEN. Do not
     /// expect new values to be added.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LogSeverity(std::borrow::Cow<'static, str>);
+    pub struct LogSeverity(i32);
 
     impl LogSeverity {
-        /// Creates a new LogSeverity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [LogSeverity](LogSeverity)
-    pub mod log_severity {
-        use super::LogSeverity;
-
         /// Log severity is not specified. This value is treated the same as NONE,
         /// but is used to distinguish between no update and update to NONE in
         /// update_masks.
-        pub const LOG_SEVERITY_UNSPECIFIED: LogSeverity =
-            LogSeverity::new("LOG_SEVERITY_UNSPECIFIED");
+        pub const LOG_SEVERITY_UNSPECIFIED: LogSeverity = LogSeverity::new(0);
 
         /// Default value at resource creation, presence of this value must be
         /// treated as no logging/disable logging.
-        pub const NONE: LogSeverity = LogSeverity::new("NONE");
+        pub const NONE: LogSeverity = LogSeverity::new(1);
 
         /// Debug or trace level logging.
-        pub const DEBUG: LogSeverity = LogSeverity::new("DEBUG");
+        pub const DEBUG: LogSeverity = LogSeverity::new(2);
 
         /// Routine information, such as ongoing status or performance.
-        pub const INFO: LogSeverity = LogSeverity::new("INFO");
+        pub const INFO: LogSeverity = LogSeverity::new(3);
 
         /// Normal but significant events, such as start up, shut down, or a
         /// configuration change.
-        pub const NOTICE: LogSeverity = LogSeverity::new("NOTICE");
+        pub const NOTICE: LogSeverity = LogSeverity::new(4);
 
         /// Warning events might cause problems.
-        pub const WARNING: LogSeverity = LogSeverity::new("WARNING");
+        pub const WARNING: LogSeverity = LogSeverity::new(5);
 
         /// Error events are likely to cause problems.
-        pub const ERROR: LogSeverity = LogSeverity::new("ERROR");
+        pub const ERROR: LogSeverity = LogSeverity::new(6);
 
         /// Critical events cause more severe problems or outages.
-        pub const CRITICAL: LogSeverity = LogSeverity::new("CRITICAL");
+        pub const CRITICAL: LogSeverity = LogSeverity::new(7);
 
         /// A person must take action immediately.
-        pub const ALERT: LogSeverity = LogSeverity::new("ALERT");
+        pub const ALERT: LogSeverity = LogSeverity::new(8);
 
         /// One or more systems are unusable.
-        pub const EMERGENCY: LogSeverity = LogSeverity::new("EMERGENCY");
+        pub const EMERGENCY: LogSeverity = LogSeverity::new(9);
+
+        /// Creates a new LogSeverity instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LOG_SEVERITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NONE"),
+                2 => std::borrow::Cow::Borrowed("DEBUG"),
+                3 => std::borrow::Cow::Borrowed("INFO"),
+                4 => std::borrow::Cow::Borrowed("NOTICE"),
+                5 => std::borrow::Cow::Borrowed("WARNING"),
+                6 => std::borrow::Cow::Borrowed("ERROR"),
+                7 => std::borrow::Cow::Borrowed("CRITICAL"),
+                8 => std::borrow::Cow::Borrowed("ALERT"),
+                9 => std::borrow::Cow::Borrowed("EMERGENCY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LOG_SEVERITY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::LOG_SEVERITY_UNSPECIFIED)
+                }
+                "NONE" => std::option::Option::Some(Self::NONE),
+                "DEBUG" => std::option::Option::Some(Self::DEBUG),
+                "INFO" => std::option::Option::Some(Self::INFO),
+                "NOTICE" => std::option::Option::Some(Self::NOTICE),
+                "WARNING" => std::option::Option::Some(Self::WARNING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
+                "ALERT" => std::option::Option::Some(Self::ALERT),
+                "EMERGENCY" => std::option::Option::Some(Self::EMERGENCY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for LogSeverity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LogSeverity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LogSeverity {
         fn default() -> Self {
-            log_severity::LOG_SEVERITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/eventarc/v1/src/transport.rs
+++ b/src/generated/cloud/eventarc/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -68,7 +68,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/triggers", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -94,7 +94,7 @@ impl crate::stubs::Eventarc for Eventarc {
                 reqwest::Method::POST,
                 format!("/v1/{}/triggers", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -124,7 +124,7 @@ impl crate::stubs::Eventarc for Eventarc {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -155,7 +155,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -177,7 +177,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -196,7 +196,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/channels", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -221,7 +221,7 @@ impl crate::stubs::Eventarc for Eventarc {
                 reqwest::Method::POST,
                 format!("/v1/{}/channels", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -251,7 +251,7 @@ impl crate::stubs::Eventarc for Eventarc {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -281,7 +281,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -301,7 +301,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -323,7 +323,7 @@ impl crate::stubs::Eventarc for Eventarc {
                 reqwest::Method::GET,
                 format!("/v1/{}/providers", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -346,7 +346,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -368,7 +368,7 @@ impl crate::stubs::Eventarc for Eventarc {
                 reqwest::Method::GET,
                 format!("/v1/{}/channelConnections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -392,7 +392,7 @@ impl crate::stubs::Eventarc for Eventarc {
                 reqwest::Method::POST,
                 format!("/v1/{}/channelConnections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -412,7 +412,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -431,7 +431,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -459,7 +459,7 @@ impl crate::stubs::Eventarc for Eventarc {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -488,7 +488,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -510,7 +510,7 @@ impl crate::stubs::Eventarc for Eventarc {
                 reqwest::Method::GET,
                 format!("/v1/{}/messageBuses", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -536,7 +536,7 @@ impl crate::stubs::Eventarc for Eventarc {
                 reqwest::Method::GET,
                 format!("/v1/{}:listEnrollments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -560,7 +560,7 @@ impl crate::stubs::Eventarc for Eventarc {
                 reqwest::Method::POST,
                 format!("/v1/{}/messageBuses", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -590,7 +590,7 @@ impl crate::stubs::Eventarc for Eventarc {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -621,7 +621,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -643,7 +643,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -665,7 +665,7 @@ impl crate::stubs::Eventarc for Eventarc {
                 reqwest::Method::GET,
                 format!("/v1/{}/enrollments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -691,7 +691,7 @@ impl crate::stubs::Eventarc for Eventarc {
                 reqwest::Method::POST,
                 format!("/v1/{}/enrollments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -721,7 +721,7 @@ impl crate::stubs::Eventarc for Eventarc {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -752,7 +752,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -774,7 +774,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -796,7 +796,7 @@ impl crate::stubs::Eventarc for Eventarc {
                 reqwest::Method::GET,
                 format!("/v1/{}/pipelines", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -822,7 +822,7 @@ impl crate::stubs::Eventarc for Eventarc {
                 reqwest::Method::POST,
                 format!("/v1/{}/pipelines", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -852,7 +852,7 @@ impl crate::stubs::Eventarc for Eventarc {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -883,7 +883,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -905,7 +905,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -927,7 +927,7 @@ impl crate::stubs::Eventarc for Eventarc {
                 reqwest::Method::GET,
                 format!("/v1/{}/googleApiSources", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -953,7 +953,7 @@ impl crate::stubs::Eventarc for Eventarc {
                 reqwest::Method::POST,
                 format!("/v1/{}/googleApiSources", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -983,7 +983,7 @@ impl crate::stubs::Eventarc for Eventarc {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1014,7 +1014,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1036,7 +1036,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1058,7 +1058,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1080,7 +1080,7 @@ impl crate::stubs::Eventarc for Eventarc {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1100,7 +1100,7 @@ impl crate::stubs::Eventarc for Eventarc {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1132,7 +1132,7 @@ impl crate::stubs::Eventarc for Eventarc {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1149,7 +1149,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1171,7 +1171,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1190,7 +1190,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1209,7 +1209,7 @@ impl crate::stubs::Eventarc for Eventarc {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/filestore/v1/src/model.rs
+++ b/src/generated/cloud/filestore/v1/src/model.rs
@@ -148,86 +148,116 @@ pub mod network_config {
 
     /// Internet protocol versions supported by Filestore.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AddressMode(std::borrow::Cow<'static, str>);
+    pub struct AddressMode(i32);
 
     impl AddressMode {
+        /// Internet protocol not set.
+        pub const ADDRESS_MODE_UNSPECIFIED: AddressMode = AddressMode::new(0);
+
+        /// Use the IPv4 internet protocol.
+        pub const MODE_IPV4: AddressMode = AddressMode::new(1);
+
         /// Creates a new AddressMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ADDRESS_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MODE_IPV4"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ADDRESS_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ADDRESS_MODE_UNSPECIFIED)
+                }
+                "MODE_IPV4" => std::option::Option::Some(Self::MODE_IPV4),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AddressMode](AddressMode)
-    pub mod address_mode {
-        use super::AddressMode;
-
-        /// Internet protocol not set.
-        pub const ADDRESS_MODE_UNSPECIFIED: AddressMode =
-            AddressMode::new("ADDRESS_MODE_UNSPECIFIED");
-
-        /// Use the IPv4 internet protocol.
-        pub const MODE_IPV4: AddressMode = AddressMode::new("MODE_IPV4");
-    }
-
-    impl std::convert::From<std::string::String> for AddressMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AddressMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AddressMode {
         fn default() -> Self {
-            address_mode::ADDRESS_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Available connection modes.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConnectMode(std::borrow::Cow<'static, str>);
+    pub struct ConnectMode(i32);
 
     impl ConnectMode {
-        /// Creates a new ConnectMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ConnectMode](ConnectMode)
-    pub mod connect_mode {
-        use super::ConnectMode;
-
         /// Not set.
-        pub const CONNECT_MODE_UNSPECIFIED: ConnectMode =
-            ConnectMode::new("CONNECT_MODE_UNSPECIFIED");
+        pub const CONNECT_MODE_UNSPECIFIED: ConnectMode = ConnectMode::new(0);
 
         /// Connect via direct peering to the Filestore service.
-        pub const DIRECT_PEERING: ConnectMode = ConnectMode::new("DIRECT_PEERING");
+        pub const DIRECT_PEERING: ConnectMode = ConnectMode::new(1);
 
         /// Connect to your Filestore instance using Private Service
         /// Access. Private services access provides an IP address range for multiple
         /// Google Cloud services, including Filestore.
-        pub const PRIVATE_SERVICE_ACCESS: ConnectMode = ConnectMode::new("PRIVATE_SERVICE_ACCESS");
+        pub const PRIVATE_SERVICE_ACCESS: ConnectMode = ConnectMode::new(2);
+
+        /// Creates a new ConnectMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CONNECT_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DIRECT_PEERING"),
+                2 => std::borrow::Cow::Borrowed("PRIVATE_SERVICE_ACCESS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CONNECT_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CONNECT_MODE_UNSPECIFIED)
+                }
+                "DIRECT_PEERING" => std::option::Option::Some(Self::DIRECT_PEERING),
+                "PRIVATE_SERVICE_ACCESS" => std::option::Option::Some(Self::PRIVATE_SERVICE_ACCESS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ConnectMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ConnectMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ConnectMode {
         fn default() -> Self {
-            connect_mode::CONNECT_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -452,85 +482,119 @@ pub mod nfs_export_options {
 
     /// The access mode.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AccessMode(std::borrow::Cow<'static, str>);
+    pub struct AccessMode(i32);
 
     impl AccessMode {
+        /// AccessMode not set.
+        pub const ACCESS_MODE_UNSPECIFIED: AccessMode = AccessMode::new(0);
+
+        /// The client can only read the file share.
+        pub const READ_ONLY: AccessMode = AccessMode::new(1);
+
+        /// The client can read and write the file share (default).
+        pub const READ_WRITE: AccessMode = AccessMode::new(2);
+
         /// Creates a new AccessMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ACCESS_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("READ_ONLY"),
+                2 => std::borrow::Cow::Borrowed("READ_WRITE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ACCESS_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ACCESS_MODE_UNSPECIFIED)
+                }
+                "READ_ONLY" => std::option::Option::Some(Self::READ_ONLY),
+                "READ_WRITE" => std::option::Option::Some(Self::READ_WRITE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AccessMode](AccessMode)
-    pub mod access_mode {
-        use super::AccessMode;
-
-        /// AccessMode not set.
-        pub const ACCESS_MODE_UNSPECIFIED: AccessMode = AccessMode::new("ACCESS_MODE_UNSPECIFIED");
-
-        /// The client can only read the file share.
-        pub const READ_ONLY: AccessMode = AccessMode::new("READ_ONLY");
-
-        /// The client can read and write the file share (default).
-        pub const READ_WRITE: AccessMode = AccessMode::new("READ_WRITE");
-    }
-
-    impl std::convert::From<std::string::String> for AccessMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AccessMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AccessMode {
         fn default() -> Self {
-            access_mode::ACCESS_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The squash mode.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SquashMode(std::borrow::Cow<'static, str>);
+    pub struct SquashMode(i32);
 
     impl SquashMode {
+        /// SquashMode not set.
+        pub const SQUASH_MODE_UNSPECIFIED: SquashMode = SquashMode::new(0);
+
+        /// The Root user has root access to the file share (default).
+        pub const NO_ROOT_SQUASH: SquashMode = SquashMode::new(1);
+
+        /// The Root user has squashed access to the anonymous uid/gid.
+        pub const ROOT_SQUASH: SquashMode = SquashMode::new(2);
+
         /// Creates a new SquashMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SQUASH_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NO_ROOT_SQUASH"),
+                2 => std::borrow::Cow::Borrowed("ROOT_SQUASH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SQUASH_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SQUASH_MODE_UNSPECIFIED)
+                }
+                "NO_ROOT_SQUASH" => std::option::Option::Some(Self::NO_ROOT_SQUASH),
+                "ROOT_SQUASH" => std::option::Option::Some(Self::ROOT_SQUASH),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SquashMode](SquashMode)
-    pub mod squash_mode {
-        use super::SquashMode;
-
-        /// SquashMode not set.
-        pub const SQUASH_MODE_UNSPECIFIED: SquashMode = SquashMode::new("SQUASH_MODE_UNSPECIFIED");
-
-        /// The Root user has root access to the file share (default).
-        pub const NO_ROOT_SQUASH: SquashMode = SquashMode::new("NO_ROOT_SQUASH");
-
-        /// The Root user has squashed access to the anonymous uid/gid.
-        pub const ROOT_SQUASH: SquashMode = SquashMode::new("ROOT_SQUASH");
-    }
-
-    impl std::convert::From<std::string::String> for SquashMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SquashMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SquashMode {
         fn default() -> Self {
-            squash_mode::SQUASH_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -613,95 +677,131 @@ pub mod replica_config {
 
     /// The replica state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The replica is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The replica is ready.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(3);
 
         /// The replica is being removed.
-        pub const REMOVING: State = State::new("REMOVING");
+        pub const REMOVING: State = State::new(4);
 
         /// The replica is experiencing an issue and might be unusable. You can get
         /// further details from the `stateReasons` field of the `ReplicaConfig`
         /// object.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                3 => std::borrow::Cow::Borrowed("READY"),
+                4 => std::borrow::Cow::Borrowed("REMOVING"),
+                5 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "REMOVING" => std::option::Option::Some(Self::REMOVING),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Additional information about the replication state, if available.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StateReason(std::borrow::Cow<'static, str>);
+    pub struct StateReason(i32);
 
     impl StateReason {
+        /// Reason not specified.
+        pub const STATE_REASON_UNSPECIFIED: StateReason = StateReason::new(0);
+
+        /// The peer instance is unreachable.
+        pub const PEER_INSTANCE_UNREACHABLE: StateReason = StateReason::new(1);
+
+        /// The remove replica peer instance operation failed.
+        pub const REMOVE_FAILED: StateReason = StateReason::new(2);
+
         /// Creates a new StateReason instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_REASON_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PEER_INSTANCE_UNREACHABLE"),
+                2 => std::borrow::Cow::Borrowed("REMOVE_FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_REASON_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::STATE_REASON_UNSPECIFIED)
+                }
+                "PEER_INSTANCE_UNREACHABLE" => {
+                    std::option::Option::Some(Self::PEER_INSTANCE_UNREACHABLE)
+                }
+                "REMOVE_FAILED" => std::option::Option::Some(Self::REMOVE_FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [StateReason](StateReason)
-    pub mod state_reason {
-        use super::StateReason;
-
-        /// Reason not specified.
-        pub const STATE_REASON_UNSPECIFIED: StateReason =
-            StateReason::new("STATE_REASON_UNSPECIFIED");
-
-        /// The peer instance is unreachable.
-        pub const PEER_INSTANCE_UNREACHABLE: StateReason =
-            StateReason::new("PEER_INSTANCE_UNREACHABLE");
-
-        /// The remove replica peer instance operation failed.
-        pub const REMOVE_FAILED: StateReason = StateReason::new("REMOVE_FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for StateReason {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for StateReason {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for StateReason {
         fn default() -> Self {
-            state_reason::STATE_REASON_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -760,45 +860,60 @@ pub mod replication {
 
     /// Replication role.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Role(std::borrow::Cow<'static, str>);
+    pub struct Role(i32);
 
     impl Role {
-        /// Creates a new Role instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Role](Role)
-    pub mod role {
-        use super::Role;
-
         /// Role not set.
-        pub const ROLE_UNSPECIFIED: Role = Role::new("ROLE_UNSPECIFIED");
+        pub const ROLE_UNSPECIFIED: Role = Role::new(0);
 
         /// The instance is the `ACTIVE` replication member, functions as
         /// the replication source instance.
-        pub const ACTIVE: Role = Role::new("ACTIVE");
+        pub const ACTIVE: Role = Role::new(1);
 
         /// The instance is the `STANDBY` replication member, functions as
         /// the replication destination instance.
-        pub const STANDBY: Role = Role::new("STANDBY");
+        pub const STANDBY: Role = Role::new(2);
+
+        /// Creates a new Role instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ROLE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("STANDBY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ROLE_UNSPECIFIED" => std::option::Option::Some(Self::ROLE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "STANDBY" => std::option::Option::Some(Self::STANDBY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Role {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Role {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Role {
         fn default() -> Self {
-            role::ROLE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1384,227 +1499,317 @@ pub mod instance {
 
     /// The instance state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The instance is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The instance is available for use.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(2);
 
         /// Work is being done on the instance. You can get further details from the
         /// `statusMessage` field of the `Instance` resource.
-        pub const REPAIRING: State = State::new("REPAIRING");
+        pub const REPAIRING: State = State::new(3);
 
         /// The instance is shutting down.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(4);
 
         /// The instance is experiencing an issue and might be unusable. You can get
         /// further details from the `statusMessage` field of the `Instance`
         /// resource.
-        pub const ERROR: State = State::new("ERROR");
+        pub const ERROR: State = State::new(6);
 
         /// The instance is restoring a backup to an existing file share and may be
         /// unusable during this time.
-        pub const RESTORING: State = State::new("RESTORING");
+        pub const RESTORING: State = State::new(7);
 
         /// The instance is suspended. You can get further details from
         /// the `suspension_reasons` field of the `Instance` resource.
-        pub const SUSPENDED: State = State::new("SUSPENDED");
+        pub const SUSPENDED: State = State::new(8);
 
         /// The instance is in the process of becoming suspended.
-        pub const SUSPENDING: State = State::new("SUSPENDING");
+        pub const SUSPENDING: State = State::new(9);
 
         /// The instance is in the process of becoming active.
-        pub const RESUMING: State = State::new("RESUMING");
+        pub const RESUMING: State = State::new(10);
 
         /// The instance is reverting to a snapshot.
-        pub const REVERTING: State = State::new("REVERTING");
+        pub const REVERTING: State = State::new(12);
 
         /// The replica instance is being promoted.
-        pub const PROMOTING: State = State::new("PROMOTING");
+        pub const PROMOTING: State = State::new(13);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                3 => std::borrow::Cow::Borrowed("REPAIRING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                6 => std::borrow::Cow::Borrowed("ERROR"),
+                7 => std::borrow::Cow::Borrowed("RESTORING"),
+                8 => std::borrow::Cow::Borrowed("SUSPENDED"),
+                9 => std::borrow::Cow::Borrowed("SUSPENDING"),
+                10 => std::borrow::Cow::Borrowed("RESUMING"),
+                12 => std::borrow::Cow::Borrowed("REVERTING"),
+                13 => std::borrow::Cow::Borrowed("PROMOTING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "REPAIRING" => std::option::Option::Some(Self::REPAIRING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "RESTORING" => std::option::Option::Some(Self::RESTORING),
+                "SUSPENDED" => std::option::Option::Some(Self::SUSPENDED),
+                "SUSPENDING" => std::option::Option::Some(Self::SUSPENDING),
+                "RESUMING" => std::option::Option::Some(Self::RESUMING),
+                "REVERTING" => std::option::Option::Some(Self::REVERTING),
+                "PROMOTING" => std::option::Option::Some(Self::PROMOTING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Available service tiers.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Tier(std::borrow::Cow<'static, str>);
+    pub struct Tier(i32);
 
     impl Tier {
-        /// Creates a new Tier instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Tier](Tier)
-    pub mod tier {
-        use super::Tier;
-
         /// Not set.
-        pub const TIER_UNSPECIFIED: Tier = Tier::new("TIER_UNSPECIFIED");
+        pub const TIER_UNSPECIFIED: Tier = Tier::new(0);
 
         /// STANDARD tier. BASIC_HDD is the preferred term for this tier.
-        pub const STANDARD: Tier = Tier::new("STANDARD");
+        pub const STANDARD: Tier = Tier::new(1);
 
         /// PREMIUM tier. BASIC_SSD is the preferred term for this tier.
-        pub const PREMIUM: Tier = Tier::new("PREMIUM");
+        pub const PREMIUM: Tier = Tier::new(2);
 
         /// BASIC instances offer a maximum capacity of 63.9 TB.
         /// BASIC_HDD is an alias for STANDARD Tier, offering economical
         /// performance backed by HDD.
-        pub const BASIC_HDD: Tier = Tier::new("BASIC_HDD");
+        pub const BASIC_HDD: Tier = Tier::new(3);
 
         /// BASIC instances offer a maximum capacity of 63.9 TB.
         /// BASIC_SSD is an alias for PREMIUM Tier, and offers improved
         /// performance backed by SSD.
-        pub const BASIC_SSD: Tier = Tier::new("BASIC_SSD");
+        pub const BASIC_SSD: Tier = Tier::new(4);
 
         /// HIGH_SCALE instances offer expanded capacity and performance scaling
         /// capabilities.
-        pub const HIGH_SCALE_SSD: Tier = Tier::new("HIGH_SCALE_SSD");
+        pub const HIGH_SCALE_SSD: Tier = Tier::new(5);
 
         /// ENTERPRISE instances offer the features and availability needed for
         /// mission-critical workloads.
-        pub const ENTERPRISE: Tier = Tier::new("ENTERPRISE");
+        pub const ENTERPRISE: Tier = Tier::new(6);
 
         /// ZONAL instances offer expanded capacity and performance scaling
         /// capabilities.
-        pub const ZONAL: Tier = Tier::new("ZONAL");
+        pub const ZONAL: Tier = Tier::new(7);
 
         /// REGIONAL instances offer the features and availability needed for
         /// mission-critical workloads.
-        pub const REGIONAL: Tier = Tier::new("REGIONAL");
+        pub const REGIONAL: Tier = Tier::new(8);
+
+        /// Creates a new Tier instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TIER_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STANDARD"),
+                2 => std::borrow::Cow::Borrowed("PREMIUM"),
+                3 => std::borrow::Cow::Borrowed("BASIC_HDD"),
+                4 => std::borrow::Cow::Borrowed("BASIC_SSD"),
+                5 => std::borrow::Cow::Borrowed("HIGH_SCALE_SSD"),
+                6 => std::borrow::Cow::Borrowed("ENTERPRISE"),
+                7 => std::borrow::Cow::Borrowed("ZONAL"),
+                8 => std::borrow::Cow::Borrowed("REGIONAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TIER_UNSPECIFIED" => std::option::Option::Some(Self::TIER_UNSPECIFIED),
+                "STANDARD" => std::option::Option::Some(Self::STANDARD),
+                "PREMIUM" => std::option::Option::Some(Self::PREMIUM),
+                "BASIC_HDD" => std::option::Option::Some(Self::BASIC_HDD),
+                "BASIC_SSD" => std::option::Option::Some(Self::BASIC_SSD),
+                "HIGH_SCALE_SSD" => std::option::Option::Some(Self::HIGH_SCALE_SSD),
+                "ENTERPRISE" => std::option::Option::Some(Self::ENTERPRISE),
+                "ZONAL" => std::option::Option::Some(Self::ZONAL),
+                "REGIONAL" => std::option::Option::Some(Self::REGIONAL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Tier {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Tier {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Tier {
         fn default() -> Self {
-            tier::TIER_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// SuspensionReason contains the possible reasons for a suspension.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SuspensionReason(std::borrow::Cow<'static, str>);
+    pub struct SuspensionReason(i32);
 
     impl SuspensionReason {
+        /// Not set.
+        pub const SUSPENSION_REASON_UNSPECIFIED: SuspensionReason = SuspensionReason::new(0);
+
+        /// The KMS key used by the instance is either revoked or denied access to.
+        pub const KMS_KEY_ISSUE: SuspensionReason = SuspensionReason::new(1);
+
         /// Creates a new SuspensionReason instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SUSPENSION_REASON_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("KMS_KEY_ISSUE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SUSPENSION_REASON_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SUSPENSION_REASON_UNSPECIFIED)
+                }
+                "KMS_KEY_ISSUE" => std::option::Option::Some(Self::KMS_KEY_ISSUE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SuspensionReason](SuspensionReason)
-    pub mod suspension_reason {
-        use super::SuspensionReason;
-
-        /// Not set.
-        pub const SUSPENSION_REASON_UNSPECIFIED: SuspensionReason =
-            SuspensionReason::new("SUSPENSION_REASON_UNSPECIFIED");
-
-        /// The KMS key used by the instance is either revoked or denied access to.
-        pub const KMS_KEY_ISSUE: SuspensionReason = SuspensionReason::new("KMS_KEY_ISSUE");
-    }
-
-    impl std::convert::From<std::string::String> for SuspensionReason {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SuspensionReason {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SuspensionReason {
         fn default() -> Self {
-            suspension_reason::SUSPENSION_REASON_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// File access protocol.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FileProtocol(std::borrow::Cow<'static, str>);
+    pub struct FileProtocol(i32);
 
     impl FileProtocol {
+        /// FILE_PROTOCOL_UNSPECIFIED serves a "not set" default value when
+        /// a FileProtocol is a separate field in a message.
+        pub const FILE_PROTOCOL_UNSPECIFIED: FileProtocol = FileProtocol::new(0);
+
+        /// NFS 3.0.
+        pub const NFS_V3: FileProtocol = FileProtocol::new(1);
+
+        /// NFS 4.1.
+        pub const NFS_V4_1: FileProtocol = FileProtocol::new(2);
+
         /// Creates a new FileProtocol instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FILE_PROTOCOL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NFS_V3"),
+                2 => std::borrow::Cow::Borrowed("NFS_V4_1"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FILE_PROTOCOL_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::FILE_PROTOCOL_UNSPECIFIED)
+                }
+                "NFS_V3" => std::option::Option::Some(Self::NFS_V3),
+                "NFS_V4_1" => std::option::Option::Some(Self::NFS_V4_1),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [FileProtocol](FileProtocol)
-    pub mod file_protocol {
-        use super::FileProtocol;
-
-        /// FILE_PROTOCOL_UNSPECIFIED serves a "not set" default value when
-        /// a FileProtocol is a separate field in a message.
-        pub const FILE_PROTOCOL_UNSPECIFIED: FileProtocol =
-            FileProtocol::new("FILE_PROTOCOL_UNSPECIFIED");
-
-        /// NFS 3.0.
-        pub const NFS_V3: FileProtocol = FileProtocol::new("NFS_V3");
-
-        /// NFS 4.1.
-        pub const NFS_V4_1: FileProtocol = FileProtocol::new("NFS_V4_1");
-    }
-
-    impl std::convert::From<std::string::String> for FileProtocol {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for FileProtocol {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for FileProtocol {
         fn default() -> Self {
-            file_protocol::FILE_PROTOCOL_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2207,46 +2412,63 @@ pub mod snapshot {
 
     /// The snapshot state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State not set.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Snapshot is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// Snapshot is available for use.
+        pub const READY: State = State::new(2);
+
+        /// Snapshot is being deleted.
+        pub const DELETING: State = State::new(3);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Snapshot is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// Snapshot is available for use.
-        pub const READY: State = State::new("READY");
-
-        /// Snapshot is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2797,54 +3019,75 @@ pub mod backup {
 
     /// The backup state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Backup is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// Backup has been taken and the operation is being finalized. At this
         /// point, changes to the file share will not be reflected in the backup.
-        pub const FINALIZING: State = State::new("FINALIZING");
+        pub const FINALIZING: State = State::new(2);
 
         /// Backup is available for use.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(3);
 
         /// Backup is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(4);
 
         /// Backup is not valid and cannot be used for creating new instances or
         /// restoring existing instances.
-        pub const INVALID: State = State::new("INVALID");
+        pub const INVALID: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("FINALIZING"),
+                3 => std::borrow::Cow::Borrowed("READY"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("INVALID"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "FINALIZING" => std::option::Option::Some(Self::FINALIZING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "INVALID" => std::option::Option::Some(Self::INVALID),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/filestore/v1/src/transport.rs
+++ b/src/generated/cloud/filestore/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -126,7 +126,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -155,7 +155,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:restore", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -172,7 +172,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:revert", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -189,7 +189,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -212,7 +212,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/snapshots", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -236,7 +236,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -258,7 +258,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/snapshots", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -278,7 +278,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -306,7 +306,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -335,7 +335,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/backups", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -358,7 +358,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -377,7 +377,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/backups", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -395,7 +395,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -423,7 +423,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -453,7 +453,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:promoteReplica", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -470,7 +470,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -492,7 +492,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -511,7 +511,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -533,7 +533,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -552,7 +552,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -571,7 +571,7 @@ impl crate::stubs::CloudFilestoreManager for CloudFilestoreManager {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/financialservices/v1/src/model.rs
+++ b/src/generated/cloud/financialservices/v1/src/model.rs
@@ -242,49 +242,68 @@ pub mod backtest_result {
 
     /// The possible states of a resource.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State is unspecified, should not occur.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The resource has not finished being created.
+        pub const CREATING: State = State::new(1);
+
+        /// The resource is active/ready to be used.
+        pub const ACTIVE: State = State::new(2);
+
+        /// The resource is in the process of being updated.
+        pub const UPDATING: State = State::new(3);
+
+        /// The resource is in the process of being deleted.
+        pub const DELETING: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State is unspecified, should not occur.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The resource has not finished being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The resource is active/ready to be used.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The resource is in the process of being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// The resource is in the process of being deleted.
-        pub const DELETING: State = State::new("DELETING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -790,44 +809,60 @@ pub mod big_query_destination {
     /// WriteDisposition controls the behavior when the destination table already
     /// exists.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct WriteDisposition(std::borrow::Cow<'static, str>);
+    pub struct WriteDisposition(i32);
 
     impl WriteDisposition {
+        /// Default behavior is the same as WRITE_EMPTY.
+        pub const WRITE_DISPOSITION_UNSPECIFIED: WriteDisposition = WriteDisposition::new(0);
+
+        /// If the table already exists and contains data, an error is returned.
+        pub const WRITE_EMPTY: WriteDisposition = WriteDisposition::new(1);
+
+        /// If the table already exists, the data will be overwritten.
+        pub const WRITE_TRUNCATE: WriteDisposition = WriteDisposition::new(2);
+
         /// Creates a new WriteDisposition instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("WRITE_DISPOSITION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("WRITE_EMPTY"),
+                2 => std::borrow::Cow::Borrowed("WRITE_TRUNCATE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "WRITE_DISPOSITION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::WRITE_DISPOSITION_UNSPECIFIED)
+                }
+                "WRITE_EMPTY" => std::option::Option::Some(Self::WRITE_EMPTY),
+                "WRITE_TRUNCATE" => std::option::Option::Some(Self::WRITE_TRUNCATE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [WriteDisposition](WriteDisposition)
-    pub mod write_disposition {
-        use super::WriteDisposition;
-
-        /// Default behavior is the same as WRITE_EMPTY.
-        pub const WRITE_DISPOSITION_UNSPECIFIED: WriteDisposition =
-            WriteDisposition::new("WRITE_DISPOSITION_UNSPECIFIED");
-
-        /// If the table already exists and contains data, an error is returned.
-        pub const WRITE_EMPTY: WriteDisposition = WriteDisposition::new("WRITE_EMPTY");
-
-        /// If the table already exists, the data will be overwritten.
-        pub const WRITE_TRUNCATE: WriteDisposition = WriteDisposition::new("WRITE_TRUNCATE");
-    }
-
-    impl std::convert::From<std::string::String> for WriteDisposition {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for WriteDisposition {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for WriteDisposition {
         fn default() -> Self {
-            write_disposition::WRITE_DISPOSITION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -973,49 +1008,68 @@ pub mod dataset {
 
     /// The possible states of a resource.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State is unspecified, should not occur.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The resource has not finished being created.
+        pub const CREATING: State = State::new(1);
+
+        /// The resource is active/ready to be used.
+        pub const ACTIVE: State = State::new(2);
+
+        /// The resource is in the process of being updated.
+        pub const UPDATING: State = State::new(3);
+
+        /// The resource is in the process of being deleted.
+        pub const DELETING: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State is unspecified, should not occur.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The resource has not finished being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The resource is active/ready to be used.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The resource is in the process of being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// The resource is in the process of being deleted.
-        pub const DELETING: State = State::new("DELETING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1716,93 +1770,129 @@ pub mod engine_config {
 
     /// The possible states of a resource.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State is unspecified, should not occur.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The resource has not finished being created.
+        pub const CREATING: State = State::new(1);
+
+        /// The resource is active/ready to be used.
+        pub const ACTIVE: State = State::new(2);
+
+        /// The resource is in the process of being updated.
+        pub const UPDATING: State = State::new(3);
+
+        /// The resource is in the process of being deleted.
+        pub const DELETING: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State is unspecified, should not occur.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The resource has not finished being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The resource is active/ready to be used.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The resource is in the process of being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// The resource is in the process of being deleted.
-        pub const DELETING: State = State::new("DELETING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The type of the hyperparameter source.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HyperparameterSourceType(std::borrow::Cow<'static, str>);
+    pub struct HyperparameterSourceType(i32);
 
     impl HyperparameterSourceType {
-        /// Creates a new HyperparameterSourceType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [HyperparameterSourceType](HyperparameterSourceType)
-    pub mod hyperparameter_source_type {
-        use super::HyperparameterSourceType;
-
         /// Hyperparameter source type is unspecified, defaults to TUNING.
         pub const HYPERPARAMETER_SOURCE_TYPE_UNSPECIFIED: HyperparameterSourceType =
-            HyperparameterSourceType::new("HYPERPARAMETER_SOURCE_TYPE_UNSPECIFIED");
+            HyperparameterSourceType::new(0);
 
         /// The EngineConfig creation starts a tuning job which selects the best
         /// hyperparameters.
-        pub const TUNING: HyperparameterSourceType = HyperparameterSourceType::new("TUNING");
+        pub const TUNING: HyperparameterSourceType = HyperparameterSourceType::new(1);
 
         /// The hyperparameters are inherited from another EngineConfig.
-        pub const INHERITED: HyperparameterSourceType = HyperparameterSourceType::new("INHERITED");
+        pub const INHERITED: HyperparameterSourceType = HyperparameterSourceType::new(2);
+
+        /// Creates a new HyperparameterSourceType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("HYPERPARAMETER_SOURCE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TUNING"),
+                2 => std::borrow::Cow::Borrowed("INHERITED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "HYPERPARAMETER_SOURCE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::HYPERPARAMETER_SOURCE_TYPE_UNSPECIFIED)
+                }
+                "TUNING" => std::option::Option::Some(Self::TUNING),
+                "INHERITED" => std::option::Option::Some(Self::INHERITED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for HyperparameterSourceType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for HyperparameterSourceType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for HyperparameterSourceType {
         fn default() -> Self {
-            hyperparameter_source_type::HYPERPARAMETER_SOURCE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2349,47 +2439,64 @@ pub mod engine_version {
     /// State determines the lifecycle of a version and the models/engine configs
     /// trained with it.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Default state, should never be used.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Version is available for training and inference.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(1);
 
         /// Models using this version can still be run, but new ones cannot be
         /// trained.
-        pub const LIMITED: State = State::new("LIMITED");
+        pub const LIMITED: State = State::new(2);
 
         /// Version is deprecated, listed for informational purposes only.
-        pub const DECOMMISSIONED: State = State::new("DECOMMISSIONED");
+        pub const DECOMMISSIONED: State = State::new(3);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("LIMITED"),
+                3 => std::borrow::Cow::Borrowed("DECOMMISSIONED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "LIMITED" => std::option::Option::Some(Self::LIMITED),
+                "DECOMMISSIONED" => std::option::Option::Some(Self::DECOMMISSIONED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2681,49 +2788,68 @@ pub mod instance {
 
     /// The Resource State
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State is unspecified, should not occur.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The resource has not finished being created.
+        pub const CREATING: State = State::new(1);
+
+        /// The resource is active/ready to be used.
+        pub const ACTIVE: State = State::new(2);
+
+        /// The resource is in the process of being updated.
+        pub const UPDATING: State = State::new(3);
+
+        /// The resource is in the process of being deleted.
+        pub const DELETING: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State is unspecified, should not occur.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The resource has not finished being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The resource is active/ready to be used.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The resource is in the process of being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// The resource is in the process of being deleted.
-        pub const DELETING: State = State::new("DELETING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3197,43 +3323,60 @@ pub mod import_registered_parties_request {
 
     /// UpdateMode controls the behavior for ImportRegisteredParties.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct UpdateMode(std::borrow::Cow<'static, str>);
+    pub struct UpdateMode(i32);
 
     impl UpdateMode {
+        /// Default mode.
+        pub const UPDATE_MODE_UNSPECIFIED: UpdateMode = UpdateMode::new(0);
+
+        /// Replace parties that are removable in Parties Table with new parties.
+        pub const REPLACE: UpdateMode = UpdateMode::new(1);
+
+        /// Add new parties to Parties Table.
+        pub const APPEND: UpdateMode = UpdateMode::new(2);
+
         /// Creates a new UpdateMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UPDATE_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REPLACE"),
+                2 => std::borrow::Cow::Borrowed("APPEND"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UPDATE_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::UPDATE_MODE_UNSPECIFIED)
+                }
+                "REPLACE" => std::option::Option::Some(Self::REPLACE),
+                "APPEND" => std::option::Option::Some(Self::APPEND),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [UpdateMode](UpdateMode)
-    pub mod update_mode {
-        use super::UpdateMode;
-
-        /// Default mode.
-        pub const UPDATE_MODE_UNSPECIFIED: UpdateMode = UpdateMode::new("UPDATE_MODE_UNSPECIFIED");
-
-        /// Replace parties that are removable in Parties Table with new parties.
-        pub const REPLACE: UpdateMode = UpdateMode::new("REPLACE");
-
-        /// Add new parties to Parties Table.
-        pub const APPEND: UpdateMode = UpdateMode::new("APPEND");
-    }
-
-    impl std::convert::From<std::string::String> for UpdateMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for UpdateMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for UpdateMode {
         fn default() -> Self {
-            update_mode::UPDATE_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3556,49 +3699,68 @@ pub mod model {
 
     /// The possible states of a resource.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State is unspecified, should not occur.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The resource has not finished being created.
+        pub const CREATING: State = State::new(1);
+
+        /// The resource is active/ready to be used.
+        pub const ACTIVE: State = State::new(2);
+
+        /// The resource is in the process of being updated.
+        pub const UPDATING: State = State::new(3);
+
+        /// The resource is in the process of being deleted.
+        pub const DELETING: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State is unspecified, should not occur.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The resource has not finished being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The resource is active/ready to be used.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The resource is in the process of being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// The resource is in the process of being deleted.
-        pub const DELETING: State = State::new("DELETING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4266,49 +4428,68 @@ pub mod prediction_result {
 
     /// The possible states of a resource.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State is unspecified, should not occur.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The resource has not finished being created.
+        pub const CREATING: State = State::new(1);
+
+        /// The resource is active/ready to be used.
+        pub const ACTIVE: State = State::new(2);
+
+        /// The resource is in the process of being updated.
+        pub const UPDATING: State = State::new(3);
+
+        /// The resource is in the process of being deleted.
+        pub const DELETING: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State is unspecified, should not occur.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The resource has not finished being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The resource is active/ready to be used.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The resource is in the process of being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// The resource is in the process of being deleted.
-        pub const DELETING: State = State::new("DELETING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4868,43 +5049,59 @@ impl wkt::message::Message for OperationMetadata {
 
 /// Indicate which LineOfBusiness a party belongs to.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LineOfBusiness(std::borrow::Cow<'static, str>);
+pub struct LineOfBusiness(i32);
 
 impl LineOfBusiness {
+    /// An unspecified LineOfBusiness. Do not use.
+    pub const LINE_OF_BUSINESS_UNSPECIFIED: LineOfBusiness = LineOfBusiness::new(0);
+
+    /// Commercial LineOfBusiness.
+    pub const COMMERCIAL: LineOfBusiness = LineOfBusiness::new(1);
+
+    /// Retail LineOfBusiness.
+    pub const RETAIL: LineOfBusiness = LineOfBusiness::new(2);
+
     /// Creates a new LineOfBusiness instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("LINE_OF_BUSINESS_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("COMMERCIAL"),
+            2 => std::borrow::Cow::Borrowed("RETAIL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "LINE_OF_BUSINESS_UNSPECIFIED" => {
+                std::option::Option::Some(Self::LINE_OF_BUSINESS_UNSPECIFIED)
+            }
+            "COMMERCIAL" => std::option::Option::Some(Self::COMMERCIAL),
+            "RETAIL" => std::option::Option::Some(Self::RETAIL),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [LineOfBusiness](LineOfBusiness)
-pub mod line_of_business {
-    use super::LineOfBusiness;
-
-    /// An unspecified LineOfBusiness. Do not use.
-    pub const LINE_OF_BUSINESS_UNSPECIFIED: LineOfBusiness =
-        LineOfBusiness::new("LINE_OF_BUSINESS_UNSPECIFIED");
-
-    /// Commercial LineOfBusiness.
-    pub const COMMERCIAL: LineOfBusiness = LineOfBusiness::new("COMMERCIAL");
-
-    /// Retail LineOfBusiness.
-    pub const RETAIL: LineOfBusiness = LineOfBusiness::new("RETAIL");
-}
-
-impl std::convert::From<std::string::String> for LineOfBusiness {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for LineOfBusiness {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for LineOfBusiness {
     fn default() -> Self {
-        line_of_business::LINE_OF_BUSINESS_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/financialservices/v1/src/transport.rs
+++ b/src/generated/cloud/financialservices/v1/src/transport.rs
@@ -50,7 +50,7 @@ impl crate::stubs::Aml for Aml {
                 reqwest::Method::GET,
                 format!("/v1/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -73,7 +73,7 @@ impl crate::stubs::Aml for Aml {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -95,7 +95,7 @@ impl crate::stubs::Aml for Aml {
                 reqwest::Method::POST,
                 format!("/v1/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -125,7 +125,7 @@ impl crate::stubs::Aml for Aml {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -155,7 +155,7 @@ impl crate::stubs::Aml for Aml {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -178,7 +178,7 @@ impl crate::stubs::Aml for Aml {
                 reqwest::Method::POST,
                 format!("/v1/{}:importRegisteredParties", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -198,7 +198,7 @@ impl crate::stubs::Aml for Aml {
                 reqwest::Method::POST,
                 format!("/v1/{}:exportRegisteredParties", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -215,7 +215,7 @@ impl crate::stubs::Aml for Aml {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/datasets", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -238,7 +238,7 @@ impl crate::stubs::Aml for Aml {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -260,7 +260,7 @@ impl crate::stubs::Aml for Aml {
                 reqwest::Method::POST,
                 format!("/v1/{}/datasets", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -290,7 +290,7 @@ impl crate::stubs::Aml for Aml {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -320,7 +320,7 @@ impl crate::stubs::Aml for Aml {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -340,7 +340,7 @@ impl crate::stubs::Aml for Aml {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/models", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -363,7 +363,7 @@ impl crate::stubs::Aml for Aml {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -382,7 +382,7 @@ impl crate::stubs::Aml for Aml {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/models", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -410,7 +410,7 @@ impl crate::stubs::Aml for Aml {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -441,7 +441,7 @@ impl crate::stubs::Aml for Aml {
                 reqwest::Method::POST,
                 format!("/v1/{}:exportMetadata", req.model),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -458,7 +458,7 @@ impl crate::stubs::Aml for Aml {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -481,7 +481,7 @@ impl crate::stubs::Aml for Aml {
                 reqwest::Method::GET,
                 format!("/v1/{}/engineConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -504,7 +504,7 @@ impl crate::stubs::Aml for Aml {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -526,7 +526,7 @@ impl crate::stubs::Aml for Aml {
                 reqwest::Method::POST,
                 format!("/v1/{}/engineConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -556,7 +556,7 @@ impl crate::stubs::Aml for Aml {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -589,7 +589,7 @@ impl crate::stubs::Aml for Aml {
                 reqwest::Method::POST,
                 format!("/v1/{}:exportMetadata", req.engine_config),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -606,7 +606,7 @@ impl crate::stubs::Aml for Aml {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -626,7 +626,7 @@ impl crate::stubs::Aml for Aml {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -648,7 +648,7 @@ impl crate::stubs::Aml for Aml {
                 reqwest::Method::GET,
                 format!("/v1/{}/engineVersions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -674,7 +674,7 @@ impl crate::stubs::Aml for Aml {
                 reqwest::Method::GET,
                 format!("/v1/{}/predictionResults", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -697,7 +697,7 @@ impl crate::stubs::Aml for Aml {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -719,7 +719,7 @@ impl crate::stubs::Aml for Aml {
                 reqwest::Method::POST,
                 format!("/v1/{}/predictionResults", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -749,7 +749,7 @@ impl crate::stubs::Aml for Aml {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -782,7 +782,7 @@ impl crate::stubs::Aml for Aml {
                 reqwest::Method::POST,
                 format!("/v1/{}:exportMetadata", req.prediction_result),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -799,7 +799,7 @@ impl crate::stubs::Aml for Aml {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -822,7 +822,7 @@ impl crate::stubs::Aml for Aml {
                 reqwest::Method::GET,
                 format!("/v1/{}/backtestResults", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -845,7 +845,7 @@ impl crate::stubs::Aml for Aml {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -867,7 +867,7 @@ impl crate::stubs::Aml for Aml {
                 reqwest::Method::POST,
                 format!("/v1/{}/backtestResults", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -897,7 +897,7 @@ impl crate::stubs::Aml for Aml {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -930,7 +930,7 @@ impl crate::stubs::Aml for Aml {
                 reqwest::Method::POST,
                 format!("/v1/{}:exportMetadata", req.backtest_result),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -947,7 +947,7 @@ impl crate::stubs::Aml for Aml {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -967,7 +967,7 @@ impl crate::stubs::Aml for Aml {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -989,7 +989,7 @@ impl crate::stubs::Aml for Aml {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1008,7 +1008,7 @@ impl crate::stubs::Aml for Aml {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1030,7 +1030,7 @@ impl crate::stubs::Aml for Aml {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1049,7 +1049,7 @@ impl crate::stubs::Aml for Aml {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1068,7 +1068,7 @@ impl crate::stubs::Aml for Aml {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/functions/v2/src/model.rs
+++ b/src/generated/cloud/functions/v2/src/model.rs
@@ -242,53 +242,74 @@ pub mod function {
 
     /// Describes the current state of the function.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Not specified. Invalid state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Function has been successfully deployed and is serving.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(1);
 
         /// Function deployment failed and the function is not serving.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(2);
 
         /// Function is being created or updated.
-        pub const DEPLOYING: State = State::new("DEPLOYING");
+        pub const DEPLOYING: State = State::new(3);
 
         /// Function is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(4);
 
         /// Function deployment failed and the function serving state is undefined.
         /// The function should be updated or deleted to move it out of this state.
-        pub const UNKNOWN: State = State::new("UNKNOWN");
+        pub const UNKNOWN: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("FAILED"),
+                3 => std::borrow::Cow::Borrowed("DEPLOYING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "DEPLOYING" => std::option::Option::Some(Self::DEPLOYING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -352,46 +373,63 @@ pub mod state_message {
 
     /// Severity of the state message.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(std::borrow::Cow<'static, str>);
+    pub struct Severity(i32);
 
     impl Severity {
+        /// Not specified. Invalid severity.
+        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
+
+        /// ERROR-level severity.
+        pub const ERROR: Severity = Severity::new(1);
+
+        /// WARNING-level severity.
+        pub const WARNING: Severity = Severity::new(2);
+
+        /// INFO-level severity.
+        pub const INFO: Severity = Severity::new(3);
+
         /// Creates a new Severity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ERROR"),
+                2 => std::borrow::Cow::Borrowed("WARNING"),
+                3 => std::borrow::Cow::Borrowed("INFO"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "WARNING" => std::option::Option::Some(Self::WARNING),
+                "INFO" => std::option::Option::Some(Self::INFO),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Severity](Severity)
-    pub mod severity {
-        use super::Severity;
-
-        /// Not specified. Invalid severity.
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new("SEVERITY_UNSPECIFIED");
-
-        /// ERROR-level severity.
-        pub const ERROR: Severity = Severity::new("ERROR");
-
-        /// WARNING-level severity.
-        pub const WARNING: Severity = Severity::new("WARNING");
-
-        /// INFO-level severity.
-        pub const INFO: Severity = Severity::new("INFO");
-    }
-
-    impl std::convert::From<std::string::String> for Severity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            severity::SEVERITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1099,49 +1137,65 @@ pub mod build_config {
 
     /// Docker Registry to use for storing function Docker images.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DockerRegistry(std::borrow::Cow<'static, str>);
+    pub struct DockerRegistry(i32);
 
     impl DockerRegistry {
-        /// Creates a new DockerRegistry instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DockerRegistry](DockerRegistry)
-    pub mod docker_registry {
-        use super::DockerRegistry;
-
         /// Unspecified.
-        pub const DOCKER_REGISTRY_UNSPECIFIED: DockerRegistry =
-            DockerRegistry::new("DOCKER_REGISTRY_UNSPECIFIED");
+        pub const DOCKER_REGISTRY_UNSPECIFIED: DockerRegistry = DockerRegistry::new(0);
 
         /// Docker images will be stored in multi-regional Container Registry
         /// repositories named `gcf`.
-        pub const CONTAINER_REGISTRY: DockerRegistry = DockerRegistry::new("CONTAINER_REGISTRY");
+        pub const CONTAINER_REGISTRY: DockerRegistry = DockerRegistry::new(1);
 
         /// Docker images will be stored in regional Artifact Registry repositories.
         /// By default, GCF will create and use repositories named `gcf-artifacts`
         /// in every region in which a function is deployed. But the repository to
         /// use can also be specified by the user using the `docker_repository`
         /// field.
-        pub const ARTIFACT_REGISTRY: DockerRegistry = DockerRegistry::new("ARTIFACT_REGISTRY");
+        pub const ARTIFACT_REGISTRY: DockerRegistry = DockerRegistry::new(2);
+
+        /// Creates a new DockerRegistry instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DOCKER_REGISTRY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CONTAINER_REGISTRY"),
+                2 => std::borrow::Cow::Borrowed("ARTIFACT_REGISTRY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DOCKER_REGISTRY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DOCKER_REGISTRY_UNSPECIFIED)
+                }
+                "CONTAINER_REGISTRY" => std::option::Option::Some(Self::CONTAINER_REGISTRY),
+                "ARTIFACT_REGISTRY" => std::option::Option::Some(Self::ARTIFACT_REGISTRY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DockerRegistry {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DockerRegistry {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DockerRegistry {
         fn default() -> Self {
-            docker_registry::DOCKER_REGISTRY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1455,47 +1509,63 @@ pub mod service_config {
     /// This controls what traffic is diverted through the VPC Access Connector
     /// resource. By default PRIVATE_RANGES_ONLY will be used.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VpcConnectorEgressSettings(std::borrow::Cow<'static, str>);
+    pub struct VpcConnectorEgressSettings(i32);
 
     impl VpcConnectorEgressSettings {
-        /// Creates a new VpcConnectorEgressSettings instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [VpcConnectorEgressSettings](VpcConnectorEgressSettings)
-    pub mod vpc_connector_egress_settings {
-        use super::VpcConnectorEgressSettings;
-
         /// Unspecified.
         pub const VPC_CONNECTOR_EGRESS_SETTINGS_UNSPECIFIED: VpcConnectorEgressSettings =
-            VpcConnectorEgressSettings::new("VPC_CONNECTOR_EGRESS_SETTINGS_UNSPECIFIED");
+            VpcConnectorEgressSettings::new(0);
 
         /// Use the VPC Access Connector only for private IP space from RFC1918.
         pub const PRIVATE_RANGES_ONLY: VpcConnectorEgressSettings =
-            VpcConnectorEgressSettings::new("PRIVATE_RANGES_ONLY");
+            VpcConnectorEgressSettings::new(1);
 
         /// Force the use of VPC Access Connector for all egress traffic from the
         /// function.
-        pub const ALL_TRAFFIC: VpcConnectorEgressSettings =
-            VpcConnectorEgressSettings::new("ALL_TRAFFIC");
+        pub const ALL_TRAFFIC: VpcConnectorEgressSettings = VpcConnectorEgressSettings::new(2);
+
+        /// Creates a new VpcConnectorEgressSettings instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VPC_CONNECTOR_EGRESS_SETTINGS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PRIVATE_RANGES_ONLY"),
+                2 => std::borrow::Cow::Borrowed("ALL_TRAFFIC"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VPC_CONNECTOR_EGRESS_SETTINGS_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::VPC_CONNECTOR_EGRESS_SETTINGS_UNSPECIFIED)
+                }
+                "PRIVATE_RANGES_ONLY" => std::option::Option::Some(Self::PRIVATE_RANGES_ONLY),
+                "ALL_TRAFFIC" => std::option::Option::Some(Self::ALL_TRAFFIC),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for VpcConnectorEgressSettings {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for VpcConnectorEgressSettings {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for VpcConnectorEgressSettings {
         fn default() -> Self {
-            vpc_connector_egress_settings::VPC_CONNECTOR_EGRESS_SETTINGS_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1505,49 +1575,67 @@ pub mod service_config {
     ///
     /// If unspecified, ALLOW_ALL will be used.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IngressSettings(std::borrow::Cow<'static, str>);
+    pub struct IngressSettings(i32);
 
     impl IngressSettings {
+        /// Unspecified.
+        pub const INGRESS_SETTINGS_UNSPECIFIED: IngressSettings = IngressSettings::new(0);
+
+        /// Allow HTTP traffic from public and private sources.
+        pub const ALLOW_ALL: IngressSettings = IngressSettings::new(1);
+
+        /// Allow HTTP traffic from only private VPC sources.
+        pub const ALLOW_INTERNAL_ONLY: IngressSettings = IngressSettings::new(2);
+
+        /// Allow HTTP traffic from private VPC sources and through GCLB.
+        pub const ALLOW_INTERNAL_AND_GCLB: IngressSettings = IngressSettings::new(3);
+
         /// Creates a new IngressSettings instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("INGRESS_SETTINGS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALLOW_ALL"),
+                2 => std::borrow::Cow::Borrowed("ALLOW_INTERNAL_ONLY"),
+                3 => std::borrow::Cow::Borrowed("ALLOW_INTERNAL_AND_GCLB"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "INGRESS_SETTINGS_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::INGRESS_SETTINGS_UNSPECIFIED)
+                }
+                "ALLOW_ALL" => std::option::Option::Some(Self::ALLOW_ALL),
+                "ALLOW_INTERNAL_ONLY" => std::option::Option::Some(Self::ALLOW_INTERNAL_ONLY),
+                "ALLOW_INTERNAL_AND_GCLB" => {
+                    std::option::Option::Some(Self::ALLOW_INTERNAL_AND_GCLB)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [IngressSettings](IngressSettings)
-    pub mod ingress_settings {
-        use super::IngressSettings;
-
-        /// Unspecified.
-        pub const INGRESS_SETTINGS_UNSPECIFIED: IngressSettings =
-            IngressSettings::new("INGRESS_SETTINGS_UNSPECIFIED");
-
-        /// Allow HTTP traffic from public and private sources.
-        pub const ALLOW_ALL: IngressSettings = IngressSettings::new("ALLOW_ALL");
-
-        /// Allow HTTP traffic from only private VPC sources.
-        pub const ALLOW_INTERNAL_ONLY: IngressSettings =
-            IngressSettings::new("ALLOW_INTERNAL_ONLY");
-
-        /// Allow HTTP traffic from private VPC sources and through GCLB.
-        pub const ALLOW_INTERNAL_AND_GCLB: IngressSettings =
-            IngressSettings::new("ALLOW_INTERNAL_AND_GCLB");
-    }
-
-    impl std::convert::From<std::string::String> for IngressSettings {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for IngressSettings {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for IngressSettings {
         fn default() -> Self {
-            ingress_settings::INGRESS_SETTINGS_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1558,48 +1646,64 @@ pub mod service_config {
     /// Security level is only configurable for 1st Gen functions, If unspecified,
     /// SECURE_OPTIONAL will be used. 2nd Gen functions are SECURE_ALWAYS ONLY.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SecurityLevel(std::borrow::Cow<'static, str>);
+    pub struct SecurityLevel(i32);
 
     impl SecurityLevel {
-        /// Creates a new SecurityLevel instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [SecurityLevel](SecurityLevel)
-    pub mod security_level {
-        use super::SecurityLevel;
-
         /// Unspecified.
-        pub const SECURITY_LEVEL_UNSPECIFIED: SecurityLevel =
-            SecurityLevel::new("SECURITY_LEVEL_UNSPECIFIED");
+        pub const SECURITY_LEVEL_UNSPECIFIED: SecurityLevel = SecurityLevel::new(0);
 
         /// Requests for a URL that match this handler that do not use HTTPS are
         /// automatically redirected to the HTTPS URL with the same path. Query
         /// parameters are reserved for the redirect.
-        pub const SECURE_ALWAYS: SecurityLevel = SecurityLevel::new("SECURE_ALWAYS");
+        pub const SECURE_ALWAYS: SecurityLevel = SecurityLevel::new(1);
 
         /// Both HTTP and HTTPS requests with URLs that match the handler succeed
         /// without redirects. The application can examine the request to determine
         /// which protocol was used and respond accordingly.
-        pub const SECURE_OPTIONAL: SecurityLevel = SecurityLevel::new("SECURE_OPTIONAL");
+        pub const SECURE_OPTIONAL: SecurityLevel = SecurityLevel::new(2);
+
+        /// Creates a new SecurityLevel instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SECURITY_LEVEL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SECURE_ALWAYS"),
+                2 => std::borrow::Cow::Borrowed("SECURE_OPTIONAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SECURITY_LEVEL_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SECURITY_LEVEL_UNSPECIFIED)
+                }
+                "SECURE_ALWAYS" => std::option::Option::Some(Self::SECURE_ALWAYS),
+                "SECURE_OPTIONAL" => std::option::Option::Some(Self::SECURE_OPTIONAL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for SecurityLevel {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SecurityLevel {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SecurityLevel {
         fn default() -> Self {
-            security_level::SECURITY_LEVEL_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1948,46 +2052,63 @@ pub mod event_trigger {
     /// Describes the retry policy in case of function's execution failure.
     /// Retried execution is charged as any other execution.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RetryPolicy(std::borrow::Cow<'static, str>);
+    pub struct RetryPolicy(i32);
 
     impl RetryPolicy {
-        /// Creates a new RetryPolicy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RetryPolicy](RetryPolicy)
-    pub mod retry_policy {
-        use super::RetryPolicy;
-
         /// Not specified.
-        pub const RETRY_POLICY_UNSPECIFIED: RetryPolicy =
-            RetryPolicy::new("RETRY_POLICY_UNSPECIFIED");
+        pub const RETRY_POLICY_UNSPECIFIED: RetryPolicy = RetryPolicy::new(0);
 
         /// Do not retry.
-        pub const RETRY_POLICY_DO_NOT_RETRY: RetryPolicy =
-            RetryPolicy::new("RETRY_POLICY_DO_NOT_RETRY");
+        pub const RETRY_POLICY_DO_NOT_RETRY: RetryPolicy = RetryPolicy::new(1);
 
         /// Retry on any failure, retry up to 7 days with an exponential backoff
         /// (capped at 10 seconds).
-        pub const RETRY_POLICY_RETRY: RetryPolicy = RetryPolicy::new("RETRY_POLICY_RETRY");
+        pub const RETRY_POLICY_RETRY: RetryPolicy = RetryPolicy::new(2);
+
+        /// Creates a new RetryPolicy instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RETRY_POLICY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RETRY_POLICY_DO_NOT_RETRY"),
+                2 => std::borrow::Cow::Borrowed("RETRY_POLICY_RETRY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RETRY_POLICY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RETRY_POLICY_UNSPECIFIED)
+                }
+                "RETRY_POLICY_DO_NOT_RETRY" => {
+                    std::option::Option::Some(Self::RETRY_POLICY_DO_NOT_RETRY)
+                }
+                "RETRY_POLICY_RETRY" => std::option::Option::Some(Self::RETRY_POLICY_RETRY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RetryPolicy {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RetryPolicy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RetryPolicy {
         fn default() -> Self {
-            retry_policy::RETRY_POLICY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2754,56 +2875,80 @@ pub mod list_runtimes_response {
 
     /// The various stages that a runtime can be in.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RuntimeStage(std::borrow::Cow<'static, str>);
+    pub struct RuntimeStage(i32);
 
     impl RuntimeStage {
+        /// Not specified.
+        pub const RUNTIME_STAGE_UNSPECIFIED: RuntimeStage = RuntimeStage::new(0);
+
+        /// The runtime is in development.
+        pub const DEVELOPMENT: RuntimeStage = RuntimeStage::new(1);
+
+        /// The runtime is in the Alpha stage.
+        pub const ALPHA: RuntimeStage = RuntimeStage::new(2);
+
+        /// The runtime is in the Beta stage.
+        pub const BETA: RuntimeStage = RuntimeStage::new(3);
+
+        /// The runtime is generally available.
+        pub const GA: RuntimeStage = RuntimeStage::new(4);
+
+        /// The runtime is deprecated.
+        pub const DEPRECATED: RuntimeStage = RuntimeStage::new(5);
+
+        /// The runtime is no longer supported.
+        pub const DECOMMISSIONED: RuntimeStage = RuntimeStage::new(6);
+
         /// Creates a new RuntimeStage instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RUNTIME_STAGE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DEVELOPMENT"),
+                2 => std::borrow::Cow::Borrowed("ALPHA"),
+                3 => std::borrow::Cow::Borrowed("BETA"),
+                4 => std::borrow::Cow::Borrowed("GA"),
+                5 => std::borrow::Cow::Borrowed("DEPRECATED"),
+                6 => std::borrow::Cow::Borrowed("DECOMMISSIONED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RUNTIME_STAGE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RUNTIME_STAGE_UNSPECIFIED)
+                }
+                "DEVELOPMENT" => std::option::Option::Some(Self::DEVELOPMENT),
+                "ALPHA" => std::option::Option::Some(Self::ALPHA),
+                "BETA" => std::option::Option::Some(Self::BETA),
+                "GA" => std::option::Option::Some(Self::GA),
+                "DEPRECATED" => std::option::Option::Some(Self::DEPRECATED),
+                "DECOMMISSIONED" => std::option::Option::Some(Self::DECOMMISSIONED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RuntimeStage](RuntimeStage)
-    pub mod runtime_stage {
-        use super::RuntimeStage;
-
-        /// Not specified.
-        pub const RUNTIME_STAGE_UNSPECIFIED: RuntimeStage =
-            RuntimeStage::new("RUNTIME_STAGE_UNSPECIFIED");
-
-        /// The runtime is in development.
-        pub const DEVELOPMENT: RuntimeStage = RuntimeStage::new("DEVELOPMENT");
-
-        /// The runtime is in the Alpha stage.
-        pub const ALPHA: RuntimeStage = RuntimeStage::new("ALPHA");
-
-        /// The runtime is in the Beta stage.
-        pub const BETA: RuntimeStage = RuntimeStage::new("BETA");
-
-        /// The runtime is generally available.
-        pub const GA: RuntimeStage = RuntimeStage::new("GA");
-
-        /// The runtime is deprecated.
-        pub const DEPRECATED: RuntimeStage = RuntimeStage::new("DEPRECATED");
-
-        /// The runtime is no longer supported.
-        pub const DECOMMISSIONED: RuntimeStage = RuntimeStage::new("DECOMMISSIONED");
-    }
-
-    impl std::convert::From<std::string::String> for RuntimeStage {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RuntimeStage {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RuntimeStage {
         fn default() -> Self {
-            runtime_stage::RUNTIME_STAGE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3144,188 +3289,261 @@ pub mod stage {
 
     /// Possible names for a Stage
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Name(std::borrow::Cow<'static, str>);
+    pub struct Name(i32);
 
     impl Name {
+        /// Not specified. Invalid name.
+        pub const NAME_UNSPECIFIED: Name = Name::new(0);
+
+        /// Artifact Regsitry Stage
+        pub const ARTIFACT_REGISTRY: Name = Name::new(1);
+
+        /// Build Stage
+        pub const BUILD: Name = Name::new(2);
+
+        /// Service Stage
+        pub const SERVICE: Name = Name::new(3);
+
+        /// Trigger Stage
+        pub const TRIGGER: Name = Name::new(4);
+
+        /// Service Rollback Stage
+        pub const SERVICE_ROLLBACK: Name = Name::new(5);
+
+        /// Trigger Rollback Stage
+        pub const TRIGGER_ROLLBACK: Name = Name::new(6);
+
         /// Creates a new Name instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("NAME_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ARTIFACT_REGISTRY"),
+                2 => std::borrow::Cow::Borrowed("BUILD"),
+                3 => std::borrow::Cow::Borrowed("SERVICE"),
+                4 => std::borrow::Cow::Borrowed("TRIGGER"),
+                5 => std::borrow::Cow::Borrowed("SERVICE_ROLLBACK"),
+                6 => std::borrow::Cow::Borrowed("TRIGGER_ROLLBACK"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "NAME_UNSPECIFIED" => std::option::Option::Some(Self::NAME_UNSPECIFIED),
+                "ARTIFACT_REGISTRY" => std::option::Option::Some(Self::ARTIFACT_REGISTRY),
+                "BUILD" => std::option::Option::Some(Self::BUILD),
+                "SERVICE" => std::option::Option::Some(Self::SERVICE),
+                "TRIGGER" => std::option::Option::Some(Self::TRIGGER),
+                "SERVICE_ROLLBACK" => std::option::Option::Some(Self::SERVICE_ROLLBACK),
+                "TRIGGER_ROLLBACK" => std::option::Option::Some(Self::TRIGGER_ROLLBACK),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Name](Name)
-    pub mod name {
-        use super::Name;
-
-        /// Not specified. Invalid name.
-        pub const NAME_UNSPECIFIED: Name = Name::new("NAME_UNSPECIFIED");
-
-        /// Artifact Regsitry Stage
-        pub const ARTIFACT_REGISTRY: Name = Name::new("ARTIFACT_REGISTRY");
-
-        /// Build Stage
-        pub const BUILD: Name = Name::new("BUILD");
-
-        /// Service Stage
-        pub const SERVICE: Name = Name::new("SERVICE");
-
-        /// Trigger Stage
-        pub const TRIGGER: Name = Name::new("TRIGGER");
-
-        /// Service Rollback Stage
-        pub const SERVICE_ROLLBACK: Name = Name::new("SERVICE_ROLLBACK");
-
-        /// Trigger Rollback Stage
-        pub const TRIGGER_ROLLBACK: Name = Name::new("TRIGGER_ROLLBACK");
-    }
-
-    impl std::convert::From<std::string::String> for Name {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Name {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Name {
         fn default() -> Self {
-            name::NAME_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Possible states for a Stage
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Not specified. Invalid state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Stage has not started.
+        pub const NOT_STARTED: State = State::new(1);
+
+        /// Stage is in progress.
+        pub const IN_PROGRESS: State = State::new(2);
+
+        /// Stage has completed.
+        pub const COMPLETE: State = State::new(3);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NOT_STARTED"),
+                2 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                3 => std::borrow::Cow::Borrowed("COMPLETE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "NOT_STARTED" => std::option::Option::Some(Self::NOT_STARTED),
+                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                "COMPLETE" => std::option::Option::Some(Self::COMPLETE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Not specified. Invalid state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Stage has not started.
-        pub const NOT_STARTED: State = State::new("NOT_STARTED");
-
-        /// Stage is in progress.
-        pub const IN_PROGRESS: State = State::new("IN_PROGRESS");
-
-        /// Stage has completed.
-        pub const COMPLETE: State = State::new("COMPLETE");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
 
 /// The type of the long running operation.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OperationType(std::borrow::Cow<'static, str>);
+pub struct OperationType(i32);
 
 impl OperationType {
+    /// Unspecified
+    pub const OPERATIONTYPE_UNSPECIFIED: OperationType = OperationType::new(0);
+
+    /// CreateFunction
+    pub const CREATE_FUNCTION: OperationType = OperationType::new(1);
+
+    /// UpdateFunction
+    pub const UPDATE_FUNCTION: OperationType = OperationType::new(2);
+
+    /// DeleteFunction
+    pub const DELETE_FUNCTION: OperationType = OperationType::new(3);
+
     /// Creates a new OperationType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("OPERATIONTYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("CREATE_FUNCTION"),
+            2 => std::borrow::Cow::Borrowed("UPDATE_FUNCTION"),
+            3 => std::borrow::Cow::Borrowed("DELETE_FUNCTION"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "OPERATIONTYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::OPERATIONTYPE_UNSPECIFIED)
+            }
+            "CREATE_FUNCTION" => std::option::Option::Some(Self::CREATE_FUNCTION),
+            "UPDATE_FUNCTION" => std::option::Option::Some(Self::UPDATE_FUNCTION),
+            "DELETE_FUNCTION" => std::option::Option::Some(Self::DELETE_FUNCTION),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [OperationType](OperationType)
-pub mod operation_type {
-    use super::OperationType;
-
-    /// Unspecified
-    pub const OPERATIONTYPE_UNSPECIFIED: OperationType =
-        OperationType::new("OPERATIONTYPE_UNSPECIFIED");
-
-    /// CreateFunction
-    pub const CREATE_FUNCTION: OperationType = OperationType::new("CREATE_FUNCTION");
-
-    /// UpdateFunction
-    pub const UPDATE_FUNCTION: OperationType = OperationType::new("UPDATE_FUNCTION");
-
-    /// DeleteFunction
-    pub const DELETE_FUNCTION: OperationType = OperationType::new("DELETE_FUNCTION");
-}
-
-impl std::convert::From<std::string::String> for OperationType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for OperationType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for OperationType {
     fn default() -> Self {
-        operation_type::OPERATIONTYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The environment the function is hosted on.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Environment(std::borrow::Cow<'static, str>);
+pub struct Environment(i32);
 
 impl Environment {
+    /// Unspecified
+    pub const ENVIRONMENT_UNSPECIFIED: Environment = Environment::new(0);
+
+    /// Gen 1
+    pub const GEN_1: Environment = Environment::new(1);
+
+    /// Gen 2
+    pub const GEN_2: Environment = Environment::new(2);
+
     /// Creates a new Environment instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ENVIRONMENT_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("GEN_1"),
+            2 => std::borrow::Cow::Borrowed("GEN_2"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ENVIRONMENT_UNSPECIFIED" => std::option::Option::Some(Self::ENVIRONMENT_UNSPECIFIED),
+            "GEN_1" => std::option::Option::Some(Self::GEN_1),
+            "GEN_2" => std::option::Option::Some(Self::GEN_2),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [Environment](Environment)
-pub mod environment {
-    use super::Environment;
-
-    /// Unspecified
-    pub const ENVIRONMENT_UNSPECIFIED: Environment = Environment::new("ENVIRONMENT_UNSPECIFIED");
-
-    /// Gen 1
-    pub const GEN_1: Environment = Environment::new("GEN_1");
-
-    /// Gen 2
-    pub const GEN_2: Environment = Environment::new("GEN_2");
-}
-
-impl std::convert::From<std::string::String> for Environment {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Environment {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Environment {
     fn default() -> Self {
-        environment::ENVIRONMENT_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/functions/v2/src/transport.rs
+++ b/src/generated/cloud/functions/v2/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::FunctionService for FunctionService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::FunctionService for FunctionService {
                 reqwest::Method::GET,
                 format!("/v2/{}/functions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -98,7 +98,7 @@ impl crate::stubs::FunctionService for FunctionService {
                 reqwest::Method::POST,
                 format!("/v2/{}/functions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -127,7 +127,7 @@ impl crate::stubs::FunctionService for FunctionService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -156,7 +156,7 @@ impl crate::stubs::FunctionService for FunctionService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -178,7 +178,7 @@ impl crate::stubs::FunctionService for FunctionService {
                 reqwest::Method::POST,
                 format!("/v2/{}/functions:generateUploadUrl", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -198,7 +198,7 @@ impl crate::stubs::FunctionService for FunctionService {
                 reqwest::Method::POST,
                 format!("/v2/{}:generateDownloadUrl", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -215,7 +215,7 @@ impl crate::stubs::FunctionService for FunctionService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/runtimes", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -235,7 +235,7 @@ impl crate::stubs::FunctionService for FunctionService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -260,7 +260,7 @@ impl crate::stubs::FunctionService for FunctionService {
                 reqwest::Method::POST,
                 format!("/v2/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -280,7 +280,7 @@ impl crate::stubs::FunctionService for FunctionService {
                 reqwest::Method::GET,
                 format!("/v2/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -312,7 +312,7 @@ impl crate::stubs::FunctionService for FunctionService {
                 reqwest::Method::POST,
                 format!("/v2/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -329,7 +329,7 @@ impl crate::stubs::FunctionService for FunctionService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -351,7 +351,7 @@ impl crate::stubs::FunctionService for FunctionService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/gkebackup/v1/src/model.rs
+++ b/src/generated/cloud/gkebackup/v1/src/model.rs
@@ -670,55 +670,76 @@ pub mod backup {
 
     /// State
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The Backup resource is in the process of being created.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The Backup resource has been created and the associated BackupJob
         /// Kubernetes resource has been injected into the source cluster.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The gkebackup agent in the cluster has begun executing the backup
         /// operation.
-        pub const IN_PROGRESS: State = State::new("IN_PROGRESS");
+        pub const IN_PROGRESS: State = State::new(2);
 
         /// The backup operation has completed successfully.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
+        pub const SUCCEEDED: State = State::new(3);
 
         /// The backup operation has failed.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(4);
 
         /// This Backup resource (and its associated artifacts) is in the process
         /// of being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                5 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1384,55 +1405,78 @@ pub mod backup_plan {
 
     /// State
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Default first value for Enums.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Waiting for cluster state to be RUNNING.
+        pub const CLUSTER_PENDING: State = State::new(1);
+
+        /// The BackupPlan is in the process of being created.
+        pub const PROVISIONING: State = State::new(2);
+
+        /// The BackupPlan has successfully been created and is ready for Backups.
+        pub const READY: State = State::new(3);
+
+        /// BackupPlan creation has failed.
+        pub const FAILED: State = State::new(4);
+
+        /// The BackupPlan has been deactivated.
+        pub const DEACTIVATED: State = State::new(5);
+
+        /// The BackupPlan is in the process of being deleted.
+        pub const DELETING: State = State::new(6);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CLUSTER_PENDING"),
+                2 => std::borrow::Cow::Borrowed("PROVISIONING"),
+                3 => std::borrow::Cow::Borrowed("READY"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                5 => std::borrow::Cow::Borrowed("DEACTIVATED"),
+                6 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CLUSTER_PENDING" => std::option::Option::Some(Self::CLUSTER_PENDING),
+                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "DEACTIVATED" => std::option::Option::Some(Self::DEACTIVATED),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Default first value for Enums.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Waiting for cluster state to be RUNNING.
-        pub const CLUSTER_PENDING: State = State::new("CLUSTER_PENDING");
-
-        /// The BackupPlan is in the process of being created.
-        pub const PROVISIONING: State = State::new("PROVISIONING");
-
-        /// The BackupPlan has successfully been created and is ready for Backups.
-        pub const READY: State = State::new("READY");
-
-        /// BackupPlan creation has failed.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// The BackupPlan has been deactivated.
-        pub const DEACTIVATED: State = State::new("DEACTIVATED");
-
-        /// The BackupPlan is in the process of being deleted.
-        pub const DELETING: State = State::new("DELETING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1875,40 +1919,55 @@ pub mod volume_type_enum {
 
     /// Supported volume types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VolumeType(std::borrow::Cow<'static, str>);
+    pub struct VolumeType(i32);
 
     impl VolumeType {
+        /// Default
+        pub const VOLUME_TYPE_UNSPECIFIED: VolumeType = VolumeType::new(0);
+
+        /// Compute Engine Persistent Disk volume
+        pub const GCE_PERSISTENT_DISK: VolumeType = VolumeType::new(1);
+
         /// Creates a new VolumeType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VOLUME_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GCE_PERSISTENT_DISK"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VOLUME_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::VOLUME_TYPE_UNSPECIFIED)
+                }
+                "GCE_PERSISTENT_DISK" => std::option::Option::Some(Self::GCE_PERSISTENT_DISK),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [VolumeType](VolumeType)
-    pub mod volume_type {
-        use super::VolumeType;
-
-        /// Default
-        pub const VOLUME_TYPE_UNSPECIFIED: VolumeType = VolumeType::new("VOLUME_TYPE_UNSPECIFIED");
-
-        /// Compute Engine Persistent Disk volume
-        pub const GCE_PERSISTENT_DISK: VolumeType = VolumeType::new("GCE_PERSISTENT_DISK");
-    }
-
-    impl std::convert::From<std::string::String> for VolumeType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for VolumeType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for VolumeType {
         fn default() -> Self {
-            volume_type::VOLUME_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4179,55 +4238,76 @@ pub mod restore {
 
     /// Possible values for state of the Restore.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The Restore resource is in the process of being created.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The Restore resource has been created and the associated RestoreJob
         /// Kubernetes resource has been injected into target cluster.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The gkebackup agent in the cluster has begun executing the restore
         /// operation.
-        pub const IN_PROGRESS: State = State::new("IN_PROGRESS");
+        pub const IN_PROGRESS: State = State::new(2);
 
         /// The restore operation has completed successfully. Restored workloads may
         /// not yet be operational.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
+        pub const SUCCEEDED: State = State::new(3);
 
         /// The restore operation has failed.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(4);
 
         /// This Restore resource is in the process of being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                5 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4912,37 +4992,22 @@ pub mod restore_config {
 
         /// Possible values for operations of a transformation rule action.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Op(std::borrow::Cow<'static, str>);
+        pub struct Op(i32);
 
         impl Op {
-            /// Creates a new Op instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [Op](Op)
-        pub mod op {
-            use super::Op;
-
             /// Unspecified operation
-            pub const OP_UNSPECIFIED: Op = Op::new("OP_UNSPECIFIED");
+            pub const OP_UNSPECIFIED: Op = Op::new(0);
 
             /// The "remove" operation removes the value at the target location.
-            pub const REMOVE: Op = Op::new("REMOVE");
+            pub const REMOVE: Op = Op::new(1);
 
             /// The "move" operation removes the value at a specified location and
             /// adds it to the target location.
-            pub const MOVE: Op = Op::new("MOVE");
+            pub const MOVE: Op = Op::new(2);
 
             /// The "copy" operation copies the value at a specified location to the
             /// target location.
-            pub const COPY: Op = Op::new("COPY");
+            pub const COPY: Op = Op::new(3);
 
             /// The "add" operation performs one of the following functions,
             /// depending upon what the target location references:
@@ -4953,27 +5018,65 @@ pub mod restore_config {
             ///   already exist, a new member is added to the object.
             /// . If the target location specifies an object member that does exist,
             ///   that member's value is replaced.
-            pub const ADD: Op = Op::new("ADD");
+            pub const ADD: Op = Op::new(4);
 
             /// The "test" operation tests that a value at the target location is
             /// equal to a specified value.
-            pub const TEST: Op = Op::new("TEST");
+            pub const TEST: Op = Op::new(5);
 
             /// The "replace" operation replaces the value at the target location
             /// with a new value.  The operation object MUST contain a "value" member
             /// whose content specifies the replacement value.
-            pub const REPLACE: Op = Op::new("REPLACE");
+            pub const REPLACE: Op = Op::new(6);
+
+            /// Creates a new Op instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("OP_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("REMOVE"),
+                    2 => std::borrow::Cow::Borrowed("MOVE"),
+                    3 => std::borrow::Cow::Borrowed("COPY"),
+                    4 => std::borrow::Cow::Borrowed("ADD"),
+                    5 => std::borrow::Cow::Borrowed("TEST"),
+                    6 => std::borrow::Cow::Borrowed("REPLACE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "OP_UNSPECIFIED" => std::option::Option::Some(Self::OP_UNSPECIFIED),
+                    "REMOVE" => std::option::Option::Some(Self::REMOVE),
+                    "MOVE" => std::option::Option::Some(Self::MOVE),
+                    "COPY" => std::option::Option::Some(Self::COPY),
+                    "ADD" => std::option::Option::Some(Self::ADD),
+                    "TEST" => std::option::Option::Some(Self::TEST),
+                    "REPLACE" => std::option::Option::Some(Self::REPLACE),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for Op {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Op {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Op {
             fn default() -> Self {
-                op::OP_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -5317,133 +5420,160 @@ pub mod restore_config {
 
     /// Defines how volume data should be restored.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VolumeDataRestorePolicy(std::borrow::Cow<'static, str>);
+    pub struct VolumeDataRestorePolicy(i32);
 
     impl VolumeDataRestorePolicy {
-        /// Creates a new VolumeDataRestorePolicy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [VolumeDataRestorePolicy](VolumeDataRestorePolicy)
-    pub mod volume_data_restore_policy {
-        use super::VolumeDataRestorePolicy;
-
         /// Unspecified (illegal).
         pub const VOLUME_DATA_RESTORE_POLICY_UNSPECIFIED: VolumeDataRestorePolicy =
-            VolumeDataRestorePolicy::new("VOLUME_DATA_RESTORE_POLICY_UNSPECIFIED");
+            VolumeDataRestorePolicy::new(0);
 
         /// For each PVC to be restored, create a new underlying volume and PV
         /// from the corresponding VolumeBackup contained within the Backup.
         pub const RESTORE_VOLUME_DATA_FROM_BACKUP: VolumeDataRestorePolicy =
-            VolumeDataRestorePolicy::new("RESTORE_VOLUME_DATA_FROM_BACKUP");
+            VolumeDataRestorePolicy::new(1);
 
         /// For each PVC to be restored, attempt to reuse the original PV contained
         /// in the Backup (with its original underlying volume). This option
         /// is likely only usable when restoring a workload to its original cluster.
         pub const REUSE_VOLUME_HANDLE_FROM_BACKUP: VolumeDataRestorePolicy =
-            VolumeDataRestorePolicy::new("REUSE_VOLUME_HANDLE_FROM_BACKUP");
+            VolumeDataRestorePolicy::new(2);
 
         /// For each PVC to be restored, create PVC without any particular
         /// action to restore data. In this case, the normal Kubernetes provisioning
         /// logic would kick in, and this would likely result in either dynamically
         /// provisioning blank PVs or binding to statically provisioned PVs.
         pub const NO_VOLUME_DATA_RESTORATION: VolumeDataRestorePolicy =
-            VolumeDataRestorePolicy::new("NO_VOLUME_DATA_RESTORATION");
+            VolumeDataRestorePolicy::new(3);
+
+        /// Creates a new VolumeDataRestorePolicy instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VOLUME_DATA_RESTORE_POLICY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RESTORE_VOLUME_DATA_FROM_BACKUP"),
+                2 => std::borrow::Cow::Borrowed("REUSE_VOLUME_HANDLE_FROM_BACKUP"),
+                3 => std::borrow::Cow::Borrowed("NO_VOLUME_DATA_RESTORATION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VOLUME_DATA_RESTORE_POLICY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::VOLUME_DATA_RESTORE_POLICY_UNSPECIFIED)
+                }
+                "RESTORE_VOLUME_DATA_FROM_BACKUP" => {
+                    std::option::Option::Some(Self::RESTORE_VOLUME_DATA_FROM_BACKUP)
+                }
+                "REUSE_VOLUME_HANDLE_FROM_BACKUP" => {
+                    std::option::Option::Some(Self::REUSE_VOLUME_HANDLE_FROM_BACKUP)
+                }
+                "NO_VOLUME_DATA_RESTORATION" => {
+                    std::option::Option::Some(Self::NO_VOLUME_DATA_RESTORATION)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for VolumeDataRestorePolicy {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for VolumeDataRestorePolicy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for VolumeDataRestorePolicy {
         fn default() -> Self {
-            volume_data_restore_policy::VOLUME_DATA_RESTORE_POLICY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Defines the behavior for handling the situation where cluster-scoped
     /// resources being restored already exist in the target cluster.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ClusterResourceConflictPolicy(std::borrow::Cow<'static, str>);
+    pub struct ClusterResourceConflictPolicy(i32);
 
     impl ClusterResourceConflictPolicy {
-        /// Creates a new ClusterResourceConflictPolicy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ClusterResourceConflictPolicy](ClusterResourceConflictPolicy)
-    pub mod cluster_resource_conflict_policy {
-        use super::ClusterResourceConflictPolicy;
-
         /// Unspecified. Only allowed if no cluster-scoped resources will be
         /// restored.
         pub const CLUSTER_RESOURCE_CONFLICT_POLICY_UNSPECIFIED: ClusterResourceConflictPolicy =
-            ClusterResourceConflictPolicy::new("CLUSTER_RESOURCE_CONFLICT_POLICY_UNSPECIFIED");
+            ClusterResourceConflictPolicy::new(0);
 
         /// Do not attempt to restore the conflicting resource.
         pub const USE_EXISTING_VERSION: ClusterResourceConflictPolicy =
-            ClusterResourceConflictPolicy::new("USE_EXISTING_VERSION");
+            ClusterResourceConflictPolicy::new(1);
 
         /// Delete the existing version before re-creating it from the Backup.
         /// This is a dangerous option which could cause unintentional
         /// data loss if used inappropriately. For example, deleting a CRD will
         /// cause Kubernetes to delete all CRs of that type.
         pub const USE_BACKUP_VERSION: ClusterResourceConflictPolicy =
-            ClusterResourceConflictPolicy::new("USE_BACKUP_VERSION");
+            ClusterResourceConflictPolicy::new(2);
+
+        /// Creates a new ClusterResourceConflictPolicy instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CLUSTER_RESOURCE_CONFLICT_POLICY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("USE_EXISTING_VERSION"),
+                2 => std::borrow::Cow::Borrowed("USE_BACKUP_VERSION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CLUSTER_RESOURCE_CONFLICT_POLICY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CLUSTER_RESOURCE_CONFLICT_POLICY_UNSPECIFIED)
+                }
+                "USE_EXISTING_VERSION" => std::option::Option::Some(Self::USE_EXISTING_VERSION),
+                "USE_BACKUP_VERSION" => std::option::Option::Some(Self::USE_BACKUP_VERSION),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ClusterResourceConflictPolicy {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ClusterResourceConflictPolicy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ClusterResourceConflictPolicy {
         fn default() -> Self {
-            cluster_resource_conflict_policy::CLUSTER_RESOURCE_CONFLICT_POLICY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Defines the behavior for handling the situation where sets of namespaced
     /// resources being restored already exist in the target cluster.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NamespacedResourceRestoreMode(std::borrow::Cow<'static, str>);
+    pub struct NamespacedResourceRestoreMode(i32);
 
     impl NamespacedResourceRestoreMode {
-        /// Creates a new NamespacedResourceRestoreMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [NamespacedResourceRestoreMode](NamespacedResourceRestoreMode)
-    pub mod namespaced_resource_restore_mode {
-        use super::NamespacedResourceRestoreMode;
-
         /// Unspecified (invalid).
         pub const NAMESPACED_RESOURCE_RESTORE_MODE_UNSPECIFIED: NamespacedResourceRestoreMode =
-            NamespacedResourceRestoreMode::new("NAMESPACED_RESOURCE_RESTORE_MODE_UNSPECIFIED");
+            NamespacedResourceRestoreMode::new(0);
 
         /// When conflicting top-level resources (either Namespaces or
         /// ProtectedApplications, depending upon the scope) are encountered, this
@@ -5453,7 +5583,7 @@ pub mod restore_config {
         /// resources from the Backup. This mode should only be used when you are
         /// intending to revert some portion of a cluster to an earlier state.
         pub const DELETE_AND_RESTORE: NamespacedResourceRestoreMode =
-            NamespacedResourceRestoreMode::new("DELETE_AND_RESTORE");
+            NamespacedResourceRestoreMode::new(1);
 
         /// If conflicting top-level resources (either Namespaces or
         /// ProtectedApplications, depending upon the scope) are encountered at the
@@ -5461,14 +5591,14 @@ pub mod restore_config {
         /// occurs during the restore process itself (e.g., because an out of band
         /// process creates conflicting resources), a conflict will be reported.
         pub const FAIL_ON_CONFLICT: NamespacedResourceRestoreMode =
-            NamespacedResourceRestoreMode::new("FAIL_ON_CONFLICT");
+            NamespacedResourceRestoreMode::new(2);
 
         /// This mode merges the backup and the target cluster and skips the
         /// conflicting resources. If a single resource to restore exists in the
         /// cluster before restoration, the resource will be skipped, otherwise it
         /// will be restored.
         pub const MERGE_SKIP_ON_CONFLICT: NamespacedResourceRestoreMode =
-            NamespacedResourceRestoreMode::new("MERGE_SKIP_ON_CONFLICT");
+            NamespacedResourceRestoreMode::new(3);
 
         /// This mode merges the backup and the target cluster and skips the
         /// conflicting resources except volume data. If a PVC to restore already
@@ -5485,7 +5615,7 @@ pub mod restore_config {
         ///   Note that this mode could cause data loss as the original PV can be
         ///   retained or deleted depending on its reclaim policy.
         pub const MERGE_REPLACE_VOLUME_ON_CONFLICT: NamespacedResourceRestoreMode =
-            NamespacedResourceRestoreMode::new("MERGE_REPLACE_VOLUME_ON_CONFLICT");
+            NamespacedResourceRestoreMode::new(4);
 
         /// This mode merges the backup and the target cluster and replaces the
         /// conflicting resources with the ones in the backup. If a single resource
@@ -5498,18 +5628,60 @@ pub mod restore_config {
         /// resources in the target cluster, and the original PV can be retained or
         /// deleted depending on its reclaim policy.
         pub const MERGE_REPLACE_ON_CONFLICT: NamespacedResourceRestoreMode =
-            NamespacedResourceRestoreMode::new("MERGE_REPLACE_ON_CONFLICT");
+            NamespacedResourceRestoreMode::new(5);
+
+        /// Creates a new NamespacedResourceRestoreMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("NAMESPACED_RESOURCE_RESTORE_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DELETE_AND_RESTORE"),
+                2 => std::borrow::Cow::Borrowed("FAIL_ON_CONFLICT"),
+                3 => std::borrow::Cow::Borrowed("MERGE_SKIP_ON_CONFLICT"),
+                4 => std::borrow::Cow::Borrowed("MERGE_REPLACE_VOLUME_ON_CONFLICT"),
+                5 => std::borrow::Cow::Borrowed("MERGE_REPLACE_ON_CONFLICT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "NAMESPACED_RESOURCE_RESTORE_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::NAMESPACED_RESOURCE_RESTORE_MODE_UNSPECIFIED)
+                }
+                "DELETE_AND_RESTORE" => std::option::Option::Some(Self::DELETE_AND_RESTORE),
+                "FAIL_ON_CONFLICT" => std::option::Option::Some(Self::FAIL_ON_CONFLICT),
+                "MERGE_SKIP_ON_CONFLICT" => std::option::Option::Some(Self::MERGE_SKIP_ON_CONFLICT),
+                "MERGE_REPLACE_VOLUME_ON_CONFLICT" => {
+                    std::option::Option::Some(Self::MERGE_REPLACE_VOLUME_ON_CONFLICT)
+                }
+                "MERGE_REPLACE_ON_CONFLICT" => {
+                    std::option::Option::Some(Self::MERGE_REPLACE_ON_CONFLICT)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for NamespacedResourceRestoreMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for NamespacedResourceRestoreMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for NamespacedResourceRestoreMode {
         fn default() -> Self {
-            namespaced_resource_restore_mode::NAMESPACED_RESOURCE_RESTORE_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -5920,49 +6092,68 @@ pub mod restore_plan {
 
     /// State
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Default first value for Enums.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Waiting for cluster state to be RUNNING.
+        pub const CLUSTER_PENDING: State = State::new(1);
+
+        /// The RestorePlan has successfully been created and is ready for Restores.
+        pub const READY: State = State::new(2);
+
+        /// RestorePlan creation has failed.
+        pub const FAILED: State = State::new(3);
+
+        /// The RestorePlan is in the process of being deleted.
+        pub const DELETING: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CLUSTER_PENDING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CLUSTER_PENDING" => std::option::Option::Some(Self::CLUSTER_PENDING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Default first value for Enums.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Waiting for cluster state to be RUNNING.
-        pub const CLUSTER_PENDING: State = State::new("CLUSTER_PENDING");
-
-        /// The RestorePlan has successfully been created and is ready for Restores.
-        pub const READY: State = State::new("READY");
-
-        /// RestorePlan creation has failed.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// The RestorePlan is in the process of being deleted.
-        pub const DELETING: State = State::new("DELETING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6163,102 +6354,138 @@ pub mod volume_backup {
 
     /// Identifies the format used for the volume backup.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VolumeBackupFormat(std::borrow::Cow<'static, str>);
+    pub struct VolumeBackupFormat(i32);
 
     impl VolumeBackupFormat {
+        /// Default value, not specified.
+        pub const VOLUME_BACKUP_FORMAT_UNSPECIFIED: VolumeBackupFormat = VolumeBackupFormat::new(0);
+
+        /// Compute Engine Persistent Disk snapshot based volume backup.
+        pub const GCE_PERSISTENT_DISK: VolumeBackupFormat = VolumeBackupFormat::new(1);
+
         /// Creates a new VolumeBackupFormat instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VOLUME_BACKUP_FORMAT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GCE_PERSISTENT_DISK"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VOLUME_BACKUP_FORMAT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::VOLUME_BACKUP_FORMAT_UNSPECIFIED)
+                }
+                "GCE_PERSISTENT_DISK" => std::option::Option::Some(Self::GCE_PERSISTENT_DISK),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [VolumeBackupFormat](VolumeBackupFormat)
-    pub mod volume_backup_format {
-        use super::VolumeBackupFormat;
-
-        /// Default value, not specified.
-        pub const VOLUME_BACKUP_FORMAT_UNSPECIFIED: VolumeBackupFormat =
-            VolumeBackupFormat::new("VOLUME_BACKUP_FORMAT_UNSPECIFIED");
-
-        /// Compute Engine Persistent Disk snapshot based volume backup.
-        pub const GCE_PERSISTENT_DISK: VolumeBackupFormat =
-            VolumeBackupFormat::new("GCE_PERSISTENT_DISK");
-    }
-
-    impl std::convert::From<std::string::String> for VolumeBackupFormat {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for VolumeBackupFormat {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for VolumeBackupFormat {
         fn default() -> Self {
-            volume_backup_format::VOLUME_BACKUP_FORMAT_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The current state of a VolumeBackup
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// This is an illegal state and should not be encountered.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// A volume for the backup was identified and backup process is about to
         /// start.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The volume backup operation has begun and is in the initial "snapshot"
         /// phase of the process. Any defined ProtectedApplication "pre" hooks will
         /// be executed before entering this state and "post" hooks will be executed
         /// upon leaving this state.
-        pub const SNAPSHOTTING: State = State::new("SNAPSHOTTING");
+        pub const SNAPSHOTTING: State = State::new(2);
 
         /// The snapshot phase of the volume backup operation has completed and
         /// the snapshot is now being uploaded to backup storage.
-        pub const UPLOADING: State = State::new("UPLOADING");
+        pub const UPLOADING: State = State::new(3);
 
         /// The volume backup operation has completed successfully.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
+        pub const SUCCEEDED: State = State::new(4);
 
         /// The volume backup operation has failed.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(5);
 
         /// This VolumeBackup resource (and its associated artifacts) is in the
         /// process of being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(6);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("SNAPSHOTTING"),
+                3 => std::borrow::Cow::Borrowed("UPLOADING"),
+                4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                5 => std::borrow::Cow::Borrowed("FAILED"),
+                6 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "SNAPSHOTTING" => std::option::Option::Some(Self::SNAPSHOTTING),
+                "UPLOADING" => std::option::Option::Some(Self::UPLOADING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6440,92 +6667,128 @@ pub mod volume_restore {
 
     /// Supported volume types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VolumeType(std::borrow::Cow<'static, str>);
+    pub struct VolumeType(i32);
 
     impl VolumeType {
+        /// Default
+        pub const VOLUME_TYPE_UNSPECIFIED: VolumeType = VolumeType::new(0);
+
+        /// Compute Engine Persistent Disk volume
+        pub const GCE_PERSISTENT_DISK: VolumeType = VolumeType::new(1);
+
         /// Creates a new VolumeType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VOLUME_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GCE_PERSISTENT_DISK"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VOLUME_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::VOLUME_TYPE_UNSPECIFIED)
+                }
+                "GCE_PERSISTENT_DISK" => std::option::Option::Some(Self::GCE_PERSISTENT_DISK),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [VolumeType](VolumeType)
-    pub mod volume_type {
-        use super::VolumeType;
-
-        /// Default
-        pub const VOLUME_TYPE_UNSPECIFIED: VolumeType = VolumeType::new("VOLUME_TYPE_UNSPECIFIED");
-
-        /// Compute Engine Persistent Disk volume
-        pub const GCE_PERSISTENT_DISK: VolumeType = VolumeType::new("GCE_PERSISTENT_DISK");
-    }
-
-    impl std::convert::From<std::string::String> for VolumeType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for VolumeType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for VolumeType {
         fn default() -> Self {
-            volume_type::VOLUME_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The current state of a VolumeRestore
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// This is an illegal state and should not be encountered.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// A volume for the restore was identified and restore process is about to
         /// start.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The volume is currently being restored.
-        pub const RESTORING: State = State::new("RESTORING");
+        pub const RESTORING: State = State::new(2);
 
         /// The volume has been successfully restored.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
+        pub const SUCCEEDED: State = State::new(3);
 
         /// The volume restoration process failed.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(4);
 
         /// This VolumeRestore resource is in the process of being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("RESTORING"),
+                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                5 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "RESTORING" => std::option::Option::Some(Self::RESTORING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/gkebackup/v1/src/transport.rs
+++ b/src/generated/cloud/gkebackup/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
                 reqwest::Method::POST,
                 format!("/v1/{}/backupPlans", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
                 reqwest::Method::GET,
                 format!("/v1/{}/backupPlans", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -98,7 +98,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -126,7 +126,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -155,7 +155,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -175,7 +175,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/backups", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -193,7 +193,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/backups", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -216,7 +216,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -244,7 +244,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -271,7 +271,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -295,7 +295,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
                 reqwest::Method::GET,
                 format!("/v1/{}/volumeBackups", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -318,7 +318,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -340,7 +340,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
                 reqwest::Method::POST,
                 format!("/v1/{}/restorePlans", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -363,7 +363,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
                 reqwest::Method::GET,
                 format!("/v1/{}/restorePlans", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -386,7 +386,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -414,7 +414,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -443,7 +443,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -467,7 +467,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
                 reqwest::Method::POST,
                 format!("/v1/{}/restores", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -487,7 +487,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/restores", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -510,7 +510,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -538,7 +538,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -567,7 +567,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -591,7 +591,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
                 reqwest::Method::GET,
                 format!("/v1/{}/volumeRestores", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -614,7 +614,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -636,7 +636,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
                 reqwest::Method::GET,
                 format!("/v1/{}:getBackupIndexDownloadUrl", req.backup),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -655,7 +655,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -677,7 +677,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -699,7 +699,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -719,7 +719,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -751,7 +751,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -768,7 +768,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -790,7 +790,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -809,7 +809,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -828,7 +828,7 @@ impl crate::stubs::BackupForGKE for BackupForGKE {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/gkeconnect/gateway/v1/src/model.rs
+++ b/src/generated/cloud/gkeconnect/gateway/v1/src/model.rs
@@ -122,44 +122,59 @@ pub mod generate_credentials_request {
 
     /// Operating systems requiring specialized kubeconfigs.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OperatingSystem(std::borrow::Cow<'static, str>);
+    pub struct OperatingSystem(i32);
 
     impl OperatingSystem {
-        /// Creates a new OperatingSystem instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [OperatingSystem](OperatingSystem)
-    pub mod operating_system {
-        use super::OperatingSystem;
-
         /// Generates a kubeconfig that works for all operating systems not defined
         /// below.
-        pub const OPERATING_SYSTEM_UNSPECIFIED: OperatingSystem =
-            OperatingSystem::new("OPERATING_SYSTEM_UNSPECIFIED");
+        pub const OPERATING_SYSTEM_UNSPECIFIED: OperatingSystem = OperatingSystem::new(0);
 
         /// Generates a kubeconfig that is specifically designed to work with
         /// Windows.
-        pub const OPERATING_SYSTEM_WINDOWS: OperatingSystem =
-            OperatingSystem::new("OPERATING_SYSTEM_WINDOWS");
+        pub const OPERATING_SYSTEM_WINDOWS: OperatingSystem = OperatingSystem::new(1);
+
+        /// Creates a new OperatingSystem instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("OPERATING_SYSTEM_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("OPERATING_SYSTEM_WINDOWS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "OPERATING_SYSTEM_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::OPERATING_SYSTEM_UNSPECIFIED)
+                }
+                "OPERATING_SYSTEM_WINDOWS" => {
+                    std::option::Option::Some(Self::OPERATING_SYSTEM_WINDOWS)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for OperatingSystem {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for OperatingSystem {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for OperatingSystem {
         fn default() -> Self {
-            operating_system::OPERATING_SYSTEM_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/gkeconnect/gateway/v1/src/transport.rs
+++ b/src/generated/cloud/gkeconnect/gateway/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::GatewayControl for GatewayControl {
                 reqwest::Method::GET,
                 format!("/v1/{}:generateCredentials", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/gkehub/configmanagement/v1/src/model.rs
+++ b/src/generated/cloud/gkehub/configmanagement/v1/src/model.rs
@@ -238,43 +238,58 @@ pub mod membership_spec {
 
     /// Whether to automatically manage the Feature.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Management(std::borrow::Cow<'static, str>);
+    pub struct Management(i32);
 
     impl Management {
+        /// Unspecified
+        pub const MANAGEMENT_UNSPECIFIED: Management = Management::new(0);
+
+        /// Google will manage the Feature for the cluster.
+        pub const MANAGEMENT_AUTOMATIC: Management = Management::new(1);
+
+        /// User will manually manage the Feature for the cluster.
+        pub const MANAGEMENT_MANUAL: Management = Management::new(2);
+
         /// Creates a new Management instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MANAGEMENT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MANAGEMENT_AUTOMATIC"),
+                2 => std::borrow::Cow::Borrowed("MANAGEMENT_MANUAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MANAGEMENT_UNSPECIFIED" => std::option::Option::Some(Self::MANAGEMENT_UNSPECIFIED),
+                "MANAGEMENT_AUTOMATIC" => std::option::Option::Some(Self::MANAGEMENT_AUTOMATIC),
+                "MANAGEMENT_MANUAL" => std::option::Option::Some(Self::MANAGEMENT_MANUAL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Management](Management)
-    pub mod management {
-        use super::Management;
-
-        /// Unspecified
-        pub const MANAGEMENT_UNSPECIFIED: Management = Management::new("MANAGEMENT_UNSPECIFIED");
-
-        /// Google will manage the Feature for the cluster.
-        pub const MANAGEMENT_AUTOMATIC: Management = Management::new("MANAGEMENT_AUTOMATIC");
-
-        /// User will manually manage the Feature for the cluster.
-        pub const MANAGEMENT_MANUAL: Management = Management::new("MANAGEMENT_MANUAL");
-    }
-
-    impl std::convert::From<std::string::String> for Management {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Management {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Management {
         fn default() -> Self {
-            management::MANAGEMENT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1038,96 +1053,136 @@ pub mod config_sync_state {
 
     /// CRDState representing the state of a CRD
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CRDState(std::borrow::Cow<'static, str>);
+    pub struct CRDState(i32);
 
     impl CRDState {
+        /// CRD's state cannot be determined
+        pub const CRD_STATE_UNSPECIFIED: CRDState = CRDState::new(0);
+
+        /// CRD is not installed
+        pub const NOT_INSTALLED: CRDState = CRDState::new(1);
+
+        /// CRD is installed
+        pub const INSTALLED: CRDState = CRDState::new(2);
+
+        /// CRD is terminating (i.e., it has been deleted and is cleaning up)
+        pub const TERMINATING: CRDState = CRDState::new(3);
+
+        /// CRD is installing
+        pub const INSTALLING: CRDState = CRDState::new(4);
+
         /// Creates a new CRDState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CRD_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NOT_INSTALLED"),
+                2 => std::borrow::Cow::Borrowed("INSTALLED"),
+                3 => std::borrow::Cow::Borrowed("TERMINATING"),
+                4 => std::borrow::Cow::Borrowed("INSTALLING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CRD_STATE_UNSPECIFIED" => std::option::Option::Some(Self::CRD_STATE_UNSPECIFIED),
+                "NOT_INSTALLED" => std::option::Option::Some(Self::NOT_INSTALLED),
+                "INSTALLED" => std::option::Option::Some(Self::INSTALLED),
+                "TERMINATING" => std::option::Option::Some(Self::TERMINATING),
+                "INSTALLING" => std::option::Option::Some(Self::INSTALLING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [CRDState](CRDState)
-    pub mod crd_state {
-        use super::CRDState;
-
-        /// CRD's state cannot be determined
-        pub const CRD_STATE_UNSPECIFIED: CRDState = CRDState::new("CRD_STATE_UNSPECIFIED");
-
-        /// CRD is not installed
-        pub const NOT_INSTALLED: CRDState = CRDState::new("NOT_INSTALLED");
-
-        /// CRD is installed
-        pub const INSTALLED: CRDState = CRDState::new("INSTALLED");
-
-        /// CRD is terminating (i.e., it has been deleted and is cleaning up)
-        pub const TERMINATING: CRDState = CRDState::new("TERMINATING");
-
-        /// CRD is installing
-        pub const INSTALLING: CRDState = CRDState::new("INSTALLING");
-    }
-
-    impl std::convert::From<std::string::String> for CRDState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CRDState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CRDState {
         fn default() -> Self {
-            crd_state::CRD_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// CS's state cannot be determined.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// CS is not installed.
+        pub const CONFIG_SYNC_NOT_INSTALLED: State = State::new(1);
+
+        /// The expected CS version is installed successfully.
+        pub const CONFIG_SYNC_INSTALLED: State = State::new(2);
+
+        /// CS encounters errors.
+        pub const CONFIG_SYNC_ERROR: State = State::new(3);
+
+        /// CS is installing or terminating.
+        pub const CONFIG_SYNC_PENDING: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CONFIG_SYNC_NOT_INSTALLED"),
+                2 => std::borrow::Cow::Borrowed("CONFIG_SYNC_INSTALLED"),
+                3 => std::borrow::Cow::Borrowed("CONFIG_SYNC_ERROR"),
+                4 => std::borrow::Cow::Borrowed("CONFIG_SYNC_PENDING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CONFIG_SYNC_NOT_INSTALLED" => {
+                    std::option::Option::Some(Self::CONFIG_SYNC_NOT_INSTALLED)
+                }
+                "CONFIG_SYNC_INSTALLED" => std::option::Option::Some(Self::CONFIG_SYNC_INSTALLED),
+                "CONFIG_SYNC_ERROR" => std::option::Option::Some(Self::CONFIG_SYNC_ERROR),
+                "CONFIG_SYNC_PENDING" => std::option::Option::Some(Self::CONFIG_SYNC_PENDING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// CS's state cannot be determined.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// CS is not installed.
-        pub const CONFIG_SYNC_NOT_INSTALLED: State = State::new("CONFIG_SYNC_NOT_INSTALLED");
-
-        /// The expected CS version is installed successfully.
-        pub const CONFIG_SYNC_INSTALLED: State = State::new("CONFIG_SYNC_INSTALLED");
-
-        /// CS encounters errors.
-        pub const CONFIG_SYNC_ERROR: State = State::new("CONFIG_SYNC_ERROR");
-
-        /// CS is installing or terminating.
-        pub const CONFIG_SYNC_PENDING: State = State::new("CONFIG_SYNC_PENDING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1469,58 +1524,83 @@ pub mod sync_state {
 
     /// An enum representing Config Sync's status of syncing configs to a cluster.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SyncCode(std::borrow::Cow<'static, str>);
+    pub struct SyncCode(i32);
 
     impl SyncCode {
+        /// Config Sync cannot determine a sync code
+        pub const SYNC_CODE_UNSPECIFIED: SyncCode = SyncCode::new(0);
+
+        /// Config Sync successfully synced the git Repo with the cluster
+        pub const SYNCED: SyncCode = SyncCode::new(1);
+
+        /// Config Sync is in the progress of syncing a new change
+        pub const PENDING: SyncCode = SyncCode::new(2);
+
+        /// Indicates an error configuring Config Sync, and user action is required
+        pub const ERROR: SyncCode = SyncCode::new(3);
+
+        /// Config Sync has been installed but not configured
+        pub const NOT_CONFIGURED: SyncCode = SyncCode::new(4);
+
+        /// Config Sync has not been installed
+        pub const NOT_INSTALLED: SyncCode = SyncCode::new(5);
+
+        /// Error authorizing with the cluster
+        pub const UNAUTHORIZED: SyncCode = SyncCode::new(6);
+
+        /// Cluster could not be reached
+        pub const UNREACHABLE: SyncCode = SyncCode::new(7);
+
         /// Creates a new SyncCode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SYNC_CODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SYNCED"),
+                2 => std::borrow::Cow::Borrowed("PENDING"),
+                3 => std::borrow::Cow::Borrowed("ERROR"),
+                4 => std::borrow::Cow::Borrowed("NOT_CONFIGURED"),
+                5 => std::borrow::Cow::Borrowed("NOT_INSTALLED"),
+                6 => std::borrow::Cow::Borrowed("UNAUTHORIZED"),
+                7 => std::borrow::Cow::Borrowed("UNREACHABLE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SYNC_CODE_UNSPECIFIED" => std::option::Option::Some(Self::SYNC_CODE_UNSPECIFIED),
+                "SYNCED" => std::option::Option::Some(Self::SYNCED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "NOT_CONFIGURED" => std::option::Option::Some(Self::NOT_CONFIGURED),
+                "NOT_INSTALLED" => std::option::Option::Some(Self::NOT_INSTALLED),
+                "UNAUTHORIZED" => std::option::Option::Some(Self::UNAUTHORIZED),
+                "UNREACHABLE" => std::option::Option::Some(Self::UNREACHABLE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SyncCode](SyncCode)
-    pub mod sync_code {
-        use super::SyncCode;
-
-        /// Config Sync cannot determine a sync code
-        pub const SYNC_CODE_UNSPECIFIED: SyncCode = SyncCode::new("SYNC_CODE_UNSPECIFIED");
-
-        /// Config Sync successfully synced the git Repo with the cluster
-        pub const SYNCED: SyncCode = SyncCode::new("SYNCED");
-
-        /// Config Sync is in the progress of syncing a new change
-        pub const PENDING: SyncCode = SyncCode::new("PENDING");
-
-        /// Indicates an error configuring Config Sync, and user action is required
-        pub const ERROR: SyncCode = SyncCode::new("ERROR");
-
-        /// Config Sync has been installed but not configured
-        pub const NOT_CONFIGURED: SyncCode = SyncCode::new("NOT_CONFIGURED");
-
-        /// Config Sync has not been installed
-        pub const NOT_INSTALLED: SyncCode = SyncCode::new("NOT_INSTALLED");
-
-        /// Error authorizing with the cluster
-        pub const UNAUTHORIZED: SyncCode = SyncCode::new("UNAUTHORIZED");
-
-        /// Cluster could not be reached
-        pub const UNREACHABLE: SyncCode = SyncCode::new("UNREACHABLE");
-    }
-
-    impl std::convert::From<std::string::String> for SyncCode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SyncCode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SyncCode {
         fn default() -> Self {
-            sync_code::SYNC_CODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1821,49 +1901,69 @@ impl wkt::message::Message for GatekeeperDeploymentState {
 
 /// Enum representing the state of an ACM's deployment on a cluster
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DeploymentState(std::borrow::Cow<'static, str>);
+pub struct DeploymentState(i32);
 
 impl DeploymentState {
+    /// Deployment's state cannot be determined
+    pub const DEPLOYMENT_STATE_UNSPECIFIED: DeploymentState = DeploymentState::new(0);
+
+    /// Deployment is not installed
+    pub const NOT_INSTALLED: DeploymentState = DeploymentState::new(1);
+
+    /// Deployment is installed
+    pub const INSTALLED: DeploymentState = DeploymentState::new(2);
+
+    /// Deployment was attempted to be installed, but has errors
+    pub const ERROR: DeploymentState = DeploymentState::new(3);
+
+    /// Deployment is installing or terminating
+    pub const PENDING: DeploymentState = DeploymentState::new(4);
+
     /// Creates a new DeploymentState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DEPLOYMENT_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("NOT_INSTALLED"),
+            2 => std::borrow::Cow::Borrowed("INSTALLED"),
+            3 => std::borrow::Cow::Borrowed("ERROR"),
+            4 => std::borrow::Cow::Borrowed("PENDING"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DEPLOYMENT_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::DEPLOYMENT_STATE_UNSPECIFIED)
+            }
+            "NOT_INSTALLED" => std::option::Option::Some(Self::NOT_INSTALLED),
+            "INSTALLED" => std::option::Option::Some(Self::INSTALLED),
+            "ERROR" => std::option::Option::Some(Self::ERROR),
+            "PENDING" => std::option::Option::Some(Self::PENDING),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [DeploymentState](DeploymentState)
-pub mod deployment_state {
-    use super::DeploymentState;
-
-    /// Deployment's state cannot be determined
-    pub const DEPLOYMENT_STATE_UNSPECIFIED: DeploymentState =
-        DeploymentState::new("DEPLOYMENT_STATE_UNSPECIFIED");
-
-    /// Deployment is not installed
-    pub const NOT_INSTALLED: DeploymentState = DeploymentState::new("NOT_INSTALLED");
-
-    /// Deployment is installed
-    pub const INSTALLED: DeploymentState = DeploymentState::new("INSTALLED");
-
-    /// Deployment was attempted to be installed, but has errors
-    pub const ERROR: DeploymentState = DeploymentState::new("ERROR");
-
-    /// Deployment is installing or terminating
-    pub const PENDING: DeploymentState = DeploymentState::new("PENDING");
-}
-
-impl std::convert::From<std::string::String> for DeploymentState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DeploymentState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DeploymentState {
     fn default() -> Self {
-        deployment_state::DEPLOYMENT_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/gkehub/v1/src/model.rs
+++ b/src/generated/cloud/gkehub/v1/src/model.rs
@@ -265,55 +265,76 @@ pub mod feature_resource_state {
 
     /// State describes the lifecycle status of a Feature.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// State is unknown or not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The Feature is being enabled, and the Feature resource is being created.
         /// Once complete, the corresponding Feature will be enabled in this Hub.
-        pub const ENABLING: State = State::new("ENABLING");
+        pub const ENABLING: State = State::new(1);
 
         /// The Feature is enabled in this Hub, and the Feature resource is fully
         /// available.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(2);
 
         /// The Feature is being disabled in this Hub, and the Feature resource
         /// is being deleted.
-        pub const DISABLING: State = State::new("DISABLING");
+        pub const DISABLING: State = State::new(3);
 
         /// The Feature resource is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(4);
 
         /// The Feature resource is being updated by the Hub Service.
-        pub const SERVICE_UPDATING: State = State::new("SERVICE_UPDATING");
+        pub const SERVICE_UPDATING: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENABLING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("DISABLING"),
+                4 => std::borrow::Cow::Borrowed("UPDATING"),
+                5 => std::borrow::Cow::Borrowed("SERVICE_UPDATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ENABLING" => std::option::Option::Some(Self::ENABLING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DISABLING" => std::option::Option::Some(Self::DISABLING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "SERVICE_UPDATING" => std::option::Option::Some(Self::SERVICE_UPDATING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -381,52 +402,69 @@ pub mod feature_state {
 
     /// Code represents a machine-readable, high-level status of the Feature.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Code(std::borrow::Cow<'static, str>);
+    pub struct Code(i32);
 
     impl Code {
-        /// Creates a new Code instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Code](Code)
-    pub mod code {
-        use super::Code;
-
         /// Unknown or not set.
-        pub const CODE_UNSPECIFIED: Code = Code::new("CODE_UNSPECIFIED");
+        pub const CODE_UNSPECIFIED: Code = Code::new(0);
 
         /// The Feature is operating normally.
-        pub const OK: Code = Code::new("OK");
+        pub const OK: Code = Code::new(1);
 
         /// The Feature has encountered an issue, and is operating in a degraded
         /// state. The Feature may need intervention to return to normal operation.
         /// See the description and any associated Feature-specific details for more
         /// information.
-        pub const WARNING: Code = Code::new("WARNING");
+        pub const WARNING: Code = Code::new(2);
 
         /// The Feature is not operating or is in a severely degraded state.
         /// The Feature may need intervention to return to normal operation.
         /// See the description and any associated Feature-specific details for more
         /// information.
-        pub const ERROR: Code = Code::new("ERROR");
+        pub const ERROR: Code = Code::new(3);
+
+        /// Creates a new Code instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("OK"),
+                2 => std::borrow::Cow::Borrowed("WARNING"),
+                3 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CODE_UNSPECIFIED" => std::option::Option::Some(Self::CODE_UNSPECIFIED),
+                "OK" => std::option::Option::Some(Self::OK),
+                "WARNING" => std::option::Option::Some(Self::WARNING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Code {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Code {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Code {
         fn default() -> Self {
-            code::CODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1508,52 +1546,73 @@ pub mod membership_state {
 
     /// Code describes the state of a Membership resource.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Code(std::borrow::Cow<'static, str>);
+    pub struct Code(i32);
 
     impl Code {
+        /// The code is not set.
+        pub const CODE_UNSPECIFIED: Code = Code::new(0);
+
+        /// The cluster is being registered.
+        pub const CREATING: Code = Code::new(1);
+
+        /// The cluster is registered.
+        pub const READY: Code = Code::new(2);
+
+        /// The cluster is being unregistered.
+        pub const DELETING: Code = Code::new(3);
+
+        /// The Membership is being updated.
+        pub const UPDATING: Code = Code::new(4);
+
+        /// The Membership is being updated by the Hub Service.
+        pub const SERVICE_UPDATING: Code = Code::new(5);
+
         /// Creates a new Code instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("UPDATING"),
+                5 => std::borrow::Cow::Borrowed("SERVICE_UPDATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CODE_UNSPECIFIED" => std::option::Option::Some(Self::CODE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "SERVICE_UPDATING" => std::option::Option::Some(Self::SERVICE_UPDATING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Code](Code)
-    pub mod code {
-        use super::Code;
-
-        /// The code is not set.
-        pub const CODE_UNSPECIFIED: Code = Code::new("CODE_UNSPECIFIED");
-
-        /// The cluster is being registered.
-        pub const CREATING: Code = Code::new("CREATING");
-
-        /// The cluster is registered.
-        pub const READY: Code = Code::new("READY");
-
-        /// The cluster is being unregistered.
-        pub const DELETING: Code = Code::new("DELETING");
-
-        /// The Membership is being updated.
-        pub const UPDATING: Code = Code::new("UPDATING");
-
-        /// The Membership is being updated by the Hub Service.
-        pub const SERVICE_UPDATING: Code = Code::new("SERVICE_UPDATING");
-    }
-
-    impl std::convert::From<std::string::String> for Code {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Code {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Code {
         fn default() -> Self {
-            code::CODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/gkehub/v1/src/transport.rs
+++ b/src/generated/cloud/gkehub/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::GkeHub for GkeHub {
                 reqwest::Method::GET,
                 format!("/v1/{}/memberships", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::GkeHub for GkeHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/features", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -98,7 +98,7 @@ impl crate::stubs::GkeHub for GkeHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -117,7 +117,7 @@ impl crate::stubs::GkeHub for GkeHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -139,7 +139,7 @@ impl crate::stubs::GkeHub for GkeHub {
                 reqwest::Method::POST,
                 format!("/v1/{}/memberships", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -163,7 +163,7 @@ impl crate::stubs::GkeHub for GkeHub {
                 reqwest::Method::POST,
                 format!("/v1/{}/features", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -184,7 +184,7 @@ impl crate::stubs::GkeHub for GkeHub {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -205,7 +205,7 @@ impl crate::stubs::GkeHub for GkeHub {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -226,7 +226,7 @@ impl crate::stubs::GkeHub for GkeHub {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -256,7 +256,7 @@ impl crate::stubs::GkeHub for GkeHub {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -289,7 +289,7 @@ impl crate::stubs::GkeHub for GkeHub {
                 reqwest::Method::GET,
                 format!("/v1/{}:generateConnectManifest", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -314,7 +314,7 @@ impl crate::stubs::GkeHub for GkeHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -336,7 +336,7 @@ impl crate::stubs::GkeHub for GkeHub {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -355,7 +355,7 @@ impl crate::stubs::GkeHub for GkeHub {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -374,7 +374,7 @@ impl crate::stubs::GkeHub for GkeHub {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/gkemulticloud/v1/src/model.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/model.rs
@@ -413,59 +413,82 @@ pub mod attached_cluster {
 
     /// The lifecycle state of the cluster.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The PROVISIONING state indicates the cluster is being registered.
-        pub const PROVISIONING: State = State::new("PROVISIONING");
+        pub const PROVISIONING: State = State::new(1);
 
         /// The RUNNING state indicates the cluster has been register and is fully
         /// usable.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(2);
 
         /// The RECONCILING state indicates that some work is actively being done on
         /// the cluster, such as upgrading software components.
-        pub const RECONCILING: State = State::new("RECONCILING");
+        pub const RECONCILING: State = State::new(3);
 
         /// The STOPPING state indicates the cluster is being de-registered.
-        pub const STOPPING: State = State::new("STOPPING");
+        pub const STOPPING: State = State::new(4);
 
         /// The ERROR state indicates the cluster is in a broken unrecoverable
         /// state.
-        pub const ERROR: State = State::new("ERROR");
+        pub const ERROR: State = State::new(5);
 
         /// The DEGRADED state indicates the cluster requires user action to
         /// restore full functionality.
-        pub const DEGRADED: State = State::new("DEGRADED");
+        pub const DEGRADED: State = State::new(6);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("RECONCILING"),
+                4 => std::borrow::Cow::Borrowed("STOPPING"),
+                5 => std::borrow::Cow::Borrowed("ERROR"),
+                6 => std::borrow::Cow::Borrowed("DEGRADED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "RECONCILING" => std::option::Option::Some(Self::RECONCILING),
+                "STOPPING" => std::option::Option::Some(Self::STOPPING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "DEGRADED" => std::option::Option::Some(Self::DEGRADED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2017,59 +2040,82 @@ pub mod aws_cluster {
 
     /// The lifecycle state of the cluster.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The PROVISIONING state indicates the cluster is being created.
-        pub const PROVISIONING: State = State::new("PROVISIONING");
+        pub const PROVISIONING: State = State::new(1);
 
         /// The RUNNING state indicates the cluster has been created and is fully
         /// usable.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(2);
 
         /// The RECONCILING state indicates that some work is actively being done on
         /// the cluster, such as upgrading the control plane replicas.
-        pub const RECONCILING: State = State::new("RECONCILING");
+        pub const RECONCILING: State = State::new(3);
 
         /// The STOPPING state indicates the cluster is being deleted.
-        pub const STOPPING: State = State::new("STOPPING");
+        pub const STOPPING: State = State::new(4);
 
         /// The ERROR state indicates the cluster is in a broken unrecoverable
         /// state.
-        pub const ERROR: State = State::new("ERROR");
+        pub const ERROR: State = State::new(5);
 
         /// The DEGRADED state indicates the cluster requires user action to
         /// restore full functionality.
-        pub const DEGRADED: State = State::new("DEGRADED");
+        pub const DEGRADED: State = State::new(6);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("RECONCILING"),
+                4 => std::borrow::Cow::Borrowed("STOPPING"),
+                5 => std::borrow::Cow::Borrowed("ERROR"),
+                6 => std::borrow::Cow::Borrowed("DEGRADED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "RECONCILING" => std::option::Option::Some(Self::RECONCILING),
+                "STOPPING" => std::option::Option::Some(Self::STOPPING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "DEGRADED" => std::option::Option::Some(Self::DEGRADED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2609,43 +2655,60 @@ pub mod aws_volume_template {
     /// See <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html>
     /// for more information.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VolumeType(std::borrow::Cow<'static, str>);
+    pub struct VolumeType(i32);
 
     impl VolumeType {
+        /// Not set.
+        pub const VOLUME_TYPE_UNSPECIFIED: VolumeType = VolumeType::new(0);
+
+        /// GP2 (General Purpose SSD volume type).
+        pub const GP2: VolumeType = VolumeType::new(1);
+
+        /// GP3 (General Purpose SSD volume type).
+        pub const GP3: VolumeType = VolumeType::new(2);
+
         /// Creates a new VolumeType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VOLUME_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GP2"),
+                2 => std::borrow::Cow::Borrowed("GP3"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VOLUME_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::VOLUME_TYPE_UNSPECIFIED)
+                }
+                "GP2" => std::option::Option::Some(Self::GP2),
+                "GP3" => std::option::Option::Some(Self::GP3),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [VolumeType](VolumeType)
-    pub mod volume_type {
-        use super::VolumeType;
-
-        /// Not set.
-        pub const VOLUME_TYPE_UNSPECIFIED: VolumeType = VolumeType::new("VOLUME_TYPE_UNSPECIFIED");
-
-        /// GP2 (General Purpose SSD volume type).
-        pub const GP2: VolumeType = VolumeType::new("GP2");
-
-        /// GP3 (General Purpose SSD volume type).
-        pub const GP3: VolumeType = VolumeType::new("GP3");
-    }
-
-    impl std::convert::From<std::string::String> for VolumeType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for VolumeType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for VolumeType {
         fn default() -> Self {
-            volume_type::VOLUME_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3004,58 +3067,81 @@ pub mod aws_node_pool {
 
     /// The lifecycle state of the node pool.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The PROVISIONING state indicates the node pool is being created.
-        pub const PROVISIONING: State = State::new("PROVISIONING");
+        pub const PROVISIONING: State = State::new(1);
 
         /// The RUNNING state indicates the node pool has been created
         /// and is fully usable.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(2);
 
         /// The RECONCILING state indicates that the node pool is being reconciled.
-        pub const RECONCILING: State = State::new("RECONCILING");
+        pub const RECONCILING: State = State::new(3);
 
         /// The STOPPING state indicates the node pool is being deleted.
-        pub const STOPPING: State = State::new("STOPPING");
+        pub const STOPPING: State = State::new(4);
 
         /// The ERROR state indicates the node pool is in a broken unrecoverable
         /// state.
-        pub const ERROR: State = State::new("ERROR");
+        pub const ERROR: State = State::new(5);
 
         /// The DEGRADED state indicates the node pool requires user action to
         /// restore full functionality.
-        pub const DEGRADED: State = State::new("DEGRADED");
+        pub const DEGRADED: State = State::new(6);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("RECONCILING"),
+                4 => std::borrow::Cow::Borrowed("STOPPING"),
+                5 => std::borrow::Cow::Borrowed("ERROR"),
+                6 => std::borrow::Cow::Borrowed("DEGRADED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "RECONCILING" => std::option::Option::Some(Self::RECONCILING),
+                "STOPPING" => std::option::Option::Some(Self::STOPPING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "DEGRADED" => std::option::Option::Some(Self::DEGRADED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3911,46 +3997,63 @@ pub mod aws_instance_placement {
 
     /// Tenancy defines how EC2 instances are distributed across physical hardware.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Tenancy(std::borrow::Cow<'static, str>);
+    pub struct Tenancy(i32);
 
     impl Tenancy {
+        /// Not set.
+        pub const TENANCY_UNSPECIFIED: Tenancy = Tenancy::new(0);
+
+        /// Use default VPC tenancy.
+        pub const DEFAULT: Tenancy = Tenancy::new(1);
+
+        /// Run a dedicated instance.
+        pub const DEDICATED: Tenancy = Tenancy::new(2);
+
+        /// Launch this instance to a dedicated host.
+        pub const HOST: Tenancy = Tenancy::new(3);
+
         /// Creates a new Tenancy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TENANCY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DEFAULT"),
+                2 => std::borrow::Cow::Borrowed("DEDICATED"),
+                3 => std::borrow::Cow::Borrowed("HOST"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TENANCY_UNSPECIFIED" => std::option::Option::Some(Self::TENANCY_UNSPECIFIED),
+                "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
+                "DEDICATED" => std::option::Option::Some(Self::DEDICATED),
+                "HOST" => std::option::Option::Some(Self::HOST),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Tenancy](Tenancy)
-    pub mod tenancy {
-        use super::Tenancy;
-
-        /// Not set.
-        pub const TENANCY_UNSPECIFIED: Tenancy = Tenancy::new("TENANCY_UNSPECIFIED");
-
-        /// Use default VPC tenancy.
-        pub const DEFAULT: Tenancy = Tenancy::new("DEFAULT");
-
-        /// Run a dedicated instance.
-        pub const DEDICATED: Tenancy = Tenancy::new("DEDICATED");
-
-        /// Launch this instance to a dedicated host.
-        pub const HOST: Tenancy = Tenancy::new("HOST");
-    }
-
-    impl std::convert::From<std::string::String> for Tenancy {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Tenancy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Tenancy {
         fn default() -> Self {
-            tenancy::TENANCY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5764,59 +5867,82 @@ pub mod azure_cluster {
 
     /// The lifecycle state of the cluster.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The PROVISIONING state indicates the cluster is being created.
-        pub const PROVISIONING: State = State::new("PROVISIONING");
+        pub const PROVISIONING: State = State::new(1);
 
         /// The RUNNING state indicates the cluster has been created and is fully
         /// usable.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(2);
 
         /// The RECONCILING state indicates that some work is actively being done on
         /// the cluster, such as upgrading the control plane replicas.
-        pub const RECONCILING: State = State::new("RECONCILING");
+        pub const RECONCILING: State = State::new(3);
 
         /// The STOPPING state indicates the cluster is being deleted.
-        pub const STOPPING: State = State::new("STOPPING");
+        pub const STOPPING: State = State::new(4);
 
         /// The ERROR state indicates the cluster is in a broken unrecoverable
         /// state.
-        pub const ERROR: State = State::new("ERROR");
+        pub const ERROR: State = State::new(5);
 
         /// The DEGRADED state indicates the cluster requires user action to
         /// restore full functionality.
-        pub const DEGRADED: State = State::new("DEGRADED");
+        pub const DEGRADED: State = State::new(6);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("RECONCILING"),
+                4 => std::borrow::Cow::Borrowed("STOPPING"),
+                5 => std::borrow::Cow::Borrowed("ERROR"),
+                6 => std::borrow::Cow::Borrowed("DEGRADED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "RECONCILING" => std::option::Option::Some(Self::RECONCILING),
+                "STOPPING" => std::option::Option::Some(Self::STOPPING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "DEGRADED" => std::option::Option::Some(Self::DEGRADED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6911,58 +7037,81 @@ pub mod azure_node_pool {
 
     /// The lifecycle state of the node pool.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The PROVISIONING state indicates the node pool is being created.
-        pub const PROVISIONING: State = State::new("PROVISIONING");
+        pub const PROVISIONING: State = State::new(1);
 
         /// The RUNNING state indicates the node pool has been created and is fully
         /// usable.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(2);
 
         /// The RECONCILING state indicates that the node pool is being reconciled.
-        pub const RECONCILING: State = State::new("RECONCILING");
+        pub const RECONCILING: State = State::new(3);
 
         /// The STOPPING state indicates the node pool is being deleted.
-        pub const STOPPING: State = State::new("STOPPING");
+        pub const STOPPING: State = State::new(4);
 
         /// The ERROR state indicates the node pool is in a broken unrecoverable
         /// state.
-        pub const ERROR: State = State::new("ERROR");
+        pub const ERROR: State = State::new(5);
 
         /// The DEGRADED state indicates the node pool requires user action to
         /// restore full functionality.
-        pub const DEGRADED: State = State::new("DEGRADED");
+        pub const DEGRADED: State = State::new(6);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("RECONCILING"),
+                4 => std::borrow::Cow::Borrowed("STOPPING"),
+                5 => std::borrow::Cow::Borrowed("ERROR"),
+                6 => std::borrow::Cow::Borrowed("DEGRADED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "RECONCILING" => std::option::Option::Some(Self::RECONCILING),
+                "STOPPING" => std::option::Option::Some(Self::STOPPING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "DEGRADED" => std::option::Option::Some(Self::DEGRADED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -9532,52 +9681,69 @@ pub mod node_taint {
 
     /// The taint effect.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Effect(std::borrow::Cow<'static, str>);
+    pub struct Effect(i32);
 
     impl Effect {
-        /// Creates a new Effect instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Effect](Effect)
-    pub mod effect {
-        use super::Effect;
-
         /// Not set.
-        pub const EFFECT_UNSPECIFIED: Effect = Effect::new("EFFECT_UNSPECIFIED");
+        pub const EFFECT_UNSPECIFIED: Effect = Effect::new(0);
 
         /// Do not allow new pods to schedule onto the node unless they tolerate the
         /// taint, but allow all pods submitted to Kubelet without going through the
         /// scheduler to start, and allow all already-running pods to continue
         /// running. Enforced by the scheduler.
-        pub const NO_SCHEDULE: Effect = Effect::new("NO_SCHEDULE");
+        pub const NO_SCHEDULE: Effect = Effect::new(1);
 
         /// Like TaintEffectNoSchedule, but the scheduler tries not to schedule
         /// new pods onto the node, rather than prohibiting new pods from scheduling
         /// onto the node entirely. Enforced by the scheduler.
-        pub const PREFER_NO_SCHEDULE: Effect = Effect::new("PREFER_NO_SCHEDULE");
+        pub const PREFER_NO_SCHEDULE: Effect = Effect::new(2);
 
         /// Evict any already-running pods that do not tolerate the taint.
         /// Currently enforced by NodeController.
-        pub const NO_EXECUTE: Effect = Effect::new("NO_EXECUTE");
+        pub const NO_EXECUTE: Effect = Effect::new(3);
+
+        /// Creates a new Effect instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EFFECT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NO_SCHEDULE"),
+                2 => std::borrow::Cow::Borrowed("PREFER_NO_SCHEDULE"),
+                3 => std::borrow::Cow::Borrowed("NO_EXECUTE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EFFECT_UNSPECIFIED" => std::option::Option::Some(Self::EFFECT_UNSPECIFIED),
+                "NO_SCHEDULE" => std::option::Option::Some(Self::NO_SCHEDULE),
+                "PREFER_NO_SCHEDULE" => std::option::Option::Some(Self::PREFER_NO_SCHEDULE),
+                "NO_EXECUTE" => std::option::Option::Some(Self::NO_EXECUTE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Effect {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Effect {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Effect {
         fn default() -> Self {
-            effect::EFFECT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -9831,43 +9997,58 @@ pub mod logging_component_config {
 
     /// The components of the logging configuration;
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Component(std::borrow::Cow<'static, str>);
+    pub struct Component(i32);
 
     impl Component {
+        /// No component is specified
+        pub const COMPONENT_UNSPECIFIED: Component = Component::new(0);
+
+        /// This indicates that system logging components is enabled.
+        pub const SYSTEM_COMPONENTS: Component = Component::new(1);
+
+        /// This indicates that user workload logging component is enabled.
+        pub const WORKLOADS: Component = Component::new(2);
+
         /// Creates a new Component instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COMPONENT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SYSTEM_COMPONENTS"),
+                2 => std::borrow::Cow::Borrowed("WORKLOADS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COMPONENT_UNSPECIFIED" => std::option::Option::Some(Self::COMPONENT_UNSPECIFIED),
+                "SYSTEM_COMPONENTS" => std::option::Option::Some(Self::SYSTEM_COMPONENTS),
+                "WORKLOADS" => std::option::Option::Some(Self::WORKLOADS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Component](Component)
-    pub mod component {
-        use super::Component;
-
-        /// No component is specified
-        pub const COMPONENT_UNSPECIFIED: Component = Component::new("COMPONENT_UNSPECIFIED");
-
-        /// This indicates that system logging components is enabled.
-        pub const SYSTEM_COMPONENTS: Component = Component::new("SYSTEM_COMPONENTS");
-
-        /// This indicates that user workload logging component is enabled.
-        pub const WORKLOADS: Component = Component::new("WORKLOADS");
-    }
-
-    impl std::convert::From<std::string::String> for Component {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Component {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Component {
         fn default() -> Self {
-            component::COMPONENT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -10024,46 +10205,63 @@ pub mod binary_authorization {
 
     /// Binary Authorization mode of operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EvaluationMode(std::borrow::Cow<'static, str>);
+    pub struct EvaluationMode(i32);
 
     impl EvaluationMode {
-        /// Creates a new EvaluationMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [EvaluationMode](EvaluationMode)
-    pub mod evaluation_mode {
-        use super::EvaluationMode;
-
         /// Default value
-        pub const EVALUATION_MODE_UNSPECIFIED: EvaluationMode =
-            EvaluationMode::new("EVALUATION_MODE_UNSPECIFIED");
+        pub const EVALUATION_MODE_UNSPECIFIED: EvaluationMode = EvaluationMode::new(0);
 
         /// Disable BinaryAuthorization
-        pub const DISABLED: EvaluationMode = EvaluationMode::new("DISABLED");
+        pub const DISABLED: EvaluationMode = EvaluationMode::new(1);
 
         /// Enforce Kubernetes admission requests with BinaryAuthorization using the
         /// project's singleton policy.
-        pub const PROJECT_SINGLETON_POLICY_ENFORCE: EvaluationMode =
-            EvaluationMode::new("PROJECT_SINGLETON_POLICY_ENFORCE");
+        pub const PROJECT_SINGLETON_POLICY_ENFORCE: EvaluationMode = EvaluationMode::new(2);
+
+        /// Creates a new EvaluationMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EVALUATION_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DISABLED"),
+                2 => std::borrow::Cow::Borrowed("PROJECT_SINGLETON_POLICY_ENFORCE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EVALUATION_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::EVALUATION_MODE_UNSPECIFIED)
+                }
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "PROJECT_SINGLETON_POLICY_ENFORCE" => {
+                    std::option::Option::Some(Self::PROJECT_SINGLETON_POLICY_ENFORCE)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for EvaluationMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EvaluationMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EvaluationMode {
         fn default() -> Self {
-            evaluation_mode::EVALUATION_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -10109,47 +10307,63 @@ pub mod security_posture_config {
 
     /// VulnerabilityMode defines enablement mode for vulnerability scanning.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VulnerabilityMode(std::borrow::Cow<'static, str>);
+    pub struct VulnerabilityMode(i32);
 
     impl VulnerabilityMode {
-        /// Creates a new VulnerabilityMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [VulnerabilityMode](VulnerabilityMode)
-    pub mod vulnerability_mode {
-        use super::VulnerabilityMode;
-
         /// Default value not specified.
-        pub const VULNERABILITY_MODE_UNSPECIFIED: VulnerabilityMode =
-            VulnerabilityMode::new("VULNERABILITY_MODE_UNSPECIFIED");
+        pub const VULNERABILITY_MODE_UNSPECIFIED: VulnerabilityMode = VulnerabilityMode::new(0);
 
         /// Disables vulnerability scanning on the cluster.
-        pub const VULNERABILITY_DISABLED: VulnerabilityMode =
-            VulnerabilityMode::new("VULNERABILITY_DISABLED");
+        pub const VULNERABILITY_DISABLED: VulnerabilityMode = VulnerabilityMode::new(1);
 
         /// Applies the Security Posture's vulnerability on cluster Enterprise level
         /// features.
-        pub const VULNERABILITY_ENTERPRISE: VulnerabilityMode =
-            VulnerabilityMode::new("VULNERABILITY_ENTERPRISE");
+        pub const VULNERABILITY_ENTERPRISE: VulnerabilityMode = VulnerabilityMode::new(2);
+
+        /// Creates a new VulnerabilityMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VULNERABILITY_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("VULNERABILITY_DISABLED"),
+                2 => std::borrow::Cow::Borrowed("VULNERABILITY_ENTERPRISE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VULNERABILITY_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::VULNERABILITY_MODE_UNSPECIFIED)
+                }
+                "VULNERABILITY_DISABLED" => std::option::Option::Some(Self::VULNERABILITY_DISABLED),
+                "VULNERABILITY_ENTERPRISE" => {
+                    std::option::Option::Some(Self::VULNERABILITY_ENTERPRISE)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for VulnerabilityMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for VulnerabilityMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for VulnerabilityMode {
         fn default() -> Self {
-            vulnerability_mode::VULNERABILITY_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/gkemulticloud/v1/src/transport.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::AttachedClusters for AttachedClusters {
                 reqwest::Method::POST,
                 format!("/v1/{}/attachedClusters", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -82,7 +82,7 @@ impl crate::stubs::AttachedClusters for AttachedClusters {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -115,7 +115,7 @@ impl crate::stubs::AttachedClusters for AttachedClusters {
                 reqwest::Method::POST,
                 format!("/v1/{}/attachedClusters:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -132,7 +132,7 @@ impl crate::stubs::AttachedClusters for AttachedClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -154,7 +154,7 @@ impl crate::stubs::AttachedClusters for AttachedClusters {
                 reqwest::Method::GET,
                 format!("/v1/{}/attachedClusters", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -175,7 +175,7 @@ impl crate::stubs::AttachedClusters for AttachedClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -198,7 +198,7 @@ impl crate::stubs::AttachedClusters for AttachedClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -220,7 +220,7 @@ impl crate::stubs::AttachedClusters for AttachedClusters {
                 reqwest::Method::GET,
                 format!("/v1/{}:generateAttachedClusterInstallManifest", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -257,7 +257,7 @@ impl crate::stubs::AttachedClusters for AttachedClusters {
                     req.attached_cluster
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -274,7 +274,7 @@ impl crate::stubs::AttachedClusters for AttachedClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -296,7 +296,7 @@ impl crate::stubs::AttachedClusters for AttachedClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -315,7 +315,7 @@ impl crate::stubs::AttachedClusters for AttachedClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -334,7 +334,7 @@ impl crate::stubs::AttachedClusters for AttachedClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -391,7 +391,7 @@ impl crate::stubs::AwsClusters for AwsClusters {
                 reqwest::Method::POST,
                 format!("/v1/{}/awsClusters", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -421,7 +421,7 @@ impl crate::stubs::AwsClusters for AwsClusters {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -451,7 +451,7 @@ impl crate::stubs::AwsClusters for AwsClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -473,7 +473,7 @@ impl crate::stubs::AwsClusters for AwsClusters {
                 reqwest::Method::GET,
                 format!("/v1/{}/awsClusters", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -494,7 +494,7 @@ impl crate::stubs::AwsClusters for AwsClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -520,7 +520,7 @@ impl crate::stubs::AwsClusters for AwsClusters {
                 reqwest::Method::POST,
                 format!("/v1/{}:generateAwsClusterAgentToken", req.aws_cluster),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -540,7 +540,7 @@ impl crate::stubs::AwsClusters for AwsClusters {
                 reqwest::Method::GET,
                 format!("/v1/{}:generateAwsAccessToken", req.aws_cluster),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -562,7 +562,7 @@ impl crate::stubs::AwsClusters for AwsClusters {
                 reqwest::Method::POST,
                 format!("/v1/{}/awsNodePools", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -592,7 +592,7 @@ impl crate::stubs::AwsClusters for AwsClusters {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -622,7 +622,7 @@ impl crate::stubs::AwsClusters for AwsClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:rollback", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -639,7 +639,7 @@ impl crate::stubs::AwsClusters for AwsClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -661,7 +661,7 @@ impl crate::stubs::AwsClusters for AwsClusters {
                 reqwest::Method::GET,
                 format!("/v1/{}/awsNodePools", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -682,7 +682,7 @@ impl crate::stubs::AwsClusters for AwsClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -708,7 +708,7 @@ impl crate::stubs::AwsClusters for AwsClusters {
                 reqwest::Method::GET,
                 format!("/v1/{}/.well-known/openid-configuration", req.aws_cluster),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -730,7 +730,7 @@ impl crate::stubs::AwsClusters for AwsClusters {
                 reqwest::Method::GET,
                 format!("/v1/{}/jwks", req.aws_cluster),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -749,7 +749,7 @@ impl crate::stubs::AwsClusters for AwsClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -768,7 +768,7 @@ impl crate::stubs::AwsClusters for AwsClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -790,7 +790,7 @@ impl crate::stubs::AwsClusters for AwsClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -809,7 +809,7 @@ impl crate::stubs::AwsClusters for AwsClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -828,7 +828,7 @@ impl crate::stubs::AwsClusters for AwsClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -885,7 +885,7 @@ impl crate::stubs::AzureClusters for AzureClusters {
                 reqwest::Method::POST,
                 format!("/v1/{}/azureClients", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -906,7 +906,7 @@ impl crate::stubs::AzureClusters for AzureClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -928,7 +928,7 @@ impl crate::stubs::AzureClusters for AzureClusters {
                 reqwest::Method::GET,
                 format!("/v1/{}/azureClients", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -949,7 +949,7 @@ impl crate::stubs::AzureClusters for AzureClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -973,7 +973,7 @@ impl crate::stubs::AzureClusters for AzureClusters {
                 reqwest::Method::POST,
                 format!("/v1/{}/azureClusters", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1003,7 +1003,7 @@ impl crate::stubs::AzureClusters for AzureClusters {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1033,7 +1033,7 @@ impl crate::stubs::AzureClusters for AzureClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1055,7 +1055,7 @@ impl crate::stubs::AzureClusters for AzureClusters {
                 reqwest::Method::GET,
                 format!("/v1/{}/azureClusters", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1076,7 +1076,7 @@ impl crate::stubs::AzureClusters for AzureClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1102,7 +1102,7 @@ impl crate::stubs::AzureClusters for AzureClusters {
                 reqwest::Method::POST,
                 format!("/v1/{}:generateAzureClusterAgentToken", req.azure_cluster),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1122,7 +1122,7 @@ impl crate::stubs::AzureClusters for AzureClusters {
                 reqwest::Method::GET,
                 format!("/v1/{}:generateAzureAccessToken", req.azure_cluster),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1144,7 +1144,7 @@ impl crate::stubs::AzureClusters for AzureClusters {
                 reqwest::Method::POST,
                 format!("/v1/{}/azureNodePools", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1174,7 +1174,7 @@ impl crate::stubs::AzureClusters for AzureClusters {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1204,7 +1204,7 @@ impl crate::stubs::AzureClusters for AzureClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1226,7 +1226,7 @@ impl crate::stubs::AzureClusters for AzureClusters {
                 reqwest::Method::GET,
                 format!("/v1/{}/azureNodePools", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1247,7 +1247,7 @@ impl crate::stubs::AzureClusters for AzureClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1273,7 +1273,7 @@ impl crate::stubs::AzureClusters for AzureClusters {
                 reqwest::Method::GET,
                 format!("/v1/{}/.well-known/openid-configuration", req.azure_cluster),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1295,7 +1295,7 @@ impl crate::stubs::AzureClusters for AzureClusters {
                 reqwest::Method::GET,
                 format!("/v1/{}/jwks", req.azure_cluster),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1314,7 +1314,7 @@ impl crate::stubs::AzureClusters for AzureClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1333,7 +1333,7 @@ impl crate::stubs::AzureClusters for AzureClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1355,7 +1355,7 @@ impl crate::stubs::AzureClusters for AzureClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1374,7 +1374,7 @@ impl crate::stubs::AzureClusters for AzureClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1393,7 +1393,7 @@ impl crate::stubs::AzureClusters for AzureClusters {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/gsuiteaddons/v1/src/transport.rs
+++ b/src/generated/cloud/gsuiteaddons/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::GSuiteAddOns for GSuiteAddOns {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -71,7 +71,7 @@ impl crate::stubs::GSuiteAddOns for GSuiteAddOns {
                 reqwest::Method::POST,
                 format!("/v1/{}/deployments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -100,7 +100,7 @@ impl crate::stubs::GSuiteAddOns for GSuiteAddOns {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -119,7 +119,7 @@ impl crate::stubs::GSuiteAddOns for GSuiteAddOns {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -141,7 +141,7 @@ impl crate::stubs::GSuiteAddOns for GSuiteAddOns {
                 reqwest::Method::GET,
                 format!("/v1/{}/deployments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -162,7 +162,7 @@ impl crate::stubs::GSuiteAddOns for GSuiteAddOns {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -182,7 +182,7 @@ impl crate::stubs::GSuiteAddOns for GSuiteAddOns {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:install", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -199,7 +199,7 @@ impl crate::stubs::GSuiteAddOns for GSuiteAddOns {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:uninstall", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -216,7 +216,7 @@ impl crate::stubs::GSuiteAddOns for GSuiteAddOns {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/iap/v1/src/model.rs
+++ b/src/generated/cloud/iap/v1/src/model.rs
@@ -825,91 +825,129 @@ pub mod reauth_settings {
 
     /// Types of reauthentication methods supported by IAP.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Method(std::borrow::Cow<'static, str>);
+    pub struct Method(i32);
 
     impl Method {
+        /// Reauthentication disabled.
+        pub const METHOD_UNSPECIFIED: Method = Method::new(0);
+
+        /// Prompts the user to log in again.
+        pub const LOGIN: Method = Method::new(1);
+
+        pub const PASSWORD: Method = Method::new(2);
+
+        /// User must use their secure key 2nd factor device.
+        pub const SECURE_KEY: Method = Method::new(3);
+
+        /// User can use any enabled 2nd factor.
+        pub const ENROLLED_SECOND_FACTORS: Method = Method::new(4);
+
         /// Creates a new Method instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("METHOD_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LOGIN"),
+                2 => std::borrow::Cow::Borrowed("PASSWORD"),
+                3 => std::borrow::Cow::Borrowed("SECURE_KEY"),
+                4 => std::borrow::Cow::Borrowed("ENROLLED_SECOND_FACTORS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "METHOD_UNSPECIFIED" => std::option::Option::Some(Self::METHOD_UNSPECIFIED),
+                "LOGIN" => std::option::Option::Some(Self::LOGIN),
+                "PASSWORD" => std::option::Option::Some(Self::PASSWORD),
+                "SECURE_KEY" => std::option::Option::Some(Self::SECURE_KEY),
+                "ENROLLED_SECOND_FACTORS" => {
+                    std::option::Option::Some(Self::ENROLLED_SECOND_FACTORS)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Method](Method)
-    pub mod method {
-        use super::Method;
-
-        /// Reauthentication disabled.
-        pub const METHOD_UNSPECIFIED: Method = Method::new("METHOD_UNSPECIFIED");
-
-        /// Prompts the user to log in again.
-        pub const LOGIN: Method = Method::new("LOGIN");
-
-        pub const PASSWORD: Method = Method::new("PASSWORD");
-
-        /// User must use their secure key 2nd factor device.
-        pub const SECURE_KEY: Method = Method::new("SECURE_KEY");
-
-        /// User can use any enabled 2nd factor.
-        pub const ENROLLED_SECOND_FACTORS: Method = Method::new("ENROLLED_SECOND_FACTORS");
-    }
-
-    impl std::convert::From<std::string::String> for Method {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Method {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Method {
         fn default() -> Self {
-            method::METHOD_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Type of policy in the case of hierarchial policies.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PolicyType(std::borrow::Cow<'static, str>);
+    pub struct PolicyType(i32);
 
     impl PolicyType {
-        /// Creates a new PolicyType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PolicyType](PolicyType)
-    pub mod policy_type {
-        use super::PolicyType;
-
         /// Default value. This value is unused.
-        pub const POLICY_TYPE_UNSPECIFIED: PolicyType = PolicyType::new("POLICY_TYPE_UNSPECIFIED");
+        pub const POLICY_TYPE_UNSPECIFIED: PolicyType = PolicyType::new(0);
 
         /// This policy acts as a minimum to other policies, lower in the hierarchy.
         /// Effective policy may only be the same or stricter.
-        pub const MINIMUM: PolicyType = PolicyType::new("MINIMUM");
+        pub const MINIMUM: PolicyType = PolicyType::new(1);
 
         /// This policy acts as a default if no other reauth policy is set.
-        pub const DEFAULT: PolicyType = PolicyType::new("DEFAULT");
+        pub const DEFAULT: PolicyType = PolicyType::new(2);
+
+        /// Creates a new PolicyType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("POLICY_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MINIMUM"),
+                2 => std::borrow::Cow::Borrowed("DEFAULT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "POLICY_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::POLICY_TYPE_UNSPECIFIED)
+                }
+                "MINIMUM" => std::option::Option::Some(Self::MINIMUM),
+                "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PolicyType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PolicyType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PolicyType {
         fn default() -> Self {
-            policy_type::POLICY_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1243,49 +1281,67 @@ pub mod attribute_propagation_settings {
     /// credential maps to a "field" in the response. For example, selecting JWT
     /// will propagate all attributes in the IAP JWT, header in the headers, etc.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OutputCredentials(std::borrow::Cow<'static, str>);
+    pub struct OutputCredentials(i32);
 
     impl OutputCredentials {
-        /// Creates a new OutputCredentials instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [OutputCredentials](OutputCredentials)
-    pub mod output_credentials {
-        use super::OutputCredentials;
-
         /// An output credential is required.
-        pub const OUTPUT_CREDENTIALS_UNSPECIFIED: OutputCredentials =
-            OutputCredentials::new("OUTPUT_CREDENTIALS_UNSPECIFIED");
+        pub const OUTPUT_CREDENTIALS_UNSPECIFIED: OutputCredentials = OutputCredentials::new(0);
 
         /// Propagate attributes in the headers with "x-goog-iap-attr-" prefix.
-        pub const HEADER: OutputCredentials = OutputCredentials::new("HEADER");
+        pub const HEADER: OutputCredentials = OutputCredentials::new(1);
 
         /// Propagate attributes in the JWT of the form: `"additional_claims": {
         /// "my_attribute": ["value1", "value2"] }`
-        pub const JWT: OutputCredentials = OutputCredentials::new("JWT");
+        pub const JWT: OutputCredentials = OutputCredentials::new(2);
 
         /// Propagate attributes in the RCToken of the form: `"additional_claims": {
         /// "my_attribute": ["value1", "value2"] }`
-        pub const RCTOKEN: OutputCredentials = OutputCredentials::new("RCTOKEN");
+        pub const RCTOKEN: OutputCredentials = OutputCredentials::new(3);
+
+        /// Creates a new OutputCredentials instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("OUTPUT_CREDENTIALS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("HEADER"),
+                2 => std::borrow::Cow::Borrowed("JWT"),
+                3 => std::borrow::Cow::Borrowed("RCTOKEN"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "OUTPUT_CREDENTIALS_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::OUTPUT_CREDENTIALS_UNSPECIFIED)
+                }
+                "HEADER" => std::option::Option::Some(Self::HEADER),
+                "JWT" => std::option::Option::Some(Self::JWT),
+                "RCTOKEN" => std::option::Option::Some(Self::RCTOKEN),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for OutputCredentials {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for OutputCredentials {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for OutputCredentials {
         fn default() -> Self {
-            output_credentials::OUTPUT_CREDENTIALS_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/iap/v1/src/transport.rs
+++ b/src/generated/cloud/iap/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::IdentityAwareProxyAdminService for IdentityAwareProxyAdminSer
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::IdentityAwareProxyAdminService for IdentityAwareProxyAdminSer
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -92,7 +92,7 @@ impl crate::stubs::IdentityAwareProxyAdminService for IdentityAwareProxyAdminSer
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -112,7 +112,7 @@ impl crate::stubs::IdentityAwareProxyAdminService for IdentityAwareProxyAdminSer
                 reqwest::Method::GET,
                 format!("/v1/{}:iapSettings", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -140,7 +140,7 @@ impl crate::stubs::IdentityAwareProxyAdminService for IdentityAwareProxyAdminSer
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -172,7 +172,7 @@ impl crate::stubs::IdentityAwareProxyAdminService for IdentityAwareProxyAdminSer
                 reqwest::Method::GET,
                 format!("/v1/{}/destGroups", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -196,7 +196,7 @@ impl crate::stubs::IdentityAwareProxyAdminService for IdentityAwareProxyAdminSer
                 reqwest::Method::POST,
                 format!("/v1/{}/destGroups", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -216,7 +216,7 @@ impl crate::stubs::IdentityAwareProxyAdminService for IdentityAwareProxyAdminSer
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -235,7 +235,7 @@ impl crate::stubs::IdentityAwareProxyAdminService for IdentityAwareProxyAdminSer
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -263,7 +263,7 @@ impl crate::stubs::IdentityAwareProxyAdminService for IdentityAwareProxyAdminSer
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -315,7 +315,7 @@ impl crate::stubs::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthSer
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/brands", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -334,7 +334,7 @@ impl crate::stubs::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthSer
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/brands", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -351,7 +351,7 @@ impl crate::stubs::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthSer
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -373,7 +373,7 @@ impl crate::stubs::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthSer
                 reqwest::Method::POST,
                 format!("/v1/{}/identityAwareProxyClients", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -395,7 +395,7 @@ impl crate::stubs::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthSer
                 reqwest::Method::GET,
                 format!("/v1/{}/identityAwareProxyClients", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -416,7 +416,7 @@ impl crate::stubs::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthSer
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -438,7 +438,7 @@ impl crate::stubs::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthSer
                 reqwest::Method::POST,
                 format!("/v1/{}:resetSecret", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -455,7 +455,7 @@ impl crate::stubs::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthSer
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/ids/v1/src/model.rs
+++ b/src/generated/cloud/ids/v1/src/model.rs
@@ -184,97 +184,135 @@ pub mod endpoint {
 
     /// Threat severity levels.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(std::borrow::Cow<'static, str>);
+    pub struct Severity(i32);
 
     impl Severity {
+        /// Not set.
+        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
+
+        /// Informational alerts.
+        pub const INFORMATIONAL: Severity = Severity::new(1);
+
+        /// Low severity alerts.
+        pub const LOW: Severity = Severity::new(2);
+
+        /// Medium severity alerts.
+        pub const MEDIUM: Severity = Severity::new(3);
+
+        /// High severity alerts.
+        pub const HIGH: Severity = Severity::new(4);
+
+        /// Critical severity alerts.
+        pub const CRITICAL: Severity = Severity::new(5);
+
         /// Creates a new Severity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INFORMATIONAL"),
+                2 => std::borrow::Cow::Borrowed("LOW"),
+                3 => std::borrow::Cow::Borrowed("MEDIUM"),
+                4 => std::borrow::Cow::Borrowed("HIGH"),
+                5 => std::borrow::Cow::Borrowed("CRITICAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
+                "INFORMATIONAL" => std::option::Option::Some(Self::INFORMATIONAL),
+                "LOW" => std::option::Option::Some(Self::LOW),
+                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
+                "HIGH" => std::option::Option::Some(Self::HIGH),
+                "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Severity](Severity)
-    pub mod severity {
-        use super::Severity;
-
-        /// Not set.
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new("SEVERITY_UNSPECIFIED");
-
-        /// Informational alerts.
-        pub const INFORMATIONAL: Severity = Severity::new("INFORMATIONAL");
-
-        /// Low severity alerts.
-        pub const LOW: Severity = Severity::new("LOW");
-
-        /// Medium severity alerts.
-        pub const MEDIUM: Severity = Severity::new("MEDIUM");
-
-        /// High severity alerts.
-        pub const HIGH: Severity = Severity::new("HIGH");
-
-        /// Critical severity alerts.
-        pub const CRITICAL: Severity = Severity::new("CRITICAL");
-    }
-
-    impl std::convert::From<std::string::String> for Severity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            severity::SEVERITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Endpoint state
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Not set.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Being created.
+        pub const CREATING: State = State::new(1);
+
+        /// Active and ready for traffic.
+        pub const READY: State = State::new(2);
+
+        /// Being deleted.
+        pub const DELETING: State = State::new(3);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// Active and ready for traffic.
-        pub const READY: State = State::new("READY");
-
-        /// Being deleted.
-        pub const DELETING: State = State::new("DELETING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/ids/v1/src/transport.rs
+++ b/src/generated/cloud/ids/v1/src/transport.rs
@@ -50,7 +50,7 @@ impl crate::stubs::Ids for Ids {
                 reqwest::Method::GET,
                 format!("/v1/{}/endpoints", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -73,7 +73,7 @@ impl crate::stubs::Ids for Ids {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -95,7 +95,7 @@ impl crate::stubs::Ids for Ids {
                 reqwest::Method::POST,
                 format!("/v1/{}/endpoints", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -116,7 +116,7 @@ impl crate::stubs::Ids for Ids {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -136,7 +136,7 @@ impl crate::stubs::Ids for Ids {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -158,7 +158,7 @@ impl crate::stubs::Ids for Ids {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -177,7 +177,7 @@ impl crate::stubs::Ids for Ids {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -196,7 +196,7 @@ impl crate::stubs::Ids for Ids {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/kms/inventory/v1/src/transport.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::KeyDashboardService for KeyDashboardService {
                 reqwest::Method::GET,
                 format!("/v1/{}/cryptoKeys", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -99,7 +99,7 @@ impl crate::stubs::KeyTrackingService for KeyTrackingService {
                 reqwest::Method::GET,
                 format!("/v1/{}/protectedResourcesSummary", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -121,7 +121,7 @@ impl crate::stubs::KeyTrackingService for KeyTrackingService {
                 reqwest::Method::GET,
                 format!("/v1/{}/protectedResources:search", req.scope),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/kms/v1/src/model.rs
+++ b/src/generated/cloud/kms/v1/src/model.rs
@@ -549,48 +549,65 @@ pub mod autokey_config {
 
     /// The states AutokeyConfig can be in.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The state of the AutokeyConfig is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The AutokeyConfig is currently active.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(1);
 
         /// A previously configured key project has been deleted and the current
         /// AutokeyConfig is unusable.
-        pub const KEY_PROJECT_DELETED: State = State::new("KEY_PROJECT_DELETED");
+        pub const KEY_PROJECT_DELETED: State = State::new(2);
 
         /// The AutokeyConfig is not yet initialized or has been reset to its default
         /// uninitialized state.
-        pub const UNINITIALIZED: State = State::new("UNINITIALIZED");
+        pub const UNINITIALIZED: State = State::new(3);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("KEY_PROJECT_DELETED"),
+                3 => std::borrow::Cow::Borrowed("UNINITIALIZED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "KEY_PROJECT_DELETED" => std::option::Option::Some(Self::KEY_PROJECT_DELETED),
+                "UNINITIALIZED" => std::option::Option::Some(Self::UNINITIALIZED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1457,27 +1474,11 @@ pub mod ekm_connection {
     /// [google.cloud.kms.v1.EkmConnection]: crate::model::EkmConnection
     /// [google.cloud.kms.v1.EkmConnection.KeyManagementMode]: crate::model::ekm_connection::KeyManagementMode
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct KeyManagementMode(std::borrow::Cow<'static, str>);
+    pub struct KeyManagementMode(i32);
 
     impl KeyManagementMode {
-        /// Creates a new KeyManagementMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [KeyManagementMode](KeyManagementMode)
-    pub mod key_management_mode {
-        use super::KeyManagementMode;
-
         /// Not specified.
-        pub const KEY_MANAGEMENT_MODE_UNSPECIFIED: KeyManagementMode =
-            KeyManagementMode::new("KEY_MANAGEMENT_MODE_UNSPECIFIED");
+        pub const KEY_MANAGEMENT_MODE_UNSPECIFIED: KeyManagementMode = KeyManagementMode::new(0);
 
         /// EKM-side key management operations on
         /// [CryptoKeys][google.cloud.kms.v1.CryptoKey] created with this
@@ -1497,7 +1498,7 @@ pub mod ekm_connection {
         /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
         /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
         /// [google.cloud.kms.v1.EkmConnection]: crate::model::EkmConnection
-        pub const MANUAL: KeyManagementMode = KeyManagementMode::new("MANUAL");
+        pub const MANUAL: KeyManagementMode = KeyManagementMode::new(1);
 
         /// All [CryptoKeys][google.cloud.kms.v1.CryptoKey] created with this
         /// [EkmConnection][google.cloud.kms.v1.EkmConnection] use EKM-side key
@@ -1519,18 +1520,50 @@ pub mod ekm_connection {
         /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
         /// [google.cloud.kms.v1.EkmConnection]: crate::model::EkmConnection
         /// [google.cloud.kms.v1.KeyManagementService.DestroyCryptoKeyVersion]: crate::client::KeyManagementService::destroy_crypto_key_version
-        pub const CLOUD_KMS: KeyManagementMode = KeyManagementMode::new("CLOUD_KMS");
+        pub const CLOUD_KMS: KeyManagementMode = KeyManagementMode::new(2);
+
+        /// Creates a new KeyManagementMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("KEY_MANAGEMENT_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MANUAL"),
+                2 => std::borrow::Cow::Borrowed("CLOUD_KMS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "KEY_MANAGEMENT_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::KEY_MANAGEMENT_MODE_UNSPECIFIED)
+                }
+                "MANUAL" => std::option::Option::Some(Self::MANUAL),
+                "CLOUD_KMS" => std::option::Option::Some(Self::CLOUD_KMS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for KeyManagementMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for KeyManagementMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for KeyManagementMode {
         fn default() -> Self {
-            key_management_mode::KEY_MANAGEMENT_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2028,27 +2061,11 @@ pub mod crypto_key {
     /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
     /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose]: crate::model::crypto_key::CryptoKeyPurpose
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CryptoKeyPurpose(std::borrow::Cow<'static, str>);
+    pub struct CryptoKeyPurpose(i32);
 
     impl CryptoKeyPurpose {
-        /// Creates a new CryptoKeyPurpose instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CryptoKeyPurpose](CryptoKeyPurpose)
-    pub mod crypto_key_purpose {
-        use super::CryptoKeyPurpose;
-
         /// Not specified.
-        pub const CRYPTO_KEY_PURPOSE_UNSPECIFIED: CryptoKeyPurpose =
-            CryptoKeyPurpose::new("CRYPTO_KEY_PURPOSE_UNSPECIFIED");
+        pub const CRYPTO_KEY_PURPOSE_UNSPECIFIED: CryptoKeyPurpose = CryptoKeyPurpose::new(0);
 
         /// [CryptoKeys][google.cloud.kms.v1.CryptoKey] with this purpose may be used
         /// with [Encrypt][google.cloud.kms.v1.KeyManagementService.Encrypt] and
@@ -2057,7 +2074,7 @@ pub mod crypto_key {
         /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
         /// [google.cloud.kms.v1.KeyManagementService.Decrypt]: crate::client::KeyManagementService::decrypt
         /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::client::KeyManagementService::encrypt
-        pub const ENCRYPT_DECRYPT: CryptoKeyPurpose = CryptoKeyPurpose::new("ENCRYPT_DECRYPT");
+        pub const ENCRYPT_DECRYPT: CryptoKeyPurpose = CryptoKeyPurpose::new(1);
 
         /// [CryptoKeys][google.cloud.kms.v1.CryptoKey] with this purpose may be used
         /// with
@@ -2068,7 +2085,7 @@ pub mod crypto_key {
         /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
         /// [google.cloud.kms.v1.KeyManagementService.AsymmetricSign]: crate::client::KeyManagementService::asymmetric_sign
         /// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::client::KeyManagementService::get_public_key
-        pub const ASYMMETRIC_SIGN: CryptoKeyPurpose = CryptoKeyPurpose::new("ASYMMETRIC_SIGN");
+        pub const ASYMMETRIC_SIGN: CryptoKeyPurpose = CryptoKeyPurpose::new(5);
 
         /// [CryptoKeys][google.cloud.kms.v1.CryptoKey] with this purpose may be used
         /// with
@@ -2079,8 +2096,7 @@ pub mod crypto_key {
         /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
         /// [google.cloud.kms.v1.KeyManagementService.AsymmetricDecrypt]: crate::client::KeyManagementService::asymmetric_decrypt
         /// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::client::KeyManagementService::get_public_key
-        pub const ASYMMETRIC_DECRYPT: CryptoKeyPurpose =
-            CryptoKeyPurpose::new("ASYMMETRIC_DECRYPT");
+        pub const ASYMMETRIC_DECRYPT: CryptoKeyPurpose = CryptoKeyPurpose::new(6);
 
         /// [CryptoKeys][google.cloud.kms.v1.CryptoKey] with this purpose may be used
         /// with [RawEncrypt][google.cloud.kms.v1.KeyManagementService.RawEncrypt]
@@ -2091,26 +2107,63 @@ pub mod crypto_key {
         /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
         /// [google.cloud.kms.v1.KeyManagementService.RawDecrypt]: crate::client::KeyManagementService::raw_decrypt
         /// [google.cloud.kms.v1.KeyManagementService.RawEncrypt]: crate::client::KeyManagementService::raw_encrypt
-        pub const RAW_ENCRYPT_DECRYPT: CryptoKeyPurpose =
-            CryptoKeyPurpose::new("RAW_ENCRYPT_DECRYPT");
+        pub const RAW_ENCRYPT_DECRYPT: CryptoKeyPurpose = CryptoKeyPurpose::new(7);
 
         /// [CryptoKeys][google.cloud.kms.v1.CryptoKey] with this purpose may be used
         /// with [MacSign][google.cloud.kms.v1.KeyManagementService.MacSign].
         ///
         /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
         /// [google.cloud.kms.v1.KeyManagementService.MacSign]: crate::client::KeyManagementService::mac_sign
-        pub const MAC: CryptoKeyPurpose = CryptoKeyPurpose::new("MAC");
+        pub const MAC: CryptoKeyPurpose = CryptoKeyPurpose::new(9);
+
+        /// Creates a new CryptoKeyPurpose instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CRYPTO_KEY_PURPOSE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENCRYPT_DECRYPT"),
+                5 => std::borrow::Cow::Borrowed("ASYMMETRIC_SIGN"),
+                6 => std::borrow::Cow::Borrowed("ASYMMETRIC_DECRYPT"),
+                7 => std::borrow::Cow::Borrowed("RAW_ENCRYPT_DECRYPT"),
+                9 => std::borrow::Cow::Borrowed("MAC"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CRYPTO_KEY_PURPOSE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CRYPTO_KEY_PURPOSE_UNSPECIFIED)
+                }
+                "ENCRYPT_DECRYPT" => std::option::Option::Some(Self::ENCRYPT_DECRYPT),
+                "ASYMMETRIC_SIGN" => std::option::Option::Some(Self::ASYMMETRIC_SIGN),
+                "ASYMMETRIC_DECRYPT" => std::option::Option::Some(Self::ASYMMETRIC_DECRYPT),
+                "RAW_ENCRYPT_DECRYPT" => std::option::Option::Some(Self::RAW_ENCRYPT_DECRYPT),
+                "MAC" => std::option::Option::Some(Self::MAC),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CryptoKeyPurpose {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CryptoKeyPurpose {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CryptoKeyPurpose {
         fn default() -> Self {
-            crypto_key_purpose::CRYPTO_KEY_PURPOSE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -2353,51 +2406,65 @@ pub mod key_operation_attestation {
 
     /// Attestation formats provided by the HSM.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AttestationFormat(std::borrow::Cow<'static, str>);
+    pub struct AttestationFormat(i32);
 
     impl AttestationFormat {
-        /// Creates a new AttestationFormat instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [AttestationFormat](AttestationFormat)
-    pub mod attestation_format {
-        use super::AttestationFormat;
-
         /// Not specified.
-        pub const ATTESTATION_FORMAT_UNSPECIFIED: AttestationFormat =
-            AttestationFormat::new("ATTESTATION_FORMAT_UNSPECIFIED");
+        pub const ATTESTATION_FORMAT_UNSPECIFIED: AttestationFormat = AttestationFormat::new(0);
 
         /// Cavium HSM attestation compressed with gzip. Note that this format is
         /// defined by Cavium and subject to change at any time.
         ///
         /// See
         /// <https://www.marvell.com/products/security-solutions/nitrox-hs-adapters/software-key-attestation.html>.
-        pub const CAVIUM_V1_COMPRESSED: AttestationFormat =
-            AttestationFormat::new("CAVIUM_V1_COMPRESSED");
+        pub const CAVIUM_V1_COMPRESSED: AttestationFormat = AttestationFormat::new(3);
 
         /// Cavium HSM attestation V2 compressed with gzip. This is a new format
         /// introduced in Cavium's version 3.2-08.
-        pub const CAVIUM_V2_COMPRESSED: AttestationFormat =
-            AttestationFormat::new("CAVIUM_V2_COMPRESSED");
+        pub const CAVIUM_V2_COMPRESSED: AttestationFormat = AttestationFormat::new(4);
+
+        /// Creates a new AttestationFormat instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ATTESTATION_FORMAT_UNSPECIFIED"),
+                3 => std::borrow::Cow::Borrowed("CAVIUM_V1_COMPRESSED"),
+                4 => std::borrow::Cow::Borrowed("CAVIUM_V2_COMPRESSED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ATTESTATION_FORMAT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ATTESTATION_FORMAT_UNSPECIFIED)
+                }
+                "CAVIUM_V1_COMPRESSED" => std::option::Option::Some(Self::CAVIUM_V1_COMPRESSED),
+                "CAVIUM_V2_COMPRESSED" => std::option::Option::Some(Self::CAVIUM_V2_COMPRESSED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for AttestationFormat {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AttestationFormat {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AttestationFormat {
         fn default() -> Self {
-            attestation_format::ATTESTATION_FORMAT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2783,195 +2850,313 @@ pub mod crypto_key_version {
     /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm.GOOGLE_SYMMETRIC_ENCRYPTION]: crate::model::crypto_key_version::crypto_key_version_algorithm::GOOGLE_SYMMETRIC_ENCRYPTION
     /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm.RSA_SIGN_PSS_2048_SHA256]: crate::model::crypto_key_version::crypto_key_version_algorithm::RSA_SIGN_PSS_2048_SHA256
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CryptoKeyVersionAlgorithm(std::borrow::Cow<'static, str>);
+    pub struct CryptoKeyVersionAlgorithm(i32);
 
     impl CryptoKeyVersionAlgorithm {
-        /// Creates a new CryptoKeyVersionAlgorithm instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CryptoKeyVersionAlgorithm](CryptoKeyVersionAlgorithm)
-    pub mod crypto_key_version_algorithm {
-        use super::CryptoKeyVersionAlgorithm;
-
         /// Not specified.
         pub const CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED");
+            CryptoKeyVersionAlgorithm::new(0);
 
         /// Creates symmetric encryption keys.
         pub const GOOGLE_SYMMETRIC_ENCRYPTION: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("GOOGLE_SYMMETRIC_ENCRYPTION");
+            CryptoKeyVersionAlgorithm::new(1);
 
         /// AES-GCM (Galois Counter Mode) using 128-bit keys.
-        pub const AES_128_GCM: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("AES_128_GCM");
+        pub const AES_128_GCM: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(41);
 
         /// AES-GCM (Galois Counter Mode) using 256-bit keys.
-        pub const AES_256_GCM: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("AES_256_GCM");
+        pub const AES_256_GCM: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(19);
 
         /// AES-CBC (Cipher Block Chaining Mode) using 128-bit keys.
-        pub const AES_128_CBC: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("AES_128_CBC");
+        pub const AES_128_CBC: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(42);
 
         /// AES-CBC (Cipher Block Chaining Mode) using 256-bit keys.
-        pub const AES_256_CBC: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("AES_256_CBC");
+        pub const AES_256_CBC: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(43);
 
         /// AES-CTR (Counter Mode) using 128-bit keys.
-        pub const AES_128_CTR: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("AES_128_CTR");
+        pub const AES_128_CTR: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(44);
 
         /// AES-CTR (Counter Mode) using 256-bit keys.
-        pub const AES_256_CTR: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("AES_256_CTR");
+        pub const AES_256_CTR: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(45);
 
         /// RSASSA-PSS 2048 bit key with a SHA256 digest.
         pub const RSA_SIGN_PSS_2048_SHA256: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("RSA_SIGN_PSS_2048_SHA256");
+            CryptoKeyVersionAlgorithm::new(2);
 
         /// RSASSA-PSS 3072 bit key with a SHA256 digest.
         pub const RSA_SIGN_PSS_3072_SHA256: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("RSA_SIGN_PSS_3072_SHA256");
+            CryptoKeyVersionAlgorithm::new(3);
 
         /// RSASSA-PSS 4096 bit key with a SHA256 digest.
         pub const RSA_SIGN_PSS_4096_SHA256: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("RSA_SIGN_PSS_4096_SHA256");
+            CryptoKeyVersionAlgorithm::new(4);
 
         /// RSASSA-PSS 4096 bit key with a SHA512 digest.
         pub const RSA_SIGN_PSS_4096_SHA512: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("RSA_SIGN_PSS_4096_SHA512");
+            CryptoKeyVersionAlgorithm::new(15);
 
         /// RSASSA-PKCS1-v1_5 with a 2048 bit key and a SHA256 digest.
         pub const RSA_SIGN_PKCS1_2048_SHA256: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("RSA_SIGN_PKCS1_2048_SHA256");
+            CryptoKeyVersionAlgorithm::new(5);
 
         /// RSASSA-PKCS1-v1_5 with a 3072 bit key and a SHA256 digest.
         pub const RSA_SIGN_PKCS1_3072_SHA256: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("RSA_SIGN_PKCS1_3072_SHA256");
+            CryptoKeyVersionAlgorithm::new(6);
 
         /// RSASSA-PKCS1-v1_5 with a 4096 bit key and a SHA256 digest.
         pub const RSA_SIGN_PKCS1_4096_SHA256: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("RSA_SIGN_PKCS1_4096_SHA256");
+            CryptoKeyVersionAlgorithm::new(7);
 
         /// RSASSA-PKCS1-v1_5 with a 4096 bit key and a SHA512 digest.
         pub const RSA_SIGN_PKCS1_4096_SHA512: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("RSA_SIGN_PKCS1_4096_SHA512");
+            CryptoKeyVersionAlgorithm::new(16);
 
         /// RSASSA-PKCS1-v1_5 signing without encoding, with a 2048 bit key.
         pub const RSA_SIGN_RAW_PKCS1_2048: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("RSA_SIGN_RAW_PKCS1_2048");
+            CryptoKeyVersionAlgorithm::new(28);
 
         /// RSASSA-PKCS1-v1_5 signing without encoding, with a 3072 bit key.
         pub const RSA_SIGN_RAW_PKCS1_3072: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("RSA_SIGN_RAW_PKCS1_3072");
+            CryptoKeyVersionAlgorithm::new(29);
 
         /// RSASSA-PKCS1-v1_5 signing without encoding, with a 4096 bit key.
         pub const RSA_SIGN_RAW_PKCS1_4096: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("RSA_SIGN_RAW_PKCS1_4096");
+            CryptoKeyVersionAlgorithm::new(30);
 
         /// RSAES-OAEP 2048 bit key with a SHA256 digest.
         pub const RSA_DECRYPT_OAEP_2048_SHA256: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("RSA_DECRYPT_OAEP_2048_SHA256");
+            CryptoKeyVersionAlgorithm::new(8);
 
         /// RSAES-OAEP 3072 bit key with a SHA256 digest.
         pub const RSA_DECRYPT_OAEP_3072_SHA256: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("RSA_DECRYPT_OAEP_3072_SHA256");
+            CryptoKeyVersionAlgorithm::new(9);
 
         /// RSAES-OAEP 4096 bit key with a SHA256 digest.
         pub const RSA_DECRYPT_OAEP_4096_SHA256: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("RSA_DECRYPT_OAEP_4096_SHA256");
+            CryptoKeyVersionAlgorithm::new(10);
 
         /// RSAES-OAEP 4096 bit key with a SHA512 digest.
         pub const RSA_DECRYPT_OAEP_4096_SHA512: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("RSA_DECRYPT_OAEP_4096_SHA512");
+            CryptoKeyVersionAlgorithm::new(17);
 
         /// RSAES-OAEP 2048 bit key with a SHA1 digest.
         pub const RSA_DECRYPT_OAEP_2048_SHA1: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("RSA_DECRYPT_OAEP_2048_SHA1");
+            CryptoKeyVersionAlgorithm::new(37);
 
         /// RSAES-OAEP 3072 bit key with a SHA1 digest.
         pub const RSA_DECRYPT_OAEP_3072_SHA1: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("RSA_DECRYPT_OAEP_3072_SHA1");
+            CryptoKeyVersionAlgorithm::new(38);
 
         /// RSAES-OAEP 4096 bit key with a SHA1 digest.
         pub const RSA_DECRYPT_OAEP_4096_SHA1: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("RSA_DECRYPT_OAEP_4096_SHA1");
+            CryptoKeyVersionAlgorithm::new(39);
 
         /// ECDSA on the NIST P-256 curve with a SHA256 digest.
         /// Other hash functions can also be used:
         /// <https://cloud.google.com/kms/docs/create-validate-signatures#ecdsa_support_for_other_hash_algorithms>
         pub const EC_SIGN_P256_SHA256: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("EC_SIGN_P256_SHA256");
+            CryptoKeyVersionAlgorithm::new(12);
 
         /// ECDSA on the NIST P-384 curve with a SHA384 digest.
         /// Other hash functions can also be used:
         /// <https://cloud.google.com/kms/docs/create-validate-signatures#ecdsa_support_for_other_hash_algorithms>
         pub const EC_SIGN_P384_SHA384: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("EC_SIGN_P384_SHA384");
+            CryptoKeyVersionAlgorithm::new(13);
 
         /// ECDSA on the non-NIST secp256k1 curve. This curve is only supported for
         /// HSM protection level.
         /// Other hash functions can also be used:
         /// <https://cloud.google.com/kms/docs/create-validate-signatures#ecdsa_support_for_other_hash_algorithms>
         pub const EC_SIGN_SECP256K1_SHA256: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("EC_SIGN_SECP256K1_SHA256");
+            CryptoKeyVersionAlgorithm::new(31);
 
         /// EdDSA on the Curve25519 in pure mode (taking data as input).
-        pub const EC_SIGN_ED25519: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("EC_SIGN_ED25519");
+        pub const EC_SIGN_ED25519: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(40);
 
         /// HMAC-SHA256 signing with a 256 bit key.
-        pub const HMAC_SHA256: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("HMAC_SHA256");
+        pub const HMAC_SHA256: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(32);
 
         /// HMAC-SHA1 signing with a 160 bit key.
-        pub const HMAC_SHA1: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("HMAC_SHA1");
+        pub const HMAC_SHA1: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(33);
 
         /// HMAC-SHA384 signing with a 384 bit key.
-        pub const HMAC_SHA384: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("HMAC_SHA384");
+        pub const HMAC_SHA384: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(34);
 
         /// HMAC-SHA512 signing with a 512 bit key.
-        pub const HMAC_SHA512: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("HMAC_SHA512");
+        pub const HMAC_SHA512: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(35);
 
         /// HMAC-SHA224 signing with a 224 bit key.
-        pub const HMAC_SHA224: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("HMAC_SHA224");
+        pub const HMAC_SHA224: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(36);
 
         /// Algorithm representing symmetric encryption by an external key manager.
         pub const EXTERNAL_SYMMETRIC_ENCRYPTION: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("EXTERNAL_SYMMETRIC_ENCRYPTION");
+            CryptoKeyVersionAlgorithm::new(18);
 
         /// The post-quantum Module-Lattice-Based Digital Signature Algorithm, at
         /// security level 3. Randomized version.
-        pub const PQ_SIGN_ML_DSA_65: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("PQ_SIGN_ML_DSA_65");
+        pub const PQ_SIGN_ML_DSA_65: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(56);
 
         /// The post-quantum stateless hash-based digital signature algorithm, at
         /// security level 1. Randomized version.
         pub const PQ_SIGN_SLH_DSA_SHA2_128S: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new("PQ_SIGN_SLH_DSA_SHA2_128S");
+            CryptoKeyVersionAlgorithm::new(57);
+
+        /// Creates a new CryptoKeyVersionAlgorithm instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GOOGLE_SYMMETRIC_ENCRYPTION"),
+                2 => std::borrow::Cow::Borrowed("RSA_SIGN_PSS_2048_SHA256"),
+                3 => std::borrow::Cow::Borrowed("RSA_SIGN_PSS_3072_SHA256"),
+                4 => std::borrow::Cow::Borrowed("RSA_SIGN_PSS_4096_SHA256"),
+                5 => std::borrow::Cow::Borrowed("RSA_SIGN_PKCS1_2048_SHA256"),
+                6 => std::borrow::Cow::Borrowed("RSA_SIGN_PKCS1_3072_SHA256"),
+                7 => std::borrow::Cow::Borrowed("RSA_SIGN_PKCS1_4096_SHA256"),
+                8 => std::borrow::Cow::Borrowed("RSA_DECRYPT_OAEP_2048_SHA256"),
+                9 => std::borrow::Cow::Borrowed("RSA_DECRYPT_OAEP_3072_SHA256"),
+                10 => std::borrow::Cow::Borrowed("RSA_DECRYPT_OAEP_4096_SHA256"),
+                12 => std::borrow::Cow::Borrowed("EC_SIGN_P256_SHA256"),
+                13 => std::borrow::Cow::Borrowed("EC_SIGN_P384_SHA384"),
+                15 => std::borrow::Cow::Borrowed("RSA_SIGN_PSS_4096_SHA512"),
+                16 => std::borrow::Cow::Borrowed("RSA_SIGN_PKCS1_4096_SHA512"),
+                17 => std::borrow::Cow::Borrowed("RSA_DECRYPT_OAEP_4096_SHA512"),
+                18 => std::borrow::Cow::Borrowed("EXTERNAL_SYMMETRIC_ENCRYPTION"),
+                19 => std::borrow::Cow::Borrowed("AES_256_GCM"),
+                28 => std::borrow::Cow::Borrowed("RSA_SIGN_RAW_PKCS1_2048"),
+                29 => std::borrow::Cow::Borrowed("RSA_SIGN_RAW_PKCS1_3072"),
+                30 => std::borrow::Cow::Borrowed("RSA_SIGN_RAW_PKCS1_4096"),
+                31 => std::borrow::Cow::Borrowed("EC_SIGN_SECP256K1_SHA256"),
+                32 => std::borrow::Cow::Borrowed("HMAC_SHA256"),
+                33 => std::borrow::Cow::Borrowed("HMAC_SHA1"),
+                34 => std::borrow::Cow::Borrowed("HMAC_SHA384"),
+                35 => std::borrow::Cow::Borrowed("HMAC_SHA512"),
+                36 => std::borrow::Cow::Borrowed("HMAC_SHA224"),
+                37 => std::borrow::Cow::Borrowed("RSA_DECRYPT_OAEP_2048_SHA1"),
+                38 => std::borrow::Cow::Borrowed("RSA_DECRYPT_OAEP_3072_SHA1"),
+                39 => std::borrow::Cow::Borrowed("RSA_DECRYPT_OAEP_4096_SHA1"),
+                40 => std::borrow::Cow::Borrowed("EC_SIGN_ED25519"),
+                41 => std::borrow::Cow::Borrowed("AES_128_GCM"),
+                42 => std::borrow::Cow::Borrowed("AES_128_CBC"),
+                43 => std::borrow::Cow::Borrowed("AES_256_CBC"),
+                44 => std::borrow::Cow::Borrowed("AES_128_CTR"),
+                45 => std::borrow::Cow::Borrowed("AES_256_CTR"),
+                56 => std::borrow::Cow::Borrowed("PQ_SIGN_ML_DSA_65"),
+                57 => std::borrow::Cow::Borrowed("PQ_SIGN_SLH_DSA_SHA2_128S"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED)
+                }
+                "GOOGLE_SYMMETRIC_ENCRYPTION" => {
+                    std::option::Option::Some(Self::GOOGLE_SYMMETRIC_ENCRYPTION)
+                }
+                "AES_128_GCM" => std::option::Option::Some(Self::AES_128_GCM),
+                "AES_256_GCM" => std::option::Option::Some(Self::AES_256_GCM),
+                "AES_128_CBC" => std::option::Option::Some(Self::AES_128_CBC),
+                "AES_256_CBC" => std::option::Option::Some(Self::AES_256_CBC),
+                "AES_128_CTR" => std::option::Option::Some(Self::AES_128_CTR),
+                "AES_256_CTR" => std::option::Option::Some(Self::AES_256_CTR),
+                "RSA_SIGN_PSS_2048_SHA256" => {
+                    std::option::Option::Some(Self::RSA_SIGN_PSS_2048_SHA256)
+                }
+                "RSA_SIGN_PSS_3072_SHA256" => {
+                    std::option::Option::Some(Self::RSA_SIGN_PSS_3072_SHA256)
+                }
+                "RSA_SIGN_PSS_4096_SHA256" => {
+                    std::option::Option::Some(Self::RSA_SIGN_PSS_4096_SHA256)
+                }
+                "RSA_SIGN_PSS_4096_SHA512" => {
+                    std::option::Option::Some(Self::RSA_SIGN_PSS_4096_SHA512)
+                }
+                "RSA_SIGN_PKCS1_2048_SHA256" => {
+                    std::option::Option::Some(Self::RSA_SIGN_PKCS1_2048_SHA256)
+                }
+                "RSA_SIGN_PKCS1_3072_SHA256" => {
+                    std::option::Option::Some(Self::RSA_SIGN_PKCS1_3072_SHA256)
+                }
+                "RSA_SIGN_PKCS1_4096_SHA256" => {
+                    std::option::Option::Some(Self::RSA_SIGN_PKCS1_4096_SHA256)
+                }
+                "RSA_SIGN_PKCS1_4096_SHA512" => {
+                    std::option::Option::Some(Self::RSA_SIGN_PKCS1_4096_SHA512)
+                }
+                "RSA_SIGN_RAW_PKCS1_2048" => {
+                    std::option::Option::Some(Self::RSA_SIGN_RAW_PKCS1_2048)
+                }
+                "RSA_SIGN_RAW_PKCS1_3072" => {
+                    std::option::Option::Some(Self::RSA_SIGN_RAW_PKCS1_3072)
+                }
+                "RSA_SIGN_RAW_PKCS1_4096" => {
+                    std::option::Option::Some(Self::RSA_SIGN_RAW_PKCS1_4096)
+                }
+                "RSA_DECRYPT_OAEP_2048_SHA256" => {
+                    std::option::Option::Some(Self::RSA_DECRYPT_OAEP_2048_SHA256)
+                }
+                "RSA_DECRYPT_OAEP_3072_SHA256" => {
+                    std::option::Option::Some(Self::RSA_DECRYPT_OAEP_3072_SHA256)
+                }
+                "RSA_DECRYPT_OAEP_4096_SHA256" => {
+                    std::option::Option::Some(Self::RSA_DECRYPT_OAEP_4096_SHA256)
+                }
+                "RSA_DECRYPT_OAEP_4096_SHA512" => {
+                    std::option::Option::Some(Self::RSA_DECRYPT_OAEP_4096_SHA512)
+                }
+                "RSA_DECRYPT_OAEP_2048_SHA1" => {
+                    std::option::Option::Some(Self::RSA_DECRYPT_OAEP_2048_SHA1)
+                }
+                "RSA_DECRYPT_OAEP_3072_SHA1" => {
+                    std::option::Option::Some(Self::RSA_DECRYPT_OAEP_3072_SHA1)
+                }
+                "RSA_DECRYPT_OAEP_4096_SHA1" => {
+                    std::option::Option::Some(Self::RSA_DECRYPT_OAEP_4096_SHA1)
+                }
+                "EC_SIGN_P256_SHA256" => std::option::Option::Some(Self::EC_SIGN_P256_SHA256),
+                "EC_SIGN_P384_SHA384" => std::option::Option::Some(Self::EC_SIGN_P384_SHA384),
+                "EC_SIGN_SECP256K1_SHA256" => {
+                    std::option::Option::Some(Self::EC_SIGN_SECP256K1_SHA256)
+                }
+                "EC_SIGN_ED25519" => std::option::Option::Some(Self::EC_SIGN_ED25519),
+                "HMAC_SHA256" => std::option::Option::Some(Self::HMAC_SHA256),
+                "HMAC_SHA1" => std::option::Option::Some(Self::HMAC_SHA1),
+                "HMAC_SHA384" => std::option::Option::Some(Self::HMAC_SHA384),
+                "HMAC_SHA512" => std::option::Option::Some(Self::HMAC_SHA512),
+                "HMAC_SHA224" => std::option::Option::Some(Self::HMAC_SHA224),
+                "EXTERNAL_SYMMETRIC_ENCRYPTION" => {
+                    std::option::Option::Some(Self::EXTERNAL_SYMMETRIC_ENCRYPTION)
+                }
+                "PQ_SIGN_ML_DSA_65" => std::option::Option::Some(Self::PQ_SIGN_ML_DSA_65),
+                "PQ_SIGN_SLH_DSA_SHA2_128S" => {
+                    std::option::Option::Some(Self::PQ_SIGN_SLH_DSA_SHA2_128S)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CryptoKeyVersionAlgorithm {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CryptoKeyVersionAlgorithm {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CryptoKeyVersionAlgorithm {
         fn default() -> Self {
-            crypto_key_version_algorithm::CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -2980,27 +3165,12 @@ pub mod crypto_key_version {
     ///
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CryptoKeyVersionState(std::borrow::Cow<'static, str>);
+    pub struct CryptoKeyVersionState(i32);
 
     impl CryptoKeyVersionState {
-        /// Creates a new CryptoKeyVersionState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CryptoKeyVersionState](CryptoKeyVersionState)
-    pub mod crypto_key_version_state {
-        use super::CryptoKeyVersionState;
-
         /// Not specified.
         pub const CRYPTO_KEY_VERSION_STATE_UNSPECIFIED: CryptoKeyVersionState =
-            CryptoKeyVersionState::new("CRYPTO_KEY_VERSION_STATE_UNSPECIFIED");
+            CryptoKeyVersionState::new(0);
 
         /// This version is still being generated. It may not be used, enabled,
         /// disabled, or destroyed yet. Cloud KMS will automatically mark this
@@ -3009,11 +3179,10 @@ pub mod crypto_key_version {
         /// as soon as the version is ready.
         ///
         /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: crate::model::crypto_key_version::crypto_key_version_state::ENABLED
-        pub const PENDING_GENERATION: CryptoKeyVersionState =
-            CryptoKeyVersionState::new("PENDING_GENERATION");
+        pub const PENDING_GENERATION: CryptoKeyVersionState = CryptoKeyVersionState::new(5);
 
         /// This version may be used for cryptographic operations.
-        pub const ENABLED: CryptoKeyVersionState = CryptoKeyVersionState::new("ENABLED");
+        pub const ENABLED: CryptoKeyVersionState = CryptoKeyVersionState::new(1);
 
         /// This version may not be used, but the key material is still available,
         /// and the version can be placed back into the
@@ -3021,7 +3190,7 @@ pub mod crypto_key_version {
         /// state.
         ///
         /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: crate::model::crypto_key_version::crypto_key_version_state::ENABLED
-        pub const DISABLED: CryptoKeyVersionState = CryptoKeyVersionState::new("DISABLED");
+        pub const DISABLED: CryptoKeyVersionState = CryptoKeyVersionState::new(2);
 
         /// This version is destroyed, and the key material is no longer stored.
         /// This version may only become
@@ -3034,7 +3203,7 @@ pub mod crypto_key_version {
         /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: crate::model::crypto_key_version::crypto_key_version_state::ENABLED
         /// [google.cloud.kms.v1.CryptoKeyVersion.reimport_eligible]: crate::model::CryptoKeyVersion::reimport_eligible
         /// [google.cloud.kms.v1.KeyManagementService.ImportCryptoKeyVersion]: crate::client::KeyManagementService::import_crypto_key_version
-        pub const DESTROYED: CryptoKeyVersionState = CryptoKeyVersionState::new("DESTROYED");
+        pub const DESTROYED: CryptoKeyVersionState = CryptoKeyVersionState::new(3);
 
         /// This version is scheduled for destruction, and will be destroyed soon.
         /// Call
@@ -3045,8 +3214,7 @@ pub mod crypto_key_version {
         ///
         /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED]: crate::model::crypto_key_version::crypto_key_version_state::DISABLED
         /// [google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]: crate::client::KeyManagementService::restore_crypto_key_version
-        pub const DESTROY_SCHEDULED: CryptoKeyVersionState =
-            CryptoKeyVersionState::new("DESTROY_SCHEDULED");
+        pub const DESTROY_SCHEDULED: CryptoKeyVersionState = CryptoKeyVersionState::new(4);
 
         /// This version is still being imported. It may not be used, enabled,
         /// disabled, or destroyed yet. Cloud KMS will automatically mark this
@@ -3055,8 +3223,7 @@ pub mod crypto_key_version {
         /// as soon as the version is ready.
         ///
         /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: crate::model::crypto_key_version::crypto_key_version_state::ENABLED
-        pub const PENDING_IMPORT: CryptoKeyVersionState =
-            CryptoKeyVersionState::new("PENDING_IMPORT");
+        pub const PENDING_IMPORT: CryptoKeyVersionState = CryptoKeyVersionState::new(6);
 
         /// This version was not imported successfully. It may not be used, enabled,
         /// disabled, or destroyed. The submitted key material has been discarded.
@@ -3064,22 +3231,20 @@ pub mod crypto_key_version {
         /// [CryptoKeyVersion.import_failure_reason][google.cloud.kms.v1.CryptoKeyVersion.import_failure_reason].
         ///
         /// [google.cloud.kms.v1.CryptoKeyVersion.import_failure_reason]: crate::model::CryptoKeyVersion::import_failure_reason
-        pub const IMPORT_FAILED: CryptoKeyVersionState =
-            CryptoKeyVersionState::new("IMPORT_FAILED");
+        pub const IMPORT_FAILED: CryptoKeyVersionState = CryptoKeyVersionState::new(7);
 
         /// This version was not generated successfully. It may not be used, enabled,
         /// disabled, or destroyed. Additional details can be found in
         /// [CryptoKeyVersion.generation_failure_reason][google.cloud.kms.v1.CryptoKeyVersion.generation_failure_reason].
         ///
         /// [google.cloud.kms.v1.CryptoKeyVersion.generation_failure_reason]: crate::model::CryptoKeyVersion::generation_failure_reason
-        pub const GENERATION_FAILED: CryptoKeyVersionState =
-            CryptoKeyVersionState::new("GENERATION_FAILED");
+        pub const GENERATION_FAILED: CryptoKeyVersionState = CryptoKeyVersionState::new(8);
 
         /// This version was destroyed, and it may not be used or enabled again.
         /// Cloud KMS is waiting for the corresponding key material residing in an
         /// external key manager to be destroyed.
         pub const PENDING_EXTERNAL_DESTRUCTION: CryptoKeyVersionState =
-            CryptoKeyVersionState::new("PENDING_EXTERNAL_DESTRUCTION");
+            CryptoKeyVersionState::new(9);
 
         /// This version was destroyed, and it may not be used or enabled again.
         /// However, Cloud KMS could not confirm that the corresponding key material
@@ -3089,18 +3254,70 @@ pub mod crypto_key_version {
         ///
         /// [google.cloud.kms.v1.CryptoKeyVersion.external_destruction_failure_reason]: crate::model::CryptoKeyVersion::external_destruction_failure_reason
         pub const EXTERNAL_DESTRUCTION_FAILED: CryptoKeyVersionState =
-            CryptoKeyVersionState::new("EXTERNAL_DESTRUCTION_FAILED");
+            CryptoKeyVersionState::new(10);
+
+        /// Creates a new CryptoKeyVersionState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CRYPTO_KEY_VERSION_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENABLED"),
+                2 => std::borrow::Cow::Borrowed("DISABLED"),
+                3 => std::borrow::Cow::Borrowed("DESTROYED"),
+                4 => std::borrow::Cow::Borrowed("DESTROY_SCHEDULED"),
+                5 => std::borrow::Cow::Borrowed("PENDING_GENERATION"),
+                6 => std::borrow::Cow::Borrowed("PENDING_IMPORT"),
+                7 => std::borrow::Cow::Borrowed("IMPORT_FAILED"),
+                8 => std::borrow::Cow::Borrowed("GENERATION_FAILED"),
+                9 => std::borrow::Cow::Borrowed("PENDING_EXTERNAL_DESTRUCTION"),
+                10 => std::borrow::Cow::Borrowed("EXTERNAL_DESTRUCTION_FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CRYPTO_KEY_VERSION_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CRYPTO_KEY_VERSION_STATE_UNSPECIFIED)
+                }
+                "PENDING_GENERATION" => std::option::Option::Some(Self::PENDING_GENERATION),
+                "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "DESTROYED" => std::option::Option::Some(Self::DESTROYED),
+                "DESTROY_SCHEDULED" => std::option::Option::Some(Self::DESTROY_SCHEDULED),
+                "PENDING_IMPORT" => std::option::Option::Some(Self::PENDING_IMPORT),
+                "IMPORT_FAILED" => std::option::Option::Some(Self::IMPORT_FAILED),
+                "GENERATION_FAILED" => std::option::Option::Some(Self::GENERATION_FAILED),
+                "PENDING_EXTERNAL_DESTRUCTION" => {
+                    std::option::Option::Some(Self::PENDING_EXTERNAL_DESTRUCTION)
+                }
+                "EXTERNAL_DESTRUCTION_FAILED" => {
+                    std::option::Option::Some(Self::EXTERNAL_DESTRUCTION_FAILED)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CryptoKeyVersionState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CryptoKeyVersionState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CryptoKeyVersionState {
         fn default() -> Self {
-            crypto_key_version_state::CRYPTO_KEY_VERSION_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -3115,24 +3332,9 @@ pub mod crypto_key_version {
     /// [google.cloud.kms.v1.KeyManagementService.ListCryptoKeyVersions]: crate::client::KeyManagementService::list_crypto_key_versions
     /// [google.cloud.kms.v1.KeyManagementService.ListCryptoKeys]: crate::client::KeyManagementService::list_crypto_keys
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CryptoKeyVersionView(std::borrow::Cow<'static, str>);
+    pub struct CryptoKeyVersionView(i32);
 
     impl CryptoKeyVersionView {
-        /// Creates a new CryptoKeyVersionView instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CryptoKeyVersionView](CryptoKeyVersionView)
-    pub mod crypto_key_version_view {
-        use super::CryptoKeyVersionView;
-
         /// Default view for each
         /// [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]. Does not
         /// include the
@@ -3141,7 +3343,7 @@ pub mod crypto_key_version {
         /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
         /// [google.cloud.kms.v1.CryptoKeyVersion.attestation]: crate::model::CryptoKeyVersion::attestation
         pub const CRYPTO_KEY_VERSION_VIEW_UNSPECIFIED: CryptoKeyVersionView =
-            CryptoKeyVersionView::new("CRYPTO_KEY_VERSION_VIEW_UNSPECIFIED");
+            CryptoKeyVersionView::new(0);
 
         /// Provides all fields in each
         /// [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion], including the
@@ -3149,18 +3351,48 @@ pub mod crypto_key_version {
         ///
         /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
         /// [google.cloud.kms.v1.CryptoKeyVersion.attestation]: crate::model::CryptoKeyVersion::attestation
-        pub const FULL: CryptoKeyVersionView = CryptoKeyVersionView::new("FULL");
+        pub const FULL: CryptoKeyVersionView = CryptoKeyVersionView::new(1);
+
+        /// Creates a new CryptoKeyVersionView instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CRYPTO_KEY_VERSION_VIEW_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FULL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CRYPTO_KEY_VERSION_VIEW_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CRYPTO_KEY_VERSION_VIEW_UNSPECIFIED)
+                }
+                "FULL" => std::option::Option::Some(Self::FULL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CryptoKeyVersionView {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CryptoKeyVersionView {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CryptoKeyVersionView {
         fn default() -> Self {
-            crypto_key_version_view::CRYPTO_KEY_VERSION_VIEW_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3392,24 +3624,9 @@ pub mod public_key {
     ///
     /// [google.cloud.kms.v1.PublicKey]: crate::model::PublicKey
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PublicKeyFormat(std::borrow::Cow<'static, str>);
+    pub struct PublicKeyFormat(i32);
 
     impl PublicKeyFormat {
-        /// Creates a new PublicKeyFormat instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PublicKeyFormat](PublicKeyFormat)
-    pub mod public_key_format {
-        use super::PublicKeyFormat;
-
         /// If the
         /// [public_key_format][google.cloud.kms.v1.GetPublicKeyRequest.public_key_format]
         /// field is not specified:
@@ -3425,31 +3642,62 @@ pub mod public_key {
         /// [google.cloud.kms.v1.GetPublicKeyRequest.public_key_format]: crate::model::GetPublicKeyRequest::public_key_format
         /// [google.cloud.kms.v1.PublicKey.pem]: crate::model::PublicKey::pem
         /// [google.cloud.kms.v1.PublicKey.public_key]: crate::model::PublicKey::public_key
-        pub const PUBLIC_KEY_FORMAT_UNSPECIFIED: PublicKeyFormat =
-            PublicKeyFormat::new("PUBLIC_KEY_FORMAT_UNSPECIFIED");
+        pub const PUBLIC_KEY_FORMAT_UNSPECIFIED: PublicKeyFormat = PublicKeyFormat::new(0);
 
         /// The returned public key will be encoded in PEM format.
         /// See the [RFC7468](https://tools.ietf.org/html/rfc7468) sections for
         /// [General Considerations](https://tools.ietf.org/html/rfc7468#section-2)
         /// and [Textual Encoding of Subject Public Key Info]
         /// (<https://tools.ietf.org/html/rfc7468#section-13>) for more information.
-        pub const PEM: PublicKeyFormat = PublicKeyFormat::new("PEM");
+        pub const PEM: PublicKeyFormat = PublicKeyFormat::new(1);
 
         /// This is supported only for PQC algorithms.
         /// The key material is returned in the format defined by NIST PQC
         /// standards (FIPS 203, FIPS 204, and FIPS 205).
-        pub const NIST_PQC: PublicKeyFormat = PublicKeyFormat::new("NIST_PQC");
+        pub const NIST_PQC: PublicKeyFormat = PublicKeyFormat::new(3);
+
+        /// Creates a new PublicKeyFormat instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PUBLIC_KEY_FORMAT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PEM"),
+                3 => std::borrow::Cow::Borrowed("NIST_PQC"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PUBLIC_KEY_FORMAT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PUBLIC_KEY_FORMAT_UNSPECIFIED)
+                }
+                "PEM" => std::option::Option::Some(Self::PEM),
+                "NIST_PQC" => std::option::Option::Some(Self::NIST_PQC),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PublicKeyFormat {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PublicKeyFormat {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PublicKeyFormat {
         fn default() -> Self {
-            public_key_format::PUBLIC_KEY_FORMAT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3738,27 +3986,11 @@ pub mod import_job {
     /// [google.cloud.kms.v1.ImportJob]: crate::model::ImportJob
     /// [google.cloud.kms.v1.ImportJob.ImportMethod]: crate::model::import_job::ImportMethod
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ImportMethod(std::borrow::Cow<'static, str>);
+    pub struct ImportMethod(i32);
 
     impl ImportMethod {
-        /// Creates a new ImportMethod instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ImportMethod](ImportMethod)
-    pub mod import_method {
-        use super::ImportMethod;
-
         /// Not specified.
-        pub const IMPORT_METHOD_UNSPECIFIED: ImportMethod =
-            ImportMethod::new("IMPORT_METHOD_UNSPECIFIED");
+        pub const IMPORT_METHOD_UNSPECIFIED: ImportMethod = ImportMethod::new(0);
 
         /// This ImportMethod represents the CKM_RSA_AES_KEY_WRAP key wrapping
         /// scheme defined in the PKCS #11 standard. In summary, this involves
@@ -3766,8 +3998,7 @@ pub mod import_job {
         /// ephemeral AES key with a 3072 bit RSA key. For more details, see
         /// [RSA AES key wrap
         /// mechanism](http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/cos01/pkcs11-curr-v2.40-cos01.html#_Toc408226908).
-        pub const RSA_OAEP_3072_SHA1_AES_256: ImportMethod =
-            ImportMethod::new("RSA_OAEP_3072_SHA1_AES_256");
+        pub const RSA_OAEP_3072_SHA1_AES_256: ImportMethod = ImportMethod::new(1);
 
         /// This ImportMethod represents the CKM_RSA_AES_KEY_WRAP key wrapping
         /// scheme defined in the PKCS #11 standard. In summary, this involves
@@ -3775,8 +4006,7 @@ pub mod import_job {
         /// ephemeral AES key with a 4096 bit RSA key. For more details, see
         /// [RSA AES key wrap
         /// mechanism](http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/cos01/pkcs11-curr-v2.40-cos01.html#_Toc408226908).
-        pub const RSA_OAEP_4096_SHA1_AES_256: ImportMethod =
-            ImportMethod::new("RSA_OAEP_4096_SHA1_AES_256");
+        pub const RSA_OAEP_4096_SHA1_AES_256: ImportMethod = ImportMethod::new(2);
 
         /// This ImportMethod represents the CKM_RSA_AES_KEY_WRAP key wrapping
         /// scheme defined in the PKCS #11 standard. In summary, this involves
@@ -3784,8 +4014,7 @@ pub mod import_job {
         /// ephemeral AES key with a 3072 bit RSA key. For more details, see
         /// [RSA AES key wrap
         /// mechanism](http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/cos01/pkcs11-curr-v2.40-cos01.html#_Toc408226908).
-        pub const RSA_OAEP_3072_SHA256_AES_256: ImportMethod =
-            ImportMethod::new("RSA_OAEP_3072_SHA256_AES_256");
+        pub const RSA_OAEP_3072_SHA256_AES_256: ImportMethod = ImportMethod::new(3);
 
         /// This ImportMethod represents the CKM_RSA_AES_KEY_WRAP key wrapping
         /// scheme defined in the PKCS #11 standard. In summary, this involves
@@ -3793,31 +4022,78 @@ pub mod import_job {
         /// ephemeral AES key with a 4096 bit RSA key. For more details, see
         /// [RSA AES key wrap
         /// mechanism](http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/cos01/pkcs11-curr-v2.40-cos01.html#_Toc408226908).
-        pub const RSA_OAEP_4096_SHA256_AES_256: ImportMethod =
-            ImportMethod::new("RSA_OAEP_4096_SHA256_AES_256");
+        pub const RSA_OAEP_4096_SHA256_AES_256: ImportMethod = ImportMethod::new(4);
 
         /// This ImportMethod represents RSAES-OAEP with a 3072 bit RSA key. The
         /// key material to be imported is wrapped directly with the RSA key. Due
         /// to technical limitations of RSA wrapping, this method cannot be used to
         /// wrap RSA keys for import.
-        pub const RSA_OAEP_3072_SHA256: ImportMethod = ImportMethod::new("RSA_OAEP_3072_SHA256");
+        pub const RSA_OAEP_3072_SHA256: ImportMethod = ImportMethod::new(5);
 
         /// This ImportMethod represents RSAES-OAEP with a 4096 bit RSA key. The
         /// key material to be imported is wrapped directly with the RSA key. Due
         /// to technical limitations of RSA wrapping, this method cannot be used to
         /// wrap RSA keys for import.
-        pub const RSA_OAEP_4096_SHA256: ImportMethod = ImportMethod::new("RSA_OAEP_4096_SHA256");
+        pub const RSA_OAEP_4096_SHA256: ImportMethod = ImportMethod::new(6);
+
+        /// Creates a new ImportMethod instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("IMPORT_METHOD_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RSA_OAEP_3072_SHA1_AES_256"),
+                2 => std::borrow::Cow::Borrowed("RSA_OAEP_4096_SHA1_AES_256"),
+                3 => std::borrow::Cow::Borrowed("RSA_OAEP_3072_SHA256_AES_256"),
+                4 => std::borrow::Cow::Borrowed("RSA_OAEP_4096_SHA256_AES_256"),
+                5 => std::borrow::Cow::Borrowed("RSA_OAEP_3072_SHA256"),
+                6 => std::borrow::Cow::Borrowed("RSA_OAEP_4096_SHA256"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "IMPORT_METHOD_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::IMPORT_METHOD_UNSPECIFIED)
+                }
+                "RSA_OAEP_3072_SHA1_AES_256" => {
+                    std::option::Option::Some(Self::RSA_OAEP_3072_SHA1_AES_256)
+                }
+                "RSA_OAEP_4096_SHA1_AES_256" => {
+                    std::option::Option::Some(Self::RSA_OAEP_4096_SHA1_AES_256)
+                }
+                "RSA_OAEP_3072_SHA256_AES_256" => {
+                    std::option::Option::Some(Self::RSA_OAEP_3072_SHA256_AES_256)
+                }
+                "RSA_OAEP_4096_SHA256_AES_256" => {
+                    std::option::Option::Some(Self::RSA_OAEP_4096_SHA256_AES_256)
+                }
+                "RSA_OAEP_3072_SHA256" => std::option::Option::Some(Self::RSA_OAEP_3072_SHA256),
+                "RSA_OAEP_4096_SHA256" => std::option::Option::Some(Self::RSA_OAEP_4096_SHA256),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ImportMethod {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ImportMethod {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ImportMethod {
         fn default() -> Self {
-            import_method::IMPORT_METHOD_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -3826,27 +4102,11 @@ pub mod import_job {
     ///
     /// [google.cloud.kms.v1.ImportJob]: crate::model::ImportJob
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ImportJobState(std::borrow::Cow<'static, str>);
+    pub struct ImportJobState(i32);
 
     impl ImportJobState {
-        /// Creates a new ImportJobState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ImportJobState](ImportJobState)
-    pub mod import_job_state {
-        use super::ImportJobState;
-
         /// Not specified.
-        pub const IMPORT_JOB_STATE_UNSPECIFIED: ImportJobState =
-            ImportJobState::new("IMPORT_JOB_STATE_UNSPECIFIED");
+        pub const IMPORT_JOB_STATE_UNSPECIFIED: ImportJobState = ImportJobState::new(0);
 
         /// The wrapping key for this job is still being generated. It may not be
         /// used. Cloud KMS will automatically mark this job as
@@ -3854,7 +4114,7 @@ pub mod import_job {
         /// the wrapping key is generated.
         ///
         /// [google.cloud.kms.v1.ImportJob.ImportJobState.ACTIVE]: crate::model::import_job::import_job_state::ACTIVE
-        pub const PENDING_GENERATION: ImportJobState = ImportJobState::new("PENDING_GENERATION");
+        pub const PENDING_GENERATION: ImportJobState = ImportJobState::new(1);
 
         /// This job may be used in
         /// [CreateCryptoKey][google.cloud.kms.v1.KeyManagementService.CreateCryptoKey]
@@ -3864,21 +4124,55 @@ pub mod import_job {
         ///
         /// [google.cloud.kms.v1.KeyManagementService.CreateCryptoKey]: crate::client::KeyManagementService::create_crypto_key
         /// [google.cloud.kms.v1.KeyManagementService.CreateCryptoKeyVersion]: crate::client::KeyManagementService::create_crypto_key_version
-        pub const ACTIVE: ImportJobState = ImportJobState::new("ACTIVE");
+        pub const ACTIVE: ImportJobState = ImportJobState::new(2);
 
         /// This job can no longer be used and may not leave this state once entered.
-        pub const EXPIRED: ImportJobState = ImportJobState::new("EXPIRED");
+        pub const EXPIRED: ImportJobState = ImportJobState::new(3);
+
+        /// Creates a new ImportJobState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("IMPORT_JOB_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING_GENERATION"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("EXPIRED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "IMPORT_JOB_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::IMPORT_JOB_STATE_UNSPECIFIED)
+                }
+                "PENDING_GENERATION" => std::option::Option::Some(Self::PENDING_GENERATION),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "EXPIRED" => std::option::Option::Some(Self::EXPIRED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ImportJobState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ImportJobState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ImportJobState {
         fn default() -> Self {
-            import_job_state::IMPORT_JOB_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8272,50 +8566,70 @@ impl wkt::message::Message for LocationMetadata {
 ///
 /// [google.cloud.kms.v1.ProtectionLevel]: crate::model::ProtectionLevel
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ProtectionLevel(std::borrow::Cow<'static, str>);
+pub struct ProtectionLevel(i32);
 
 impl ProtectionLevel {
+    /// Not specified.
+    pub const PROTECTION_LEVEL_UNSPECIFIED: ProtectionLevel = ProtectionLevel::new(0);
+
+    /// Crypto operations are performed in software.
+    pub const SOFTWARE: ProtectionLevel = ProtectionLevel::new(1);
+
+    /// Crypto operations are performed in a Hardware Security Module.
+    pub const HSM: ProtectionLevel = ProtectionLevel::new(2);
+
+    /// Crypto operations are performed by an external key manager.
+    pub const EXTERNAL: ProtectionLevel = ProtectionLevel::new(3);
+
+    /// Crypto operations are performed in an EKM-over-VPC backend.
+    pub const EXTERNAL_VPC: ProtectionLevel = ProtectionLevel::new(4);
+
     /// Creates a new ProtectionLevel instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("PROTECTION_LEVEL_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SOFTWARE"),
+            2 => std::borrow::Cow::Borrowed("HSM"),
+            3 => std::borrow::Cow::Borrowed("EXTERNAL"),
+            4 => std::borrow::Cow::Borrowed("EXTERNAL_VPC"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "PROTECTION_LEVEL_UNSPECIFIED" => {
+                std::option::Option::Some(Self::PROTECTION_LEVEL_UNSPECIFIED)
+            }
+            "SOFTWARE" => std::option::Option::Some(Self::SOFTWARE),
+            "HSM" => std::option::Option::Some(Self::HSM),
+            "EXTERNAL" => std::option::Option::Some(Self::EXTERNAL),
+            "EXTERNAL_VPC" => std::option::Option::Some(Self::EXTERNAL_VPC),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [ProtectionLevel](ProtectionLevel)
-pub mod protection_level {
-    use super::ProtectionLevel;
-
-    /// Not specified.
-    pub const PROTECTION_LEVEL_UNSPECIFIED: ProtectionLevel =
-        ProtectionLevel::new("PROTECTION_LEVEL_UNSPECIFIED");
-
-    /// Crypto operations are performed in software.
-    pub const SOFTWARE: ProtectionLevel = ProtectionLevel::new("SOFTWARE");
-
-    /// Crypto operations are performed in a Hardware Security Module.
-    pub const HSM: ProtectionLevel = ProtectionLevel::new("HSM");
-
-    /// Crypto operations are performed by an external key manager.
-    pub const EXTERNAL: ProtectionLevel = ProtectionLevel::new("EXTERNAL");
-
-    /// Crypto operations are performed in an EKM-over-VPC backend.
-    pub const EXTERNAL_VPC: ProtectionLevel = ProtectionLevel::new("EXTERNAL_VPC");
-}
-
-impl std::convert::From<std::string::String> for ProtectionLevel {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ProtectionLevel {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ProtectionLevel {
     fn default() -> Self {
-        protection_level::PROTECTION_LEVEL_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -8323,54 +8637,34 @@ impl std::default::Default for ProtectionLevel {
 /// <https://cloud.google.com/assured-workloads/key-access-justifications/docs/justification-codes>
 /// for the detailed semantic meaning of justification reason codes.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AccessReason(std::borrow::Cow<'static, str>);
+pub struct AccessReason(i32);
 
 impl AccessReason {
-    /// Creates a new AccessReason instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [AccessReason](AccessReason)
-pub mod access_reason {
-    use super::AccessReason;
-
     /// Unspecified access reason.
-    pub const REASON_UNSPECIFIED: AccessReason = AccessReason::new("REASON_UNSPECIFIED");
+    pub const REASON_UNSPECIFIED: AccessReason = AccessReason::new(0);
 
     /// Customer-initiated support.
-    pub const CUSTOMER_INITIATED_SUPPORT: AccessReason =
-        AccessReason::new("CUSTOMER_INITIATED_SUPPORT");
+    pub const CUSTOMER_INITIATED_SUPPORT: AccessReason = AccessReason::new(1);
 
     /// Google-initiated access for system management and troubleshooting.
-    pub const GOOGLE_INITIATED_SERVICE: AccessReason =
-        AccessReason::new("GOOGLE_INITIATED_SERVICE");
+    pub const GOOGLE_INITIATED_SERVICE: AccessReason = AccessReason::new(2);
 
     /// Google-initiated access in response to a legal request or legal process.
-    pub const THIRD_PARTY_DATA_REQUEST: AccessReason =
-        AccessReason::new("THIRD_PARTY_DATA_REQUEST");
+    pub const THIRD_PARTY_DATA_REQUEST: AccessReason = AccessReason::new(3);
 
     /// Google-initiated access for security, fraud, abuse, or compliance purposes.
-    pub const GOOGLE_INITIATED_REVIEW: AccessReason = AccessReason::new("GOOGLE_INITIATED_REVIEW");
+    pub const GOOGLE_INITIATED_REVIEW: AccessReason = AccessReason::new(4);
 
     /// Customer uses their account to perform any access to their own data which
     /// their IAM policy authorizes.
-    pub const CUSTOMER_INITIATED_ACCESS: AccessReason =
-        AccessReason::new("CUSTOMER_INITIATED_ACCESS");
+    pub const CUSTOMER_INITIATED_ACCESS: AccessReason = AccessReason::new(5);
 
     /// Google systems access customer data to help optimize the structure of the
     /// data or quality for future uses by the customer.
-    pub const GOOGLE_INITIATED_SYSTEM_OPERATION: AccessReason =
-        AccessReason::new("GOOGLE_INITIATED_SYSTEM_OPERATION");
+    pub const GOOGLE_INITIATED_SYSTEM_OPERATION: AccessReason = AccessReason::new(6);
 
     /// No reason is expected for this key request.
-    pub const REASON_NOT_EXPECTED: AccessReason = AccessReason::new("REASON_NOT_EXPECTED");
+    pub const REASON_NOT_EXPECTED: AccessReason = AccessReason::new(7);
 
     /// Customer uses their account to perform any access to their own data which
     /// their IAM policy authorizes, and one of the following is true:
@@ -8380,8 +8674,7 @@ pub mod access_reason {
     /// * A Google-initiated emergency access operation has interacted with a
     ///   resource in the same project or folder as the currently accessed resource
     ///   within the past 7 days.
-    pub const MODIFIED_CUSTOMER_INITIATED_ACCESS: AccessReason =
-        AccessReason::new("MODIFIED_CUSTOMER_INITIATED_ACCESS");
+    pub const MODIFIED_CUSTOMER_INITIATED_ACCESS: AccessReason = AccessReason::new(8);
 
     /// Google systems access customer data to help optimize the structure of the
     /// data or quality for future uses by the customer, and one of the following
@@ -8392,12 +8685,10 @@ pub mod access_reason {
     /// * A Google-initiated emergency access operation has interacted with a
     ///   resource in the same project or folder as the currently accessed resource
     ///   within the past 7 days.
-    pub const MODIFIED_GOOGLE_INITIATED_SYSTEM_OPERATION: AccessReason =
-        AccessReason::new("MODIFIED_GOOGLE_INITIATED_SYSTEM_OPERATION");
+    pub const MODIFIED_GOOGLE_INITIATED_SYSTEM_OPERATION: AccessReason = AccessReason::new(9);
 
     /// Google-initiated access to maintain system reliability.
-    pub const GOOGLE_RESPONSE_TO_PRODUCTION_ALERT: AccessReason =
-        AccessReason::new("GOOGLE_RESPONSE_TO_PRODUCTION_ALERT");
+    pub const GOOGLE_RESPONSE_TO_PRODUCTION_ALERT: AccessReason = AccessReason::new(10);
 
     /// One of the following operations is being executed while simultaneously
     /// encountering an internal technical issue which prevented a more precise
@@ -8409,18 +8700,79 @@ pub mod access_reason {
     ///   IAM policy authorizes.
     /// * Customer-initiated Google support access.
     /// * Google-initiated support access to protect system reliability.
-    pub const CUSTOMER_AUTHORIZED_WORKFLOW_SERVICING: AccessReason =
-        AccessReason::new("CUSTOMER_AUTHORIZED_WORKFLOW_SERVICING");
+    pub const CUSTOMER_AUTHORIZED_WORKFLOW_SERVICING: AccessReason = AccessReason::new(11);
+
+    /// Creates a new AccessReason instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("REASON_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("CUSTOMER_INITIATED_SUPPORT"),
+            2 => std::borrow::Cow::Borrowed("GOOGLE_INITIATED_SERVICE"),
+            3 => std::borrow::Cow::Borrowed("THIRD_PARTY_DATA_REQUEST"),
+            4 => std::borrow::Cow::Borrowed("GOOGLE_INITIATED_REVIEW"),
+            5 => std::borrow::Cow::Borrowed("CUSTOMER_INITIATED_ACCESS"),
+            6 => std::borrow::Cow::Borrowed("GOOGLE_INITIATED_SYSTEM_OPERATION"),
+            7 => std::borrow::Cow::Borrowed("REASON_NOT_EXPECTED"),
+            8 => std::borrow::Cow::Borrowed("MODIFIED_CUSTOMER_INITIATED_ACCESS"),
+            9 => std::borrow::Cow::Borrowed("MODIFIED_GOOGLE_INITIATED_SYSTEM_OPERATION"),
+            10 => std::borrow::Cow::Borrowed("GOOGLE_RESPONSE_TO_PRODUCTION_ALERT"),
+            11 => std::borrow::Cow::Borrowed("CUSTOMER_AUTHORIZED_WORKFLOW_SERVICING"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "REASON_UNSPECIFIED" => std::option::Option::Some(Self::REASON_UNSPECIFIED),
+            "CUSTOMER_INITIATED_SUPPORT" => {
+                std::option::Option::Some(Self::CUSTOMER_INITIATED_SUPPORT)
+            }
+            "GOOGLE_INITIATED_SERVICE" => std::option::Option::Some(Self::GOOGLE_INITIATED_SERVICE),
+            "THIRD_PARTY_DATA_REQUEST" => std::option::Option::Some(Self::THIRD_PARTY_DATA_REQUEST),
+            "GOOGLE_INITIATED_REVIEW" => std::option::Option::Some(Self::GOOGLE_INITIATED_REVIEW),
+            "CUSTOMER_INITIATED_ACCESS" => {
+                std::option::Option::Some(Self::CUSTOMER_INITIATED_ACCESS)
+            }
+            "GOOGLE_INITIATED_SYSTEM_OPERATION" => {
+                std::option::Option::Some(Self::GOOGLE_INITIATED_SYSTEM_OPERATION)
+            }
+            "REASON_NOT_EXPECTED" => std::option::Option::Some(Self::REASON_NOT_EXPECTED),
+            "MODIFIED_CUSTOMER_INITIATED_ACCESS" => {
+                std::option::Option::Some(Self::MODIFIED_CUSTOMER_INITIATED_ACCESS)
+            }
+            "MODIFIED_GOOGLE_INITIATED_SYSTEM_OPERATION" => {
+                std::option::Option::Some(Self::MODIFIED_GOOGLE_INITIATED_SYSTEM_OPERATION)
+            }
+            "GOOGLE_RESPONSE_TO_PRODUCTION_ALERT" => {
+                std::option::Option::Some(Self::GOOGLE_RESPONSE_TO_PRODUCTION_ALERT)
+            }
+            "CUSTOMER_AUTHORIZED_WORKFLOW_SERVICING" => {
+                std::option::Option::Some(Self::CUSTOMER_AUTHORIZED_WORKFLOW_SERVICING)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for AccessReason {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for AccessReason {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for AccessReason {
     fn default() -> Self {
-        access_reason::REASON_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/kms/v1/src/transport.rs
+++ b/src/generated/cloud/kms/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::Autokey for Autokey {
                 reqwest::Method::POST,
                 format!("/v1/{}/keyHandles", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::Autokey for Autokey {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -94,7 +94,7 @@ impl crate::stubs::Autokey for Autokey {
                 reqwest::Method::GET,
                 format!("/v1/{}/keyHandles", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -116,7 +116,7 @@ impl crate::stubs::Autokey for Autokey {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -138,7 +138,7 @@ impl crate::stubs::Autokey for Autokey {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -160,7 +160,7 @@ impl crate::stubs::Autokey for Autokey {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -180,7 +180,7 @@ impl crate::stubs::Autokey for Autokey {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -212,7 +212,7 @@ impl crate::stubs::Autokey for Autokey {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -229,7 +229,7 @@ impl crate::stubs::Autokey for Autokey {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -294,7 +294,7 @@ impl crate::stubs::AutokeyAdmin for AutokeyAdmin {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -323,7 +323,7 @@ impl crate::stubs::AutokeyAdmin for AutokeyAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -345,7 +345,7 @@ impl crate::stubs::AutokeyAdmin for AutokeyAdmin {
                 reqwest::Method::GET,
                 format!("/v1/{}:showEffectiveAutokeyConfig", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -364,7 +364,7 @@ impl crate::stubs::AutokeyAdmin for AutokeyAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -386,7 +386,7 @@ impl crate::stubs::AutokeyAdmin for AutokeyAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -408,7 +408,7 @@ impl crate::stubs::AutokeyAdmin for AutokeyAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -428,7 +428,7 @@ impl crate::stubs::AutokeyAdmin for AutokeyAdmin {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -460,7 +460,7 @@ impl crate::stubs::AutokeyAdmin for AutokeyAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -477,7 +477,7 @@ impl crate::stubs::AutokeyAdmin for AutokeyAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -522,7 +522,7 @@ impl crate::stubs::EkmService for EkmService {
                 reqwest::Method::GET,
                 format!("/v1/{}/ekmConnections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -545,7 +545,7 @@ impl crate::stubs::EkmService for EkmService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -567,7 +567,7 @@ impl crate::stubs::EkmService for EkmService {
                 reqwest::Method::POST,
                 format!("/v1/{}/ekmConnections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -596,7 +596,7 @@ impl crate::stubs::EkmService for EkmService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -625,7 +625,7 @@ impl crate::stubs::EkmService for EkmService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -653,7 +653,7 @@ impl crate::stubs::EkmService for EkmService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -685,7 +685,7 @@ impl crate::stubs::EkmService for EkmService {
                 reqwest::Method::GET,
                 format!("/v1/{}:verifyConnectivity", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -704,7 +704,7 @@ impl crate::stubs::EkmService for EkmService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -726,7 +726,7 @@ impl crate::stubs::EkmService for EkmService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -748,7 +748,7 @@ impl crate::stubs::EkmService for EkmService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -768,7 +768,7 @@ impl crate::stubs::EkmService for EkmService {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -800,7 +800,7 @@ impl crate::stubs::EkmService for EkmService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -817,7 +817,7 @@ impl crate::stubs::EkmService for EkmService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -859,7 +859,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/keyRings", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -885,7 +885,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
                 reqwest::Method::GET,
                 format!("/v1/{}/cryptoKeys", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -912,7 +912,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
                 reqwest::Method::GET,
                 format!("/v1/{}/cryptoKeyVersions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -939,7 +939,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
                 reqwest::Method::GET,
                 format!("/v1/{}/importJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -962,7 +962,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -981,7 +981,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1000,7 +1000,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1019,7 +1019,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/publicKey", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1039,7 +1039,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1061,7 +1061,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
                 reqwest::Method::POST,
                 format!("/v1/{}/keyRings", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1084,7 +1084,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
                 reqwest::Method::POST,
                 format!("/v1/{}/cryptoKeys", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1111,7 +1111,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
                 reqwest::Method::POST,
                 format!("/v1/{}/cryptoKeyVersions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1133,7 +1133,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
                 reqwest::Method::POST,
                 format!("/v1/{}/cryptoKeyVersions:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1153,7 +1153,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
                 reqwest::Method::POST,
                 format!("/v1/{}/importJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1182,7 +1182,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1220,7 +1220,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1252,7 +1252,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
                 reqwest::Method::POST,
                 format!("/v1/{}:updatePrimaryVersion", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1269,7 +1269,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:destroy", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1286,7 +1286,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:restore", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1303,7 +1303,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:encrypt", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1320,7 +1320,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:decrypt", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1340,7 +1340,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
                 reqwest::Method::POST,
                 format!("/v1/{}:rawEncrypt", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1360,7 +1360,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
                 reqwest::Method::POST,
                 format!("/v1/{}:rawDecrypt", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1380,7 +1380,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
                 reqwest::Method::POST,
                 format!("/v1/{}:asymmetricSign", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1400,7 +1400,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
                 reqwest::Method::POST,
                 format!("/v1/{}:asymmetricDecrypt", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1417,7 +1417,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:macSign", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1434,7 +1434,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:macVerify", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1454,7 +1454,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
                 reqwest::Method::POST,
                 format!("/v1/{}:generateRandomBytes", req.location),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1471,7 +1471,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1493,7 +1493,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1515,7 +1515,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1535,7 +1535,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1567,7 +1567,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1584,7 +1584,7 @@ impl crate::stubs::KeyManagementService for KeyManagementService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/language/v2/src/model.rs
+++ b/src/generated/cloud/language/v2/src/model.rs
@@ -142,43 +142,58 @@ pub mod document {
 
     /// The document types enum.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// The content type is not specified.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// Plain text
+        pub const PLAIN_TEXT: Type = Type::new(1);
+
+        /// HTML
+        pub const HTML: Type = Type::new(2);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PLAIN_TEXT"),
+                2 => std::borrow::Cow::Borrowed("HTML"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "PLAIN_TEXT" => std::option::Option::Some(Self::PLAIN_TEXT),
+                "HTML" => std::option::Option::Some(Self::HTML),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// The content type is not specified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// Plain text
-        pub const PLAIN_TEXT: Type = Type::new("PLAIN_TEXT");
-
-        /// HTML
-        pub const HTML: Type = Type::new("HTML");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -349,47 +364,32 @@ pub mod entity {
     /// below lists the associated fields for entities that have different
     /// metadata.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// Unknown
-        pub const UNKNOWN: Type = Type::new("UNKNOWN");
+        pub const UNKNOWN: Type = Type::new(0);
 
         /// Person
-        pub const PERSON: Type = Type::new("PERSON");
+        pub const PERSON: Type = Type::new(1);
 
         /// Location
-        pub const LOCATION: Type = Type::new("LOCATION");
+        pub const LOCATION: Type = Type::new(2);
 
         /// Organization
-        pub const ORGANIZATION: Type = Type::new("ORGANIZATION");
+        pub const ORGANIZATION: Type = Type::new(3);
 
         /// Event
-        pub const EVENT: Type = Type::new("EVENT");
+        pub const EVENT: Type = Type::new(4);
 
         /// Artwork
-        pub const WORK_OF_ART: Type = Type::new("WORK_OF_ART");
+        pub const WORK_OF_ART: Type = Type::new(5);
 
         /// Consumer product
-        pub const CONSUMER_GOOD: Type = Type::new("CONSUMER_GOOD");
+        pub const CONSUMER_GOOD: Type = Type::new(6);
 
         /// Other types of entities
-        pub const OTHER: Type = Type::new("OTHER");
+        pub const OTHER: Type = Type::new(7);
 
         /// Phone number
         ///
@@ -402,7 +402,7 @@ pub mod entity {
         /// * `area_code` - region or area code, if detected
         /// * `extension` - phone extension (to be dialed after connection), if
         ///   detected
-        pub const PHONE_NUMBER: Type = Type::new("PHONE_NUMBER");
+        pub const PHONE_NUMBER: Type = Type::new(9);
 
         /// Address
         ///
@@ -419,7 +419,7 @@ pub mod entity {
         ///   detected
         /// * `sublocality` - used in Asian addresses to demark a district within a
         ///   city, if detected
-        pub const ADDRESS: Type = Type::new("ADDRESS");
+        pub const ADDRESS: Type = Type::new(10);
 
         /// Date
         ///
@@ -428,28 +428,78 @@ pub mod entity {
         /// * `year` - four digit year, if detected
         /// * `month` - two digit month number, if detected
         /// * `day` - two digit day number, if detected
-        pub const DATE: Type = Type::new("DATE");
+        pub const DATE: Type = Type::new(11);
 
         /// Number
         ///
         /// The metadata is the number itself.
-        pub const NUMBER: Type = Type::new("NUMBER");
+        pub const NUMBER: Type = Type::new(12);
 
         /// Price
         ///
         /// The metadata identifies the `value` and `currency`.
-        pub const PRICE: Type = Type::new("PRICE");
+        pub const PRICE: Type = Type::new(13);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("PERSON"),
+                2 => std::borrow::Cow::Borrowed("LOCATION"),
+                3 => std::borrow::Cow::Borrowed("ORGANIZATION"),
+                4 => std::borrow::Cow::Borrowed("EVENT"),
+                5 => std::borrow::Cow::Borrowed("WORK_OF_ART"),
+                6 => std::borrow::Cow::Borrowed("CONSUMER_GOOD"),
+                7 => std::borrow::Cow::Borrowed("OTHER"),
+                9 => std::borrow::Cow::Borrowed("PHONE_NUMBER"),
+                10 => std::borrow::Cow::Borrowed("ADDRESS"),
+                11 => std::borrow::Cow::Borrowed("DATE"),
+                12 => std::borrow::Cow::Borrowed("NUMBER"),
+                13 => std::borrow::Cow::Borrowed("PRICE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                "PERSON" => std::option::Option::Some(Self::PERSON),
+                "LOCATION" => std::option::Option::Some(Self::LOCATION),
+                "ORGANIZATION" => std::option::Option::Some(Self::ORGANIZATION),
+                "EVENT" => std::option::Option::Some(Self::EVENT),
+                "WORK_OF_ART" => std::option::Option::Some(Self::WORK_OF_ART),
+                "CONSUMER_GOOD" => std::option::Option::Some(Self::CONSUMER_GOOD),
+                "OTHER" => std::option::Option::Some(Self::OTHER),
+                "PHONE_NUMBER" => std::option::Option::Some(Self::PHONE_NUMBER),
+                "ADDRESS" => std::option::Option::Some(Self::ADDRESS),
+                "DATE" => std::option::Option::Some(Self::DATE),
+                "NUMBER" => std::option::Option::Some(Self::NUMBER),
+                "PRICE" => std::option::Option::Some(Self::PRICE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::UNKNOWN
+            Self::new(0)
         }
     }
 }
@@ -576,43 +626,58 @@ pub mod entity_mention {
 
     /// The supported types of mentions.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Unknown
+        pub const TYPE_UNKNOWN: Type = Type::new(0);
+
+        /// Proper name
+        pub const PROPER: Type = Type::new(1);
+
+        /// Common noun (or noun compound)
+        pub const COMMON: Type = Type::new(2);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("PROPER"),
+                2 => std::borrow::Cow::Borrowed("COMMON"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNKNOWN" => std::option::Option::Some(Self::TYPE_UNKNOWN),
+                "PROPER" => std::option::Option::Some(Self::PROPER),
+                "COMMON" => std::option::Option::Some(Self::COMMON),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Unknown
-        pub const TYPE_UNKNOWN: Type = Type::new("TYPE_UNKNOWN");
-
-        /// Proper name
-        pub const PROPER: Type = Type::new("PROPER");
-
-        /// Common noun (or noun compound)
-        pub const COMMON: Type = Type::new("COMMON");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNKNOWN
+            Self::new(0)
         }
     }
 }
@@ -1069,48 +1134,64 @@ pub mod moderate_text_request {
 
     /// The model version to use for ModerateText.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ModelVersion(std::borrow::Cow<'static, str>);
+    pub struct ModelVersion(i32);
 
     impl ModelVersion {
-        /// Creates a new ModelVersion instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ModelVersion](ModelVersion)
-    pub mod model_version {
-        use super::ModelVersion;
-
         /// The default model version.
-        pub const MODEL_VERSION_UNSPECIFIED: ModelVersion =
-            ModelVersion::new("MODEL_VERSION_UNSPECIFIED");
+        pub const MODEL_VERSION_UNSPECIFIED: ModelVersion = ModelVersion::new(0);
 
         /// Use the v1 model, this model is used by default when not provided.
         /// The v1 model only returns probability (confidence) score for each
         /// category.
-        pub const MODEL_VERSION_1: ModelVersion = ModelVersion::new("MODEL_VERSION_1");
+        pub const MODEL_VERSION_1: ModelVersion = ModelVersion::new(1);
 
         /// Use the v2 model.
         /// The v2 model only returns probability (confidence) score for each
         /// category, and returns severity score for a subset of the categories.
-        pub const MODEL_VERSION_2: ModelVersion = ModelVersion::new("MODEL_VERSION_2");
+        pub const MODEL_VERSION_2: ModelVersion = ModelVersion::new(2);
+
+        /// Creates a new ModelVersion instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MODEL_VERSION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MODEL_VERSION_1"),
+                2 => std::borrow::Cow::Borrowed("MODEL_VERSION_2"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MODEL_VERSION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MODEL_VERSION_UNSPECIFIED)
+                }
+                "MODEL_VERSION_1" => std::option::Option::Some(Self::MODEL_VERSION_1),
+                "MODEL_VERSION_2" => std::option::Option::Some(Self::MODEL_VERSION_2),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ModelVersion {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ModelVersion {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ModelVersion {
         fn default() -> Self {
-            model_version::MODEL_VERSION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1429,52 +1510,69 @@ impl wkt::message::Message for AnnotateTextResponse {
 /// languages that natively use different text encodings may access offsets
 /// differently.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EncodingType(std::borrow::Cow<'static, str>);
+pub struct EncodingType(i32);
 
 impl EncodingType {
-    /// Creates a new EncodingType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [EncodingType](EncodingType)
-pub mod encoding_type {
-    use super::EncodingType;
-
     /// If `EncodingType` is not specified, encoding-dependent information (such as
     /// `begin_offset`) will be set at `-1`.
-    pub const NONE: EncodingType = EncodingType::new("NONE");
+    pub const NONE: EncodingType = EncodingType::new(0);
 
     /// Encoding-dependent information (such as `begin_offset`) is calculated based
     /// on the UTF-8 encoding of the input. C++ and Go are examples of languages
     /// that use this encoding natively.
-    pub const UTF8: EncodingType = EncodingType::new("UTF8");
+    pub const UTF8: EncodingType = EncodingType::new(1);
 
     /// Encoding-dependent information (such as `begin_offset`) is calculated based
     /// on the UTF-16 encoding of the input. Java and JavaScript are examples of
     /// languages that use this encoding natively.
-    pub const UTF16: EncodingType = EncodingType::new("UTF16");
+    pub const UTF16: EncodingType = EncodingType::new(2);
 
     /// Encoding-dependent information (such as `begin_offset`) is calculated based
     /// on the UTF-32 encoding of the input. Python is an example of a language
     /// that uses this encoding natively.
-    pub const UTF32: EncodingType = EncodingType::new("UTF32");
+    pub const UTF32: EncodingType = EncodingType::new(3);
+
+    /// Creates a new EncodingType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("NONE"),
+            1 => std::borrow::Cow::Borrowed("UTF8"),
+            2 => std::borrow::Cow::Borrowed("UTF16"),
+            3 => std::borrow::Cow::Borrowed("UTF32"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "NONE" => std::option::Option::Some(Self::NONE),
+            "UTF8" => std::option::Option::Some(Self::UTF8),
+            "UTF16" => std::option::Option::Some(Self::UTF16),
+            "UTF32" => std::option::Option::Some(Self::UTF32),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for EncodingType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for EncodingType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for EncodingType {
     fn default() -> Self {
-        encoding_type::NONE
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/language/v2/src/transport.rs
+++ b/src/generated/cloud/language/v2/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::LanguageService for LanguageService {
                 reqwest::Method::POST,
                 "/v2/documents:analyzeSentiment".to_string(),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::LanguageService for LanguageService {
                 reqwest::Method::POST,
                 "/v2/documents:analyzeEntities".to_string(),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -92,7 +92,7 @@ impl crate::stubs::LanguageService for LanguageService {
                 reqwest::Method::POST,
                 "/v2/documents:classifyText".to_string(),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -112,7 +112,7 @@ impl crate::stubs::LanguageService for LanguageService {
                 reqwest::Method::POST,
                 "/v2/documents:moderateText".to_string(),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -132,7 +132,7 @@ impl crate::stubs::LanguageService for LanguageService {
                 reqwest::Method::POST,
                 "/v2/documents:annotateText".to_string(),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/location/src/transport.rs
+++ b/src/generated/cloud/location/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::Locations for Locations {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -71,7 +71,7 @@ impl crate::stubs::Locations for Locations {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/managedidentities/v1/src/model.rs
+++ b/src/generated/cloud/managedidentities/v1/src/model.rs
@@ -904,59 +904,84 @@ pub mod domain {
 
     /// Represents the different states of a managed domain.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The domain is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The domain has been created and is fully usable.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(2);
 
         /// The domain's configuration is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(3);
 
         /// The domain is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(4);
 
         /// The domain is being repaired and may be unusable. Details
         /// can be found in the `status_message` field.
-        pub const REPAIRING: State = State::new("REPAIRING");
+        pub const REPAIRING: State = State::new(5);
 
         /// The domain is undergoing maintenance.
-        pub const PERFORMING_MAINTENANCE: State = State::new("PERFORMING_MAINTENANCE");
+        pub const PERFORMING_MAINTENANCE: State = State::new(6);
 
         /// The domain is not serving requests.
-        pub const UNAVAILABLE: State = State::new("UNAVAILABLE");
+        pub const UNAVAILABLE: State = State::new(7);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("REPAIRING"),
+                6 => std::borrow::Cow::Borrowed("PERFORMING_MAINTENANCE"),
+                7 => std::borrow::Cow::Borrowed("UNAVAILABLE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "REPAIRING" => std::option::Option::Some(Self::REPAIRING),
+                "PERFORMING_MAINTENANCE" => std::option::Option::Some(Self::PERFORMING_MAINTENANCE),
+                "UNAVAILABLE" => std::option::Option::Some(Self::UNAVAILABLE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1131,94 +1156,130 @@ pub mod trust {
 
     /// Represents the different states of a domain trust.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Not set.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The domain trust is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// The domain trust is being updated.
+        pub const UPDATING: State = State::new(2);
+
+        /// The domain trust is being deleted.
+        pub const DELETING: State = State::new(3);
+
+        /// The domain trust is connected.
+        pub const CONNECTED: State = State::new(4);
+
+        /// The domain trust is disconnected.
+        pub const DISCONNECTED: State = State::new(5);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("UPDATING"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("CONNECTED"),
+                5 => std::borrow::Cow::Borrowed("DISCONNECTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "CONNECTED" => std::option::Option::Some(Self::CONNECTED),
+                "DISCONNECTED" => std::option::Option::Some(Self::DISCONNECTED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The domain trust is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The domain trust is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// The domain trust is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// The domain trust is connected.
-        pub const CONNECTED: State = State::new("CONNECTED");
-
-        /// The domain trust is disconnected.
-        pub const DISCONNECTED: State = State::new("DISCONNECTED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Represents the different inter-forest trust types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TrustType(std::borrow::Cow<'static, str>);
+    pub struct TrustType(i32);
 
     impl TrustType {
+        /// Not set.
+        pub const TRUST_TYPE_UNSPECIFIED: TrustType = TrustType::new(0);
+
+        /// The forest trust.
+        pub const FOREST: TrustType = TrustType::new(1);
+
+        /// The external domain trust.
+        pub const EXTERNAL: TrustType = TrustType::new(2);
+
         /// Creates a new TrustType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TRUST_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FOREST"),
+                2 => std::borrow::Cow::Borrowed("EXTERNAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TRUST_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TRUST_TYPE_UNSPECIFIED),
+                "FOREST" => std::option::Option::Some(Self::FOREST),
+                "EXTERNAL" => std::option::Option::Some(Self::EXTERNAL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [TrustType](TrustType)
-    pub mod trust_type {
-        use super::TrustType;
-
-        /// Not set.
-        pub const TRUST_TYPE_UNSPECIFIED: TrustType = TrustType::new("TRUST_TYPE_UNSPECIFIED");
-
-        /// The forest trust.
-        pub const FOREST: TrustType = TrustType::new("FOREST");
-
-        /// The external domain trust.
-        pub const EXTERNAL: TrustType = TrustType::new("EXTERNAL");
-    }
-
-    impl std::convert::From<std::string::String> for TrustType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TrustType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TrustType {
         fn default() -> Self {
-            trust_type::TRUST_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1227,47 +1288,65 @@ pub mod trust {
     /// [System.DirectoryServices.ActiveDirectory.TrustDirection](https://docs.microsoft.com/en-us/dotnet/api/system.directoryservices.activedirectory.trustdirection?view=netframework-4.7.2)
     /// for more information.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TrustDirection(std::borrow::Cow<'static, str>);
+    pub struct TrustDirection(i32);
 
     impl TrustDirection {
+        /// Not set.
+        pub const TRUST_DIRECTION_UNSPECIFIED: TrustDirection = TrustDirection::new(0);
+
+        /// The inbound direction represents the trusting side.
+        pub const INBOUND: TrustDirection = TrustDirection::new(1);
+
+        /// The outboud direction represents the trusted side.
+        pub const OUTBOUND: TrustDirection = TrustDirection::new(2);
+
+        /// The bidirectional direction represents the trusted / trusting side.
+        pub const BIDIRECTIONAL: TrustDirection = TrustDirection::new(3);
+
         /// Creates a new TrustDirection instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TRUST_DIRECTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INBOUND"),
+                2 => std::borrow::Cow::Borrowed("OUTBOUND"),
+                3 => std::borrow::Cow::Borrowed("BIDIRECTIONAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TRUST_DIRECTION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::TRUST_DIRECTION_UNSPECIFIED)
+                }
+                "INBOUND" => std::option::Option::Some(Self::INBOUND),
+                "OUTBOUND" => std::option::Option::Some(Self::OUTBOUND),
+                "BIDIRECTIONAL" => std::option::Option::Some(Self::BIDIRECTIONAL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [TrustDirection](TrustDirection)
-    pub mod trust_direction {
-        use super::TrustDirection;
-
-        /// Not set.
-        pub const TRUST_DIRECTION_UNSPECIFIED: TrustDirection =
-            TrustDirection::new("TRUST_DIRECTION_UNSPECIFIED");
-
-        /// The inbound direction represents the trusting side.
-        pub const INBOUND: TrustDirection = TrustDirection::new("INBOUND");
-
-        /// The outboud direction represents the trusted side.
-        pub const OUTBOUND: TrustDirection = TrustDirection::new("OUTBOUND");
-
-        /// The bidirectional direction represents the trusted / trusting side.
-        pub const BIDIRECTIONAL: TrustDirection = TrustDirection::new("BIDIRECTIONAL");
-    }
-
-    impl std::convert::From<std::string::String> for TrustDirection {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TrustDirection {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TrustDirection {
         fn default() -> Self {
-            trust_direction::TRUST_DIRECTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/managedidentities/v1/src/transport.rs
+++ b/src/generated/cloud/managedidentities/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::ManagedIdentitiesService for ManagedIdentitiesService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/domains", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -70,7 +70,7 @@ impl crate::stubs::ManagedIdentitiesService for ManagedIdentitiesService {
                 reqwest::Method::POST,
                 format!("/v1/{}:resetAdminPassword", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -87,7 +87,7 @@ impl crate::stubs::ManagedIdentitiesService for ManagedIdentitiesService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/domains", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -110,7 +110,7 @@ impl crate::stubs::ManagedIdentitiesService for ManagedIdentitiesService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -138,7 +138,7 @@ impl crate::stubs::ManagedIdentitiesService for ManagedIdentitiesService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -165,7 +165,7 @@ impl crate::stubs::ManagedIdentitiesService for ManagedIdentitiesService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -187,7 +187,7 @@ impl crate::stubs::ManagedIdentitiesService for ManagedIdentitiesService {
                 reqwest::Method::POST,
                 format!("/v1/{}:attachTrust", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -207,7 +207,7 @@ impl crate::stubs::ManagedIdentitiesService for ManagedIdentitiesService {
                 reqwest::Method::POST,
                 format!("/v1/{}:reconfigureTrust", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -227,7 +227,7 @@ impl crate::stubs::ManagedIdentitiesService for ManagedIdentitiesService {
                 reqwest::Method::POST,
                 format!("/v1/{}:detachTrust", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -247,7 +247,7 @@ impl crate::stubs::ManagedIdentitiesService for ManagedIdentitiesService {
                 reqwest::Method::POST,
                 format!("/v1/{}:validateTrust", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -264,7 +264,7 @@ impl crate::stubs::ManagedIdentitiesService for ManagedIdentitiesService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -286,7 +286,7 @@ impl crate::stubs::ManagedIdentitiesService for ManagedIdentitiesService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -305,7 +305,7 @@ impl crate::stubs::ManagedIdentitiesService for ManagedIdentitiesService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -324,7 +324,7 @@ impl crate::stubs::ManagedIdentitiesService for ManagedIdentitiesService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/memcache/v1/src/model.rs
+++ b/src/generated/cloud/memcache/v1/src/model.rs
@@ -454,49 +454,68 @@ pub mod instance {
 
         /// Different states of a Memcached node.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(std::borrow::Cow<'static, str>);
+        pub struct State(i32);
 
         impl State {
+            /// Node state is not set.
+            pub const STATE_UNSPECIFIED: State = State::new(0);
+
+            /// Node is being created.
+            pub const CREATING: State = State::new(1);
+
+            /// Node has been created and ready to be used.
+            pub const READY: State = State::new(2);
+
+            /// Node is being deleted.
+            pub const DELETING: State = State::new(3);
+
+            /// Node is being updated.
+            pub const UPDATING: State = State::new(4);
+
             /// Creates a new State instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("CREATING"),
+                    2 => std::borrow::Cow::Borrowed("READY"),
+                    3 => std::borrow::Cow::Borrowed("DELETING"),
+                    4 => std::borrow::Cow::Borrowed("UPDATING"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                    "CREATING" => std::option::Option::Some(Self::CREATING),
+                    "READY" => std::option::Option::Some(Self::READY),
+                    "DELETING" => std::option::Option::Some(Self::DELETING),
+                    "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [State](State)
-        pub mod state {
-            use super::State;
-
-            /// Node state is not set.
-            pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-            /// Node is being created.
-            pub const CREATING: State = State::new("CREATING");
-
-            /// Node has been created and ready to be used.
-            pub const READY: State = State::new("READY");
-
-            /// Node is being deleted.
-            pub const DELETING: State = State::new("DELETING");
-
-            /// Node is being updated.
-            pub const UPDATING: State = State::new("UPDATING");
-        }
-
-        impl std::convert::From<std::string::String> for State {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                state::STATE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -547,94 +566,129 @@ pub mod instance {
         use super::*;
 
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Code(std::borrow::Cow<'static, str>);
+        pub struct Code(i32);
 
         impl Code {
+            /// Message Code not set.
+            pub const CODE_UNSPECIFIED: Code = Code::new(0);
+
+            /// Memcached nodes are distributed unevenly.
+            pub const ZONE_DISTRIBUTION_UNBALANCED: Code = Code::new(1);
+
             /// Creates a new Code instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("CODE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("ZONE_DISTRIBUTION_UNBALANCED"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "CODE_UNSPECIFIED" => std::option::Option::Some(Self::CODE_UNSPECIFIED),
+                    "ZONE_DISTRIBUTION_UNBALANCED" => {
+                        std::option::Option::Some(Self::ZONE_DISTRIBUTION_UNBALANCED)
+                    }
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Code](Code)
-        pub mod code {
-            use super::Code;
-
-            /// Message Code not set.
-            pub const CODE_UNSPECIFIED: Code = Code::new("CODE_UNSPECIFIED");
-
-            /// Memcached nodes are distributed unevenly.
-            pub const ZONE_DISTRIBUTION_UNBALANCED: Code =
-                Code::new("ZONE_DISTRIBUTION_UNBALANCED");
-        }
-
-        impl std::convert::From<std::string::String> for Code {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Code {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Code {
             fn default() -> Self {
-                code::CODE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// Different states of a Memcached instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Memcached instance is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// Memcached instance has been created and ready to be used.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(2);
 
         /// Memcached instance is updating configuration such as maintenance policy
         /// and schedule.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(3);
 
         /// Memcached instance is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(4);
 
         /// Memcached instance is going through maintenance, e.g. data plane rollout.
-        pub const PERFORMING_MAINTENANCE: State = State::new("PERFORMING_MAINTENANCE");
+        pub const PERFORMING_MAINTENANCE: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("PERFORMING_MAINTENANCE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "PERFORMING_MAINTENANCE" => std::option::Option::Some(Self::PERFORMING_MAINTENANCE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -896,49 +950,66 @@ pub mod reschedule_maintenance_request {
 
     /// Reschedule options.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RescheduleType(std::borrow::Cow<'static, str>);
+    pub struct RescheduleType(i32);
 
     impl RescheduleType {
-        /// Creates a new RescheduleType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RescheduleType](RescheduleType)
-    pub mod reschedule_type {
-        use super::RescheduleType;
-
         /// Not set.
-        pub const RESCHEDULE_TYPE_UNSPECIFIED: RescheduleType =
-            RescheduleType::new("RESCHEDULE_TYPE_UNSPECIFIED");
+        pub const RESCHEDULE_TYPE_UNSPECIFIED: RescheduleType = RescheduleType::new(0);
 
         /// If the user wants to schedule the maintenance to happen now.
-        pub const IMMEDIATE: RescheduleType = RescheduleType::new("IMMEDIATE");
+        pub const IMMEDIATE: RescheduleType = RescheduleType::new(1);
 
         /// If the user wants to use the existing maintenance policy to find the
         /// next available window.
-        pub const NEXT_AVAILABLE_WINDOW: RescheduleType =
-            RescheduleType::new("NEXT_AVAILABLE_WINDOW");
+        pub const NEXT_AVAILABLE_WINDOW: RescheduleType = RescheduleType::new(2);
 
         /// If the user wants to reschedule the maintenance to a specific time.
-        pub const SPECIFIC_TIME: RescheduleType = RescheduleType::new("SPECIFIC_TIME");
+        pub const SPECIFIC_TIME: RescheduleType = RescheduleType::new(3);
+
+        /// Creates a new RescheduleType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RESCHEDULE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IMMEDIATE"),
+                2 => std::borrow::Cow::Borrowed("NEXT_AVAILABLE_WINDOW"),
+                3 => std::borrow::Cow::Borrowed("SPECIFIC_TIME"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RESCHEDULE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RESCHEDULE_TYPE_UNSPECIFIED)
+                }
+                "IMMEDIATE" => std::option::Option::Some(Self::IMMEDIATE),
+                "NEXT_AVAILABLE_WINDOW" => std::option::Option::Some(Self::NEXT_AVAILABLE_WINDOW),
+                "SPECIFIC_TIME" => std::option::Option::Some(Self::SPECIFIC_TIME),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RescheduleType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RescheduleType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RescheduleType {
         fn default() -> Self {
-            reschedule_type::RESCHEDULE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1608,39 +1679,53 @@ impl wkt::message::Message for ZoneMetadata {
 
 /// Memcached versions supported by our service.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct MemcacheVersion(std::borrow::Cow<'static, str>);
+pub struct MemcacheVersion(i32);
 
 impl MemcacheVersion {
+    pub const MEMCACHE_VERSION_UNSPECIFIED: MemcacheVersion = MemcacheVersion::new(0);
+
+    /// Memcached 1.5 version.
+    pub const MEMCACHE_1_5: MemcacheVersion = MemcacheVersion::new(1);
+
     /// Creates a new MemcacheVersion instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("MEMCACHE_VERSION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("MEMCACHE_1_5"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "MEMCACHE_VERSION_UNSPECIFIED" => {
+                std::option::Option::Some(Self::MEMCACHE_VERSION_UNSPECIFIED)
+            }
+            "MEMCACHE_1_5" => std::option::Option::Some(Self::MEMCACHE_1_5),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [MemcacheVersion](MemcacheVersion)
-pub mod memcache_version {
-    use super::MemcacheVersion;
-
-    pub const MEMCACHE_VERSION_UNSPECIFIED: MemcacheVersion =
-        MemcacheVersion::new("MEMCACHE_VERSION_UNSPECIFIED");
-
-    /// Memcached 1.5 version.
-    pub const MEMCACHE_1_5: MemcacheVersion = MemcacheVersion::new("MEMCACHE_1_5");
-}
-
-impl std::convert::From<std::string::String> for MemcacheVersion {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for MemcacheVersion {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for MemcacheVersion {
     fn default() -> Self {
-        memcache_version::MEMCACHE_VERSION_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/memcache/v1/src/transport.rs
+++ b/src/generated/cloud/memcache/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::CloudMemcache for CloudMemcache {
                 reqwest::Method::GET,
                 format!("/v1/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::CloudMemcache for CloudMemcache {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::CloudMemcache for CloudMemcache {
                 reqwest::Method::POST,
                 format!("/v1/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -126,7 +126,7 @@ impl crate::stubs::CloudMemcache for CloudMemcache {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -158,7 +158,7 @@ impl crate::stubs::CloudMemcache for CloudMemcache {
                 reqwest::Method::PATCH,
                 format!("/v1/{}:updateParameters", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -175,7 +175,7 @@ impl crate::stubs::CloudMemcache for CloudMemcache {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -197,7 +197,7 @@ impl crate::stubs::CloudMemcache for CloudMemcache {
                 reqwest::Method::POST,
                 format!("/v1/{}:applyParameters", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -217,7 +217,7 @@ impl crate::stubs::CloudMemcache for CloudMemcache {
                 reqwest::Method::POST,
                 format!("/v1/{}:rescheduleMaintenance", req.instance),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -234,7 +234,7 @@ impl crate::stubs::CloudMemcache for CloudMemcache {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -256,7 +256,7 @@ impl crate::stubs::CloudMemcache for CloudMemcache {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -275,7 +275,7 @@ impl crate::stubs::CloudMemcache for CloudMemcache {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -297,7 +297,7 @@ impl crate::stubs::CloudMemcache for CloudMemcache {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -316,7 +316,7 @@ impl crate::stubs::CloudMemcache for CloudMemcache {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -335,7 +335,7 @@ impl crate::stubs::CloudMemcache for CloudMemcache {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/memorystore/v1/src/model.rs
+++ b/src/generated/cloud/memorystore/v1/src/model.rs
@@ -631,137 +631,190 @@ pub mod instance {
 
     /// Possible states of the instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Not set.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Instance is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// Instance has been created and is usable.
+        pub const ACTIVE: State = State::new(2);
+
+        /// Instance is being updated.
+        pub const UPDATING: State = State::new(3);
+
+        /// Instance is being deleted.
+        pub const DELETING: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Instance is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// Instance has been created and is usable.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// Instance is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// Instance is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Possible authorization modes of the instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AuthorizationMode(std::borrow::Cow<'static, str>);
+    pub struct AuthorizationMode(i32);
 
     impl AuthorizationMode {
+        /// Not set.
+        pub const AUTHORIZATION_MODE_UNSPECIFIED: AuthorizationMode = AuthorizationMode::new(0);
+
+        /// Authorization disabled.
+        pub const AUTH_DISABLED: AuthorizationMode = AuthorizationMode::new(1);
+
+        /// IAM basic authorization.
+        pub const IAM_AUTH: AuthorizationMode = AuthorizationMode::new(2);
+
         /// Creates a new AuthorizationMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("AUTHORIZATION_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AUTH_DISABLED"),
+                2 => std::borrow::Cow::Borrowed("IAM_AUTH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "AUTHORIZATION_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::AUTHORIZATION_MODE_UNSPECIFIED)
+                }
+                "AUTH_DISABLED" => std::option::Option::Some(Self::AUTH_DISABLED),
+                "IAM_AUTH" => std::option::Option::Some(Self::IAM_AUTH),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AuthorizationMode](AuthorizationMode)
-    pub mod authorization_mode {
-        use super::AuthorizationMode;
-
-        /// Not set.
-        pub const AUTHORIZATION_MODE_UNSPECIFIED: AuthorizationMode =
-            AuthorizationMode::new("AUTHORIZATION_MODE_UNSPECIFIED");
-
-        /// Authorization disabled.
-        pub const AUTH_DISABLED: AuthorizationMode = AuthorizationMode::new("AUTH_DISABLED");
-
-        /// IAM basic authorization.
-        pub const IAM_AUTH: AuthorizationMode = AuthorizationMode::new("IAM_AUTH");
-    }
-
-    impl std::convert::From<std::string::String> for AuthorizationMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AuthorizationMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AuthorizationMode {
         fn default() -> Self {
-            authorization_mode::AUTHORIZATION_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Possible in-transit encryption modes of the instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TransitEncryptionMode(std::borrow::Cow<'static, str>);
+    pub struct TransitEncryptionMode(i32);
 
     impl TransitEncryptionMode {
-        /// Creates a new TransitEncryptionMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [TransitEncryptionMode](TransitEncryptionMode)
-    pub mod transit_encryption_mode {
-        use super::TransitEncryptionMode;
-
         /// Not set.
         pub const TRANSIT_ENCRYPTION_MODE_UNSPECIFIED: TransitEncryptionMode =
-            TransitEncryptionMode::new("TRANSIT_ENCRYPTION_MODE_UNSPECIFIED");
+            TransitEncryptionMode::new(0);
 
         /// In-transit encryption is disabled.
         pub const TRANSIT_ENCRYPTION_DISABLED: TransitEncryptionMode =
-            TransitEncryptionMode::new("TRANSIT_ENCRYPTION_DISABLED");
+            TransitEncryptionMode::new(1);
 
         /// Server-managed encryption is used for in-transit encryption.
-        pub const SERVER_AUTHENTICATION: TransitEncryptionMode =
-            TransitEncryptionMode::new("SERVER_AUTHENTICATION");
+        pub const SERVER_AUTHENTICATION: TransitEncryptionMode = TransitEncryptionMode::new(2);
+
+        /// Creates a new TransitEncryptionMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TRANSIT_ENCRYPTION_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TRANSIT_ENCRYPTION_DISABLED"),
+                2 => std::borrow::Cow::Borrowed("SERVER_AUTHENTICATION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TRANSIT_ENCRYPTION_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::TRANSIT_ENCRYPTION_MODE_UNSPECIFIED)
+                }
+                "TRANSIT_ENCRYPTION_DISABLED" => {
+                    std::option::Option::Some(Self::TRANSIT_ENCRYPTION_DISABLED)
+                }
+                "SERVER_AUTHENTICATION" => std::option::Option::Some(Self::SERVER_AUTHENTICATION),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for TransitEncryptionMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TransitEncryptionMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TransitEncryptionMode {
         fn default() -> Self {
-            transit_encryption_mode::TRANSIT_ENCRYPTION_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -769,94 +822,130 @@ pub mod instance {
     /// <https://cloud.google.com/memorystore/docs/valkey/instance-node-specification>
     /// for more information.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NodeType(std::borrow::Cow<'static, str>);
+    pub struct NodeType(i32);
 
     impl NodeType {
+        /// Not set.
+        pub const NODE_TYPE_UNSPECIFIED: NodeType = NodeType::new(0);
+
+        /// Shared core nano.
+        pub const SHARED_CORE_NANO: NodeType = NodeType::new(1);
+
+        /// High memory medium.
+        pub const HIGHMEM_MEDIUM: NodeType = NodeType::new(2);
+
+        /// High memory extra large.
+        pub const HIGHMEM_XLARGE: NodeType = NodeType::new(3);
+
+        /// Standard small.
+        pub const STANDARD_SMALL: NodeType = NodeType::new(4);
+
         /// Creates a new NodeType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("NODE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SHARED_CORE_NANO"),
+                2 => std::borrow::Cow::Borrowed("HIGHMEM_MEDIUM"),
+                3 => std::borrow::Cow::Borrowed("HIGHMEM_XLARGE"),
+                4 => std::borrow::Cow::Borrowed("STANDARD_SMALL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "NODE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::NODE_TYPE_UNSPECIFIED),
+                "SHARED_CORE_NANO" => std::option::Option::Some(Self::SHARED_CORE_NANO),
+                "HIGHMEM_MEDIUM" => std::option::Option::Some(Self::HIGHMEM_MEDIUM),
+                "HIGHMEM_XLARGE" => std::option::Option::Some(Self::HIGHMEM_XLARGE),
+                "STANDARD_SMALL" => std::option::Option::Some(Self::STANDARD_SMALL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [NodeType](NodeType)
-    pub mod node_type {
-        use super::NodeType;
-
-        /// Not set.
-        pub const NODE_TYPE_UNSPECIFIED: NodeType = NodeType::new("NODE_TYPE_UNSPECIFIED");
-
-        /// Shared core nano.
-        pub const SHARED_CORE_NANO: NodeType = NodeType::new("SHARED_CORE_NANO");
-
-        /// High memory medium.
-        pub const HIGHMEM_MEDIUM: NodeType = NodeType::new("HIGHMEM_MEDIUM");
-
-        /// High memory extra large.
-        pub const HIGHMEM_XLARGE: NodeType = NodeType::new("HIGHMEM_XLARGE");
-
-        /// Standard small.
-        pub const STANDARD_SMALL: NodeType = NodeType::new("STANDARD_SMALL");
-    }
-
-    impl std::convert::From<std::string::String> for NodeType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for NodeType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for NodeType {
         fn default() -> Self {
-            node_type::NODE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The mode config, which is used to enable/disable cluster mode.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(std::borrow::Cow<'static, str>);
+    pub struct Mode(i32);
 
     impl Mode {
+        /// Mode is not specified.
+        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
+
+        /// Deprecated: Use CLUSTER_DISABLED instead.
+        pub const STANDALONE: Mode = Mode::new(1);
+
+        /// Instance is in cluster mode.
+        pub const CLUSTER: Mode = Mode::new(2);
+
+        /// Cluster mode is disabled for the instance.
+        pub const CLUSTER_DISABLED: Mode = Mode::new(4);
+
         /// Creates a new Mode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STANDALONE"),
+                2 => std::borrow::Cow::Borrowed("CLUSTER"),
+                4 => std::borrow::Cow::Borrowed("CLUSTER_DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
+                "STANDALONE" => std::option::Option::Some(Self::STANDALONE),
+                "CLUSTER" => std::option::Option::Some(Self::CLUSTER),
+                "CLUSTER_DISABLED" => std::option::Option::Some(Self::CLUSTER_DISABLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Mode](Mode)
-    pub mod mode {
-        use super::Mode;
-
-        /// Mode is not specified.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new("MODE_UNSPECIFIED");
-
-        /// Deprecated: Use CLUSTER_DISABLED instead.
-        pub const STANDALONE: Mode = Mode::new("STANDALONE");
-
-        /// Instance is in cluster mode.
-        pub const CLUSTER: Mode = Mode::new("CLUSTER");
-
-        /// Cluster mode is disabled for the instance.
-        pub const CLUSTER_DISABLED: Mode = Mode::new("CLUSTER_DISABLED");
-    }
-
-    impl std::convert::From<std::string::String> for Mode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            mode::MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1327,50 +1416,70 @@ pub mod persistence_config {
 
         /// Possible snapshot periods.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SnapshotPeriod(std::borrow::Cow<'static, str>);
+        pub struct SnapshotPeriod(i32);
 
         impl SnapshotPeriod {
+            /// Not set.
+            pub const SNAPSHOT_PERIOD_UNSPECIFIED: SnapshotPeriod = SnapshotPeriod::new(0);
+
+            /// One hour.
+            pub const ONE_HOUR: SnapshotPeriod = SnapshotPeriod::new(1);
+
+            /// Six hours.
+            pub const SIX_HOURS: SnapshotPeriod = SnapshotPeriod::new(2);
+
+            /// Twelve hours.
+            pub const TWELVE_HOURS: SnapshotPeriod = SnapshotPeriod::new(3);
+
+            /// Twenty four hours.
+            pub const TWENTY_FOUR_HOURS: SnapshotPeriod = SnapshotPeriod::new(4);
+
             /// Creates a new SnapshotPeriod instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("SNAPSHOT_PERIOD_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("ONE_HOUR"),
+                    2 => std::borrow::Cow::Borrowed("SIX_HOURS"),
+                    3 => std::borrow::Cow::Borrowed("TWELVE_HOURS"),
+                    4 => std::borrow::Cow::Borrowed("TWENTY_FOUR_HOURS"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "SNAPSHOT_PERIOD_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::SNAPSHOT_PERIOD_UNSPECIFIED)
+                    }
+                    "ONE_HOUR" => std::option::Option::Some(Self::ONE_HOUR),
+                    "SIX_HOURS" => std::option::Option::Some(Self::SIX_HOURS),
+                    "TWELVE_HOURS" => std::option::Option::Some(Self::TWELVE_HOURS),
+                    "TWENTY_FOUR_HOURS" => std::option::Option::Some(Self::TWENTY_FOUR_HOURS),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [SnapshotPeriod](SnapshotPeriod)
-        pub mod snapshot_period {
-            use super::SnapshotPeriod;
-
-            /// Not set.
-            pub const SNAPSHOT_PERIOD_UNSPECIFIED: SnapshotPeriod =
-                SnapshotPeriod::new("SNAPSHOT_PERIOD_UNSPECIFIED");
-
-            /// One hour.
-            pub const ONE_HOUR: SnapshotPeriod = SnapshotPeriod::new("ONE_HOUR");
-
-            /// Six hours.
-            pub const SIX_HOURS: SnapshotPeriod = SnapshotPeriod::new("SIX_HOURS");
-
-            /// Twelve hours.
-            pub const TWELVE_HOURS: SnapshotPeriod = SnapshotPeriod::new("TWELVE_HOURS");
-
-            /// Twenty four hours.
-            pub const TWENTY_FOUR_HOURS: SnapshotPeriod = SnapshotPeriod::new("TWENTY_FOUR_HOURS");
-        }
-
-        impl std::convert::From<std::string::String> for SnapshotPeriod {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for SnapshotPeriod {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for SnapshotPeriod {
             fn default() -> Self {
-                snapshot_period::SNAPSHOT_PERIOD_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -1415,97 +1524,133 @@ pub mod persistence_config {
 
         /// Possible fsync modes.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct AppendFsync(std::borrow::Cow<'static, str>);
+        pub struct AppendFsync(i32);
 
         impl AppendFsync {
-            /// Creates a new AppendFsync instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [AppendFsync](AppendFsync)
-        pub mod append_fsync {
-            use super::AppendFsync;
-
             /// Not set. Default: EVERY_SEC
-            pub const APPEND_FSYNC_UNSPECIFIED: AppendFsync =
-                AppendFsync::new("APPEND_FSYNC_UNSPECIFIED");
+            pub const APPEND_FSYNC_UNSPECIFIED: AppendFsync = AppendFsync::new(0);
 
             /// Never fsync. Normally Linux will flush data every 30 seconds with this
             /// configuration, but it's up to the kernel's exact tuning.
-            pub const NEVER: AppendFsync = AppendFsync::new("NEVER");
+            pub const NEVER: AppendFsync = AppendFsync::new(1);
 
             /// Fsync every second. You may lose 1 second of data if there is a
             /// disaster.
-            pub const EVERY_SEC: AppendFsync = AppendFsync::new("EVERY_SEC");
+            pub const EVERY_SEC: AppendFsync = AppendFsync::new(2);
 
             /// Fsync every time new write commands are appended to the AOF. The best
             /// data loss protection at the cost of performance.
-            pub const ALWAYS: AppendFsync = AppendFsync::new("ALWAYS");
+            pub const ALWAYS: AppendFsync = AppendFsync::new(3);
+
+            /// Creates a new AppendFsync instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("APPEND_FSYNC_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("NEVER"),
+                    2 => std::borrow::Cow::Borrowed("EVERY_SEC"),
+                    3 => std::borrow::Cow::Borrowed("ALWAYS"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "APPEND_FSYNC_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::APPEND_FSYNC_UNSPECIFIED)
+                    }
+                    "NEVER" => std::option::Option::Some(Self::NEVER),
+                    "EVERY_SEC" => std::option::Option::Some(Self::EVERY_SEC),
+                    "ALWAYS" => std::option::Option::Some(Self::ALWAYS),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for AppendFsync {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for AppendFsync {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for AppendFsync {
             fn default() -> Self {
-                append_fsync::APPEND_FSYNC_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// Possible persistence modes.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PersistenceMode(std::borrow::Cow<'static, str>);
+    pub struct PersistenceMode(i32);
 
     impl PersistenceMode {
+        /// Not set.
+        pub const PERSISTENCE_MODE_UNSPECIFIED: PersistenceMode = PersistenceMode::new(0);
+
+        /// Persistence is disabled, and any snapshot data is deleted.
+        pub const DISABLED: PersistenceMode = PersistenceMode::new(1);
+
+        /// RDB based persistence is enabled.
+        pub const RDB: PersistenceMode = PersistenceMode::new(2);
+
+        /// AOF based persistence is enabled.
+        pub const AOF: PersistenceMode = PersistenceMode::new(3);
+
         /// Creates a new PersistenceMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PERSISTENCE_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DISABLED"),
+                2 => std::borrow::Cow::Borrowed("RDB"),
+                3 => std::borrow::Cow::Borrowed("AOF"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PERSISTENCE_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PERSISTENCE_MODE_UNSPECIFIED)
+                }
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "RDB" => std::option::Option::Some(Self::RDB),
+                "AOF" => std::option::Option::Some(Self::AOF),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [PersistenceMode](PersistenceMode)
-    pub mod persistence_mode {
-        use super::PersistenceMode;
-
-        /// Not set.
-        pub const PERSISTENCE_MODE_UNSPECIFIED: PersistenceMode =
-            PersistenceMode::new("PERSISTENCE_MODE_UNSPECIFIED");
-
-        /// Persistence is disabled, and any snapshot data is deleted.
-        pub const DISABLED: PersistenceMode = PersistenceMode::new("DISABLED");
-
-        /// RDB based persistence is enabled.
-        pub const RDB: PersistenceMode = PersistenceMode::new("RDB");
-
-        /// AOF based persistence is enabled.
-        pub const AOF: PersistenceMode = PersistenceMode::new("AOF");
-    }
-
-    impl std::convert::From<std::string::String> for PersistenceMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PersistenceMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PersistenceMode {
         fn default() -> Self {
-            persistence_mode::PERSISTENCE_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1589,45 +1734,62 @@ pub mod zone_distribution_config {
 
     /// Possible zone distribution modes.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ZoneDistributionMode(std::borrow::Cow<'static, str>);
+    pub struct ZoneDistributionMode(i32);
 
     impl ZoneDistributionMode {
-        /// Creates a new ZoneDistributionMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ZoneDistributionMode](ZoneDistributionMode)
-    pub mod zone_distribution_mode {
-        use super::ZoneDistributionMode;
-
         /// Not Set. Default: MULTI_ZONE
         pub const ZONE_DISTRIBUTION_MODE_UNSPECIFIED: ZoneDistributionMode =
-            ZoneDistributionMode::new("ZONE_DISTRIBUTION_MODE_UNSPECIFIED");
+            ZoneDistributionMode::new(0);
 
         /// Distribute resources across 3 zones picked at random within the
         /// region.
-        pub const MULTI_ZONE: ZoneDistributionMode = ZoneDistributionMode::new("MULTI_ZONE");
+        pub const MULTI_ZONE: ZoneDistributionMode = ZoneDistributionMode::new(1);
 
         /// Provision resources in a single zone. Zone field must be specified.
-        pub const SINGLE_ZONE: ZoneDistributionMode = ZoneDistributionMode::new("SINGLE_ZONE");
+        pub const SINGLE_ZONE: ZoneDistributionMode = ZoneDistributionMode::new(2);
+
+        /// Creates a new ZoneDistributionMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ZONE_DISTRIBUTION_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MULTI_ZONE"),
+                2 => std::borrow::Cow::Borrowed("SINGLE_ZONE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ZONE_DISTRIBUTION_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ZONE_DISTRIBUTION_MODE_UNSPECIFIED)
+                }
+                "MULTI_ZONE" => std::option::Option::Some(Self::MULTI_ZONE),
+                "SINGLE_ZONE" => std::option::Option::Some(Self::SINGLE_ZONE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ZoneDistributionMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ZoneDistributionMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ZoneDistributionMode {
         fn default() -> Self {
-            zone_distribution_mode::ZONE_DISTRIBUTION_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2322,92 +2484,125 @@ impl wkt::message::Message for OperationMetadata {
 
 /// Status of the PSC connection.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PscConnectionStatus(std::borrow::Cow<'static, str>);
+pub struct PscConnectionStatus(i32);
 
 impl PscConnectionStatus {
+    /// PSC connection status is not specified.
+    pub const PSC_CONNECTION_STATUS_UNSPECIFIED: PscConnectionStatus = PscConnectionStatus::new(0);
+
+    /// The connection is active
+    pub const ACTIVE: PscConnectionStatus = PscConnectionStatus::new(1);
+
+    /// Connection not found
+    pub const NOT_FOUND: PscConnectionStatus = PscConnectionStatus::new(2);
+
     /// Creates a new PscConnectionStatus instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("PSC_CONNECTION_STATUS_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ACTIVE"),
+            2 => std::borrow::Cow::Borrowed("NOT_FOUND"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "PSC_CONNECTION_STATUS_UNSPECIFIED" => {
+                std::option::Option::Some(Self::PSC_CONNECTION_STATUS_UNSPECIFIED)
+            }
+            "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+            "NOT_FOUND" => std::option::Option::Some(Self::NOT_FOUND),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [PscConnectionStatus](PscConnectionStatus)
-pub mod psc_connection_status {
-    use super::PscConnectionStatus;
-
-    /// PSC connection status is not specified.
-    pub const PSC_CONNECTION_STATUS_UNSPECIFIED: PscConnectionStatus =
-        PscConnectionStatus::new("PSC_CONNECTION_STATUS_UNSPECIFIED");
-
-    /// The connection is active
-    pub const ACTIVE: PscConnectionStatus = PscConnectionStatus::new("ACTIVE");
-
-    /// Connection not found
-    pub const NOT_FOUND: PscConnectionStatus = PscConnectionStatus::new("NOT_FOUND");
-}
-
-impl std::convert::From<std::string::String> for PscConnectionStatus {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for PscConnectionStatus {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for PscConnectionStatus {
     fn default() -> Self {
-        psc_connection_status::PSC_CONNECTION_STATUS_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Type of a PSC connection
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ConnectionType(std::borrow::Cow<'static, str>);
+pub struct ConnectionType(i32);
 
 impl ConnectionType {
+    /// Connection Type is not set
+    pub const CONNECTION_TYPE_UNSPECIFIED: ConnectionType = ConnectionType::new(0);
+
+    /// Connection that will be used for topology discovery.
+    pub const CONNECTION_TYPE_DISCOVERY: ConnectionType = ConnectionType::new(1);
+
+    /// Connection that will be used as primary endpoint to access primary.
+    pub const CONNECTION_TYPE_PRIMARY: ConnectionType = ConnectionType::new(2);
+
+    /// Connection that will be used as reader endpoint to access replicas.
+    pub const CONNECTION_TYPE_READER: ConnectionType = ConnectionType::new(3);
+
     /// Creates a new ConnectionType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("CONNECTION_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("CONNECTION_TYPE_DISCOVERY"),
+            2 => std::borrow::Cow::Borrowed("CONNECTION_TYPE_PRIMARY"),
+            3 => std::borrow::Cow::Borrowed("CONNECTION_TYPE_READER"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "CONNECTION_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::CONNECTION_TYPE_UNSPECIFIED)
+            }
+            "CONNECTION_TYPE_DISCOVERY" => {
+                std::option::Option::Some(Self::CONNECTION_TYPE_DISCOVERY)
+            }
+            "CONNECTION_TYPE_PRIMARY" => std::option::Option::Some(Self::CONNECTION_TYPE_PRIMARY),
+            "CONNECTION_TYPE_READER" => std::option::Option::Some(Self::CONNECTION_TYPE_READER),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [ConnectionType](ConnectionType)
-pub mod connection_type {
-    use super::ConnectionType;
-
-    /// Connection Type is not set
-    pub const CONNECTION_TYPE_UNSPECIFIED: ConnectionType =
-        ConnectionType::new("CONNECTION_TYPE_UNSPECIFIED");
-
-    /// Connection that will be used for topology discovery.
-    pub const CONNECTION_TYPE_DISCOVERY: ConnectionType =
-        ConnectionType::new("CONNECTION_TYPE_DISCOVERY");
-
-    /// Connection that will be used as primary endpoint to access primary.
-    pub const CONNECTION_TYPE_PRIMARY: ConnectionType =
-        ConnectionType::new("CONNECTION_TYPE_PRIMARY");
-
-    /// Connection that will be used as reader endpoint to access replicas.
-    pub const CONNECTION_TYPE_READER: ConnectionType =
-        ConnectionType::new("CONNECTION_TYPE_READER");
-}
-
-impl std::convert::From<std::string::String> for ConnectionType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ConnectionType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ConnectionType {
     fn default() -> Self {
-        connection_type::CONNECTION_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/memorystore/v1/src/transport.rs
+++ b/src/generated/cloud/memorystore/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::Memorystore for Memorystore {
                 reqwest::Method::GET,
                 format!("/v1/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::Memorystore for Memorystore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::Memorystore for Memorystore {
                 reqwest::Method::POST,
                 format!("/v1/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -127,7 +127,7 @@ impl crate::stubs::Memorystore for Memorystore {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -157,7 +157,7 @@ impl crate::stubs::Memorystore for Memorystore {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -180,7 +180,7 @@ impl crate::stubs::Memorystore for Memorystore {
                 reqwest::Method::GET,
                 format!("/v1/{}/certificateAuthority", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -199,7 +199,7 @@ impl crate::stubs::Memorystore for Memorystore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -221,7 +221,7 @@ impl crate::stubs::Memorystore for Memorystore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -240,7 +240,7 @@ impl crate::stubs::Memorystore for Memorystore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -262,7 +262,7 @@ impl crate::stubs::Memorystore for Memorystore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -281,7 +281,7 @@ impl crate::stubs::Memorystore for Memorystore {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -300,7 +300,7 @@ impl crate::stubs::Memorystore for Memorystore {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/metastore/v1/src/model.rs
+++ b/src/generated/cloud/metastore/v1/src/model.rs
@@ -370,105 +370,145 @@ pub mod service {
 
     /// The current state of the metastore service.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The state of the metastore service is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The metastore service is in the process of being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The metastore service is running and ready to serve queries.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(2);
 
         /// The metastore service is entering suspension. Its query-serving
         /// availability may cease unexpectedly.
-        pub const SUSPENDING: State = State::new("SUSPENDING");
+        pub const SUSPENDING: State = State::new(3);
 
         /// The metastore service is suspended and unable to serve queries.
-        pub const SUSPENDED: State = State::new("SUSPENDED");
+        pub const SUSPENDED: State = State::new(4);
 
         /// The metastore service is being updated. It remains usable but cannot
         /// accept additional update requests or be deleted at this time.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(5);
 
         /// The metastore service is undergoing deletion. It cannot be used.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(6);
 
         /// The metastore service has encountered an error and cannot be used. The
         /// metastore service should be deleted.
-        pub const ERROR: State = State::new("ERROR");
+        pub const ERROR: State = State::new(7);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("SUSPENDING"),
+                4 => std::borrow::Cow::Borrowed("SUSPENDED"),
+                5 => std::borrow::Cow::Borrowed("UPDATING"),
+                6 => std::borrow::Cow::Borrowed("DELETING"),
+                7 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "SUSPENDING" => std::option::Option::Some(Self::SUSPENDING),
+                "SUSPENDED" => std::option::Option::Some(Self::SUSPENDED),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Available service tiers.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Tier(std::borrow::Cow<'static, str>);
+    pub struct Tier(i32);
 
     impl Tier {
-        /// Creates a new Tier instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Tier](Tier)
-    pub mod tier {
-        use super::Tier;
-
         /// The tier is not set.
-        pub const TIER_UNSPECIFIED: Tier = Tier::new("TIER_UNSPECIFIED");
+        pub const TIER_UNSPECIFIED: Tier = Tier::new(0);
 
         /// The developer tier provides limited scalability and no fault tolerance.
         /// Good for low-cost proof-of-concept.
-        pub const DEVELOPER: Tier = Tier::new("DEVELOPER");
+        pub const DEVELOPER: Tier = Tier::new(1);
 
         /// The enterprise tier provides multi-zone high availability, and sufficient
         /// scalability for enterprise-level Dataproc Metastore workloads.
-        pub const ENTERPRISE: Tier = Tier::new("ENTERPRISE");
+        pub const ENTERPRISE: Tier = Tier::new(3);
+
+        /// Creates a new Tier instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TIER_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DEVELOPER"),
+                3 => std::borrow::Cow::Borrowed("ENTERPRISE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TIER_UNSPECIFIED" => std::option::Option::Some(Self::TIER_UNSPECIFIED),
+                "DEVELOPER" => std::option::Option::Some(Self::DEVELOPER),
+                "ENTERPRISE" => std::option::Option::Some(Self::ENTERPRISE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Tier {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Tier {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Tier {
         fn default() -> Self {
-            tier::TIER_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -476,90 +516,122 @@ pub mod service {
     /// features may be introduced initially into less stable release channels and
     /// can be automatically promoted into more stable release channels.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ReleaseChannel(std::borrow::Cow<'static, str>);
+    pub struct ReleaseChannel(i32);
 
     impl ReleaseChannel {
-        /// Creates a new ReleaseChannel instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ReleaseChannel](ReleaseChannel)
-    pub mod release_channel {
-        use super::ReleaseChannel;
-
         /// Release channel is not specified.
-        pub const RELEASE_CHANNEL_UNSPECIFIED: ReleaseChannel =
-            ReleaseChannel::new("RELEASE_CHANNEL_UNSPECIFIED");
+        pub const RELEASE_CHANNEL_UNSPECIFIED: ReleaseChannel = ReleaseChannel::new(0);
 
         /// The `CANARY` release channel contains the newest features, which may be
         /// unstable and subject to unresolved issues with no known workarounds.
         /// Services using the `CANARY` release channel are not subject to any SLAs.
-        pub const CANARY: ReleaseChannel = ReleaseChannel::new("CANARY");
+        pub const CANARY: ReleaseChannel = ReleaseChannel::new(1);
 
         /// The `STABLE` release channel contains features that are considered stable
         /// and have been validated for production use.
-        pub const STABLE: ReleaseChannel = ReleaseChannel::new("STABLE");
+        pub const STABLE: ReleaseChannel = ReleaseChannel::new(2);
+
+        /// Creates a new ReleaseChannel instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RELEASE_CHANNEL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CANARY"),
+                2 => std::borrow::Cow::Borrowed("STABLE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RELEASE_CHANNEL_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RELEASE_CHANNEL_UNSPECIFIED)
+                }
+                "CANARY" => std::option::Option::Some(Self::CANARY),
+                "STABLE" => std::option::Option::Some(Self::STABLE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ReleaseChannel {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ReleaseChannel {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ReleaseChannel {
         fn default() -> Self {
-            release_channel::RELEASE_CHANNEL_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The backend database type for the metastore service.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DatabaseType(std::borrow::Cow<'static, str>);
+    pub struct DatabaseType(i32);
 
     impl DatabaseType {
+        /// The DATABASE_TYPE is not set.
+        pub const DATABASE_TYPE_UNSPECIFIED: DatabaseType = DatabaseType::new(0);
+
+        /// MySQL is used to persist the metastore data.
+        pub const MYSQL: DatabaseType = DatabaseType::new(1);
+
+        /// Spanner is used to persist the metastore data.
+        pub const SPANNER: DatabaseType = DatabaseType::new(2);
+
         /// Creates a new DatabaseType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATABASE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MYSQL"),
+                2 => std::borrow::Cow::Borrowed("SPANNER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATABASE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DATABASE_TYPE_UNSPECIFIED)
+                }
+                "MYSQL" => std::option::Option::Some(Self::MYSQL),
+                "SPANNER" => std::option::Option::Some(Self::SPANNER),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DatabaseType](DatabaseType)
-    pub mod database_type {
-        use super::DatabaseType;
-
-        /// The DATABASE_TYPE is not set.
-        pub const DATABASE_TYPE_UNSPECIFIED: DatabaseType =
-            DatabaseType::new("DATABASE_TYPE_UNSPECIFIED");
-
-        /// MySQL is used to persist the metastore data.
-        pub const MYSQL: DatabaseType = DatabaseType::new("MYSQL");
-
-        /// Spanner is used to persist the metastore data.
-        pub const SPANNER: DatabaseType = DatabaseType::new("SPANNER");
-    }
-
-    impl std::convert::From<std::string::String> for DatabaseType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DatabaseType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DatabaseType {
         fn default() -> Self {
-            database_type::DATABASE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -732,44 +804,60 @@ pub mod hive_metastore_config {
 
     /// Protocols available for serving the metastore service endpoint.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EndpointProtocol(std::borrow::Cow<'static, str>);
+    pub struct EndpointProtocol(i32);
 
     impl EndpointProtocol {
+        /// The protocol is not set.
+        pub const ENDPOINT_PROTOCOL_UNSPECIFIED: EndpointProtocol = EndpointProtocol::new(0);
+
+        /// Use the legacy Apache Thrift protocol for the metastore service endpoint.
+        pub const THRIFT: EndpointProtocol = EndpointProtocol::new(1);
+
+        /// Use the modernized gRPC protocol for the metastore service endpoint.
+        pub const GRPC: EndpointProtocol = EndpointProtocol::new(2);
+
         /// Creates a new EndpointProtocol instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ENDPOINT_PROTOCOL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("THRIFT"),
+                2 => std::borrow::Cow::Borrowed("GRPC"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ENDPOINT_PROTOCOL_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ENDPOINT_PROTOCOL_UNSPECIFIED)
+                }
+                "THRIFT" => std::option::Option::Some(Self::THRIFT),
+                "GRPC" => std::option::Option::Some(Self::GRPC),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [EndpointProtocol](EndpointProtocol)
-    pub mod endpoint_protocol {
-        use super::EndpointProtocol;
-
-        /// The protocol is not set.
-        pub const ENDPOINT_PROTOCOL_UNSPECIFIED: EndpointProtocol =
-            EndpointProtocol::new("ENDPOINT_PROTOCOL_UNSPECIFIED");
-
-        /// Use the legacy Apache Thrift protocol for the metastore service endpoint.
-        pub const THRIFT: EndpointProtocol = EndpointProtocol::new("THRIFT");
-
-        /// Use the modernized gRPC protocol for the metastore service endpoint.
-        pub const GRPC: EndpointProtocol = EndpointProtocol::new("GRPC");
-    }
-
-    impl std::convert::From<std::string::String> for EndpointProtocol {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EndpointProtocol {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EndpointProtocol {
         fn default() -> Self {
-            endpoint_protocol::ENDPOINT_PROTOCOL_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1192,43 +1280,58 @@ pub mod telemetry_config {
     use super::*;
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LogFormat(std::borrow::Cow<'static, str>);
+    pub struct LogFormat(i32);
 
     impl LogFormat {
+        /// The LOG_FORMAT is not set.
+        pub const LOG_FORMAT_UNSPECIFIED: LogFormat = LogFormat::new(0);
+
+        /// Logging output uses the legacy `textPayload` format.
+        pub const LEGACY: LogFormat = LogFormat::new(1);
+
+        /// Logging output uses the `jsonPayload` format.
+        pub const JSON: LogFormat = LogFormat::new(2);
+
         /// Creates a new LogFormat instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LOG_FORMAT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LEGACY"),
+                2 => std::borrow::Cow::Borrowed("JSON"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LOG_FORMAT_UNSPECIFIED" => std::option::Option::Some(Self::LOG_FORMAT_UNSPECIFIED),
+                "LEGACY" => std::option::Option::Some(Self::LEGACY),
+                "JSON" => std::option::Option::Some(Self::JSON),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [LogFormat](LogFormat)
-    pub mod log_format {
-        use super::LogFormat;
-
-        /// The LOG_FORMAT is not set.
-        pub const LOG_FORMAT_UNSPECIFIED: LogFormat = LogFormat::new("LOG_FORMAT_UNSPECIFIED");
-
-        /// Logging output uses the legacy `textPayload` format.
-        pub const LEGACY: LogFormat = LogFormat::new("LEGACY");
-
-        /// Logging output uses the `jsonPayload` format.
-        pub const JSON: LogFormat = LogFormat::new("JSON");
-    }
-
-    impl std::convert::From<std::string::String> for LogFormat {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LogFormat {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LogFormat {
         fn default() -> Self {
-            log_format::LOG_FORMAT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1505,91 +1608,124 @@ pub mod metadata_import {
 
         /// The type of the database.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct DatabaseType(std::borrow::Cow<'static, str>);
+        pub struct DatabaseType(i32);
 
         impl DatabaseType {
+            /// The type of the source database is unknown.
+            pub const DATABASE_TYPE_UNSPECIFIED: DatabaseType = DatabaseType::new(0);
+
+            /// The type of the source database is MySQL.
+            pub const MYSQL: DatabaseType = DatabaseType::new(1);
+
             /// Creates a new DatabaseType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("DATABASE_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("MYSQL"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "DATABASE_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::DATABASE_TYPE_UNSPECIFIED)
+                    }
+                    "MYSQL" => std::option::Option::Some(Self::MYSQL),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [DatabaseType](DatabaseType)
-        pub mod database_type {
-            use super::DatabaseType;
-
-            /// The type of the source database is unknown.
-            pub const DATABASE_TYPE_UNSPECIFIED: DatabaseType =
-                DatabaseType::new("DATABASE_TYPE_UNSPECIFIED");
-
-            /// The type of the source database is MySQL.
-            pub const MYSQL: DatabaseType = DatabaseType::new("MYSQL");
-        }
-
-        impl std::convert::From<std::string::String> for DatabaseType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for DatabaseType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for DatabaseType {
             fn default() -> Self {
-                database_type::DATABASE_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// The current state of the metadata import.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The state of the metadata import is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The metadata import is running.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(1);
 
         /// The metadata import completed successfully.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
+        pub const SUCCEEDED: State = State::new(2);
 
         /// The metadata import is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(3);
 
         /// The metadata import failed, and attempted metadata changes were rolled
         /// back.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(4);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RUNNING"),
+                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1721,49 +1857,68 @@ pub mod metadata_export {
 
     /// The current state of the metadata export.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The state of the metadata export is unknown.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The metadata export is running.
+        pub const RUNNING: State = State::new(1);
+
+        /// The metadata export completed successfully.
+        pub const SUCCEEDED: State = State::new(2);
+
+        /// The metadata export failed.
+        pub const FAILED: State = State::new(3);
+
+        /// The metadata export is cancelled.
+        pub const CANCELLED: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RUNNING"),
+                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                4 => std::borrow::Cow::Borrowed("CANCELLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The state of the metadata export is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The metadata export is running.
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// The metadata export completed successfully.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-        /// The metadata export failed.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// The metadata export is cancelled.
-        pub const CANCELLED: State = State::new("CANCELLED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1892,52 +2047,73 @@ pub mod backup {
 
     /// The current state of the backup.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The state of the backup is unknown.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The backup is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// The backup is being deleted.
+        pub const DELETING: State = State::new(2);
+
+        /// The backup is active and ready to use.
+        pub const ACTIVE: State = State::new(3);
+
+        /// The backup failed.
+        pub const FAILED: State = State::new(4);
+
+        /// The backup is being restored.
+        pub const RESTORING: State = State::new(5);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("DELETING"),
+                3 => std::borrow::Cow::Borrowed("ACTIVE"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                5 => std::borrow::Cow::Borrowed("RESTORING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "RESTORING" => std::option::Option::Some(Self::RESTORING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The state of the backup is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The backup is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The backup is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// The backup is active and ready to use.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The backup failed.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// The backup is being restored.
-        pub const RESTORING: State = State::new("RESTORING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2040,92 +2216,127 @@ pub mod restore {
 
     /// The current state of the restore.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The state of the metadata restore is unknown.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The metadata restore is running.
+        pub const RUNNING: State = State::new(1);
+
+        /// The metadata restore completed successfully.
+        pub const SUCCEEDED: State = State::new(2);
+
+        /// The metadata restore failed.
+        pub const FAILED: State = State::new(3);
+
+        /// The metadata restore is cancelled.
+        pub const CANCELLED: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RUNNING"),
+                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                4 => std::borrow::Cow::Borrowed("CANCELLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The state of the metadata restore is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The metadata restore is running.
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// The metadata restore completed successfully.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-        /// The metadata restore failed.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// The metadata restore is cancelled.
-        pub const CANCELLED: State = State::new("CANCELLED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The type of restore. If unspecified, defaults to `METADATA_ONLY`.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RestoreType(std::borrow::Cow<'static, str>);
+    pub struct RestoreType(i32);
 
     impl RestoreType {
+        /// The restore type is unknown.
+        pub const RESTORE_TYPE_UNSPECIFIED: RestoreType = RestoreType::new(0);
+
+        /// The service's metadata and configuration are restored.
+        pub const FULL: RestoreType = RestoreType::new(1);
+
+        /// Only the service's metadata is restored.
+        pub const METADATA_ONLY: RestoreType = RestoreType::new(2);
+
         /// Creates a new RestoreType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RESTORE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FULL"),
+                2 => std::borrow::Cow::Borrowed("METADATA_ONLY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RESTORE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RESTORE_TYPE_UNSPECIFIED)
+                }
+                "FULL" => std::option::Option::Some(Self::FULL),
+                "METADATA_ONLY" => std::option::Option::Some(Self::METADATA_ONLY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RestoreType](RestoreType)
-    pub mod restore_type {
-        use super::RestoreType;
-
-        /// The restore type is unknown.
-        pub const RESTORE_TYPE_UNSPECIFIED: RestoreType =
-            RestoreType::new("RESTORE_TYPE_UNSPECIFIED");
-
-        /// The service's metadata and configuration are restored.
-        pub const FULL: RestoreType = RestoreType::new("FULL");
-
-        /// Only the service's metadata is restored.
-        pub const METADATA_ONLY: RestoreType = RestoreType::new("METADATA_ONLY");
-    }
-
-    impl std::convert::From<std::string::String> for RestoreType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RestoreType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RestoreType {
         fn default() -> Self {
-            restore_type::RESTORE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2227,53 +2438,75 @@ pub mod scaling_config {
 
     /// Metastore instance sizes.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct InstanceSize(std::borrow::Cow<'static, str>);
+    pub struct InstanceSize(i32);
 
     impl InstanceSize {
+        /// Unspecified instance size
+        pub const INSTANCE_SIZE_UNSPECIFIED: InstanceSize = InstanceSize::new(0);
+
+        /// Extra small instance size, maps to a scaling factor of 0.1.
+        pub const EXTRA_SMALL: InstanceSize = InstanceSize::new(1);
+
+        /// Small instance size, maps to a scaling factor of 0.5.
+        pub const SMALL: InstanceSize = InstanceSize::new(2);
+
+        /// Medium instance size, maps to a scaling factor of 1.0.
+        pub const MEDIUM: InstanceSize = InstanceSize::new(3);
+
+        /// Large instance size, maps to a scaling factor of 3.0.
+        pub const LARGE: InstanceSize = InstanceSize::new(4);
+
+        /// Extra large instance size, maps to a scaling factor of 6.0.
+        pub const EXTRA_LARGE: InstanceSize = InstanceSize::new(5);
+
         /// Creates a new InstanceSize instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("INSTANCE_SIZE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("EXTRA_SMALL"),
+                2 => std::borrow::Cow::Borrowed("SMALL"),
+                3 => std::borrow::Cow::Borrowed("MEDIUM"),
+                4 => std::borrow::Cow::Borrowed("LARGE"),
+                5 => std::borrow::Cow::Borrowed("EXTRA_LARGE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "INSTANCE_SIZE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::INSTANCE_SIZE_UNSPECIFIED)
+                }
+                "EXTRA_SMALL" => std::option::Option::Some(Self::EXTRA_SMALL),
+                "SMALL" => std::option::Option::Some(Self::SMALL),
+                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
+                "LARGE" => std::option::Option::Some(Self::LARGE),
+                "EXTRA_LARGE" => std::option::Option::Some(Self::EXTRA_LARGE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [InstanceSize](InstanceSize)
-    pub mod instance_size {
-        use super::InstanceSize;
-
-        /// Unspecified instance size
-        pub const INSTANCE_SIZE_UNSPECIFIED: InstanceSize =
-            InstanceSize::new("INSTANCE_SIZE_UNSPECIFIED");
-
-        /// Extra small instance size, maps to a scaling factor of 0.1.
-        pub const EXTRA_SMALL: InstanceSize = InstanceSize::new("EXTRA_SMALL");
-
-        /// Small instance size, maps to a scaling factor of 0.5.
-        pub const SMALL: InstanceSize = InstanceSize::new("SMALL");
-
-        /// Medium instance size, maps to a scaling factor of 1.0.
-        pub const MEDIUM: InstanceSize = InstanceSize::new("MEDIUM");
-
-        /// Large instance size, maps to a scaling factor of 3.0.
-        pub const LARGE: InstanceSize = InstanceSize::new("LARGE");
-
-        /// Extra large instance size, maps to a scaling factor of 6.0.
-        pub const EXTRA_LARGE: InstanceSize = InstanceSize::new("EXTRA_LARGE");
-    }
-
-    impl std::convert::From<std::string::String> for InstanceSize {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for InstanceSize {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for InstanceSize {
         fn default() -> Self {
-            instance_size::INSTANCE_SIZE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -3833,43 +4066,58 @@ pub mod database_dump_spec {
 
     /// The type of the database dump.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// The type of the database dump is unknown.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// Database dump is a MySQL dump file.
+        pub const MYSQL: Type = Type::new(1);
+
+        /// Database dump contains Avro files.
+        pub const AVRO: Type = Type::new(2);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MYSQL"),
+                2 => std::borrow::Cow::Borrowed("AVRO"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "MYSQL" => std::option::Option::Some(Self::MYSQL),
+                "AVRO" => std::option::Option::Some(Self::AVRO),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// The type of the database dump is unknown.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// Database dump is a MySQL dump file.
-        pub const MYSQL: Type = Type::new("MYSQL");
-
-        /// Database dump contains Avro files.
-        pub const AVRO: Type = Type::new("AVRO");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4328,54 +4576,75 @@ pub mod federation {
 
     /// The current state of the federation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The state of the metastore federation is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The metastore federation is in the process of being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The metastore federation is running and ready to serve queries.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(2);
 
         /// The metastore federation is being updated. It remains usable but cannot
         /// accept additional update requests or be deleted at this time.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(3);
 
         /// The metastore federation is undergoing deletion. It cannot be used.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(4);
 
         /// The metastore federation has encountered an error and cannot be used. The
         /// metastore federation should be deleted.
-        pub const ERROR: State = State::new("ERROR");
+        pub const ERROR: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4437,44 +4706,60 @@ pub mod backend_metastore {
 
     /// The type of the backend metastore.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MetastoreType(std::borrow::Cow<'static, str>);
+    pub struct MetastoreType(i32);
 
     impl MetastoreType {
+        /// The metastore type is not set.
+        pub const METASTORE_TYPE_UNSPECIFIED: MetastoreType = MetastoreType::new(0);
+
+        /// The backend metastore is BigQuery.
+        pub const BIGQUERY: MetastoreType = MetastoreType::new(2);
+
+        /// The backend metastore is Dataproc Metastore.
+        pub const DATAPROC_METASTORE: MetastoreType = MetastoreType::new(3);
+
         /// Creates a new MetastoreType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("METASTORE_TYPE_UNSPECIFIED"),
+                2 => std::borrow::Cow::Borrowed("BIGQUERY"),
+                3 => std::borrow::Cow::Borrowed("DATAPROC_METASTORE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "METASTORE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::METASTORE_TYPE_UNSPECIFIED)
+                }
+                "BIGQUERY" => std::option::Option::Some(Self::BIGQUERY),
+                "DATAPROC_METASTORE" => std::option::Option::Some(Self::DATAPROC_METASTORE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [MetastoreType](MetastoreType)
-    pub mod metastore_type {
-        use super::MetastoreType;
-
-        /// The metastore type is not set.
-        pub const METASTORE_TYPE_UNSPECIFIED: MetastoreType =
-            MetastoreType::new("METASTORE_TYPE_UNSPECIFIED");
-
-        /// The backend metastore is BigQuery.
-        pub const BIGQUERY: MetastoreType = MetastoreType::new("BIGQUERY");
-
-        /// The backend metastore is Dataproc Metastore.
-        pub const DATAPROC_METASTORE: MetastoreType = MetastoreType::new("DATAPROC_METASTORE");
-    }
-
-    impl std::convert::From<std::string::String> for MetastoreType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MetastoreType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MetastoreType {
         fn default() -> Self {
-            metastore_type::METASTORE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/metastore/v1/src/transport.rs
+++ b/src/generated/cloud/metastore/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/services", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -94,7 +94,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
                 reqwest::Method::POST,
                 format!("/v1/{}/services", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -124,7 +124,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -154,7 +154,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -177,7 +177,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
                 reqwest::Method::GET,
                 format!("/v1/{}/metadataImports", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -200,7 +200,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -222,7 +222,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
                 reqwest::Method::POST,
                 format!("/v1/{}/metadataImports", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -252,7 +252,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -285,7 +285,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
                 reqwest::Method::POST,
                 format!("/v1/{}:exportMetadata", req.service),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -305,7 +305,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
                 reqwest::Method::POST,
                 format!("/v1/{}:restore", req.service),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -322,7 +322,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/backups", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -345,7 +345,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -364,7 +364,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/backups", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -383,7 +383,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -406,7 +406,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
                 reqwest::Method::POST,
                 format!("/v1/{}:queryMetadata", req.service),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -426,7 +426,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
                 reqwest::Method::POST,
                 format!("/v1/{}:moveTableToDatabase", req.service),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -446,7 +446,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
                 reqwest::Method::POST,
                 format!("/v1/{}:alterLocation", req.service),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -463,7 +463,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -485,7 +485,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -507,7 +507,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -527,7 +527,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -559,7 +559,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -576,7 +576,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -598,7 +598,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -617,7 +617,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -636,7 +636,7 @@ impl crate::stubs::DataprocMetastore for DataprocMetastore {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -693,7 +693,7 @@ impl crate::stubs::DataprocMetastoreFederation for DataprocMetastoreFederation {
                 reqwest::Method::GET,
                 format!("/v1/{}/federations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -716,7 +716,7 @@ impl crate::stubs::DataprocMetastoreFederation for DataprocMetastoreFederation {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -738,7 +738,7 @@ impl crate::stubs::DataprocMetastoreFederation for DataprocMetastoreFederation {
                 reqwest::Method::POST,
                 format!("/v1/{}/federations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -768,7 +768,7 @@ impl crate::stubs::DataprocMetastoreFederation for DataprocMetastoreFederation {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -798,7 +798,7 @@ impl crate::stubs::DataprocMetastoreFederation for DataprocMetastoreFederation {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -818,7 +818,7 @@ impl crate::stubs::DataprocMetastoreFederation for DataprocMetastoreFederation {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -840,7 +840,7 @@ impl crate::stubs::DataprocMetastoreFederation for DataprocMetastoreFederation {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -862,7 +862,7 @@ impl crate::stubs::DataprocMetastoreFederation for DataprocMetastoreFederation {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -882,7 +882,7 @@ impl crate::stubs::DataprocMetastoreFederation for DataprocMetastoreFederation {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -914,7 +914,7 @@ impl crate::stubs::DataprocMetastoreFederation for DataprocMetastoreFederation {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -931,7 +931,7 @@ impl crate::stubs::DataprocMetastoreFederation for DataprocMetastoreFederation {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -953,7 +953,7 @@ impl crate::stubs::DataprocMetastoreFederation for DataprocMetastoreFederation {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -972,7 +972,7 @@ impl crate::stubs::DataprocMetastoreFederation for DataprocMetastoreFederation {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -991,7 +991,7 @@ impl crate::stubs::DataprocMetastoreFederation for DataprocMetastoreFederation {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/migrationcenter/v1/src/model.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/model.rs
@@ -529,66 +529,97 @@ pub mod import_job {
 
     /// Enumerates possible states of an import job.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ImportJobState(std::borrow::Cow<'static, str>);
+    pub struct ImportJobState(i32);
 
     impl ImportJobState {
+        /// Default value.
+        pub const IMPORT_JOB_STATE_UNSPECIFIED: ImportJobState = ImportJobState::new(0);
+
+        /// The import job is pending.
+        pub const IMPORT_JOB_STATE_PENDING: ImportJobState = ImportJobState::new(1);
+
+        /// The processing of the import job is ongoing.
+        pub const IMPORT_JOB_STATE_RUNNING: ImportJobState = ImportJobState::new(2);
+
+        /// The import job processing has completed.
+        pub const IMPORT_JOB_STATE_COMPLETED: ImportJobState = ImportJobState::new(3);
+
+        /// The import job failed to be processed.
+        pub const IMPORT_JOB_STATE_FAILED: ImportJobState = ImportJobState::new(4);
+
+        /// The import job is being validated.
+        pub const IMPORT_JOB_STATE_VALIDATING: ImportJobState = ImportJobState::new(5);
+
+        /// The import job contains blocking errors.
+        pub const IMPORT_JOB_STATE_FAILED_VALIDATION: ImportJobState = ImportJobState::new(6);
+
+        /// The validation of the job completed with no blocking errors.
+        pub const IMPORT_JOB_STATE_READY: ImportJobState = ImportJobState::new(7);
+
         /// Creates a new ImportJobState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("IMPORT_JOB_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IMPORT_JOB_STATE_PENDING"),
+                2 => std::borrow::Cow::Borrowed("IMPORT_JOB_STATE_RUNNING"),
+                3 => std::borrow::Cow::Borrowed("IMPORT_JOB_STATE_COMPLETED"),
+                4 => std::borrow::Cow::Borrowed("IMPORT_JOB_STATE_FAILED"),
+                5 => std::borrow::Cow::Borrowed("IMPORT_JOB_STATE_VALIDATING"),
+                6 => std::borrow::Cow::Borrowed("IMPORT_JOB_STATE_FAILED_VALIDATION"),
+                7 => std::borrow::Cow::Borrowed("IMPORT_JOB_STATE_READY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "IMPORT_JOB_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::IMPORT_JOB_STATE_UNSPECIFIED)
+                }
+                "IMPORT_JOB_STATE_PENDING" => {
+                    std::option::Option::Some(Self::IMPORT_JOB_STATE_PENDING)
+                }
+                "IMPORT_JOB_STATE_RUNNING" => {
+                    std::option::Option::Some(Self::IMPORT_JOB_STATE_RUNNING)
+                }
+                "IMPORT_JOB_STATE_COMPLETED" => {
+                    std::option::Option::Some(Self::IMPORT_JOB_STATE_COMPLETED)
+                }
+                "IMPORT_JOB_STATE_FAILED" => {
+                    std::option::Option::Some(Self::IMPORT_JOB_STATE_FAILED)
+                }
+                "IMPORT_JOB_STATE_VALIDATING" => {
+                    std::option::Option::Some(Self::IMPORT_JOB_STATE_VALIDATING)
+                }
+                "IMPORT_JOB_STATE_FAILED_VALIDATION" => {
+                    std::option::Option::Some(Self::IMPORT_JOB_STATE_FAILED_VALIDATION)
+                }
+                "IMPORT_JOB_STATE_READY" => std::option::Option::Some(Self::IMPORT_JOB_STATE_READY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ImportJobState](ImportJobState)
-    pub mod import_job_state {
-        use super::ImportJobState;
-
-        /// Default value.
-        pub const IMPORT_JOB_STATE_UNSPECIFIED: ImportJobState =
-            ImportJobState::new("IMPORT_JOB_STATE_UNSPECIFIED");
-
-        /// The import job is pending.
-        pub const IMPORT_JOB_STATE_PENDING: ImportJobState =
-            ImportJobState::new("IMPORT_JOB_STATE_PENDING");
-
-        /// The processing of the import job is ongoing.
-        pub const IMPORT_JOB_STATE_RUNNING: ImportJobState =
-            ImportJobState::new("IMPORT_JOB_STATE_RUNNING");
-
-        /// The import job processing has completed.
-        pub const IMPORT_JOB_STATE_COMPLETED: ImportJobState =
-            ImportJobState::new("IMPORT_JOB_STATE_COMPLETED");
-
-        /// The import job failed to be processed.
-        pub const IMPORT_JOB_STATE_FAILED: ImportJobState =
-            ImportJobState::new("IMPORT_JOB_STATE_FAILED");
-
-        /// The import job is being validated.
-        pub const IMPORT_JOB_STATE_VALIDATING: ImportJobState =
-            ImportJobState::new("IMPORT_JOB_STATE_VALIDATING");
-
-        /// The import job contains blocking errors.
-        pub const IMPORT_JOB_STATE_FAILED_VALIDATION: ImportJobState =
-            ImportJobState::new("IMPORT_JOB_STATE_FAILED_VALIDATION");
-
-        /// The validation of the job completed with no blocking errors.
-        pub const IMPORT_JOB_STATE_READY: ImportJobState =
-            ImportJobState::new("IMPORT_JOB_STATE_READY");
-    }
-
-    impl std::convert::From<std::string::String> for ImportJobState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ImportJobState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ImportJobState {
         fn default() -> Self {
-            import_job_state::IMPORT_JOB_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -733,43 +764,58 @@ pub mod import_data_file {
 
     /// Enumerates possible states of an import data file.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Default value.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The data file is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// The data file completed initialization.
+        pub const ACTIVE: State = State::new(2);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Default value.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The data file is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The data file completed initialization.
-        pub const ACTIVE: State = State::new("ACTIVE");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1090,97 +1136,135 @@ pub mod source {
     use super::*;
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SourceType(std::borrow::Cow<'static, str>);
+    pub struct SourceType(i32);
 
     impl SourceType {
+        /// Unspecified
+        pub const SOURCE_TYPE_UNKNOWN: SourceType = SourceType::new(0);
+
+        /// Manually uploaded file (e.g. CSV)
+        pub const SOURCE_TYPE_UPLOAD: SourceType = SourceType::new(1);
+
+        /// Guest-level info
+        pub const SOURCE_TYPE_GUEST_OS_SCAN: SourceType = SourceType::new(2);
+
+        /// Inventory-level scan
+        pub const SOURCE_TYPE_INVENTORY_SCAN: SourceType = SourceType::new(3);
+
+        /// Third-party owned sources.
+        pub const SOURCE_TYPE_CUSTOM: SourceType = SourceType::new(4);
+
         /// Creates a new SourceType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SOURCE_TYPE_UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("SOURCE_TYPE_UPLOAD"),
+                2 => std::borrow::Cow::Borrowed("SOURCE_TYPE_GUEST_OS_SCAN"),
+                3 => std::borrow::Cow::Borrowed("SOURCE_TYPE_INVENTORY_SCAN"),
+                4 => std::borrow::Cow::Borrowed("SOURCE_TYPE_CUSTOM"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SOURCE_TYPE_UNKNOWN" => std::option::Option::Some(Self::SOURCE_TYPE_UNKNOWN),
+                "SOURCE_TYPE_UPLOAD" => std::option::Option::Some(Self::SOURCE_TYPE_UPLOAD),
+                "SOURCE_TYPE_GUEST_OS_SCAN" => {
+                    std::option::Option::Some(Self::SOURCE_TYPE_GUEST_OS_SCAN)
+                }
+                "SOURCE_TYPE_INVENTORY_SCAN" => {
+                    std::option::Option::Some(Self::SOURCE_TYPE_INVENTORY_SCAN)
+                }
+                "SOURCE_TYPE_CUSTOM" => std::option::Option::Some(Self::SOURCE_TYPE_CUSTOM),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SourceType](SourceType)
-    pub mod source_type {
-        use super::SourceType;
-
-        /// Unspecified
-        pub const SOURCE_TYPE_UNKNOWN: SourceType = SourceType::new("SOURCE_TYPE_UNKNOWN");
-
-        /// Manually uploaded file (e.g. CSV)
-        pub const SOURCE_TYPE_UPLOAD: SourceType = SourceType::new("SOURCE_TYPE_UPLOAD");
-
-        /// Guest-level info
-        pub const SOURCE_TYPE_GUEST_OS_SCAN: SourceType =
-            SourceType::new("SOURCE_TYPE_GUEST_OS_SCAN");
-
-        /// Inventory-level scan
-        pub const SOURCE_TYPE_INVENTORY_SCAN: SourceType =
-            SourceType::new("SOURCE_TYPE_INVENTORY_SCAN");
-
-        /// Third-party owned sources.
-        pub const SOURCE_TYPE_CUSTOM: SourceType = SourceType::new("SOURCE_TYPE_CUSTOM");
-    }
-
-    impl std::convert::From<std::string::String> for SourceType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SourceType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SourceType {
         fn default() -> Self {
-            source_type::SOURCE_TYPE_UNKNOWN
+            Self::new(0)
         }
     }
 
     /// Enumerates possible states of a source.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The source is active and ready to be used.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(1);
 
         /// In the process of being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(2);
 
         /// Source is in an invalid state. Asset frames reported to it will be
         /// ignored.
-        pub const INVALID: State = State::new("INVALID");
+        pub const INVALID: State = State::new(3);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("DELETING"),
+                3 => std::borrow::Cow::Borrowed("INVALID"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "INVALID" => std::option::Option::Some(Self::INVALID),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1439,85 +1523,117 @@ pub mod report {
 
     /// Report type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Default Report type.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// Total cost of ownership Report type.
+        pub const TOTAL_COST_OF_OWNERSHIP: Type = Type::new(1);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TOTAL_COST_OF_OWNERSHIP"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "TOTAL_COST_OF_OWNERSHIP" => {
+                    std::option::Option::Some(Self::TOTAL_COST_OF_OWNERSHIP)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Default Report type.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// Total cost of ownership Report type.
-        pub const TOTAL_COST_OF_OWNERSHIP: Type = Type::new("TOTAL_COST_OF_OWNERSHIP");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Report creation state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Default Report creation state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Creating Report.
+        pub const PENDING: State = State::new(1);
+
+        /// Successfully created Report.
+        pub const SUCCEEDED: State = State::new(2);
+
+        /// Failed to create Report.
+        pub const FAILED: State = State::new(3);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Default Report creation state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Creating Report.
-        pub const PENDING: State = State::new("PENDING");
-
-        /// Successfully created Report.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-        /// Failed to create Report.
-        pub const FAILED: State = State::new("FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5562,57 +5678,82 @@ pub mod machine_details {
 
     /// Machine power state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PowerState(std::borrow::Cow<'static, str>);
+    pub struct PowerState(i32);
 
     impl PowerState {
-        /// Creates a new PowerState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PowerState](PowerState)
-    pub mod power_state {
-        use super::PowerState;
-
         /// Power state is unknown.
-        pub const POWER_STATE_UNSPECIFIED: PowerState = PowerState::new("POWER_STATE_UNSPECIFIED");
+        pub const POWER_STATE_UNSPECIFIED: PowerState = PowerState::new(0);
 
         /// The machine is preparing to enter the ACTIVE state. An instance may enter
         /// the PENDING state when it launches for the first time, or when it is
         /// started after being in the SUSPENDED state.
-        pub const PENDING: PowerState = PowerState::new("PENDING");
+        pub const PENDING: PowerState = PowerState::new(1);
 
         /// The machine is active.
-        pub const ACTIVE: PowerState = PowerState::new("ACTIVE");
+        pub const ACTIVE: PowerState = PowerState::new(2);
 
         /// The machine is being turned off.
-        pub const SUSPENDING: PowerState = PowerState::new("SUSPENDING");
+        pub const SUSPENDING: PowerState = PowerState::new(3);
 
         /// The machine is off.
-        pub const SUSPENDED: PowerState = PowerState::new("SUSPENDED");
+        pub const SUSPENDED: PowerState = PowerState::new(4);
 
         /// The machine is being deleted from the hosting platform.
-        pub const DELETING: PowerState = PowerState::new("DELETING");
+        pub const DELETING: PowerState = PowerState::new(5);
 
         /// The machine is deleted from the hosting platform.
-        pub const DELETED: PowerState = PowerState::new("DELETED");
+        pub const DELETED: PowerState = PowerState::new(6);
+
+        /// Creates a new PowerState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("POWER_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("SUSPENDING"),
+                4 => std::borrow::Cow::Borrowed("SUSPENDED"),
+                5 => std::borrow::Cow::Borrowed("DELETING"),
+                6 => std::borrow::Cow::Borrowed("DELETED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "POWER_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::POWER_STATE_UNSPECIFIED)
+                }
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "SUSPENDING" => std::option::Option::Some(Self::SUSPENDING),
+                "SUSPENDED" => std::option::Option::Some(Self::SUSPENDED),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "DELETED" => std::option::Option::Some(Self::DELETED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PowerState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PowerState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PowerState {
         fn default() -> Self {
-            power_state::POWER_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5735,87 +5876,119 @@ pub mod machine_architecture_details {
 
     /// Firmware type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FirmwareType(std::borrow::Cow<'static, str>);
+    pub struct FirmwareType(i32);
 
     impl FirmwareType {
+        /// Unspecified or unknown.
+        pub const FIRMWARE_TYPE_UNSPECIFIED: FirmwareType = FirmwareType::new(0);
+
+        /// BIOS firmware.
+        pub const BIOS: FirmwareType = FirmwareType::new(1);
+
+        /// EFI firmware.
+        pub const EFI: FirmwareType = FirmwareType::new(2);
+
         /// Creates a new FirmwareType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FIRMWARE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BIOS"),
+                2 => std::borrow::Cow::Borrowed("EFI"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FIRMWARE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::FIRMWARE_TYPE_UNSPECIFIED)
+                }
+                "BIOS" => std::option::Option::Some(Self::BIOS),
+                "EFI" => std::option::Option::Some(Self::EFI),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [FirmwareType](FirmwareType)
-    pub mod firmware_type {
-        use super::FirmwareType;
-
-        /// Unspecified or unknown.
-        pub const FIRMWARE_TYPE_UNSPECIFIED: FirmwareType =
-            FirmwareType::new("FIRMWARE_TYPE_UNSPECIFIED");
-
-        /// BIOS firmware.
-        pub const BIOS: FirmwareType = FirmwareType::new("BIOS");
-
-        /// EFI firmware.
-        pub const EFI: FirmwareType = FirmwareType::new("EFI");
-    }
-
-    impl std::convert::From<std::string::String> for FirmwareType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for FirmwareType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for FirmwareType {
         fn default() -> Self {
-            firmware_type::FIRMWARE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// CPU hyper-threading support.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CpuHyperThreading(std::borrow::Cow<'static, str>);
+    pub struct CpuHyperThreading(i32);
 
     impl CpuHyperThreading {
+        /// Unspecified or unknown.
+        pub const CPU_HYPER_THREADING_UNSPECIFIED: CpuHyperThreading = CpuHyperThreading::new(0);
+
+        /// Hyper-threading is disabled.
+        pub const DISABLED: CpuHyperThreading = CpuHyperThreading::new(1);
+
+        /// Hyper-threading is enabled.
+        pub const ENABLED: CpuHyperThreading = CpuHyperThreading::new(2);
+
         /// Creates a new CpuHyperThreading instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CPU_HYPER_THREADING_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DISABLED"),
+                2 => std::borrow::Cow::Borrowed("ENABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CPU_HYPER_THREADING_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CPU_HYPER_THREADING_UNSPECIFIED)
+                }
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [CpuHyperThreading](CpuHyperThreading)
-    pub mod cpu_hyper_threading {
-        use super::CpuHyperThreading;
-
-        /// Unspecified or unknown.
-        pub const CPU_HYPER_THREADING_UNSPECIFIED: CpuHyperThreading =
-            CpuHyperThreading::new("CPU_HYPER_THREADING_UNSPECIFIED");
-
-        /// Hyper-threading is disabled.
-        pub const DISABLED: CpuHyperThreading = CpuHyperThreading::new("DISABLED");
-
-        /// Hyper-threading is enabled.
-        pub const ENABLED: CpuHyperThreading = CpuHyperThreading::new("ENABLED");
-    }
-
-    impl std::convert::From<std::string::String> for CpuHyperThreading {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CpuHyperThreading {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CpuHyperThreading {
         fn default() -> Self {
-            cpu_hyper_threading::CPU_HYPER_THREADING_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6179,46 +6352,64 @@ pub mod network_address {
 
     /// Network address assignment.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AddressAssignment(std::borrow::Cow<'static, str>);
+    pub struct AddressAssignment(i32);
 
     impl AddressAssignment {
+        /// Unknown (default value).
+        pub const ADDRESS_ASSIGNMENT_UNSPECIFIED: AddressAssignment = AddressAssignment::new(0);
+
+        /// Staticly assigned IP.
+        pub const ADDRESS_ASSIGNMENT_STATIC: AddressAssignment = AddressAssignment::new(1);
+
+        /// Dynamically assigned IP (DHCP).
+        pub const ADDRESS_ASSIGNMENT_DHCP: AddressAssignment = AddressAssignment::new(2);
+
         /// Creates a new AddressAssignment instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ADDRESS_ASSIGNMENT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ADDRESS_ASSIGNMENT_STATIC"),
+                2 => std::borrow::Cow::Borrowed("ADDRESS_ASSIGNMENT_DHCP"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ADDRESS_ASSIGNMENT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ADDRESS_ASSIGNMENT_UNSPECIFIED)
+                }
+                "ADDRESS_ASSIGNMENT_STATIC" => {
+                    std::option::Option::Some(Self::ADDRESS_ASSIGNMENT_STATIC)
+                }
+                "ADDRESS_ASSIGNMENT_DHCP" => {
+                    std::option::Option::Some(Self::ADDRESS_ASSIGNMENT_DHCP)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AddressAssignment](AddressAssignment)
-    pub mod address_assignment {
-        use super::AddressAssignment;
-
-        /// Unknown (default value).
-        pub const ADDRESS_ASSIGNMENT_UNSPECIFIED: AddressAssignment =
-            AddressAssignment::new("ADDRESS_ASSIGNMENT_UNSPECIFIED");
-
-        /// Staticly assigned IP.
-        pub const ADDRESS_ASSIGNMENT_STATIC: AddressAssignment =
-            AddressAssignment::new("ADDRESS_ASSIGNMENT_STATIC");
-
-        /// Dynamically assigned IP (DHCP).
-        pub const ADDRESS_ASSIGNMENT_DHCP: AddressAssignment =
-            AddressAssignment::new("ADDRESS_ASSIGNMENT_DHCP");
-    }
-
-    impl std::convert::From<std::string::String> for AddressAssignment {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AddressAssignment {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AddressAssignment {
         fn default() -> Self {
-            address_assignment::ADDRESS_ASSIGNMENT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6454,59 +6645,85 @@ pub mod disk_entry {
 
     /// Disks interface type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct InterfaceType(std::borrow::Cow<'static, str>);
+    pub struct InterfaceType(i32);
 
     impl InterfaceType {
+        /// Interface type unknown or unspecified.
+        pub const INTERFACE_TYPE_UNSPECIFIED: InterfaceType = InterfaceType::new(0);
+
+        /// IDE interface type.
+        pub const IDE: InterfaceType = InterfaceType::new(1);
+
+        /// SATA interface type.
+        pub const SATA: InterfaceType = InterfaceType::new(2);
+
+        /// SAS interface type.
+        pub const SAS: InterfaceType = InterfaceType::new(3);
+
+        /// SCSI interface type.
+        pub const SCSI: InterfaceType = InterfaceType::new(4);
+
+        /// NVME interface type.
+        pub const NVME: InterfaceType = InterfaceType::new(5);
+
+        /// FC interface type.
+        pub const FC: InterfaceType = InterfaceType::new(6);
+
+        /// iSCSI interface type.
+        pub const ISCSI: InterfaceType = InterfaceType::new(7);
+
         /// Creates a new InterfaceType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("INTERFACE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IDE"),
+                2 => std::borrow::Cow::Borrowed("SATA"),
+                3 => std::borrow::Cow::Borrowed("SAS"),
+                4 => std::borrow::Cow::Borrowed("SCSI"),
+                5 => std::borrow::Cow::Borrowed("NVME"),
+                6 => std::borrow::Cow::Borrowed("FC"),
+                7 => std::borrow::Cow::Borrowed("ISCSI"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "INTERFACE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::INTERFACE_TYPE_UNSPECIFIED)
+                }
+                "IDE" => std::option::Option::Some(Self::IDE),
+                "SATA" => std::option::Option::Some(Self::SATA),
+                "SAS" => std::option::Option::Some(Self::SAS),
+                "SCSI" => std::option::Option::Some(Self::SCSI),
+                "NVME" => std::option::Option::Some(Self::NVME),
+                "FC" => std::option::Option::Some(Self::FC),
+                "ISCSI" => std::option::Option::Some(Self::ISCSI),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [InterfaceType](InterfaceType)
-    pub mod interface_type {
-        use super::InterfaceType;
-
-        /// Interface type unknown or unspecified.
-        pub const INTERFACE_TYPE_UNSPECIFIED: InterfaceType =
-            InterfaceType::new("INTERFACE_TYPE_UNSPECIFIED");
-
-        /// IDE interface type.
-        pub const IDE: InterfaceType = InterfaceType::new("IDE");
-
-        /// SATA interface type.
-        pub const SATA: InterfaceType = InterfaceType::new("SATA");
-
-        /// SAS interface type.
-        pub const SAS: InterfaceType = InterfaceType::new("SAS");
-
-        /// SCSI interface type.
-        pub const SCSI: InterfaceType = InterfaceType::new("SCSI");
-
-        /// NVME interface type.
-        pub const NVME: InterfaceType = InterfaceType::new("NVME");
-
-        /// FC interface type.
-        pub const FC: InterfaceType = InterfaceType::new("FC");
-
-        /// iSCSI interface type.
-        pub const ISCSI: InterfaceType = InterfaceType::new("ISCSI");
-    }
-
-    impl std::convert::From<std::string::String> for InterfaceType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for InterfaceType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for InterfaceType {
         fn default() -> Self {
-            interface_type::INTERFACE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -6724,154 +6941,217 @@ pub mod vmware_disk_config {
 
     /// VMDK backing type possible values.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BackingType(std::borrow::Cow<'static, str>);
+    pub struct BackingType(i32);
 
     impl BackingType {
+        /// Default value.
+        pub const BACKING_TYPE_UNSPECIFIED: BackingType = BackingType::new(0);
+
+        /// Flat v1.
+        pub const BACKING_TYPE_FLAT_V1: BackingType = BackingType::new(1);
+
+        /// Flat v2.
+        pub const BACKING_TYPE_FLAT_V2: BackingType = BackingType::new(2);
+
+        /// Persistent memory, also known as Non-Volatile Memory (NVM).
+        pub const BACKING_TYPE_PMEM: BackingType = BackingType::new(3);
+
+        /// Raw Disk Memory v1.
+        pub const BACKING_TYPE_RDM_V1: BackingType = BackingType::new(4);
+
+        /// Raw Disk Memory v2.
+        pub const BACKING_TYPE_RDM_V2: BackingType = BackingType::new(5);
+
+        /// SEsparse is a snapshot format introduced in vSphere 5.5 for large disks.
+        pub const BACKING_TYPE_SESPARSE: BackingType = BackingType::new(6);
+
+        /// SEsparse v1.
+        pub const BACKING_TYPE_SESPARSE_V1: BackingType = BackingType::new(7);
+
+        /// SEsparse v1.
+        pub const BACKING_TYPE_SESPARSE_V2: BackingType = BackingType::new(8);
+
         /// Creates a new BackingType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("BACKING_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BACKING_TYPE_FLAT_V1"),
+                2 => std::borrow::Cow::Borrowed("BACKING_TYPE_FLAT_V2"),
+                3 => std::borrow::Cow::Borrowed("BACKING_TYPE_PMEM"),
+                4 => std::borrow::Cow::Borrowed("BACKING_TYPE_RDM_V1"),
+                5 => std::borrow::Cow::Borrowed("BACKING_TYPE_RDM_V2"),
+                6 => std::borrow::Cow::Borrowed("BACKING_TYPE_SESPARSE"),
+                7 => std::borrow::Cow::Borrowed("BACKING_TYPE_SESPARSE_V1"),
+                8 => std::borrow::Cow::Borrowed("BACKING_TYPE_SESPARSE_V2"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "BACKING_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::BACKING_TYPE_UNSPECIFIED)
+                }
+                "BACKING_TYPE_FLAT_V1" => std::option::Option::Some(Self::BACKING_TYPE_FLAT_V1),
+                "BACKING_TYPE_FLAT_V2" => std::option::Option::Some(Self::BACKING_TYPE_FLAT_V2),
+                "BACKING_TYPE_PMEM" => std::option::Option::Some(Self::BACKING_TYPE_PMEM),
+                "BACKING_TYPE_RDM_V1" => std::option::Option::Some(Self::BACKING_TYPE_RDM_V1),
+                "BACKING_TYPE_RDM_V2" => std::option::Option::Some(Self::BACKING_TYPE_RDM_V2),
+                "BACKING_TYPE_SESPARSE" => std::option::Option::Some(Self::BACKING_TYPE_SESPARSE),
+                "BACKING_TYPE_SESPARSE_V1" => {
+                    std::option::Option::Some(Self::BACKING_TYPE_SESPARSE_V1)
+                }
+                "BACKING_TYPE_SESPARSE_V2" => {
+                    std::option::Option::Some(Self::BACKING_TYPE_SESPARSE_V2)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [BackingType](BackingType)
-    pub mod backing_type {
-        use super::BackingType;
-
-        /// Default value.
-        pub const BACKING_TYPE_UNSPECIFIED: BackingType =
-            BackingType::new("BACKING_TYPE_UNSPECIFIED");
-
-        /// Flat v1.
-        pub const BACKING_TYPE_FLAT_V1: BackingType = BackingType::new("BACKING_TYPE_FLAT_V1");
-
-        /// Flat v2.
-        pub const BACKING_TYPE_FLAT_V2: BackingType = BackingType::new("BACKING_TYPE_FLAT_V2");
-
-        /// Persistent memory, also known as Non-Volatile Memory (NVM).
-        pub const BACKING_TYPE_PMEM: BackingType = BackingType::new("BACKING_TYPE_PMEM");
-
-        /// Raw Disk Memory v1.
-        pub const BACKING_TYPE_RDM_V1: BackingType = BackingType::new("BACKING_TYPE_RDM_V1");
-
-        /// Raw Disk Memory v2.
-        pub const BACKING_TYPE_RDM_V2: BackingType = BackingType::new("BACKING_TYPE_RDM_V2");
-
-        /// SEsparse is a snapshot format introduced in vSphere 5.5 for large disks.
-        pub const BACKING_TYPE_SESPARSE: BackingType = BackingType::new("BACKING_TYPE_SESPARSE");
-
-        /// SEsparse v1.
-        pub const BACKING_TYPE_SESPARSE_V1: BackingType =
-            BackingType::new("BACKING_TYPE_SESPARSE_V1");
-
-        /// SEsparse v1.
-        pub const BACKING_TYPE_SESPARSE_V2: BackingType =
-            BackingType::new("BACKING_TYPE_SESPARSE_V2");
-    }
-
-    impl std::convert::From<std::string::String> for BackingType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for BackingType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for BackingType {
         fn default() -> Self {
-            backing_type::BACKING_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// VMDK disk mode.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VmdkMode(std::borrow::Cow<'static, str>);
+    pub struct VmdkMode(i32);
 
     impl VmdkMode {
+        /// VMDK disk mode unspecified or unknown.
+        pub const VMDK_MODE_UNSPECIFIED: VmdkMode = VmdkMode::new(0);
+
+        /// Dependent disk mode.
+        pub const DEPENDENT: VmdkMode = VmdkMode::new(1);
+
+        /// Independent - Persistent disk mode.
+        pub const INDEPENDENT_PERSISTENT: VmdkMode = VmdkMode::new(2);
+
+        /// Independent - Nonpersistent disk mode.
+        pub const INDEPENDENT_NONPERSISTENT: VmdkMode = VmdkMode::new(3);
+
         /// Creates a new VmdkMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VMDK_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DEPENDENT"),
+                2 => std::borrow::Cow::Borrowed("INDEPENDENT_PERSISTENT"),
+                3 => std::borrow::Cow::Borrowed("INDEPENDENT_NONPERSISTENT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VMDK_MODE_UNSPECIFIED" => std::option::Option::Some(Self::VMDK_MODE_UNSPECIFIED),
+                "DEPENDENT" => std::option::Option::Some(Self::DEPENDENT),
+                "INDEPENDENT_PERSISTENT" => std::option::Option::Some(Self::INDEPENDENT_PERSISTENT),
+                "INDEPENDENT_NONPERSISTENT" => {
+                    std::option::Option::Some(Self::INDEPENDENT_NONPERSISTENT)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [VmdkMode](VmdkMode)
-    pub mod vmdk_mode {
-        use super::VmdkMode;
-
-        /// VMDK disk mode unspecified or unknown.
-        pub const VMDK_MODE_UNSPECIFIED: VmdkMode = VmdkMode::new("VMDK_MODE_UNSPECIFIED");
-
-        /// Dependent disk mode.
-        pub const DEPENDENT: VmdkMode = VmdkMode::new("DEPENDENT");
-
-        /// Independent - Persistent disk mode.
-        pub const INDEPENDENT_PERSISTENT: VmdkMode = VmdkMode::new("INDEPENDENT_PERSISTENT");
-
-        /// Independent - Nonpersistent disk mode.
-        pub const INDEPENDENT_NONPERSISTENT: VmdkMode = VmdkMode::new("INDEPENDENT_NONPERSISTENT");
-    }
-
-    impl std::convert::From<std::string::String> for VmdkMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for VmdkMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for VmdkMode {
         fn default() -> Self {
-            vmdk_mode::VMDK_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// RDM compatibility mode.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RdmCompatibility(std::borrow::Cow<'static, str>);
+    pub struct RdmCompatibility(i32);
 
     impl RdmCompatibility {
+        /// Compatibility mode unspecified or unknown.
+        pub const RDM_COMPATIBILITY_UNSPECIFIED: RdmCompatibility = RdmCompatibility::new(0);
+
+        /// Physical compatibility mode.
+        pub const PHYSICAL_COMPATIBILITY: RdmCompatibility = RdmCompatibility::new(1);
+
+        /// Virtual compatibility mode.
+        pub const VIRTUAL_COMPATIBILITY: RdmCompatibility = RdmCompatibility::new(2);
+
         /// Creates a new RdmCompatibility instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RDM_COMPATIBILITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PHYSICAL_COMPATIBILITY"),
+                2 => std::borrow::Cow::Borrowed("VIRTUAL_COMPATIBILITY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RDM_COMPATIBILITY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RDM_COMPATIBILITY_UNSPECIFIED)
+                }
+                "PHYSICAL_COMPATIBILITY" => std::option::Option::Some(Self::PHYSICAL_COMPATIBILITY),
+                "VIRTUAL_COMPATIBILITY" => std::option::Option::Some(Self::VIRTUAL_COMPATIBILITY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RdmCompatibility](RdmCompatibility)
-    pub mod rdm_compatibility {
-        use super::RdmCompatibility;
-
-        /// Compatibility mode unspecified or unknown.
-        pub const RDM_COMPATIBILITY_UNSPECIFIED: RdmCompatibility =
-            RdmCompatibility::new("RDM_COMPATIBILITY_UNSPECIFIED");
-
-        /// Physical compatibility mode.
-        pub const PHYSICAL_COMPATIBILITY: RdmCompatibility =
-            RdmCompatibility::new("PHYSICAL_COMPATIBILITY");
-
-        /// Virtual compatibility mode.
-        pub const VIRTUAL_COMPATIBILITY: RdmCompatibility =
-            RdmCompatibility::new("VIRTUAL_COMPATIBILITY");
-    }
-
-    impl std::convert::From<std::string::String> for RdmCompatibility {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RdmCompatibility {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RdmCompatibility {
         fn default() -> Self {
-            rdm_compatibility::RDM_COMPATIBILITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7048,49 +7328,69 @@ pub mod guest_config_details {
 
     /// Security-Enhanced Linux (SELinux) mode.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SeLinuxMode(std::borrow::Cow<'static, str>);
+    pub struct SeLinuxMode(i32);
 
     impl SeLinuxMode {
+        /// SELinux mode unknown or unspecified.
+        pub const SE_LINUX_MODE_UNSPECIFIED: SeLinuxMode = SeLinuxMode::new(0);
+
+        /// SELinux is disabled.
+        pub const SE_LINUX_MODE_DISABLED: SeLinuxMode = SeLinuxMode::new(1);
+
+        /// SELinux permissive mode.
+        pub const SE_LINUX_MODE_PERMISSIVE: SeLinuxMode = SeLinuxMode::new(2);
+
+        /// SELinux enforcing mode.
+        pub const SE_LINUX_MODE_ENFORCING: SeLinuxMode = SeLinuxMode::new(3);
+
         /// Creates a new SeLinuxMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SE_LINUX_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SE_LINUX_MODE_DISABLED"),
+                2 => std::borrow::Cow::Borrowed("SE_LINUX_MODE_PERMISSIVE"),
+                3 => std::borrow::Cow::Borrowed("SE_LINUX_MODE_ENFORCING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SE_LINUX_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SE_LINUX_MODE_UNSPECIFIED)
+                }
+                "SE_LINUX_MODE_DISABLED" => std::option::Option::Some(Self::SE_LINUX_MODE_DISABLED),
+                "SE_LINUX_MODE_PERMISSIVE" => {
+                    std::option::Option::Some(Self::SE_LINUX_MODE_PERMISSIVE)
+                }
+                "SE_LINUX_MODE_ENFORCING" => {
+                    std::option::Option::Some(Self::SE_LINUX_MODE_ENFORCING)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SeLinuxMode](SeLinuxMode)
-    pub mod se_linux_mode {
-        use super::SeLinuxMode;
-
-        /// SELinux mode unknown or unspecified.
-        pub const SE_LINUX_MODE_UNSPECIFIED: SeLinuxMode =
-            SeLinuxMode::new("SE_LINUX_MODE_UNSPECIFIED");
-
-        /// SELinux is disabled.
-        pub const SE_LINUX_MODE_DISABLED: SeLinuxMode = SeLinuxMode::new("SE_LINUX_MODE_DISABLED");
-
-        /// SELinux permissive mode.
-        pub const SE_LINUX_MODE_PERMISSIVE: SeLinuxMode =
-            SeLinuxMode::new("SE_LINUX_MODE_PERMISSIVE");
-
-        /// SELinux enforcing mode.
-        pub const SE_LINUX_MODE_ENFORCING: SeLinuxMode =
-            SeLinuxMode::new("SE_LINUX_MODE_ENFORCING");
-    }
-
-    impl std::convert::From<std::string::String> for SeLinuxMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SeLinuxMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SeLinuxMode {
         fn default() -> Self {
-            se_linux_mode::SE_LINUX_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7617,97 +7917,135 @@ pub mod running_service {
 
     /// Service state (OS-agnostic).
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Service state unspecified.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Service is active.
+        pub const ACTIVE: State = State::new(1);
+
+        /// Service is paused.
+        pub const PAUSED: State = State::new(2);
+
+        /// Service is stopped.
+        pub const STOPPED: State = State::new(3);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("PAUSED"),
+                3 => std::borrow::Cow::Borrowed("STOPPED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "PAUSED" => std::option::Option::Some(Self::PAUSED),
+                "STOPPED" => std::option::Option::Some(Self::STOPPED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Service state unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Service is active.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// Service is paused.
-        pub const PAUSED: State = State::new("PAUSED");
-
-        /// Service is stopped.
-        pub const STOPPED: State = State::new("STOPPED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Service start mode (OS-agnostic).
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StartMode(std::borrow::Cow<'static, str>);
+    pub struct StartMode(i32);
 
     impl StartMode {
+        /// Start mode unspecified.
+        pub const START_MODE_UNSPECIFIED: StartMode = StartMode::new(0);
+
+        /// The service is a device driver started by the system loader.
+        pub const BOOT: StartMode = StartMode::new(1);
+
+        /// The service is a device driver started by the IOInitSystem function.
+        pub const SYSTEM: StartMode = StartMode::new(2);
+
+        /// The service is started by the operating system, at system start-up
+        pub const AUTO: StartMode = StartMode::new(3);
+
+        /// The service is started only manually, by a user.
+        pub const MANUAL: StartMode = StartMode::new(4);
+
+        /// The service is disabled.
+        pub const DISABLED: StartMode = StartMode::new(5);
+
         /// Creates a new StartMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("START_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BOOT"),
+                2 => std::borrow::Cow::Borrowed("SYSTEM"),
+                3 => std::borrow::Cow::Borrowed("AUTO"),
+                4 => std::borrow::Cow::Borrowed("MANUAL"),
+                5 => std::borrow::Cow::Borrowed("DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "START_MODE_UNSPECIFIED" => std::option::Option::Some(Self::START_MODE_UNSPECIFIED),
+                "BOOT" => std::option::Option::Some(Self::BOOT),
+                "SYSTEM" => std::option::Option::Some(Self::SYSTEM),
+                "AUTO" => std::option::Option::Some(Self::AUTO),
+                "MANUAL" => std::option::Option::Some(Self::MANUAL),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [StartMode](StartMode)
-    pub mod start_mode {
-        use super::StartMode;
-
-        /// Start mode unspecified.
-        pub const START_MODE_UNSPECIFIED: StartMode = StartMode::new("START_MODE_UNSPECIFIED");
-
-        /// The service is a device driver started by the system loader.
-        pub const BOOT: StartMode = StartMode::new("BOOT");
-
-        /// The service is a device driver started by the IOInitSystem function.
-        pub const SYSTEM: StartMode = StartMode::new("SYSTEM");
-
-        /// The service is started by the operating system, at system start-up
-        pub const AUTO: StartMode = StartMode::new("AUTO");
-
-        /// The service is started only manually, by a user.
-        pub const MANUAL: StartMode = StartMode::new("MANUAL");
-
-        /// The service is disabled.
-        pub const DISABLED: StartMode = StartMode::new("DISABLED");
-    }
-
-    impl std::convert::From<std::string::String> for StartMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for StartMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for StartMode {
         fn default() -> Self {
-            start_mode::START_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8013,52 +8351,73 @@ pub mod network_connection {
 
     /// Network connection state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Connection state is unknown or unspecified.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The connection is being opened.
+        pub const OPENING: State = State::new(1);
+
+        /// The connection is open.
+        pub const OPEN: State = State::new(2);
+
+        /// Listening for incoming connections.
+        pub const LISTEN: State = State::new(3);
+
+        /// The connection is being closed.
+        pub const CLOSING: State = State::new(4);
+
+        /// The connection is closed.
+        pub const CLOSED: State = State::new(5);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("OPENING"),
+                2 => std::borrow::Cow::Borrowed("OPEN"),
+                3 => std::borrow::Cow::Borrowed("LISTEN"),
+                4 => std::borrow::Cow::Borrowed("CLOSING"),
+                5 => std::borrow::Cow::Borrowed("CLOSED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "OPENING" => std::option::Option::Some(Self::OPENING),
+                "OPEN" => std::option::Option::Some(Self::OPEN),
+                "LISTEN" => std::option::Option::Some(Self::LISTEN),
+                "CLOSING" => std::option::Option::Some(Self::CLOSING),
+                "CLOSED" => std::option::Option::Some(Self::CLOSED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Connection state is unknown or unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The connection is being opened.
-        pub const OPENING: State = State::new("OPENING");
-
-        /// The connection is open.
-        pub const OPEN: State = State::new("OPEN");
-
-        /// Listening for incoming connections.
-        pub const LISTEN: State = State::new("LISTEN");
-
-        /// The connection is being closed.
-        pub const CLOSING: State = State::new("CLOSING");
-
-        /// The connection is closed.
-        pub const CLOSED: State = State::new("CLOSED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -9795,46 +10154,63 @@ pub mod fit_descriptor {
 
     /// Fit level.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FitLevel(std::borrow::Cow<'static, str>);
+    pub struct FitLevel(i32);
 
     impl FitLevel {
+        /// Not enough information.
+        pub const FIT_LEVEL_UNSPECIFIED: FitLevel = FitLevel::new(0);
+
+        /// Fit.
+        pub const FIT: FitLevel = FitLevel::new(1);
+
+        /// No Fit.
+        pub const NO_FIT: FitLevel = FitLevel::new(2);
+
+        /// Fit with effort.
+        pub const REQUIRES_EFFORT: FitLevel = FitLevel::new(3);
+
         /// Creates a new FitLevel instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FIT_LEVEL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FIT"),
+                2 => std::borrow::Cow::Borrowed("NO_FIT"),
+                3 => std::borrow::Cow::Borrowed("REQUIRES_EFFORT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FIT_LEVEL_UNSPECIFIED" => std::option::Option::Some(Self::FIT_LEVEL_UNSPECIFIED),
+                "FIT" => std::option::Option::Some(Self::FIT),
+                "NO_FIT" => std::option::Option::Some(Self::NO_FIT),
+                "REQUIRES_EFFORT" => std::option::Option::Some(Self::REQUIRES_EFFORT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [FitLevel](FitLevel)
-    pub mod fit_level {
-        use super::FitLevel;
-
-        /// Not enough information.
-        pub const FIT_LEVEL_UNSPECIFIED: FitLevel = FitLevel::new("FIT_LEVEL_UNSPECIFIED");
-
-        /// Fit.
-        pub const FIT: FitLevel = FitLevel::new("FIT");
-
-        /// No Fit.
-        pub const NO_FIT: FitLevel = FitLevel::new("NO_FIT");
-
-        /// Fit with effort.
-        pub const REQUIRES_EFFORT: FitLevel = FitLevel::new("REQUIRES_EFFORT");
-    }
-
-    impl std::convert::From<std::string::String> for FitLevel {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for FitLevel {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for FitLevel {
         fn default() -> Self {
-            fit_level::FIT_LEVEL_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -10701,42 +11077,59 @@ pub mod import_error {
 
     /// Enumerate possible error severity.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(std::borrow::Cow<'static, str>);
+    pub struct Severity(i32);
 
     impl Severity {
+        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
+
+        pub const ERROR: Severity = Severity::new(1);
+
+        pub const WARNING: Severity = Severity::new(2);
+
+        pub const INFO: Severity = Severity::new(3);
+
         /// Creates a new Severity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ERROR"),
+                2 => std::borrow::Cow::Borrowed("WARNING"),
+                3 => std::borrow::Cow::Borrowed("INFO"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "WARNING" => std::option::Option::Some(Self::WARNING),
+                "INFO" => std::option::Option::Some(Self::INFO),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Severity](Severity)
-    pub mod severity {
-        use super::Severity;
-
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new("SEVERITY_UNSPECIFIED");
-
-        pub const ERROR: Severity = Severity::new("ERROR");
-
-        pub const WARNING: Severity = Severity::new("WARNING");
-
-        pub const INFO: Severity = Severity::new("INFO");
-    }
-
-    impl std::convert::From<std::string::String> for Severity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            severity::SEVERITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -11269,57 +11662,83 @@ pub mod vmware_engine_preferences {
 
     /// Type of committed use discount.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CommitmentPlan(std::borrow::Cow<'static, str>);
+    pub struct CommitmentPlan(i32);
 
     impl CommitmentPlan {
+        /// Unspecified commitment plan.
+        pub const COMMITMENT_PLAN_UNSPECIFIED: CommitmentPlan = CommitmentPlan::new(0);
+
+        /// No commitment plan (on-demand usage).
+        pub const ON_DEMAND: CommitmentPlan = CommitmentPlan::new(1);
+
+        /// 1 year commitment (monthly payments).
+        pub const COMMITMENT_1_YEAR_MONTHLY_PAYMENTS: CommitmentPlan = CommitmentPlan::new(2);
+
+        /// 3 year commitment (monthly payments).
+        pub const COMMITMENT_3_YEAR_MONTHLY_PAYMENTS: CommitmentPlan = CommitmentPlan::new(3);
+
+        /// 1 year commitment (upfront payment).
+        pub const COMMITMENT_1_YEAR_UPFRONT_PAYMENT: CommitmentPlan = CommitmentPlan::new(4);
+
+        /// 3 years commitment (upfront payment).
+        pub const COMMITMENT_3_YEAR_UPFRONT_PAYMENT: CommitmentPlan = CommitmentPlan::new(5);
+
         /// Creates a new CommitmentPlan instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COMMITMENT_PLAN_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ON_DEMAND"),
+                2 => std::borrow::Cow::Borrowed("COMMITMENT_1_YEAR_MONTHLY_PAYMENTS"),
+                3 => std::borrow::Cow::Borrowed("COMMITMENT_3_YEAR_MONTHLY_PAYMENTS"),
+                4 => std::borrow::Cow::Borrowed("COMMITMENT_1_YEAR_UPFRONT_PAYMENT"),
+                5 => std::borrow::Cow::Borrowed("COMMITMENT_3_YEAR_UPFRONT_PAYMENT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COMMITMENT_PLAN_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::COMMITMENT_PLAN_UNSPECIFIED)
+                }
+                "ON_DEMAND" => std::option::Option::Some(Self::ON_DEMAND),
+                "COMMITMENT_1_YEAR_MONTHLY_PAYMENTS" => {
+                    std::option::Option::Some(Self::COMMITMENT_1_YEAR_MONTHLY_PAYMENTS)
+                }
+                "COMMITMENT_3_YEAR_MONTHLY_PAYMENTS" => {
+                    std::option::Option::Some(Self::COMMITMENT_3_YEAR_MONTHLY_PAYMENTS)
+                }
+                "COMMITMENT_1_YEAR_UPFRONT_PAYMENT" => {
+                    std::option::Option::Some(Self::COMMITMENT_1_YEAR_UPFRONT_PAYMENT)
+                }
+                "COMMITMENT_3_YEAR_UPFRONT_PAYMENT" => {
+                    std::option::Option::Some(Self::COMMITMENT_3_YEAR_UPFRONT_PAYMENT)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [CommitmentPlan](CommitmentPlan)
-    pub mod commitment_plan {
-        use super::CommitmentPlan;
-
-        /// Unspecified commitment plan.
-        pub const COMMITMENT_PLAN_UNSPECIFIED: CommitmentPlan =
-            CommitmentPlan::new("COMMITMENT_PLAN_UNSPECIFIED");
-
-        /// No commitment plan (on-demand usage).
-        pub const ON_DEMAND: CommitmentPlan = CommitmentPlan::new("ON_DEMAND");
-
-        /// 1 year commitment (monthly payments).
-        pub const COMMITMENT_1_YEAR_MONTHLY_PAYMENTS: CommitmentPlan =
-            CommitmentPlan::new("COMMITMENT_1_YEAR_MONTHLY_PAYMENTS");
-
-        /// 3 year commitment (monthly payments).
-        pub const COMMITMENT_3_YEAR_MONTHLY_PAYMENTS: CommitmentPlan =
-            CommitmentPlan::new("COMMITMENT_3_YEAR_MONTHLY_PAYMENTS");
-
-        /// 1 year commitment (upfront payment).
-        pub const COMMITMENT_1_YEAR_UPFRONT_PAYMENT: CommitmentPlan =
-            CommitmentPlan::new("COMMITMENT_1_YEAR_UPFRONT_PAYMENT");
-
-        /// 3 years commitment (upfront payment).
-        pub const COMMITMENT_3_YEAR_UPFRONT_PAYMENT: CommitmentPlan =
-            CommitmentPlan::new("COMMITMENT_3_YEAR_UPFRONT_PAYMENT");
-    }
-
-    impl std::convert::From<std::string::String> for CommitmentPlan {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CommitmentPlan {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CommitmentPlan {
         fn default() -> Self {
-            commitment_plan::COMMITMENT_PLAN_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -11407,96 +11826,141 @@ pub mod sole_tenancy_preferences {
 
     /// Sole Tenancy nodes maintenance policy.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HostMaintenancePolicy(std::borrow::Cow<'static, str>);
+    pub struct HostMaintenancePolicy(i32);
 
     impl HostMaintenancePolicy {
-        /// Creates a new HostMaintenancePolicy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [HostMaintenancePolicy](HostMaintenancePolicy)
-    pub mod host_maintenance_policy {
-        use super::HostMaintenancePolicy;
-
         /// Unspecified host maintenance policy.
         pub const HOST_MAINTENANCE_POLICY_UNSPECIFIED: HostMaintenancePolicy =
-            HostMaintenancePolicy::new("HOST_MAINTENANCE_POLICY_UNSPECIFIED");
+            HostMaintenancePolicy::new(0);
 
         /// Default host maintenance policy.
         pub const HOST_MAINTENANCE_POLICY_DEFAULT: HostMaintenancePolicy =
-            HostMaintenancePolicy::new("HOST_MAINTENANCE_POLICY_DEFAULT");
+            HostMaintenancePolicy::new(1);
 
         /// Restart in place host maintenance policy.
         pub const HOST_MAINTENANCE_POLICY_RESTART_IN_PLACE: HostMaintenancePolicy =
-            HostMaintenancePolicy::new("HOST_MAINTENANCE_POLICY_RESTART_IN_PLACE");
+            HostMaintenancePolicy::new(2);
 
         /// Migrate within node group host maintenance policy.
         pub const HOST_MAINTENANCE_POLICY_MIGRATE_WITHIN_NODE_GROUP: HostMaintenancePolicy =
-            HostMaintenancePolicy::new("HOST_MAINTENANCE_POLICY_MIGRATE_WITHIN_NODE_GROUP");
+            HostMaintenancePolicy::new(3);
+
+        /// Creates a new HostMaintenancePolicy instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("HOST_MAINTENANCE_POLICY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("HOST_MAINTENANCE_POLICY_DEFAULT"),
+                2 => std::borrow::Cow::Borrowed("HOST_MAINTENANCE_POLICY_RESTART_IN_PLACE"),
+                3 => {
+                    std::borrow::Cow::Borrowed("HOST_MAINTENANCE_POLICY_MIGRATE_WITHIN_NODE_GROUP")
+                }
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "HOST_MAINTENANCE_POLICY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::HOST_MAINTENANCE_POLICY_UNSPECIFIED)
+                }
+                "HOST_MAINTENANCE_POLICY_DEFAULT" => {
+                    std::option::Option::Some(Self::HOST_MAINTENANCE_POLICY_DEFAULT)
+                }
+                "HOST_MAINTENANCE_POLICY_RESTART_IN_PLACE" => {
+                    std::option::Option::Some(Self::HOST_MAINTENANCE_POLICY_RESTART_IN_PLACE)
+                }
+                "HOST_MAINTENANCE_POLICY_MIGRATE_WITHIN_NODE_GROUP" => std::option::Option::Some(
+                    Self::HOST_MAINTENANCE_POLICY_MIGRATE_WITHIN_NODE_GROUP,
+                ),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for HostMaintenancePolicy {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for HostMaintenancePolicy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for HostMaintenancePolicy {
         fn default() -> Self {
-            host_maintenance_policy::HOST_MAINTENANCE_POLICY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Type of committed use discount.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CommitmentPlan(std::borrow::Cow<'static, str>);
+    pub struct CommitmentPlan(i32);
 
     impl CommitmentPlan {
+        /// Unspecified commitment plan.
+        pub const COMMITMENT_PLAN_UNSPECIFIED: CommitmentPlan = CommitmentPlan::new(0);
+
+        /// No commitment plan (on-demand usage).
+        pub const ON_DEMAND: CommitmentPlan = CommitmentPlan::new(1);
+
+        /// 1 year commitment.
+        pub const COMMITMENT_1_YEAR: CommitmentPlan = CommitmentPlan::new(2);
+
+        /// 3 years commitment.
+        pub const COMMITMENT_3_YEAR: CommitmentPlan = CommitmentPlan::new(3);
+
         /// Creates a new CommitmentPlan instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COMMITMENT_PLAN_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ON_DEMAND"),
+                2 => std::borrow::Cow::Borrowed("COMMITMENT_1_YEAR"),
+                3 => std::borrow::Cow::Borrowed("COMMITMENT_3_YEAR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COMMITMENT_PLAN_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::COMMITMENT_PLAN_UNSPECIFIED)
+                }
+                "ON_DEMAND" => std::option::Option::Some(Self::ON_DEMAND),
+                "COMMITMENT_1_YEAR" => std::option::Option::Some(Self::COMMITMENT_1_YEAR),
+                "COMMITMENT_3_YEAR" => std::option::Option::Some(Self::COMMITMENT_3_YEAR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [CommitmentPlan](CommitmentPlan)
-    pub mod commitment_plan {
-        use super::CommitmentPlan;
-
-        /// Unspecified commitment plan.
-        pub const COMMITMENT_PLAN_UNSPECIFIED: CommitmentPlan =
-            CommitmentPlan::new("COMMITMENT_PLAN_UNSPECIFIED");
-
-        /// No commitment plan (on-demand usage).
-        pub const ON_DEMAND: CommitmentPlan = CommitmentPlan::new("ON_DEMAND");
-
-        /// 1 year commitment.
-        pub const COMMITMENT_1_YEAR: CommitmentPlan = CommitmentPlan::new("COMMITMENT_1_YEAR");
-
-        /// 3 years commitment.
-        pub const COMMITMENT_3_YEAR: CommitmentPlan = CommitmentPlan::new("COMMITMENT_3_YEAR");
-    }
-
-    impl std::convert::From<std::string::String> for CommitmentPlan {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CommitmentPlan {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CommitmentPlan {
         fn default() -> Self {
-            commitment_plan::COMMITMENT_PLAN_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -12712,341 +13176,463 @@ pub mod report_summary {
 /// Specifies the types of asset views that provide complete or partial details
 /// of an asset.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AssetView(std::borrow::Cow<'static, str>);
+pub struct AssetView(i32);
 
 impl AssetView {
+    /// The asset view is not specified. The API displays the basic view by
+    /// default.
+    pub const ASSET_VIEW_UNSPECIFIED: AssetView = AssetView::new(0);
+
+    /// The asset view includes only basic metadata of the asset.
+    pub const ASSET_VIEW_BASIC: AssetView = AssetView::new(1);
+
+    /// The asset view includes all the metadata of an asset and performance data.
+    pub const ASSET_VIEW_FULL: AssetView = AssetView::new(2);
+
     /// Creates a new AssetView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ASSET_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ASSET_VIEW_BASIC"),
+            2 => std::borrow::Cow::Borrowed("ASSET_VIEW_FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ASSET_VIEW_UNSPECIFIED" => std::option::Option::Some(Self::ASSET_VIEW_UNSPECIFIED),
+            "ASSET_VIEW_BASIC" => std::option::Option::Some(Self::ASSET_VIEW_BASIC),
+            "ASSET_VIEW_FULL" => std::option::Option::Some(Self::ASSET_VIEW_FULL),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [AssetView](AssetView)
-pub mod asset_view {
-    use super::AssetView;
-
-    /// The asset view is not specified. The API displays the basic view by
-    /// default.
-    pub const ASSET_VIEW_UNSPECIFIED: AssetView = AssetView::new("ASSET_VIEW_UNSPECIFIED");
-
-    /// The asset view includes only basic metadata of the asset.
-    pub const ASSET_VIEW_BASIC: AssetView = AssetView::new("ASSET_VIEW_BASIC");
-
-    /// The asset view includes all the metadata of an asset and performance data.
-    pub const ASSET_VIEW_FULL: AssetView = AssetView::new("ASSET_VIEW_FULL");
-}
-
-impl std::convert::From<std::string::String> for AssetView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for AssetView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for AssetView {
     fn default() -> Self {
-        asset_view::ASSET_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Known categories of operating systems.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OperatingSystemFamily(std::borrow::Cow<'static, str>);
+pub struct OperatingSystemFamily(i32);
 
 impl OperatingSystemFamily {
+    pub const OS_FAMILY_UNKNOWN: OperatingSystemFamily = OperatingSystemFamily::new(0);
+
+    /// Microsoft Windows Server and Desktop.
+    pub const OS_FAMILY_WINDOWS: OperatingSystemFamily = OperatingSystemFamily::new(1);
+
+    /// Various Linux flavors.
+    pub const OS_FAMILY_LINUX: OperatingSystemFamily = OperatingSystemFamily::new(2);
+
+    /// Non-Linux Unix flavors.
+    pub const OS_FAMILY_UNIX: OperatingSystemFamily = OperatingSystemFamily::new(3);
+
     /// Creates a new OperatingSystemFamily instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("OS_FAMILY_UNKNOWN"),
+            1 => std::borrow::Cow::Borrowed("OS_FAMILY_WINDOWS"),
+            2 => std::borrow::Cow::Borrowed("OS_FAMILY_LINUX"),
+            3 => std::borrow::Cow::Borrowed("OS_FAMILY_UNIX"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "OS_FAMILY_UNKNOWN" => std::option::Option::Some(Self::OS_FAMILY_UNKNOWN),
+            "OS_FAMILY_WINDOWS" => std::option::Option::Some(Self::OS_FAMILY_WINDOWS),
+            "OS_FAMILY_LINUX" => std::option::Option::Some(Self::OS_FAMILY_LINUX),
+            "OS_FAMILY_UNIX" => std::option::Option::Some(Self::OS_FAMILY_UNIX),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [OperatingSystemFamily](OperatingSystemFamily)
-pub mod operating_system_family {
-    use super::OperatingSystemFamily;
-
-    pub const OS_FAMILY_UNKNOWN: OperatingSystemFamily =
-        OperatingSystemFamily::new("OS_FAMILY_UNKNOWN");
-
-    /// Microsoft Windows Server and Desktop.
-    pub const OS_FAMILY_WINDOWS: OperatingSystemFamily =
-        OperatingSystemFamily::new("OS_FAMILY_WINDOWS");
-
-    /// Various Linux flavors.
-    pub const OS_FAMILY_LINUX: OperatingSystemFamily =
-        OperatingSystemFamily::new("OS_FAMILY_LINUX");
-
-    /// Non-Linux Unix flavors.
-    pub const OS_FAMILY_UNIX: OperatingSystemFamily = OperatingSystemFamily::new("OS_FAMILY_UNIX");
-}
-
-impl std::convert::From<std::string::String> for OperatingSystemFamily {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for OperatingSystemFamily {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for OperatingSystemFamily {
     fn default() -> Self {
-        operating_system_family::OS_FAMILY_UNKNOWN
+        Self::new(0)
     }
 }
 
 /// Specifies the data formats supported by Migration Center.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ImportJobFormat(std::borrow::Cow<'static, str>);
+pub struct ImportJobFormat(i32);
 
 impl ImportJobFormat {
-    /// Creates a new ImportJobFormat instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ImportJobFormat](ImportJobFormat)
-pub mod import_job_format {
-    use super::ImportJobFormat;
-
     /// Default value.
-    pub const IMPORT_JOB_FORMAT_UNSPECIFIED: ImportJobFormat =
-        ImportJobFormat::new("IMPORT_JOB_FORMAT_UNSPECIFIED");
+    pub const IMPORT_JOB_FORMAT_UNSPECIFIED: ImportJobFormat = ImportJobFormat::new(0);
 
     /// RVTools format (XLSX).
-    pub const IMPORT_JOB_FORMAT_RVTOOLS_XLSX: ImportJobFormat =
-        ImportJobFormat::new("IMPORT_JOB_FORMAT_RVTOOLS_XLSX");
+    pub const IMPORT_JOB_FORMAT_RVTOOLS_XLSX: ImportJobFormat = ImportJobFormat::new(1);
 
     /// RVTools format (CSV).
-    pub const IMPORT_JOB_FORMAT_RVTOOLS_CSV: ImportJobFormat =
-        ImportJobFormat::new("IMPORT_JOB_FORMAT_RVTOOLS_CSV");
+    pub const IMPORT_JOB_FORMAT_RVTOOLS_CSV: ImportJobFormat = ImportJobFormat::new(2);
 
     /// CSV format exported from AWS using the
     /// [AWS collection
     /// script][<https://github.com/GoogleCloudPlatform/aws-to-stratozone-export>].
-    pub const IMPORT_JOB_FORMAT_EXPORTED_AWS_CSV: ImportJobFormat =
-        ImportJobFormat::new("IMPORT_JOB_FORMAT_EXPORTED_AWS_CSV");
+    pub const IMPORT_JOB_FORMAT_EXPORTED_AWS_CSV: ImportJobFormat = ImportJobFormat::new(4);
 
     /// CSV format exported from Azure using the
     /// [Azure collection
     /// script][<https://github.com/GoogleCloudPlatform/azure-to-stratozone-export>].
-    pub const IMPORT_JOB_FORMAT_EXPORTED_AZURE_CSV: ImportJobFormat =
-        ImportJobFormat::new("IMPORT_JOB_FORMAT_EXPORTED_AZURE_CSV");
+    pub const IMPORT_JOB_FORMAT_EXPORTED_AZURE_CSV: ImportJobFormat = ImportJobFormat::new(5);
 
     /// CSV format created manually and following the StratoZone format. For more
     /// information, see [Manually create and upload data
     /// tables][<https://cloud.google.com/migrate/stratozone/docs/import-data-portal>].
-    pub const IMPORT_JOB_FORMAT_STRATOZONE_CSV: ImportJobFormat =
-        ImportJobFormat::new("IMPORT_JOB_FORMAT_STRATOZONE_CSV");
+    pub const IMPORT_JOB_FORMAT_STRATOZONE_CSV: ImportJobFormat = ImportJobFormat::new(6);
+
+    /// Creates a new ImportJobFormat instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("IMPORT_JOB_FORMAT_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("IMPORT_JOB_FORMAT_RVTOOLS_XLSX"),
+            2 => std::borrow::Cow::Borrowed("IMPORT_JOB_FORMAT_RVTOOLS_CSV"),
+            4 => std::borrow::Cow::Borrowed("IMPORT_JOB_FORMAT_EXPORTED_AWS_CSV"),
+            5 => std::borrow::Cow::Borrowed("IMPORT_JOB_FORMAT_EXPORTED_AZURE_CSV"),
+            6 => std::borrow::Cow::Borrowed("IMPORT_JOB_FORMAT_STRATOZONE_CSV"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "IMPORT_JOB_FORMAT_UNSPECIFIED" => {
+                std::option::Option::Some(Self::IMPORT_JOB_FORMAT_UNSPECIFIED)
+            }
+            "IMPORT_JOB_FORMAT_RVTOOLS_XLSX" => {
+                std::option::Option::Some(Self::IMPORT_JOB_FORMAT_RVTOOLS_XLSX)
+            }
+            "IMPORT_JOB_FORMAT_RVTOOLS_CSV" => {
+                std::option::Option::Some(Self::IMPORT_JOB_FORMAT_RVTOOLS_CSV)
+            }
+            "IMPORT_JOB_FORMAT_EXPORTED_AWS_CSV" => {
+                std::option::Option::Some(Self::IMPORT_JOB_FORMAT_EXPORTED_AWS_CSV)
+            }
+            "IMPORT_JOB_FORMAT_EXPORTED_AZURE_CSV" => {
+                std::option::Option::Some(Self::IMPORT_JOB_FORMAT_EXPORTED_AZURE_CSV)
+            }
+            "IMPORT_JOB_FORMAT_STRATOZONE_CSV" => {
+                std::option::Option::Some(Self::IMPORT_JOB_FORMAT_STRATOZONE_CSV)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ImportJobFormat {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ImportJobFormat {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ImportJobFormat {
     fn default() -> Self {
-        import_job_format::IMPORT_JOB_FORMAT_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Specifies the types of import job views that provide complete or partial
 /// details of an import job.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ImportJobView(std::borrow::Cow<'static, str>);
+pub struct ImportJobView(i32);
 
 impl ImportJobView {
-    /// Creates a new ImportJobView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ImportJobView](ImportJobView)
-pub mod import_job_view {
-    use super::ImportJobView;
-
     /// The import job view is not specified. The API displays the basic view by
     /// default.
-    pub const IMPORT_JOB_VIEW_UNSPECIFIED: ImportJobView =
-        ImportJobView::new("IMPORT_JOB_VIEW_UNSPECIFIED");
+    pub const IMPORT_JOB_VIEW_UNSPECIFIED: ImportJobView = ImportJobView::new(0);
 
     /// The import job view includes basic metadata of an import job.
     /// This view does not include payload information.
-    pub const IMPORT_JOB_VIEW_BASIC: ImportJobView = ImportJobView::new("IMPORT_JOB_VIEW_BASIC");
+    pub const IMPORT_JOB_VIEW_BASIC: ImportJobView = ImportJobView::new(1);
 
     /// The import job view includes all metadata of an import job.
-    pub const IMPORT_JOB_VIEW_FULL: ImportJobView = ImportJobView::new("IMPORT_JOB_VIEW_FULL");
+    pub const IMPORT_JOB_VIEW_FULL: ImportJobView = ImportJobView::new(2);
+
+    /// Creates a new ImportJobView instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("IMPORT_JOB_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("IMPORT_JOB_VIEW_BASIC"),
+            2 => std::borrow::Cow::Borrowed("IMPORT_JOB_VIEW_FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "IMPORT_JOB_VIEW_UNSPECIFIED" => {
+                std::option::Option::Some(Self::IMPORT_JOB_VIEW_UNSPECIFIED)
+            }
+            "IMPORT_JOB_VIEW_BASIC" => std::option::Option::Some(Self::IMPORT_JOB_VIEW_BASIC),
+            "IMPORT_JOB_VIEW_FULL" => std::option::Option::Some(Self::IMPORT_JOB_VIEW_FULL),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ImportJobView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ImportJobView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ImportJobView {
     fn default() -> Self {
-        import_job_view::IMPORT_JOB_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// ErrorFrameView can be specified in ErrorFrames List and Get requests to
 /// control the level of details that is returned for the original frame.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ErrorFrameView(std::borrow::Cow<'static, str>);
+pub struct ErrorFrameView(i32);
 
 impl ErrorFrameView {
+    /// Value is unset. The system will fallback to the default value.
+    pub const ERROR_FRAME_VIEW_UNSPECIFIED: ErrorFrameView = ErrorFrameView::new(0);
+
+    /// Include basic frame data, but not the full contents.
+    pub const ERROR_FRAME_VIEW_BASIC: ErrorFrameView = ErrorFrameView::new(1);
+
+    /// Include everything.
+    pub const ERROR_FRAME_VIEW_FULL: ErrorFrameView = ErrorFrameView::new(2);
+
     /// Creates a new ErrorFrameView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ERROR_FRAME_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ERROR_FRAME_VIEW_BASIC"),
+            2 => std::borrow::Cow::Borrowed("ERROR_FRAME_VIEW_FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ERROR_FRAME_VIEW_UNSPECIFIED" => {
+                std::option::Option::Some(Self::ERROR_FRAME_VIEW_UNSPECIFIED)
+            }
+            "ERROR_FRAME_VIEW_BASIC" => std::option::Option::Some(Self::ERROR_FRAME_VIEW_BASIC),
+            "ERROR_FRAME_VIEW_FULL" => std::option::Option::Some(Self::ERROR_FRAME_VIEW_FULL),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [ErrorFrameView](ErrorFrameView)
-pub mod error_frame_view {
-    use super::ErrorFrameView;
-
-    /// Value is unset. The system will fallback to the default value.
-    pub const ERROR_FRAME_VIEW_UNSPECIFIED: ErrorFrameView =
-        ErrorFrameView::new("ERROR_FRAME_VIEW_UNSPECIFIED");
-
-    /// Include basic frame data, but not the full contents.
-    pub const ERROR_FRAME_VIEW_BASIC: ErrorFrameView =
-        ErrorFrameView::new("ERROR_FRAME_VIEW_BASIC");
-
-    /// Include everything.
-    pub const ERROR_FRAME_VIEW_FULL: ErrorFrameView = ErrorFrameView::new("ERROR_FRAME_VIEW_FULL");
-}
-
-impl std::convert::From<std::string::String> for ErrorFrameView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ErrorFrameView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ErrorFrameView {
     fn default() -> Self {
-        error_frame_view::ERROR_FRAME_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The persistent disk (PD) types of Compute Engine virtual machines.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PersistentDiskType(std::borrow::Cow<'static, str>);
+pub struct PersistentDiskType(i32);
 
 impl PersistentDiskType {
-    /// Creates a new PersistentDiskType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [PersistentDiskType](PersistentDiskType)
-pub mod persistent_disk_type {
-    use super::PersistentDiskType;
-
     /// Unspecified (default value).
     /// Selecting this value allows the system to use any disk type according
     /// to reported usage. This a good value to start with.
-    pub const PERSISTENT_DISK_TYPE_UNSPECIFIED: PersistentDiskType =
-        PersistentDiskType::new("PERSISTENT_DISK_TYPE_UNSPECIFIED");
+    pub const PERSISTENT_DISK_TYPE_UNSPECIFIED: PersistentDiskType = PersistentDiskType::new(0);
 
     /// Standard HDD Persistent Disk.
-    pub const PERSISTENT_DISK_TYPE_STANDARD: PersistentDiskType =
-        PersistentDiskType::new("PERSISTENT_DISK_TYPE_STANDARD");
+    pub const PERSISTENT_DISK_TYPE_STANDARD: PersistentDiskType = PersistentDiskType::new(1);
 
     /// Balanced Persistent Disk.
-    pub const PERSISTENT_DISK_TYPE_BALANCED: PersistentDiskType =
-        PersistentDiskType::new("PERSISTENT_DISK_TYPE_BALANCED");
+    pub const PERSISTENT_DISK_TYPE_BALANCED: PersistentDiskType = PersistentDiskType::new(2);
 
     /// SSD Persistent Disk.
-    pub const PERSISTENT_DISK_TYPE_SSD: PersistentDiskType =
-        PersistentDiskType::new("PERSISTENT_DISK_TYPE_SSD");
+    pub const PERSISTENT_DISK_TYPE_SSD: PersistentDiskType = PersistentDiskType::new(3);
+
+    /// Creates a new PersistentDiskType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("PERSISTENT_DISK_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PERSISTENT_DISK_TYPE_STANDARD"),
+            2 => std::borrow::Cow::Borrowed("PERSISTENT_DISK_TYPE_BALANCED"),
+            3 => std::borrow::Cow::Borrowed("PERSISTENT_DISK_TYPE_SSD"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "PERSISTENT_DISK_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::PERSISTENT_DISK_TYPE_UNSPECIFIED)
+            }
+            "PERSISTENT_DISK_TYPE_STANDARD" => {
+                std::option::Option::Some(Self::PERSISTENT_DISK_TYPE_STANDARD)
+            }
+            "PERSISTENT_DISK_TYPE_BALANCED" => {
+                std::option::Option::Some(Self::PERSISTENT_DISK_TYPE_BALANCED)
+            }
+            "PERSISTENT_DISK_TYPE_SSD" => std::option::Option::Some(Self::PERSISTENT_DISK_TYPE_SSD),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for PersistentDiskType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for PersistentDiskType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for PersistentDiskType {
     fn default() -> Self {
-        persistent_disk_type::PERSISTENT_DISK_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The License type for premium images (RHEL, RHEL for SAP, SLES, SLES for SAP,
 /// Windows Server).
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LicenseType(std::borrow::Cow<'static, str>);
+pub struct LicenseType(i32);
 
 impl LicenseType {
-    /// Creates a new LicenseType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [LicenseType](LicenseType)
-pub mod license_type {
-    use super::LicenseType;
-
     /// Unspecified (default value).
-    pub const LICENSE_TYPE_UNSPECIFIED: LicenseType = LicenseType::new("LICENSE_TYPE_UNSPECIFIED");
+    pub const LICENSE_TYPE_UNSPECIFIED: LicenseType = LicenseType::new(0);
 
     /// Default Google Cloud licensing plan. Licensing is charged per usage.
     /// This a good value to start with.
-    pub const LICENSE_TYPE_DEFAULT: LicenseType = LicenseType::new("LICENSE_TYPE_DEFAULT");
+    pub const LICENSE_TYPE_DEFAULT: LicenseType = LicenseType::new(1);
 
     /// Bring-your-own-license (BYOL) plan. User provides the OS license.
-    pub const LICENSE_TYPE_BRING_YOUR_OWN_LICENSE: LicenseType =
-        LicenseType::new("LICENSE_TYPE_BRING_YOUR_OWN_LICENSE");
+    pub const LICENSE_TYPE_BRING_YOUR_OWN_LICENSE: LicenseType = LicenseType::new(2);
+
+    /// Creates a new LicenseType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("LICENSE_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("LICENSE_TYPE_DEFAULT"),
+            2 => std::borrow::Cow::Borrowed("LICENSE_TYPE_BRING_YOUR_OWN_LICENSE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "LICENSE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::LICENSE_TYPE_UNSPECIFIED),
+            "LICENSE_TYPE_DEFAULT" => std::option::Option::Some(Self::LICENSE_TYPE_DEFAULT),
+            "LICENSE_TYPE_BRING_YOUR_OWN_LICENSE" => {
+                std::option::Option::Some(Self::LICENSE_TYPE_BRING_YOUR_OWN_LICENSE)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for LicenseType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for LicenseType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for LicenseType {
     fn default() -> Self {
-        license_type::LICENSE_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -13054,200 +13640,285 @@ impl std::default::Default for LicenseType {
 /// strategy, in addition to actual usage data of the virtual machine, can help
 /// determine the recommended shape on the target platform.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SizingOptimizationStrategy(std::borrow::Cow<'static, str>);
+pub struct SizingOptimizationStrategy(i32);
 
 impl SizingOptimizationStrategy {
-    /// Creates a new SizingOptimizationStrategy instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [SizingOptimizationStrategy](SizingOptimizationStrategy)
-pub mod sizing_optimization_strategy {
-    use super::SizingOptimizationStrategy;
-
     /// Unspecified (default value).
     pub const SIZING_OPTIMIZATION_STRATEGY_UNSPECIFIED: SizingOptimizationStrategy =
-        SizingOptimizationStrategy::new("SIZING_OPTIMIZATION_STRATEGY_UNSPECIFIED");
+        SizingOptimizationStrategy::new(0);
 
     /// No optimization applied. Virtual machine sizing matches as closely as
     /// possible the machine shape on the source site, not considering any actual
     /// performance data.
     pub const SIZING_OPTIMIZATION_STRATEGY_SAME_AS_SOURCE: SizingOptimizationStrategy =
-        SizingOptimizationStrategy::new("SIZING_OPTIMIZATION_STRATEGY_SAME_AS_SOURCE");
+        SizingOptimizationStrategy::new(1);
 
     /// Virtual machine sizing will match the reported usage and shape, with some
     /// slack. This a good value to start with.
     pub const SIZING_OPTIMIZATION_STRATEGY_MODERATE: SizingOptimizationStrategy =
-        SizingOptimizationStrategy::new("SIZING_OPTIMIZATION_STRATEGY_MODERATE");
+        SizingOptimizationStrategy::new(2);
 
     /// Virtual machine sizing will match the reported usage, with little slack.
     /// Using this option can help reduce costs.
     pub const SIZING_OPTIMIZATION_STRATEGY_AGGRESSIVE: SizingOptimizationStrategy =
-        SizingOptimizationStrategy::new("SIZING_OPTIMIZATION_STRATEGY_AGGRESSIVE");
+        SizingOptimizationStrategy::new(3);
+
+    /// Creates a new SizingOptimizationStrategy instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SIZING_OPTIMIZATION_STRATEGY_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SIZING_OPTIMIZATION_STRATEGY_SAME_AS_SOURCE"),
+            2 => std::borrow::Cow::Borrowed("SIZING_OPTIMIZATION_STRATEGY_MODERATE"),
+            3 => std::borrow::Cow::Borrowed("SIZING_OPTIMIZATION_STRATEGY_AGGRESSIVE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SIZING_OPTIMIZATION_STRATEGY_UNSPECIFIED" => {
+                std::option::Option::Some(Self::SIZING_OPTIMIZATION_STRATEGY_UNSPECIFIED)
+            }
+            "SIZING_OPTIMIZATION_STRATEGY_SAME_AS_SOURCE" => {
+                std::option::Option::Some(Self::SIZING_OPTIMIZATION_STRATEGY_SAME_AS_SOURCE)
+            }
+            "SIZING_OPTIMIZATION_STRATEGY_MODERATE" => {
+                std::option::Option::Some(Self::SIZING_OPTIMIZATION_STRATEGY_MODERATE)
+            }
+            "SIZING_OPTIMIZATION_STRATEGY_AGGRESSIVE" => {
+                std::option::Option::Some(Self::SIZING_OPTIMIZATION_STRATEGY_AGGRESSIVE)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for SizingOptimizationStrategy {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SizingOptimizationStrategy {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SizingOptimizationStrategy {
     fn default() -> Self {
-        sizing_optimization_strategy::SIZING_OPTIMIZATION_STRATEGY_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The plan of commitments for VM resource-based committed use discount (CUD).
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct CommitmentPlan(std::borrow::Cow<'static, str>);
+pub struct CommitmentPlan(i32);
 
 impl CommitmentPlan {
+    /// Unspecified commitment plan.
+    pub const COMMITMENT_PLAN_UNSPECIFIED: CommitmentPlan = CommitmentPlan::new(0);
+
+    /// No commitment plan.
+    pub const COMMITMENT_PLAN_NONE: CommitmentPlan = CommitmentPlan::new(1);
+
+    /// 1 year commitment.
+    pub const COMMITMENT_PLAN_ONE_YEAR: CommitmentPlan = CommitmentPlan::new(2);
+
+    /// 3 years commitment.
+    pub const COMMITMENT_PLAN_THREE_YEARS: CommitmentPlan = CommitmentPlan::new(3);
+
     /// Creates a new CommitmentPlan instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("COMMITMENT_PLAN_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("COMMITMENT_PLAN_NONE"),
+            2 => std::borrow::Cow::Borrowed("COMMITMENT_PLAN_ONE_YEAR"),
+            3 => std::borrow::Cow::Borrowed("COMMITMENT_PLAN_THREE_YEARS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "COMMITMENT_PLAN_UNSPECIFIED" => {
+                std::option::Option::Some(Self::COMMITMENT_PLAN_UNSPECIFIED)
+            }
+            "COMMITMENT_PLAN_NONE" => std::option::Option::Some(Self::COMMITMENT_PLAN_NONE),
+            "COMMITMENT_PLAN_ONE_YEAR" => std::option::Option::Some(Self::COMMITMENT_PLAN_ONE_YEAR),
+            "COMMITMENT_PLAN_THREE_YEARS" => {
+                std::option::Option::Some(Self::COMMITMENT_PLAN_THREE_YEARS)
+            }
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [CommitmentPlan](CommitmentPlan)
-pub mod commitment_plan {
-    use super::CommitmentPlan;
-
-    /// Unspecified commitment plan.
-    pub const COMMITMENT_PLAN_UNSPECIFIED: CommitmentPlan =
-        CommitmentPlan::new("COMMITMENT_PLAN_UNSPECIFIED");
-
-    /// No commitment plan.
-    pub const COMMITMENT_PLAN_NONE: CommitmentPlan = CommitmentPlan::new("COMMITMENT_PLAN_NONE");
-
-    /// 1 year commitment.
-    pub const COMMITMENT_PLAN_ONE_YEAR: CommitmentPlan =
-        CommitmentPlan::new("COMMITMENT_PLAN_ONE_YEAR");
-
-    /// 3 years commitment.
-    pub const COMMITMENT_PLAN_THREE_YEARS: CommitmentPlan =
-        CommitmentPlan::new("COMMITMENT_PLAN_THREE_YEARS");
-}
-
-impl std::convert::From<std::string::String> for CommitmentPlan {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for CommitmentPlan {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for CommitmentPlan {
     fn default() -> Self {
-        commitment_plan::COMMITMENT_PLAN_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The preference for a specific Google Cloud product platform.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ComputeMigrationTargetProduct(std::borrow::Cow<'static, str>);
+pub struct ComputeMigrationTargetProduct(i32);
 
 impl ComputeMigrationTargetProduct {
-    /// Creates a new ComputeMigrationTargetProduct instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ComputeMigrationTargetProduct](ComputeMigrationTargetProduct)
-pub mod compute_migration_target_product {
-    use super::ComputeMigrationTargetProduct;
-
     /// Unspecified (default value).
     pub const COMPUTE_MIGRATION_TARGET_PRODUCT_UNSPECIFIED: ComputeMigrationTargetProduct =
-        ComputeMigrationTargetProduct::new("COMPUTE_MIGRATION_TARGET_PRODUCT_UNSPECIFIED");
+        ComputeMigrationTargetProduct::new(0);
 
     /// Prefer to migrate to Google Cloud Compute Engine.
     pub const COMPUTE_MIGRATION_TARGET_PRODUCT_COMPUTE_ENGINE: ComputeMigrationTargetProduct =
-        ComputeMigrationTargetProduct::new("COMPUTE_MIGRATION_TARGET_PRODUCT_COMPUTE_ENGINE");
+        ComputeMigrationTargetProduct::new(1);
 
     /// Prefer to migrate to Google Cloud VMware Engine.
     pub const COMPUTE_MIGRATION_TARGET_PRODUCT_VMWARE_ENGINE: ComputeMigrationTargetProduct =
-        ComputeMigrationTargetProduct::new("COMPUTE_MIGRATION_TARGET_PRODUCT_VMWARE_ENGINE");
+        ComputeMigrationTargetProduct::new(2);
 
     /// Prefer to migrate to Google Cloud Sole Tenant Nodes.
     pub const COMPUTE_MIGRATION_TARGET_PRODUCT_SOLE_TENANCY: ComputeMigrationTargetProduct =
-        ComputeMigrationTargetProduct::new("COMPUTE_MIGRATION_TARGET_PRODUCT_SOLE_TENANCY");
+        ComputeMigrationTargetProduct::new(3);
+
+    /// Creates a new ComputeMigrationTargetProduct instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("COMPUTE_MIGRATION_TARGET_PRODUCT_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("COMPUTE_MIGRATION_TARGET_PRODUCT_COMPUTE_ENGINE"),
+            2 => std::borrow::Cow::Borrowed("COMPUTE_MIGRATION_TARGET_PRODUCT_VMWARE_ENGINE"),
+            3 => std::borrow::Cow::Borrowed("COMPUTE_MIGRATION_TARGET_PRODUCT_SOLE_TENANCY"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "COMPUTE_MIGRATION_TARGET_PRODUCT_UNSPECIFIED" => {
+                std::option::Option::Some(Self::COMPUTE_MIGRATION_TARGET_PRODUCT_UNSPECIFIED)
+            }
+            "COMPUTE_MIGRATION_TARGET_PRODUCT_COMPUTE_ENGINE" => {
+                std::option::Option::Some(Self::COMPUTE_MIGRATION_TARGET_PRODUCT_COMPUTE_ENGINE)
+            }
+            "COMPUTE_MIGRATION_TARGET_PRODUCT_VMWARE_ENGINE" => {
+                std::option::Option::Some(Self::COMPUTE_MIGRATION_TARGET_PRODUCT_VMWARE_ENGINE)
+            }
+            "COMPUTE_MIGRATION_TARGET_PRODUCT_SOLE_TENANCY" => {
+                std::option::Option::Some(Self::COMPUTE_MIGRATION_TARGET_PRODUCT_SOLE_TENANCY)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ComputeMigrationTargetProduct {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ComputeMigrationTargetProduct {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ComputeMigrationTargetProduct {
     fn default() -> Self {
-        compute_migration_target_product::COMPUTE_MIGRATION_TARGET_PRODUCT_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Specifies the types of views that provide complete or partial details
 /// of a Report.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ReportView(std::borrow::Cow<'static, str>);
+pub struct ReportView(i32);
 
 impl ReportView {
-    /// Creates a new ReportView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ReportView](ReportView)
-pub mod report_view {
-    use super::ReportView;
-
     /// The report view is not specified. The API displays the basic view by
     /// default.
-    pub const REPORT_VIEW_UNSPECIFIED: ReportView = ReportView::new("REPORT_VIEW_UNSPECIFIED");
+    pub const REPORT_VIEW_UNSPECIFIED: ReportView = ReportView::new(0);
 
     /// The report view includes only basic metadata of the Report. Useful for
     /// list views.
-    pub const REPORT_VIEW_BASIC: ReportView = ReportView::new("REPORT_VIEW_BASIC");
+    pub const REPORT_VIEW_BASIC: ReportView = ReportView::new(1);
 
     /// The report view includes all the metadata of the Report. Useful for
     /// preview.
-    pub const REPORT_VIEW_FULL: ReportView = ReportView::new("REPORT_VIEW_FULL");
+    pub const REPORT_VIEW_FULL: ReportView = ReportView::new(2);
 
     /// The report view includes the standard metadata of an report. Useful for
     /// detail view.
-    pub const REPORT_VIEW_STANDARD: ReportView = ReportView::new("REPORT_VIEW_STANDARD");
+    pub const REPORT_VIEW_STANDARD: ReportView = ReportView::new(3);
+
+    /// Creates a new ReportView instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("REPORT_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("REPORT_VIEW_BASIC"),
+            2 => std::borrow::Cow::Borrowed("REPORT_VIEW_FULL"),
+            3 => std::borrow::Cow::Borrowed("REPORT_VIEW_STANDARD"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "REPORT_VIEW_UNSPECIFIED" => std::option::Option::Some(Self::REPORT_VIEW_UNSPECIFIED),
+            "REPORT_VIEW_BASIC" => std::option::Option::Some(Self::REPORT_VIEW_BASIC),
+            "REPORT_VIEW_FULL" => std::option::Option::Some(Self::REPORT_VIEW_FULL),
+            "REPORT_VIEW_STANDARD" => std::option::Option::Some(Self::REPORT_VIEW_STANDARD),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ReportView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ReportView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ReportView {
     fn default() -> Self {
-        report_view::REPORT_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/migrationcenter/v1/src/transport.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/assets", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -73,7 +73,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -102,7 +102,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -133,7 +133,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
                 reqwest::Method::POST,
                 format!("/v1/{}/assets:batchUpdate", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -150,7 +150,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -173,7 +173,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
                 reqwest::Method::POST,
                 format!("/v1/{}/assets:batchDelete", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -193,7 +193,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
                 reqwest::Method::POST,
                 format!("/v1/{}/assets:reportAssetFrames", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -214,7 +214,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
                 reqwest::Method::POST,
                 format!("/v1/{}/assets:aggregateValues", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -234,7 +234,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
                 reqwest::Method::POST,
                 format!("/v1/{}/importJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -258,7 +258,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
                 reqwest::Method::GET,
                 format!("/v1/{}/importJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -282,7 +282,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -302,7 +302,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -332,7 +332,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -362,7 +362,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:validate", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -379,7 +379,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:run", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -396,7 +396,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -418,7 +418,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
                 reqwest::Method::GET,
                 format!("/v1/{}/importDataFiles", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -444,7 +444,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
                 reqwest::Method::POST,
                 format!("/v1/{}/importDataFiles", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -465,7 +465,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -485,7 +485,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/groups", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -508,7 +508,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -527,7 +527,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/groups", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -555,7 +555,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -583,7 +583,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -606,7 +606,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
                 reqwest::Method::POST,
                 format!("/v1/{}:addAssets", req.group),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -626,7 +626,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
                 reqwest::Method::POST,
                 format!("/v1/{}:removeAssets", req.group),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -646,7 +646,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
                 reqwest::Method::GET,
                 format!("/v1/{}/errorFrames", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -668,7 +668,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -688,7 +688,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/sources", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -711,7 +711,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -730,7 +730,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/sources", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -758,7 +758,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -786,7 +786,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -809,7 +809,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
                 reqwest::Method::GET,
                 format!("/v1/{}/preferenceSets", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -831,7 +831,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -853,7 +853,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
                 reqwest::Method::POST,
                 format!("/v1/{}/preferenceSets", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -883,7 +883,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -913,7 +913,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -933,7 +933,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -961,7 +961,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -994,7 +994,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
                 reqwest::Method::POST,
                 format!("/v1/{}/reportConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1015,7 +1015,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1037,7 +1037,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
                 reqwest::Method::GET,
                 format!("/v1/{}/reportConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1060,7 +1060,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1081,7 +1081,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/reports", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1100,7 +1100,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1120,7 +1120,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/reports", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1144,7 +1144,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1164,7 +1164,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1186,7 +1186,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1205,7 +1205,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1227,7 +1227,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1246,7 +1246,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1265,7 +1265,7 @@ impl crate::stubs::MigrationCenter for MigrationCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/modelarmor/v1/src/model.rs
+++ b/src/generated/cloud/modelarmor/v1/src/model.rs
@@ -921,46 +921,63 @@ pub mod pi_and_jailbreak_filter_settings {
     /// Option to specify the state of Prompt Injection and Jailbreak filter
     /// (ENABLED/DISABLED).
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PiAndJailbreakFilterEnforcement(std::borrow::Cow<'static, str>);
+    pub struct PiAndJailbreakFilterEnforcement(i32);
 
     impl PiAndJailbreakFilterEnforcement {
-        /// Creates a new PiAndJailbreakFilterEnforcement instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PiAndJailbreakFilterEnforcement](PiAndJailbreakFilterEnforcement)
-    pub mod pi_and_jailbreak_filter_enforcement {
-        use super::PiAndJailbreakFilterEnforcement;
-
         /// Same as Disabled
         pub const PI_AND_JAILBREAK_FILTER_ENFORCEMENT_UNSPECIFIED: PiAndJailbreakFilterEnforcement =
-            PiAndJailbreakFilterEnforcement::new("PI_AND_JAILBREAK_FILTER_ENFORCEMENT_UNSPECIFIED");
+            PiAndJailbreakFilterEnforcement::new(0);
 
         /// Enabled
         pub const ENABLED: PiAndJailbreakFilterEnforcement =
-            PiAndJailbreakFilterEnforcement::new("ENABLED");
+            PiAndJailbreakFilterEnforcement::new(1);
 
         /// Enabled
         pub const DISABLED: PiAndJailbreakFilterEnforcement =
-            PiAndJailbreakFilterEnforcement::new("DISABLED");
+            PiAndJailbreakFilterEnforcement::new(2);
+
+        /// Creates a new PiAndJailbreakFilterEnforcement instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PI_AND_JAILBREAK_FILTER_ENFORCEMENT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENABLED"),
+                2 => std::borrow::Cow::Borrowed("DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PI_AND_JAILBREAK_FILTER_ENFORCEMENT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PI_AND_JAILBREAK_FILTER_ENFORCEMENT_UNSPECIFIED)
+                }
+                "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PiAndJailbreakFilterEnforcement {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PiAndJailbreakFilterEnforcement {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PiAndJailbreakFilterEnforcement {
         fn default() -> Self {
-            pi_and_jailbreak_filter_enforcement::PI_AND_JAILBREAK_FILTER_ENFORCEMENT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1008,46 +1025,61 @@ pub mod malicious_uri_filter_settings {
 
     /// Option to specify the state of Malicious URI filter (ENABLED/DISABLED).
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MaliciousUriFilterEnforcement(std::borrow::Cow<'static, str>);
+    pub struct MaliciousUriFilterEnforcement(i32);
 
     impl MaliciousUriFilterEnforcement {
+        /// Same as Disabled
+        pub const MALICIOUS_URI_FILTER_ENFORCEMENT_UNSPECIFIED: MaliciousUriFilterEnforcement =
+            MaliciousUriFilterEnforcement::new(0);
+
+        /// Enabled
+        pub const ENABLED: MaliciousUriFilterEnforcement = MaliciousUriFilterEnforcement::new(1);
+
+        /// Disabled
+        pub const DISABLED: MaliciousUriFilterEnforcement = MaliciousUriFilterEnforcement::new(2);
+
         /// Creates a new MaliciousUriFilterEnforcement instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MALICIOUS_URI_FILTER_ENFORCEMENT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENABLED"),
+                2 => std::borrow::Cow::Borrowed("DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MALICIOUS_URI_FILTER_ENFORCEMENT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MALICIOUS_URI_FILTER_ENFORCEMENT_UNSPECIFIED)
+                }
+                "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [MaliciousUriFilterEnforcement](MaliciousUriFilterEnforcement)
-    pub mod malicious_uri_filter_enforcement {
-        use super::MaliciousUriFilterEnforcement;
-
-        /// Same as Disabled
-        pub const MALICIOUS_URI_FILTER_ENFORCEMENT_UNSPECIFIED: MaliciousUriFilterEnforcement =
-            MaliciousUriFilterEnforcement::new("MALICIOUS_URI_FILTER_ENFORCEMENT_UNSPECIFIED");
-
-        /// Enabled
-        pub const ENABLED: MaliciousUriFilterEnforcement =
-            MaliciousUriFilterEnforcement::new("ENABLED");
-
-        /// Disabled
-        pub const DISABLED: MaliciousUriFilterEnforcement =
-            MaliciousUriFilterEnforcement::new("DISABLED");
-    }
-
-    impl std::convert::From<std::string::String> for MaliciousUriFilterEnforcement {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MaliciousUriFilterEnforcement {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MaliciousUriFilterEnforcement {
         fn default() -> Self {
-            malicious_uri_filter_enforcement::MALICIOUS_URI_FILTER_ENFORCEMENT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1306,44 +1338,61 @@ pub mod sdp_basic_config {
     /// Option to specify the state of Sensitive Data Protection basic config
     /// (ENABLED/DISABLED).
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SdpBasicConfigEnforcement(std::borrow::Cow<'static, str>);
+    pub struct SdpBasicConfigEnforcement(i32);
 
     impl SdpBasicConfigEnforcement {
+        /// Same as Disabled
+        pub const SDP_BASIC_CONFIG_ENFORCEMENT_UNSPECIFIED: SdpBasicConfigEnforcement =
+            SdpBasicConfigEnforcement::new(0);
+
+        /// Enabled
+        pub const ENABLED: SdpBasicConfigEnforcement = SdpBasicConfigEnforcement::new(1);
+
+        /// Disabled
+        pub const DISABLED: SdpBasicConfigEnforcement = SdpBasicConfigEnforcement::new(2);
+
         /// Creates a new SdpBasicConfigEnforcement instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SDP_BASIC_CONFIG_ENFORCEMENT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENABLED"),
+                2 => std::borrow::Cow::Borrowed("DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SDP_BASIC_CONFIG_ENFORCEMENT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SDP_BASIC_CONFIG_ENFORCEMENT_UNSPECIFIED)
+                }
+                "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SdpBasicConfigEnforcement](SdpBasicConfigEnforcement)
-    pub mod sdp_basic_config_enforcement {
-        use super::SdpBasicConfigEnforcement;
-
-        /// Same as Disabled
-        pub const SDP_BASIC_CONFIG_ENFORCEMENT_UNSPECIFIED: SdpBasicConfigEnforcement =
-            SdpBasicConfigEnforcement::new("SDP_BASIC_CONFIG_ENFORCEMENT_UNSPECIFIED");
-
-        /// Enabled
-        pub const ENABLED: SdpBasicConfigEnforcement = SdpBasicConfigEnforcement::new("ENABLED");
-
-        /// Disabled
-        pub const DISABLED: SdpBasicConfigEnforcement = SdpBasicConfigEnforcement::new("DISABLED");
-    }
-
-    impl std::convert::From<std::string::String> for SdpBasicConfigEnforcement {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SdpBasicConfigEnforcement {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SdpBasicConfigEnforcement {
         fn default() -> Self {
-            sdp_basic_config_enforcement::SDP_BASIC_CONFIG_ENFORCEMENT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2475,44 +2524,60 @@ pub mod byte_data_item {
 
     /// Option to specify the type of byte data.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ByteItemType(std::borrow::Cow<'static, str>);
+    pub struct ByteItemType(i32);
 
     impl ByteItemType {
+        /// Unused
+        pub const BYTE_ITEM_TYPE_UNSPECIFIED: ByteItemType = ByteItemType::new(0);
+
+        /// plain text
+        pub const PLAINTEXT_UTF8: ByteItemType = ByteItemType::new(1);
+
+        /// PDF
+        pub const PDF: ByteItemType = ByteItemType::new(2);
+
         /// Creates a new ByteItemType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("BYTE_ITEM_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PLAINTEXT_UTF8"),
+                2 => std::borrow::Cow::Borrowed("PDF"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "BYTE_ITEM_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::BYTE_ITEM_TYPE_UNSPECIFIED)
+                }
+                "PLAINTEXT_UTF8" => std::option::Option::Some(Self::PLAINTEXT_UTF8),
+                "PDF" => std::option::Option::Some(Self::PDF),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ByteItemType](ByteItemType)
-    pub mod byte_item_type {
-        use super::ByteItemType;
-
-        /// Unused
-        pub const BYTE_ITEM_TYPE_UNSPECIFIED: ByteItemType =
-            ByteItemType::new("BYTE_ITEM_TYPE_UNSPECIFIED");
-
-        /// plain text
-        pub const PLAINTEXT_UTF8: ByteItemType = ByteItemType::new("PLAINTEXT_UTF8");
-
-        /// PDF
-        pub const PDF: ByteItemType = ByteItemType::new("PDF");
-    }
-
-    impl std::convert::From<std::string::String> for ByteItemType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ByteItemType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ByteItemType {
         fn default() -> Self {
-            byte_item_type::BYTE_ITEM_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3053,48 +3118,66 @@ pub mod virus_scan_filter_result {
 
     /// Type of content scanned.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ScannedContentType(std::borrow::Cow<'static, str>);
+    pub struct ScannedContentType(i32);
 
     impl ScannedContentType {
-        /// Creates a new ScannedContentType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ScannedContentType](ScannedContentType)
-    pub mod scanned_content_type {
-        use super::ScannedContentType;
-
         /// Unused
-        pub const SCANNED_CONTENT_TYPE_UNSPECIFIED: ScannedContentType =
-            ScannedContentType::new("SCANNED_CONTENT_TYPE_UNSPECIFIED");
+        pub const SCANNED_CONTENT_TYPE_UNSPECIFIED: ScannedContentType = ScannedContentType::new(0);
 
         /// Unknown content
-        pub const UNKNOWN: ScannedContentType = ScannedContentType::new("UNKNOWN");
+        pub const UNKNOWN: ScannedContentType = ScannedContentType::new(1);
 
         /// Plaintext
-        pub const PLAINTEXT: ScannedContentType = ScannedContentType::new("PLAINTEXT");
+        pub const PLAINTEXT: ScannedContentType = ScannedContentType::new(2);
 
         /// PDF
         /// Scanning for only PDF is supported.
-        pub const PDF: ScannedContentType = ScannedContentType::new("PDF");
+        pub const PDF: ScannedContentType = ScannedContentType::new(3);
+
+        /// Creates a new ScannedContentType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SCANNED_CONTENT_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                2 => std::borrow::Cow::Borrowed("PLAINTEXT"),
+                3 => std::borrow::Cow::Borrowed("PDF"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SCANNED_CONTENT_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SCANNED_CONTENT_TYPE_UNSPECIFIED)
+                }
+                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                "PLAINTEXT" => std::option::Option::Some(Self::PLAINTEXT),
+                "PDF" => std::option::Option::Some(Self::PDF),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ScannedContentType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ScannedContentType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ScannedContentType {
         fn default() -> Self {
-            scanned_content_type::SCANNED_CONTENT_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3162,54 +3245,79 @@ pub mod virus_detail {
 
     /// Defines all the threat types of a virus
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ThreatType(std::borrow::Cow<'static, str>);
+    pub struct ThreatType(i32);
 
     impl ThreatType {
+        /// Unused
+        pub const THREAT_TYPE_UNSPECIFIED: ThreatType = ThreatType::new(0);
+
+        /// Unable to categorize threat
+        pub const UNKNOWN: ThreatType = ThreatType::new(1);
+
+        /// Virus or Worm threat.
+        pub const VIRUS_OR_WORM: ThreatType = ThreatType::new(2);
+
+        /// Malicious program. E.g. Spyware, Trojan.
+        pub const MALICIOUS_PROGRAM: ThreatType = ThreatType::new(3);
+
+        /// Potentially harmful content. E.g. Injected code, Macro
+        pub const POTENTIALLY_HARMFUL_CONTENT: ThreatType = ThreatType::new(4);
+
+        /// Potentially unwanted content. E.g. Adware.
+        pub const POTENTIALLY_UNWANTED_CONTENT: ThreatType = ThreatType::new(5);
+
         /// Creates a new ThreatType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("THREAT_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                2 => std::borrow::Cow::Borrowed("VIRUS_OR_WORM"),
+                3 => std::borrow::Cow::Borrowed("MALICIOUS_PROGRAM"),
+                4 => std::borrow::Cow::Borrowed("POTENTIALLY_HARMFUL_CONTENT"),
+                5 => std::borrow::Cow::Borrowed("POTENTIALLY_UNWANTED_CONTENT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "THREAT_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::THREAT_TYPE_UNSPECIFIED)
+                }
+                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                "VIRUS_OR_WORM" => std::option::Option::Some(Self::VIRUS_OR_WORM),
+                "MALICIOUS_PROGRAM" => std::option::Option::Some(Self::MALICIOUS_PROGRAM),
+                "POTENTIALLY_HARMFUL_CONTENT" => {
+                    std::option::Option::Some(Self::POTENTIALLY_HARMFUL_CONTENT)
+                }
+                "POTENTIALLY_UNWANTED_CONTENT" => {
+                    std::option::Option::Some(Self::POTENTIALLY_UNWANTED_CONTENT)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ThreatType](ThreatType)
-    pub mod threat_type {
-        use super::ThreatType;
-
-        /// Unused
-        pub const THREAT_TYPE_UNSPECIFIED: ThreatType = ThreatType::new("THREAT_TYPE_UNSPECIFIED");
-
-        /// Unable to categorize threat
-        pub const UNKNOWN: ThreatType = ThreatType::new("UNKNOWN");
-
-        /// Virus or Worm threat.
-        pub const VIRUS_OR_WORM: ThreatType = ThreatType::new("VIRUS_OR_WORM");
-
-        /// Malicious program. E.g. Spyware, Trojan.
-        pub const MALICIOUS_PROGRAM: ThreatType = ThreatType::new("MALICIOUS_PROGRAM");
-
-        /// Potentially harmful content. E.g. Injected code, Macro
-        pub const POTENTIALLY_HARMFUL_CONTENT: ThreatType =
-            ThreatType::new("POTENTIALLY_HARMFUL_CONTENT");
-
-        /// Potentially unwanted content. E.g. Adware.
-        pub const POTENTIALLY_UNWANTED_CONTENT: ThreatType =
-            ThreatType::new("POTENTIALLY_UNWANTED_CONTENT");
-    }
-
-    impl std::convert::From<std::string::String> for ThreatType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ThreatType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ThreatType {
         fn default() -> Self {
-            threat_type::THREAT_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3324,47 +3432,65 @@ pub mod message_item {
 
     /// Option to specify the type of message.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MessageType(std::borrow::Cow<'static, str>);
+    pub struct MessageType(i32);
 
     impl MessageType {
+        /// Unused
+        pub const MESSAGE_TYPE_UNSPECIFIED: MessageType = MessageType::new(0);
+
+        /// Information related message.
+        pub const INFO: MessageType = MessageType::new(1);
+
+        /// Warning related message.
+        pub const WARNING: MessageType = MessageType::new(2);
+
+        /// Error message.
+        pub const ERROR: MessageType = MessageType::new(3);
+
         /// Creates a new MessageType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MESSAGE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INFO"),
+                2 => std::borrow::Cow::Borrowed("WARNING"),
+                3 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MESSAGE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MESSAGE_TYPE_UNSPECIFIED)
+                }
+                "INFO" => std::option::Option::Some(Self::INFO),
+                "WARNING" => std::option::Option::Some(Self::WARNING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [MessageType](MessageType)
-    pub mod message_type {
-        use super::MessageType;
-
-        /// Unused
-        pub const MESSAGE_TYPE_UNSPECIFIED: MessageType =
-            MessageType::new("MESSAGE_TYPE_UNSPECIFIED");
-
-        /// Information related message.
-        pub const INFO: MessageType = MessageType::new("INFO");
-
-        /// Warning related message.
-        pub const WARNING: MessageType = MessageType::new("WARNING");
-
-        /// Error message.
-        pub const ERROR: MessageType = MessageType::new("ERROR");
-    }
-
-    impl std::convert::From<std::string::String> for MessageType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MessageType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MessageType {
         fn default() -> Self {
-            message_type::MESSAGE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3414,139 +3540,190 @@ impl wkt::message::Message for RangeInfo {
 
 /// Option to specify filter match state.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct FilterMatchState(std::borrow::Cow<'static, str>);
+pub struct FilterMatchState(i32);
 
 impl FilterMatchState {
+    /// Unused
+    pub const FILTER_MATCH_STATE_UNSPECIFIED: FilterMatchState = FilterMatchState::new(0);
+
+    /// Matching criteria is not achieved for filters.
+    pub const NO_MATCH_FOUND: FilterMatchState = FilterMatchState::new(1);
+
+    /// Matching criteria is achieved for the filter.
+    pub const MATCH_FOUND: FilterMatchState = FilterMatchState::new(2);
+
     /// Creates a new FilterMatchState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("FILTER_MATCH_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("NO_MATCH_FOUND"),
+            2 => std::borrow::Cow::Borrowed("MATCH_FOUND"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "FILTER_MATCH_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::FILTER_MATCH_STATE_UNSPECIFIED)
+            }
+            "NO_MATCH_FOUND" => std::option::Option::Some(Self::NO_MATCH_FOUND),
+            "MATCH_FOUND" => std::option::Option::Some(Self::MATCH_FOUND),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [FilterMatchState](FilterMatchState)
-pub mod filter_match_state {
-    use super::FilterMatchState;
-
-    /// Unused
-    pub const FILTER_MATCH_STATE_UNSPECIFIED: FilterMatchState =
-        FilterMatchState::new("FILTER_MATCH_STATE_UNSPECIFIED");
-
-    /// Matching criteria is not achieved for filters.
-    pub const NO_MATCH_FOUND: FilterMatchState = FilterMatchState::new("NO_MATCH_FOUND");
-
-    /// Matching criteria is achieved for the filter.
-    pub const MATCH_FOUND: FilterMatchState = FilterMatchState::new("MATCH_FOUND");
-}
-
-impl std::convert::From<std::string::String> for FilterMatchState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for FilterMatchState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for FilterMatchState {
     fn default() -> Self {
-        filter_match_state::FILTER_MATCH_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Enum which reports whether a specific filter executed successfully or not.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct FilterExecutionState(std::borrow::Cow<'static, str>);
+pub struct FilterExecutionState(i32);
 
 impl FilterExecutionState {
-    /// Creates a new FilterExecutionState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [FilterExecutionState](FilterExecutionState)
-pub mod filter_execution_state {
-    use super::FilterExecutionState;
-
     /// Unused
     pub const FILTER_EXECUTION_STATE_UNSPECIFIED: FilterExecutionState =
-        FilterExecutionState::new("FILTER_EXECUTION_STATE_UNSPECIFIED");
+        FilterExecutionState::new(0);
 
     /// Filter executed successfully
-    pub const EXECUTION_SUCCESS: FilterExecutionState =
-        FilterExecutionState::new("EXECUTION_SUCCESS");
+    pub const EXECUTION_SUCCESS: FilterExecutionState = FilterExecutionState::new(1);
 
     /// Filter execution was skipped. This can happen due to server-side error
     /// or permission issue.
-    pub const EXECUTION_SKIPPED: FilterExecutionState =
-        FilterExecutionState::new("EXECUTION_SKIPPED");
+    pub const EXECUTION_SKIPPED: FilterExecutionState = FilterExecutionState::new(2);
+
+    /// Creates a new FilterExecutionState instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("FILTER_EXECUTION_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("EXECUTION_SUCCESS"),
+            2 => std::borrow::Cow::Borrowed("EXECUTION_SKIPPED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "FILTER_EXECUTION_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::FILTER_EXECUTION_STATE_UNSPECIFIED)
+            }
+            "EXECUTION_SUCCESS" => std::option::Option::Some(Self::EXECUTION_SUCCESS),
+            "EXECUTION_SKIPPED" => std::option::Option::Some(Self::EXECUTION_SKIPPED),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for FilterExecutionState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for FilterExecutionState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for FilterExecutionState {
     fn default() -> Self {
-        filter_execution_state::FILTER_EXECUTION_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Options for responsible AI Filter Types.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RaiFilterType(std::borrow::Cow<'static, str>);
+pub struct RaiFilterType(i32);
 
 impl RaiFilterType {
+    /// Unspecified filter type.
+    pub const RAI_FILTER_TYPE_UNSPECIFIED: RaiFilterType = RaiFilterType::new(0);
+
+    /// Sexually Explicit.
+    pub const SEXUALLY_EXPLICIT: RaiFilterType = RaiFilterType::new(2);
+
+    /// Hate Speech.
+    pub const HATE_SPEECH: RaiFilterType = RaiFilterType::new(3);
+
+    /// Harassment.
+    pub const HARASSMENT: RaiFilterType = RaiFilterType::new(6);
+
+    /// Danger
+    pub const DANGEROUS: RaiFilterType = RaiFilterType::new(17);
+
     /// Creates a new RaiFilterType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("RAI_FILTER_TYPE_UNSPECIFIED"),
+            2 => std::borrow::Cow::Borrowed("SEXUALLY_EXPLICIT"),
+            3 => std::borrow::Cow::Borrowed("HATE_SPEECH"),
+            6 => std::borrow::Cow::Borrowed("HARASSMENT"),
+            17 => std::borrow::Cow::Borrowed("DANGEROUS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "RAI_FILTER_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::RAI_FILTER_TYPE_UNSPECIFIED)
+            }
+            "SEXUALLY_EXPLICIT" => std::option::Option::Some(Self::SEXUALLY_EXPLICIT),
+            "HATE_SPEECH" => std::option::Option::Some(Self::HATE_SPEECH),
+            "HARASSMENT" => std::option::Option::Some(Self::HARASSMENT),
+            "DANGEROUS" => std::option::Option::Some(Self::DANGEROUS),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [RaiFilterType](RaiFilterType)
-pub mod rai_filter_type {
-    use super::RaiFilterType;
-
-    /// Unspecified filter type.
-    pub const RAI_FILTER_TYPE_UNSPECIFIED: RaiFilterType =
-        RaiFilterType::new("RAI_FILTER_TYPE_UNSPECIFIED");
-
-    /// Sexually Explicit.
-    pub const SEXUALLY_EXPLICIT: RaiFilterType = RaiFilterType::new("SEXUALLY_EXPLICIT");
-
-    /// Hate Speech.
-    pub const HATE_SPEECH: RaiFilterType = RaiFilterType::new("HATE_SPEECH");
-
-    /// Harassment.
-    pub const HARASSMENT: RaiFilterType = RaiFilterType::new("HARASSMENT");
-
-    /// Danger
-    pub const DANGEROUS: RaiFilterType = RaiFilterType::new("DANGEROUS");
-}
-
-impl std::convert::From<std::string::String> for RaiFilterType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for RaiFilterType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for RaiFilterType {
     fn default() -> Self {
-        rai_filter_type::RAI_FILTER_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -3554,148 +3731,206 @@ impl std::default::Default for RaiFilterType {
 /// Higher value maps to a greater confidence level. To enforce stricter level a
 /// lower value should be used.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DetectionConfidenceLevel(std::borrow::Cow<'static, str>);
+pub struct DetectionConfidenceLevel(i32);
 
 impl DetectionConfidenceLevel {
+    /// Same as LOW_AND_ABOVE.
+    pub const DETECTION_CONFIDENCE_LEVEL_UNSPECIFIED: DetectionConfidenceLevel =
+        DetectionConfidenceLevel::new(0);
+
+    /// Highest chance of a false positive.
+    pub const LOW_AND_ABOVE: DetectionConfidenceLevel = DetectionConfidenceLevel::new(1);
+
+    /// Some chance of false positives.
+    pub const MEDIUM_AND_ABOVE: DetectionConfidenceLevel = DetectionConfidenceLevel::new(2);
+
+    /// Low chance of false positives.
+    pub const HIGH: DetectionConfidenceLevel = DetectionConfidenceLevel::new(3);
+
     /// Creates a new DetectionConfidenceLevel instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DETECTION_CONFIDENCE_LEVEL_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("LOW_AND_ABOVE"),
+            2 => std::borrow::Cow::Borrowed("MEDIUM_AND_ABOVE"),
+            3 => std::borrow::Cow::Borrowed("HIGH"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DETECTION_CONFIDENCE_LEVEL_UNSPECIFIED" => {
+                std::option::Option::Some(Self::DETECTION_CONFIDENCE_LEVEL_UNSPECIFIED)
+            }
+            "LOW_AND_ABOVE" => std::option::Option::Some(Self::LOW_AND_ABOVE),
+            "MEDIUM_AND_ABOVE" => std::option::Option::Some(Self::MEDIUM_AND_ABOVE),
+            "HIGH" => std::option::Option::Some(Self::HIGH),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [DetectionConfidenceLevel](DetectionConfidenceLevel)
-pub mod detection_confidence_level {
-    use super::DetectionConfidenceLevel;
-
-    /// Same as LOW_AND_ABOVE.
-    pub const DETECTION_CONFIDENCE_LEVEL_UNSPECIFIED: DetectionConfidenceLevel =
-        DetectionConfidenceLevel::new("DETECTION_CONFIDENCE_LEVEL_UNSPECIFIED");
-
-    /// Highest chance of a false positive.
-    pub const LOW_AND_ABOVE: DetectionConfidenceLevel =
-        DetectionConfidenceLevel::new("LOW_AND_ABOVE");
-
-    /// Some chance of false positives.
-    pub const MEDIUM_AND_ABOVE: DetectionConfidenceLevel =
-        DetectionConfidenceLevel::new("MEDIUM_AND_ABOVE");
-
-    /// Low chance of false positives.
-    pub const HIGH: DetectionConfidenceLevel = DetectionConfidenceLevel::new("HIGH");
-}
-
-impl std::convert::From<std::string::String> for DetectionConfidenceLevel {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DetectionConfidenceLevel {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DetectionConfidenceLevel {
     fn default() -> Self {
-        detection_confidence_level::DETECTION_CONFIDENCE_LEVEL_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// For more information about each Sensitive Data Protection likelihood level,
 /// see <https://cloud.google.com/sensitive-data-protection/docs/likelihood>.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SdpFindingLikelihood(std::borrow::Cow<'static, str>);
+pub struct SdpFindingLikelihood(i32);
 
 impl SdpFindingLikelihood {
+    /// Default value; same as POSSIBLE.
+    pub const SDP_FINDING_LIKELIHOOD_UNSPECIFIED: SdpFindingLikelihood =
+        SdpFindingLikelihood::new(0);
+
+    /// Highest chance of a false positive.
+    pub const VERY_UNLIKELY: SdpFindingLikelihood = SdpFindingLikelihood::new(1);
+
+    /// High chance of a false positive.
+    pub const UNLIKELY: SdpFindingLikelihood = SdpFindingLikelihood::new(2);
+
+    /// Some matching signals. The default value.
+    pub const POSSIBLE: SdpFindingLikelihood = SdpFindingLikelihood::new(3);
+
+    /// Low chance of a false positive.
+    pub const LIKELY: SdpFindingLikelihood = SdpFindingLikelihood::new(4);
+
+    /// Confidence level is high. Lowest chance of a false positive.
+    pub const VERY_LIKELY: SdpFindingLikelihood = SdpFindingLikelihood::new(5);
+
     /// Creates a new SdpFindingLikelihood instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SDP_FINDING_LIKELIHOOD_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("VERY_UNLIKELY"),
+            2 => std::borrow::Cow::Borrowed("UNLIKELY"),
+            3 => std::borrow::Cow::Borrowed("POSSIBLE"),
+            4 => std::borrow::Cow::Borrowed("LIKELY"),
+            5 => std::borrow::Cow::Borrowed("VERY_LIKELY"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SDP_FINDING_LIKELIHOOD_UNSPECIFIED" => {
+                std::option::Option::Some(Self::SDP_FINDING_LIKELIHOOD_UNSPECIFIED)
+            }
+            "VERY_UNLIKELY" => std::option::Option::Some(Self::VERY_UNLIKELY),
+            "UNLIKELY" => std::option::Option::Some(Self::UNLIKELY),
+            "POSSIBLE" => std::option::Option::Some(Self::POSSIBLE),
+            "LIKELY" => std::option::Option::Some(Self::LIKELY),
+            "VERY_LIKELY" => std::option::Option::Some(Self::VERY_LIKELY),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [SdpFindingLikelihood](SdpFindingLikelihood)
-pub mod sdp_finding_likelihood {
-    use super::SdpFindingLikelihood;
-
-    /// Default value; same as POSSIBLE.
-    pub const SDP_FINDING_LIKELIHOOD_UNSPECIFIED: SdpFindingLikelihood =
-        SdpFindingLikelihood::new("SDP_FINDING_LIKELIHOOD_UNSPECIFIED");
-
-    /// Highest chance of a false positive.
-    pub const VERY_UNLIKELY: SdpFindingLikelihood = SdpFindingLikelihood::new("VERY_UNLIKELY");
-
-    /// High chance of a false positive.
-    pub const UNLIKELY: SdpFindingLikelihood = SdpFindingLikelihood::new("UNLIKELY");
-
-    /// Some matching signals. The default value.
-    pub const POSSIBLE: SdpFindingLikelihood = SdpFindingLikelihood::new("POSSIBLE");
-
-    /// Low chance of a false positive.
-    pub const LIKELY: SdpFindingLikelihood = SdpFindingLikelihood::new("LIKELY");
-
-    /// Confidence level is high. Lowest chance of a false positive.
-    pub const VERY_LIKELY: SdpFindingLikelihood = SdpFindingLikelihood::new("VERY_LIKELY");
-}
-
-impl std::convert::From<std::string::String> for SdpFindingLikelihood {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SdpFindingLikelihood {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SdpFindingLikelihood {
     fn default() -> Self {
-        sdp_finding_likelihood::SDP_FINDING_LIKELIHOOD_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// A field indicating the outcome of the invocation, irrespective of match
 /// status.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct InvocationResult(std::borrow::Cow<'static, str>);
+pub struct InvocationResult(i32);
 
 impl InvocationResult {
+    /// Unused. Default value.
+    pub const INVOCATION_RESULT_UNSPECIFIED: InvocationResult = InvocationResult::new(0);
+
+    /// All filters were invoked successfully.
+    pub const SUCCESS: InvocationResult = InvocationResult::new(1);
+
+    /// Some filters were skipped or failed.
+    pub const PARTIAL: InvocationResult = InvocationResult::new(2);
+
+    /// All filters were skipped or failed.
+    pub const FAILURE: InvocationResult = InvocationResult::new(3);
+
     /// Creates a new InvocationResult instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("INVOCATION_RESULT_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SUCCESS"),
+            2 => std::borrow::Cow::Borrowed("PARTIAL"),
+            3 => std::borrow::Cow::Borrowed("FAILURE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "INVOCATION_RESULT_UNSPECIFIED" => {
+                std::option::Option::Some(Self::INVOCATION_RESULT_UNSPECIFIED)
+            }
+            "SUCCESS" => std::option::Option::Some(Self::SUCCESS),
+            "PARTIAL" => std::option::Option::Some(Self::PARTIAL),
+            "FAILURE" => std::option::Option::Some(Self::FAILURE),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [InvocationResult](InvocationResult)
-pub mod invocation_result {
-    use super::InvocationResult;
-
-    /// Unused. Default value.
-    pub const INVOCATION_RESULT_UNSPECIFIED: InvocationResult =
-        InvocationResult::new("INVOCATION_RESULT_UNSPECIFIED");
-
-    /// All filters were invoked successfully.
-    pub const SUCCESS: InvocationResult = InvocationResult::new("SUCCESS");
-
-    /// Some filters were skipped or failed.
-    pub const PARTIAL: InvocationResult = InvocationResult::new("PARTIAL");
-
-    /// All filters were skipped or failed.
-    pub const FAILURE: InvocationResult = InvocationResult::new("FAILURE");
-}
-
-impl std::convert::From<std::string::String> for InvocationResult {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for InvocationResult {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for InvocationResult {
     fn default() -> Self {
-        invocation_result::INVOCATION_RESULT_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/modelarmor/v1/src/transport.rs
+++ b/src/generated/cloud/modelarmor/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::ModelArmor for ModelArmor {
                 reqwest::Method::GET,
                 format!("/v1/{}/templates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::ModelArmor for ModelArmor {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::ModelArmor for ModelArmor {
                 reqwest::Method::POST,
                 format!("/v1/{}/templates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -127,7 +127,7 @@ impl crate::stubs::ModelArmor for ModelArmor {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -157,7 +157,7 @@ impl crate::stubs::ModelArmor for ModelArmor {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -177,7 +177,7 @@ impl crate::stubs::ModelArmor for ModelArmor {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -205,7 +205,7 @@ impl crate::stubs::ModelArmor for ModelArmor {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -237,7 +237,7 @@ impl crate::stubs::ModelArmor for ModelArmor {
                 reqwest::Method::POST,
                 format!("/v1/{}:sanitizeUserPrompt", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -257,7 +257,7 @@ impl crate::stubs::ModelArmor for ModelArmor {
                 reqwest::Method::POST,
                 format!("/v1/{}:sanitizeModelResponse", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -274,7 +274,7 @@ impl crate::stubs::ModelArmor for ModelArmor {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -296,7 +296,7 @@ impl crate::stubs::ModelArmor for ModelArmor {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/netapp/v1/src/model.rs
+++ b/src/generated/cloud/netapp/v1/src/model.rs
@@ -622,58 +622,83 @@ pub mod active_directory {
 
     /// The Active Directory States
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified Active Directory State
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Active Directory State is Creating
+        pub const CREATING: State = State::new(1);
+
+        /// Active Directory State is Ready
+        pub const READY: State = State::new(2);
+
+        /// Active Directory State is Updating
+        pub const UPDATING: State = State::new(3);
+
+        /// Active Directory State is In use
+        pub const IN_USE: State = State::new(4);
+
+        /// Active Directory State is Deleting
+        pub const DELETING: State = State::new(5);
+
+        /// Active Directory State is Error
+        pub const ERROR: State = State::new(6);
+
+        /// Active Directory State is Diagnosing.
+        pub const DIAGNOSING: State = State::new(7);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("IN_USE"),
+                5 => std::borrow::Cow::Borrowed("DELETING"),
+                6 => std::borrow::Cow::Borrowed("ERROR"),
+                7 => std::borrow::Cow::Borrowed("DIAGNOSING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "IN_USE" => std::option::Option::Some(Self::IN_USE),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "DIAGNOSING" => std::option::Option::Some(Self::DIAGNOSING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified Active Directory State
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Active Directory State is Creating
-        pub const CREATING: State = State::new("CREATING");
-
-        /// Active Directory State is Ready
-        pub const READY: State = State::new("READY");
-
-        /// Active Directory State is Updating
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// Active Directory State is In use
-        pub const IN_USE: State = State::new("IN_USE");
-
-        /// Active Directory State is Deleting
-        pub const DELETING: State = State::new("DELETING");
-
-        /// Active Directory State is Error
-        pub const ERROR: State = State::new("ERROR");
-
-        /// Active Directory State is Diagnosing.
-        pub const DIAGNOSING: State = State::new("DIAGNOSING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -847,101 +872,139 @@ pub mod backup {
 
     /// The Backup States
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Backup is being created. While in this state, the snapshot for the backup
         /// point-in-time may not have been created yet, and so the point-in-time may
         /// not have been fixed.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// Backup is being uploaded. While in this state, none of the writes to the
         /// volume will be included in the backup.
-        pub const UPLOADING: State = State::new("UPLOADING");
+        pub const UPLOADING: State = State::new(2);
 
         /// Backup is available for use.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(3);
 
         /// Backup is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(4);
 
         /// Backup is not valid and cannot be used for creating new volumes or
         /// restoring existing volumes.
-        pub const ERROR: State = State::new("ERROR");
+        pub const ERROR: State = State::new(5);
 
         /// Backup is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(6);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("UPLOADING"),
+                3 => std::borrow::Cow::Borrowed("READY"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("ERROR"),
+                6 => std::borrow::Cow::Borrowed("UPDATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "UPLOADING" => std::option::Option::Some(Self::UPLOADING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Backup types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Unspecified backup type.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// Manual backup type.
+        pub const MANUAL: Type = Type::new(1);
+
+        /// Scheduled backup type.
+        pub const SCHEDULED: Type = Type::new(2);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MANUAL"),
+                2 => std::borrow::Cow::Borrowed("SCHEDULED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "MANUAL" => std::option::Option::Some(Self::MANUAL),
+                "SCHEDULED" => std::option::Option::Some(Self::SCHEDULED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Unspecified backup type.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// Manual backup type.
-        pub const MANUAL: Type = Type::new("MANUAL");
-
-        /// Scheduled backup type.
-        pub const SCHEDULED: Type = Type::new("SCHEDULED");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1425,52 +1488,73 @@ pub mod backup_policy {
     use super::*;
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State not set.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// BackupPolicy is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// BackupPolicy is available for use.
+        pub const READY: State = State::new(2);
+
+        /// BackupPolicy is being deleted.
+        pub const DELETING: State = State::new(3);
+
+        /// BackupPolicy is not valid and cannot be used.
+        pub const ERROR: State = State::new(4);
+
+        /// BackupPolicy is being updated.
+        pub const UPDATING: State = State::new(5);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("ERROR"),
+                5 => std::borrow::Cow::Borrowed("UPDATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// BackupPolicy is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// BackupPolicy is available for use.
-        pub const READY: State = State::new("READY");
-
-        /// BackupPolicy is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// BackupPolicy is not valid and cannot be used.
-        pub const ERROR: State = State::new("ERROR");
-
-        /// BackupPolicy is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1878,52 +1962,73 @@ pub mod backup_vault {
 
     /// The Backup Vault States
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State not set.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// BackupVault is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// BackupVault is available for use.
+        pub const READY: State = State::new(2);
+
+        /// BackupVault is being deleted.
+        pub const DELETING: State = State::new(3);
+
+        /// BackupVault is not valid and cannot be used.
+        pub const ERROR: State = State::new(4);
+
+        /// BackupVault is being updated.
+        pub const UPDATING: State = State::new(5);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("ERROR"),
+                5 => std::borrow::Cow::Borrowed("UPDATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// BackupVault is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// BackupVault is available for use.
-        pub const READY: State = State::new("READY");
-
-        /// BackupVault is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// BackupVault is not valid and cannot be used.
-        pub const ERROR: State = State::new("ERROR");
-
-        /// BackupVault is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2936,72 +3041,105 @@ pub mod kms_config {
 
     /// The KmsConfig States
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified KmsConfig State
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// KmsConfig State is Ready
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(1);
 
         /// KmsConfig State is Creating
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(2);
 
         /// KmsConfig State is Deleting
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(3);
 
         /// KmsConfig State is Updating
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(4);
 
         /// KmsConfig State is In Use.
-        pub const IN_USE: State = State::new("IN_USE");
+        pub const IN_USE: State = State::new(5);
 
         /// KmsConfig State is Error
-        pub const ERROR: State = State::new("ERROR");
+        pub const ERROR: State = State::new(6);
 
         /// KmsConfig State is Pending to verify crypto key access.
-        pub const KEY_CHECK_PENDING: State = State::new("KEY_CHECK_PENDING");
+        pub const KEY_CHECK_PENDING: State = State::new(7);
 
         /// KmsConfig State is Not accessbile by the SDE service account to the
         /// crypto key.
-        pub const KEY_NOT_REACHABLE: State = State::new("KEY_NOT_REACHABLE");
+        pub const KEY_NOT_REACHABLE: State = State::new(8);
 
         /// KmsConfig State is Disabling.
-        pub const DISABLING: State = State::new("DISABLING");
+        pub const DISABLING: State = State::new(9);
 
         /// KmsConfig State is Disabled.
-        pub const DISABLED: State = State::new("DISABLED");
+        pub const DISABLED: State = State::new(10);
 
         /// KmsConfig State is Migrating.
         /// The existing volumes are migrating from SMEK to CMEK.
-        pub const MIGRATING: State = State::new("MIGRATING");
+        pub const MIGRATING: State = State::new(11);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("READY"),
+                2 => std::borrow::Cow::Borrowed("CREATING"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("UPDATING"),
+                5 => std::borrow::Cow::Borrowed("IN_USE"),
+                6 => std::borrow::Cow::Borrowed("ERROR"),
+                7 => std::borrow::Cow::Borrowed("KEY_CHECK_PENDING"),
+                8 => std::borrow::Cow::Borrowed("KEY_NOT_REACHABLE"),
+                9 => std::borrow::Cow::Borrowed("DISABLING"),
+                10 => std::borrow::Cow::Borrowed("DISABLED"),
+                11 => std::borrow::Cow::Borrowed("MIGRATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "READY" => std::option::Option::Some(Self::READY),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "IN_USE" => std::option::Option::Some(Self::IN_USE),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "KEY_CHECK_PENDING" => std::option::Option::Some(Self::KEY_CHECK_PENDING),
+                "KEY_NOT_REACHABLE" => std::option::Option::Some(Self::KEY_NOT_REACHABLE),
+                "DISABLING" => std::option::Option::Some(Self::DISABLING),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "MIGRATING" => std::option::Option::Some(Self::MIGRATING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3439,100 +3577,140 @@ pub mod quota_rule {
 
     /// Types of Quota Rule
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Unspecified type for quota rule
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// Individual user quota rule
+        pub const INDIVIDUAL_USER_QUOTA: Type = Type::new(1);
+
+        /// Individual group quota rule
+        pub const INDIVIDUAL_GROUP_QUOTA: Type = Type::new(2);
+
+        /// Default user quota rule
+        pub const DEFAULT_USER_QUOTA: Type = Type::new(3);
+
+        /// Default group quota rule
+        pub const DEFAULT_GROUP_QUOTA: Type = Type::new(4);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INDIVIDUAL_USER_QUOTA"),
+                2 => std::borrow::Cow::Borrowed("INDIVIDUAL_GROUP_QUOTA"),
+                3 => std::borrow::Cow::Borrowed("DEFAULT_USER_QUOTA"),
+                4 => std::borrow::Cow::Borrowed("DEFAULT_GROUP_QUOTA"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "INDIVIDUAL_USER_QUOTA" => std::option::Option::Some(Self::INDIVIDUAL_USER_QUOTA),
+                "INDIVIDUAL_GROUP_QUOTA" => std::option::Option::Some(Self::INDIVIDUAL_GROUP_QUOTA),
+                "DEFAULT_USER_QUOTA" => std::option::Option::Some(Self::DEFAULT_USER_QUOTA),
+                "DEFAULT_GROUP_QUOTA" => std::option::Option::Some(Self::DEFAULT_GROUP_QUOTA),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Unspecified type for quota rule
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// Individual user quota rule
-        pub const INDIVIDUAL_USER_QUOTA: Type = Type::new("INDIVIDUAL_USER_QUOTA");
-
-        /// Individual group quota rule
-        pub const INDIVIDUAL_GROUP_QUOTA: Type = Type::new("INDIVIDUAL_GROUP_QUOTA");
-
-        /// Default user quota rule
-        pub const DEFAULT_USER_QUOTA: Type = Type::new("DEFAULT_USER_QUOTA");
-
-        /// Default group quota rule
-        pub const DEFAULT_GROUP_QUOTA: Type = Type::new("DEFAULT_GROUP_QUOTA");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Quota Rule states
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified state for quota rule
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Quota rule is creating
+        pub const CREATING: State = State::new(1);
+
+        /// Quota rule is updating
+        pub const UPDATING: State = State::new(2);
+
+        /// Quota rule is deleting
+        pub const DELETING: State = State::new(3);
+
+        /// Quota rule is ready
+        pub const READY: State = State::new(4);
+
+        /// Quota rule is in error state.
+        pub const ERROR: State = State::new(5);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("UPDATING"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("READY"),
+                5 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified state for quota rule
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Quota rule is creating
-        pub const CREATING: State = State::new("CREATING");
-
-        /// Quota rule is updating
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// Quota rule is deleting
-        pub const DELETING: State = State::new("DELETING");
-
-        /// Quota rule is ready
-        pub const READY: State = State::new("READY");
-
-        /// Quota rule is in error state.
-        pub const ERROR: State = State::new("ERROR");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3926,102 +4104,145 @@ pub mod replication {
     /// The replication states
     /// New enum values may be added in future to indicate possible new states.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified replication State
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Replication is creating.
+        pub const CREATING: State = State::new(1);
+
+        /// Replication is ready.
+        pub const READY: State = State::new(2);
+
+        /// Replication is updating.
+        pub const UPDATING: State = State::new(3);
+
+        /// Replication is deleting.
+        pub const DELETING: State = State::new(5);
+
+        /// Replication is in error state.
+        pub const ERROR: State = State::new(6);
+
+        /// Replication is waiting for cluster peering to be established.
+        pub const PENDING_CLUSTER_PEERING: State = State::new(8);
+
+        /// Replication is waiting for SVM peering to be established.
+        pub const PENDING_SVM_PEERING: State = State::new(9);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                5 => std::borrow::Cow::Borrowed("DELETING"),
+                6 => std::borrow::Cow::Borrowed("ERROR"),
+                8 => std::borrow::Cow::Borrowed("PENDING_CLUSTER_PEERING"),
+                9 => std::borrow::Cow::Borrowed("PENDING_SVM_PEERING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "PENDING_CLUSTER_PEERING" => {
+                    std::option::Option::Some(Self::PENDING_CLUSTER_PEERING)
+                }
+                "PENDING_SVM_PEERING" => std::option::Option::Some(Self::PENDING_SVM_PEERING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified replication State
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Replication is creating.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// Replication is ready.
-        pub const READY: State = State::new("READY");
-
-        /// Replication is updating.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// Replication is deleting.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// Replication is in error state.
-        pub const ERROR: State = State::new("ERROR");
-
-        /// Replication is waiting for cluster peering to be established.
-        pub const PENDING_CLUSTER_PEERING: State = State::new("PENDING_CLUSTER_PEERING");
-
-        /// Replication is waiting for SVM peering to be established.
-        pub const PENDING_SVM_PEERING: State = State::new("PENDING_SVM_PEERING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// New enum values may be added in future to support different replication
     /// topology.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ReplicationRole(std::borrow::Cow<'static, str>);
+    pub struct ReplicationRole(i32);
 
     impl ReplicationRole {
+        /// Unspecified replication role
+        pub const REPLICATION_ROLE_UNSPECIFIED: ReplicationRole = ReplicationRole::new(0);
+
+        /// Indicates Source volume.
+        pub const SOURCE: ReplicationRole = ReplicationRole::new(1);
+
+        /// Indicates Destination volume.
+        pub const DESTINATION: ReplicationRole = ReplicationRole::new(2);
+
         /// Creates a new ReplicationRole instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("REPLICATION_ROLE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SOURCE"),
+                2 => std::borrow::Cow::Borrowed("DESTINATION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "REPLICATION_ROLE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::REPLICATION_ROLE_UNSPECIFIED)
+                }
+                "SOURCE" => std::option::Option::Some(Self::SOURCE),
+                "DESTINATION" => std::option::Option::Some(Self::DESTINATION),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ReplicationRole](ReplicationRole)
-    pub mod replication_role {
-        use super::ReplicationRole;
-
-        /// Unspecified replication role
-        pub const REPLICATION_ROLE_UNSPECIFIED: ReplicationRole =
-            ReplicationRole::new("REPLICATION_ROLE_UNSPECIFIED");
-
-        /// Indicates Source volume.
-        pub const SOURCE: ReplicationRole = ReplicationRole::new("SOURCE");
-
-        /// Indicates Destination volume.
-        pub const DESTINATION: ReplicationRole = ReplicationRole::new("DESTINATION");
-    }
-
-    impl std::convert::From<std::string::String> for ReplicationRole {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ReplicationRole {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ReplicationRole {
         fn default() -> Self {
-            replication_role::REPLICATION_ROLE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -4029,149 +4250,207 @@ pub mod replication {
     /// New enum values may be added in future to support different frequency of
     /// replication.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ReplicationSchedule(std::borrow::Cow<'static, str>);
+    pub struct ReplicationSchedule(i32);
 
     impl ReplicationSchedule {
+        /// Unspecified ReplicationSchedule
+        pub const REPLICATION_SCHEDULE_UNSPECIFIED: ReplicationSchedule =
+            ReplicationSchedule::new(0);
+
+        /// Replication happens once every 10 minutes.
+        pub const EVERY_10_MINUTES: ReplicationSchedule = ReplicationSchedule::new(1);
+
+        /// Replication happens once every hour.
+        pub const HOURLY: ReplicationSchedule = ReplicationSchedule::new(2);
+
+        /// Replication happens once every day.
+        pub const DAILY: ReplicationSchedule = ReplicationSchedule::new(3);
+
         /// Creates a new ReplicationSchedule instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("REPLICATION_SCHEDULE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("EVERY_10_MINUTES"),
+                2 => std::borrow::Cow::Borrowed("HOURLY"),
+                3 => std::borrow::Cow::Borrowed("DAILY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "REPLICATION_SCHEDULE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::REPLICATION_SCHEDULE_UNSPECIFIED)
+                }
+                "EVERY_10_MINUTES" => std::option::Option::Some(Self::EVERY_10_MINUTES),
+                "HOURLY" => std::option::Option::Some(Self::HOURLY),
+                "DAILY" => std::option::Option::Some(Self::DAILY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ReplicationSchedule](ReplicationSchedule)
-    pub mod replication_schedule {
-        use super::ReplicationSchedule;
-
-        /// Unspecified ReplicationSchedule
-        pub const REPLICATION_SCHEDULE_UNSPECIFIED: ReplicationSchedule =
-            ReplicationSchedule::new("REPLICATION_SCHEDULE_UNSPECIFIED");
-
-        /// Replication happens once every 10 minutes.
-        pub const EVERY_10_MINUTES: ReplicationSchedule =
-            ReplicationSchedule::new("EVERY_10_MINUTES");
-
-        /// Replication happens once every hour.
-        pub const HOURLY: ReplicationSchedule = ReplicationSchedule::new("HOURLY");
-
-        /// Replication happens once every day.
-        pub const DAILY: ReplicationSchedule = ReplicationSchedule::new("DAILY");
-    }
-
-    impl std::convert::From<std::string::String> for ReplicationSchedule {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ReplicationSchedule {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ReplicationSchedule {
         fn default() -> Self {
-            replication_schedule::REPLICATION_SCHEDULE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Mirroring states.
     /// No new value is expected to be added in future.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MirrorState(std::borrow::Cow<'static, str>);
+    pub struct MirrorState(i32);
 
     impl MirrorState {
-        /// Creates a new MirrorState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [MirrorState](MirrorState)
-    pub mod mirror_state {
-        use super::MirrorState;
-
         /// Unspecified MirrorState
-        pub const MIRROR_STATE_UNSPECIFIED: MirrorState =
-            MirrorState::new("MIRROR_STATE_UNSPECIFIED");
+        pub const MIRROR_STATE_UNSPECIFIED: MirrorState = MirrorState::new(0);
 
         /// Destination volume is being prepared.
-        pub const PREPARING: MirrorState = MirrorState::new("PREPARING");
+        pub const PREPARING: MirrorState = MirrorState::new(1);
 
         /// Destination volume has been initialized and is ready to receive
         /// replication transfers.
-        pub const MIRRORED: MirrorState = MirrorState::new("MIRRORED");
+        pub const MIRRORED: MirrorState = MirrorState::new(2);
 
         /// Destination volume is not receiving replication transfers.
-        pub const STOPPED: MirrorState = MirrorState::new("STOPPED");
+        pub const STOPPED: MirrorState = MirrorState::new(3);
 
         /// Incremental replication is in progress.
-        pub const TRANSFERRING: MirrorState = MirrorState::new("TRANSFERRING");
+        pub const TRANSFERRING: MirrorState = MirrorState::new(4);
 
         /// Baseline replication is in progress.
-        pub const BASELINE_TRANSFERRING: MirrorState = MirrorState::new("BASELINE_TRANSFERRING");
+        pub const BASELINE_TRANSFERRING: MirrorState = MirrorState::new(5);
 
         /// Replication is aborted.
-        pub const ABORTED: MirrorState = MirrorState::new("ABORTED");
+        pub const ABORTED: MirrorState = MirrorState::new(6);
+
+        /// Creates a new MirrorState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MIRROR_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PREPARING"),
+                2 => std::borrow::Cow::Borrowed("MIRRORED"),
+                3 => std::borrow::Cow::Borrowed("STOPPED"),
+                4 => std::borrow::Cow::Borrowed("TRANSFERRING"),
+                5 => std::borrow::Cow::Borrowed("BASELINE_TRANSFERRING"),
+                6 => std::borrow::Cow::Borrowed("ABORTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MIRROR_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MIRROR_STATE_UNSPECIFIED)
+                }
+                "PREPARING" => std::option::Option::Some(Self::PREPARING),
+                "MIRRORED" => std::option::Option::Some(Self::MIRRORED),
+                "STOPPED" => std::option::Option::Some(Self::STOPPED),
+                "TRANSFERRING" => std::option::Option::Some(Self::TRANSFERRING),
+                "BASELINE_TRANSFERRING" => std::option::Option::Some(Self::BASELINE_TRANSFERRING),
+                "ABORTED" => std::option::Option::Some(Self::ABORTED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for MirrorState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MirrorState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MirrorState {
         fn default() -> Self {
-            mirror_state::MIRROR_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Hybrid replication type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HybridReplicationType(std::borrow::Cow<'static, str>);
+    pub struct HybridReplicationType(i32);
 
     impl HybridReplicationType {
+        /// Unspecified hybrid replication type.
+        pub const HYBRID_REPLICATION_TYPE_UNSPECIFIED: HybridReplicationType =
+            HybridReplicationType::new(0);
+
+        /// Hybrid replication type for migration.
+        pub const MIGRATION: HybridReplicationType = HybridReplicationType::new(1);
+
+        /// Hybrid replication type for continuous replication.
+        pub const CONTINUOUS_REPLICATION: HybridReplicationType = HybridReplicationType::new(2);
+
         /// Creates a new HybridReplicationType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("HYBRID_REPLICATION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MIGRATION"),
+                2 => std::borrow::Cow::Borrowed("CONTINUOUS_REPLICATION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "HYBRID_REPLICATION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::HYBRID_REPLICATION_TYPE_UNSPECIFIED)
+                }
+                "MIGRATION" => std::option::Option::Some(Self::MIGRATION),
+                "CONTINUOUS_REPLICATION" => std::option::Option::Some(Self::CONTINUOUS_REPLICATION),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [HybridReplicationType](HybridReplicationType)
-    pub mod hybrid_replication_type {
-        use super::HybridReplicationType;
-
-        /// Unspecified hybrid replication type.
-        pub const HYBRID_REPLICATION_TYPE_UNSPECIFIED: HybridReplicationType =
-            HybridReplicationType::new("HYBRID_REPLICATION_TYPE_UNSPECIFIED");
-
-        /// Hybrid replication type for migration.
-        pub const MIGRATION: HybridReplicationType = HybridReplicationType::new("MIGRATION");
-
-        /// Hybrid replication type for continuous replication.
-        pub const CONTINUOUS_REPLICATION: HybridReplicationType =
-            HybridReplicationType::new("CONTINUOUS_REPLICATION");
-    }
-
-    impl std::convert::From<std::string::String> for HybridReplicationType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for HybridReplicationType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for HybridReplicationType {
         fn default() -> Self {
-            hybrid_replication_type::HYBRID_REPLICATION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5303,55 +5582,78 @@ pub mod snapshot {
 
     /// The Snapshot States
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified Snapshot State
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Snapshot State is Ready
+        pub const READY: State = State::new(1);
+
+        /// Snapshot State is Creating
+        pub const CREATING: State = State::new(2);
+
+        /// Snapshot State is Deleting
+        pub const DELETING: State = State::new(3);
+
+        /// Snapshot State is Updating
+        pub const UPDATING: State = State::new(4);
+
+        /// Snapshot State is Disabled
+        pub const DISABLED: State = State::new(5);
+
+        /// Snapshot State is Error
+        pub const ERROR: State = State::new(6);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("READY"),
+                2 => std::borrow::Cow::Borrowed("CREATING"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("UPDATING"),
+                5 => std::borrow::Cow::Borrowed("DISABLED"),
+                6 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "READY" => std::option::Option::Some(Self::READY),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified Snapshot State
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Snapshot State is Ready
-        pub const READY: State = State::new("READY");
-
-        /// Snapshot State is Creating
-        pub const CREATING: State = State::new("CREATING");
-
-        /// Snapshot State is Deleting
-        pub const DELETING: State = State::new("DELETING");
-
-        /// Snapshot State is Updating
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// Snapshot State is Disabled
-        pub const DISABLED: State = State::new("DISABLED");
-
-        /// Snapshot State is Error
-        pub const ERROR: State = State::new("ERROR");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5964,58 +6266,83 @@ pub mod storage_pool {
 
     /// The Storage Pool States
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified Storage Pool State
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Storage Pool State is Ready
+        pub const READY: State = State::new(1);
+
+        /// Storage Pool State is Creating
+        pub const CREATING: State = State::new(2);
+
+        /// Storage Pool State is Deleting
+        pub const DELETING: State = State::new(3);
+
+        /// Storage Pool State is Updating
+        pub const UPDATING: State = State::new(4);
+
+        /// Storage Pool State is Restoring
+        pub const RESTORING: State = State::new(5);
+
+        /// Storage Pool State is Disabled
+        pub const DISABLED: State = State::new(6);
+
+        /// Storage Pool State is Error
+        pub const ERROR: State = State::new(7);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("READY"),
+                2 => std::borrow::Cow::Borrowed("CREATING"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("UPDATING"),
+                5 => std::borrow::Cow::Borrowed("RESTORING"),
+                6 => std::borrow::Cow::Borrowed("DISABLED"),
+                7 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "READY" => std::option::Option::Some(Self::READY),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "RESTORING" => std::option::Option::Some(Self::RESTORING),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified Storage Pool State
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Storage Pool State is Ready
-        pub const READY: State = State::new("READY");
-
-        /// Storage Pool State is Creating
-        pub const CREATING: State = State::new("CREATING");
-
-        /// Storage Pool State is Deleting
-        pub const DELETING: State = State::new("DELETING");
-
-        /// Storage Pool State is Updating
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// Storage Pool State is Restoring
-        pub const RESTORING: State = State::new("RESTORING");
-
-        /// Storage Pool State is Disabled
-        pub const DISABLED: State = State::new("DISABLED");
-
-        /// Storage Pool State is Error
-        pub const ERROR: State = State::new("ERROR");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6900,66 +7227,95 @@ pub mod volume {
 
     /// The volume states
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified Volume State
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Volume State is Ready
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(1);
 
         /// Volume State is Creating
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(2);
 
         /// Volume State is Deleting
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(3);
 
         /// Volume State is Updating
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(4);
 
         /// Volume State is Restoring
-        pub const RESTORING: State = State::new("RESTORING");
+        pub const RESTORING: State = State::new(5);
 
         /// Volume State is Disabled
-        pub const DISABLED: State = State::new("DISABLED");
+        pub const DISABLED: State = State::new(6);
 
         /// Volume State is Error
-        pub const ERROR: State = State::new("ERROR");
+        pub const ERROR: State = State::new(7);
 
         /// Volume State is Preparing. Note that this is different from CREATING
         /// where CREATING means the volume is being created, while PREPARING means
         /// the volume is created and now being prepared for the replication.
-        pub const PREPARING: State = State::new("PREPARING");
+        pub const PREPARING: State = State::new(8);
 
         /// Volume State is Read Only
-        pub const READ_ONLY: State = State::new("READ_ONLY");
+        pub const READ_ONLY: State = State::new(9);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("READY"),
+                2 => std::borrow::Cow::Borrowed("CREATING"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("UPDATING"),
+                5 => std::borrow::Cow::Borrowed("RESTORING"),
+                6 => std::borrow::Cow::Borrowed("DISABLED"),
+                7 => std::borrow::Cow::Borrowed("ERROR"),
+                8 => std::borrow::Cow::Borrowed("PREPARING"),
+                9 => std::borrow::Cow::Borrowed("READ_ONLY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "READY" => std::option::Option::Some(Self::READY),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "RESTORING" => std::option::Option::Some(Self::RESTORING),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "PREPARING" => std::option::Option::Some(Self::PREPARING),
+                "READ_ONLY" => std::option::Option::Some(Self::READ_ONLY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7799,44 +8155,61 @@ pub mod tiering_policy {
 
     /// Tier action for the volume.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TierAction(std::borrow::Cow<'static, str>);
+    pub struct TierAction(i32);
 
     impl TierAction {
-        /// Creates a new TierAction instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [TierAction](TierAction)
-    pub mod tier_action {
-        use super::TierAction;
-
         /// Unspecified.
-        pub const TIER_ACTION_UNSPECIFIED: TierAction = TierAction::new("TIER_ACTION_UNSPECIFIED");
+        pub const TIER_ACTION_UNSPECIFIED: TierAction = TierAction::new(0);
 
         /// When tiering is enabled, new cold data will be tiered.
-        pub const ENABLED: TierAction = TierAction::new("ENABLED");
+        pub const ENABLED: TierAction = TierAction::new(1);
 
         /// When paused, tiering won't be performed on new data. Existing data stays
         /// tiered until accessed.
-        pub const PAUSED: TierAction = TierAction::new("PAUSED");
+        pub const PAUSED: TierAction = TierAction::new(2);
+
+        /// Creates a new TierAction instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TIER_ACTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENABLED"),
+                2 => std::borrow::Cow::Borrowed("PAUSED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TIER_ACTION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::TIER_ACTION_UNSPECIFIED)
+                }
+                "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                "PAUSED" => std::option::Option::Some(Self::PAUSED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for TierAction {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TierAction {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TierAction {
         fn default() -> Self {
-            tier_action::TIER_ACTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7966,415 +8339,572 @@ impl wkt::message::Message for HybridReplicationParameters {
 
 /// The service level of a storage pool and its volumes.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ServiceLevel(std::borrow::Cow<'static, str>);
+pub struct ServiceLevel(i32);
 
 impl ServiceLevel {
+    /// Unspecified service level.
+    pub const SERVICE_LEVEL_UNSPECIFIED: ServiceLevel = ServiceLevel::new(0);
+
+    /// Premium service level.
+    pub const PREMIUM: ServiceLevel = ServiceLevel::new(1);
+
+    /// Extreme service level.
+    pub const EXTREME: ServiceLevel = ServiceLevel::new(2);
+
+    /// Standard service level.
+    pub const STANDARD: ServiceLevel = ServiceLevel::new(3);
+
+    /// Flex service level.
+    pub const FLEX: ServiceLevel = ServiceLevel::new(4);
+
     /// Creates a new ServiceLevel instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SERVICE_LEVEL_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PREMIUM"),
+            2 => std::borrow::Cow::Borrowed("EXTREME"),
+            3 => std::borrow::Cow::Borrowed("STANDARD"),
+            4 => std::borrow::Cow::Borrowed("FLEX"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SERVICE_LEVEL_UNSPECIFIED" => {
+                std::option::Option::Some(Self::SERVICE_LEVEL_UNSPECIFIED)
+            }
+            "PREMIUM" => std::option::Option::Some(Self::PREMIUM),
+            "EXTREME" => std::option::Option::Some(Self::EXTREME),
+            "STANDARD" => std::option::Option::Some(Self::STANDARD),
+            "FLEX" => std::option::Option::Some(Self::FLEX),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [ServiceLevel](ServiceLevel)
-pub mod service_level {
-    use super::ServiceLevel;
-
-    /// Unspecified service level.
-    pub const SERVICE_LEVEL_UNSPECIFIED: ServiceLevel =
-        ServiceLevel::new("SERVICE_LEVEL_UNSPECIFIED");
-
-    /// Premium service level.
-    pub const PREMIUM: ServiceLevel = ServiceLevel::new("PREMIUM");
-
-    /// Extreme service level.
-    pub const EXTREME: ServiceLevel = ServiceLevel::new("EXTREME");
-
-    /// Standard service level.
-    pub const STANDARD: ServiceLevel = ServiceLevel::new("STANDARD");
-
-    /// Flex service level.
-    pub const FLEX: ServiceLevel = ServiceLevel::new("FLEX");
-}
-
-impl std::convert::From<std::string::String> for ServiceLevel {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ServiceLevel {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ServiceLevel {
     fn default() -> Self {
-        service_level::SERVICE_LEVEL_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Flex Storage Pool performance.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct FlexPerformance(std::borrow::Cow<'static, str>);
+pub struct FlexPerformance(i32);
 
 impl FlexPerformance {
+    /// Unspecified flex performance.
+    pub const FLEX_PERFORMANCE_UNSPECIFIED: FlexPerformance = FlexPerformance::new(0);
+
+    /// Flex Storage Pool with default performance.
+    pub const FLEX_PERFORMANCE_DEFAULT: FlexPerformance = FlexPerformance::new(1);
+
+    /// Flex Storage Pool with custom performance.
+    pub const FLEX_PERFORMANCE_CUSTOM: FlexPerformance = FlexPerformance::new(2);
+
     /// Creates a new FlexPerformance instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("FLEX_PERFORMANCE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("FLEX_PERFORMANCE_DEFAULT"),
+            2 => std::borrow::Cow::Borrowed("FLEX_PERFORMANCE_CUSTOM"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "FLEX_PERFORMANCE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::FLEX_PERFORMANCE_UNSPECIFIED)
+            }
+            "FLEX_PERFORMANCE_DEFAULT" => std::option::Option::Some(Self::FLEX_PERFORMANCE_DEFAULT),
+            "FLEX_PERFORMANCE_CUSTOM" => std::option::Option::Some(Self::FLEX_PERFORMANCE_CUSTOM),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [FlexPerformance](FlexPerformance)
-pub mod flex_performance {
-    use super::FlexPerformance;
-
-    /// Unspecified flex performance.
-    pub const FLEX_PERFORMANCE_UNSPECIFIED: FlexPerformance =
-        FlexPerformance::new("FLEX_PERFORMANCE_UNSPECIFIED");
-
-    /// Flex Storage Pool with default performance.
-    pub const FLEX_PERFORMANCE_DEFAULT: FlexPerformance =
-        FlexPerformance::new("FLEX_PERFORMANCE_DEFAULT");
-
-    /// Flex Storage Pool with custom performance.
-    pub const FLEX_PERFORMANCE_CUSTOM: FlexPerformance =
-        FlexPerformance::new("FLEX_PERFORMANCE_CUSTOM");
-}
-
-impl std::convert::From<std::string::String> for FlexPerformance {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for FlexPerformance {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for FlexPerformance {
     fn default() -> Self {
-        flex_performance::FLEX_PERFORMANCE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The volume encryption key source.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EncryptionType(std::borrow::Cow<'static, str>);
+pub struct EncryptionType(i32);
 
 impl EncryptionType {
+    /// The source of the encryption key is not specified.
+    pub const ENCRYPTION_TYPE_UNSPECIFIED: EncryptionType = EncryptionType::new(0);
+
+    /// Google managed encryption key.
+    pub const SERVICE_MANAGED: EncryptionType = EncryptionType::new(1);
+
+    /// Customer managed encryption key, which is stored in KMS.
+    pub const CLOUD_KMS: EncryptionType = EncryptionType::new(2);
+
     /// Creates a new EncryptionType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ENCRYPTION_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SERVICE_MANAGED"),
+            2 => std::borrow::Cow::Borrowed("CLOUD_KMS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ENCRYPTION_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::ENCRYPTION_TYPE_UNSPECIFIED)
+            }
+            "SERVICE_MANAGED" => std::option::Option::Some(Self::SERVICE_MANAGED),
+            "CLOUD_KMS" => std::option::Option::Some(Self::CLOUD_KMS),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [EncryptionType](EncryptionType)
-pub mod encryption_type {
-    use super::EncryptionType;
-
-    /// The source of the encryption key is not specified.
-    pub const ENCRYPTION_TYPE_UNSPECIFIED: EncryptionType =
-        EncryptionType::new("ENCRYPTION_TYPE_UNSPECIFIED");
-
-    /// Google managed encryption key.
-    pub const SERVICE_MANAGED: EncryptionType = EncryptionType::new("SERVICE_MANAGED");
-
-    /// Customer managed encryption key, which is stored in KMS.
-    pub const CLOUD_KMS: EncryptionType = EncryptionType::new("CLOUD_KMS");
-}
-
-impl std::convert::From<std::string::String> for EncryptionType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for EncryptionType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for EncryptionType {
     fn default() -> Self {
-        encryption_type::ENCRYPTION_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Type of directory service
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DirectoryServiceType(std::borrow::Cow<'static, str>);
+pub struct DirectoryServiceType(i32);
 
 impl DirectoryServiceType {
+    /// Directory service type is not specified.
+    pub const DIRECTORY_SERVICE_TYPE_UNSPECIFIED: DirectoryServiceType =
+        DirectoryServiceType::new(0);
+
+    /// Active directory policy attached to the storage pool.
+    pub const ACTIVE_DIRECTORY: DirectoryServiceType = DirectoryServiceType::new(1);
+
     /// Creates a new DirectoryServiceType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DIRECTORY_SERVICE_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ACTIVE_DIRECTORY"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DIRECTORY_SERVICE_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::DIRECTORY_SERVICE_TYPE_UNSPECIFIED)
+            }
+            "ACTIVE_DIRECTORY" => std::option::Option::Some(Self::ACTIVE_DIRECTORY),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [DirectoryServiceType](DirectoryServiceType)
-pub mod directory_service_type {
-    use super::DirectoryServiceType;
-
-    /// Directory service type is not specified.
-    pub const DIRECTORY_SERVICE_TYPE_UNSPECIFIED: DirectoryServiceType =
-        DirectoryServiceType::new("DIRECTORY_SERVICE_TYPE_UNSPECIFIED");
-
-    /// Active directory policy attached to the storage pool.
-    pub const ACTIVE_DIRECTORY: DirectoryServiceType =
-        DirectoryServiceType::new("ACTIVE_DIRECTORY");
-}
-
-impl std::convert::From<std::string::String> for DirectoryServiceType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DirectoryServiceType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DirectoryServiceType {
     fn default() -> Self {
-        directory_service_type::DIRECTORY_SERVICE_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Protocols is an enum of all the supported network protocols for a volume.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Protocols(std::borrow::Cow<'static, str>);
+pub struct Protocols(i32);
 
 impl Protocols {
+    /// Unspecified protocol
+    pub const PROTOCOLS_UNSPECIFIED: Protocols = Protocols::new(0);
+
+    /// NFS V3 protocol
+    pub const NFSV3: Protocols = Protocols::new(1);
+
+    /// NFS V4 protocol
+    pub const NFSV4: Protocols = Protocols::new(2);
+
+    /// SMB protocol
+    pub const SMB: Protocols = Protocols::new(3);
+
     /// Creates a new Protocols instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("PROTOCOLS_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("NFSV3"),
+            2 => std::borrow::Cow::Borrowed("NFSV4"),
+            3 => std::borrow::Cow::Borrowed("SMB"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "PROTOCOLS_UNSPECIFIED" => std::option::Option::Some(Self::PROTOCOLS_UNSPECIFIED),
+            "NFSV3" => std::option::Option::Some(Self::NFSV3),
+            "NFSV4" => std::option::Option::Some(Self::NFSV4),
+            "SMB" => std::option::Option::Some(Self::SMB),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [Protocols](Protocols)
-pub mod protocols {
-    use super::Protocols;
-
-    /// Unspecified protocol
-    pub const PROTOCOLS_UNSPECIFIED: Protocols = Protocols::new("PROTOCOLS_UNSPECIFIED");
-
-    /// NFS V3 protocol
-    pub const NFSV3: Protocols = Protocols::new("NFSV3");
-
-    /// NFS V4 protocol
-    pub const NFSV4: Protocols = Protocols::new("NFSV4");
-
-    /// SMB protocol
-    pub const SMB: Protocols = Protocols::new("SMB");
-}
-
-impl std::convert::From<std::string::String> for Protocols {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Protocols {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Protocols {
     fn default() -> Self {
-        protocols::PROTOCOLS_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// AccessType is an enum of all the supported access types for a volume.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AccessType(std::borrow::Cow<'static, str>);
+pub struct AccessType(i32);
 
 impl AccessType {
+    /// Unspecified Access Type
+    pub const ACCESS_TYPE_UNSPECIFIED: AccessType = AccessType::new(0);
+
+    /// Read Only
+    pub const READ_ONLY: AccessType = AccessType::new(1);
+
+    /// Read Write
+    pub const READ_WRITE: AccessType = AccessType::new(2);
+
+    /// None
+    pub const READ_NONE: AccessType = AccessType::new(3);
+
     /// Creates a new AccessType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ACCESS_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("READ_ONLY"),
+            2 => std::borrow::Cow::Borrowed("READ_WRITE"),
+            3 => std::borrow::Cow::Borrowed("READ_NONE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ACCESS_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::ACCESS_TYPE_UNSPECIFIED),
+            "READ_ONLY" => std::option::Option::Some(Self::READ_ONLY),
+            "READ_WRITE" => std::option::Option::Some(Self::READ_WRITE),
+            "READ_NONE" => std::option::Option::Some(Self::READ_NONE),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [AccessType](AccessType)
-pub mod access_type {
-    use super::AccessType;
-
-    /// Unspecified Access Type
-    pub const ACCESS_TYPE_UNSPECIFIED: AccessType = AccessType::new("ACCESS_TYPE_UNSPECIFIED");
-
-    /// Read Only
-    pub const READ_ONLY: AccessType = AccessType::new("READ_ONLY");
-
-    /// Read Write
-    pub const READ_WRITE: AccessType = AccessType::new("READ_WRITE");
-
-    /// None
-    pub const READ_NONE: AccessType = AccessType::new("READ_NONE");
-}
-
-impl std::convert::From<std::string::String> for AccessType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for AccessType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for AccessType {
     fn default() -> Self {
-        access_type::ACCESS_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// SMBSettings
 /// Modifies the behaviour of a SMB volume.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SMBSettings(std::borrow::Cow<'static, str>);
+pub struct SMBSettings(i32);
 
 impl SMBSettings {
+    /// Unspecified default option
+    pub const SMB_SETTINGS_UNSPECIFIED: SMBSettings = SMBSettings::new(0);
+
+    /// SMB setting encrypt data
+    pub const ENCRYPT_DATA: SMBSettings = SMBSettings::new(1);
+
+    /// SMB setting browsable
+    pub const BROWSABLE: SMBSettings = SMBSettings::new(2);
+
+    /// SMB setting notify change
+    pub const CHANGE_NOTIFY: SMBSettings = SMBSettings::new(3);
+
+    /// SMB setting not to notify change
+    pub const NON_BROWSABLE: SMBSettings = SMBSettings::new(4);
+
+    /// SMB setting oplocks
+    pub const OPLOCKS: SMBSettings = SMBSettings::new(5);
+
+    /// SMB setting to show snapshots
+    pub const SHOW_SNAPSHOT: SMBSettings = SMBSettings::new(6);
+
+    /// SMB setting to show previous versions
+    pub const SHOW_PREVIOUS_VERSIONS: SMBSettings = SMBSettings::new(7);
+
+    /// SMB setting to access volume based on enumerartion
+    pub const ACCESS_BASED_ENUMERATION: SMBSettings = SMBSettings::new(8);
+
+    /// Continuously available enumeration
+    pub const CONTINUOUSLY_AVAILABLE: SMBSettings = SMBSettings::new(9);
+
     /// Creates a new SMBSettings instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SMB_SETTINGS_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ENCRYPT_DATA"),
+            2 => std::borrow::Cow::Borrowed("BROWSABLE"),
+            3 => std::borrow::Cow::Borrowed("CHANGE_NOTIFY"),
+            4 => std::borrow::Cow::Borrowed("NON_BROWSABLE"),
+            5 => std::borrow::Cow::Borrowed("OPLOCKS"),
+            6 => std::borrow::Cow::Borrowed("SHOW_SNAPSHOT"),
+            7 => std::borrow::Cow::Borrowed("SHOW_PREVIOUS_VERSIONS"),
+            8 => std::borrow::Cow::Borrowed("ACCESS_BASED_ENUMERATION"),
+            9 => std::borrow::Cow::Borrowed("CONTINUOUSLY_AVAILABLE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SMB_SETTINGS_UNSPECIFIED" => std::option::Option::Some(Self::SMB_SETTINGS_UNSPECIFIED),
+            "ENCRYPT_DATA" => std::option::Option::Some(Self::ENCRYPT_DATA),
+            "BROWSABLE" => std::option::Option::Some(Self::BROWSABLE),
+            "CHANGE_NOTIFY" => std::option::Option::Some(Self::CHANGE_NOTIFY),
+            "NON_BROWSABLE" => std::option::Option::Some(Self::NON_BROWSABLE),
+            "OPLOCKS" => std::option::Option::Some(Self::OPLOCKS),
+            "SHOW_SNAPSHOT" => std::option::Option::Some(Self::SHOW_SNAPSHOT),
+            "SHOW_PREVIOUS_VERSIONS" => std::option::Option::Some(Self::SHOW_PREVIOUS_VERSIONS),
+            "ACCESS_BASED_ENUMERATION" => std::option::Option::Some(Self::ACCESS_BASED_ENUMERATION),
+            "CONTINUOUSLY_AVAILABLE" => std::option::Option::Some(Self::CONTINUOUSLY_AVAILABLE),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [SMBSettings](SMBSettings)
-pub mod smb_settings {
-    use super::SMBSettings;
-
-    /// Unspecified default option
-    pub const SMB_SETTINGS_UNSPECIFIED: SMBSettings = SMBSettings::new("SMB_SETTINGS_UNSPECIFIED");
-
-    /// SMB setting encrypt data
-    pub const ENCRYPT_DATA: SMBSettings = SMBSettings::new("ENCRYPT_DATA");
-
-    /// SMB setting browsable
-    pub const BROWSABLE: SMBSettings = SMBSettings::new("BROWSABLE");
-
-    /// SMB setting notify change
-    pub const CHANGE_NOTIFY: SMBSettings = SMBSettings::new("CHANGE_NOTIFY");
-
-    /// SMB setting not to notify change
-    pub const NON_BROWSABLE: SMBSettings = SMBSettings::new("NON_BROWSABLE");
-
-    /// SMB setting oplocks
-    pub const OPLOCKS: SMBSettings = SMBSettings::new("OPLOCKS");
-
-    /// SMB setting to show snapshots
-    pub const SHOW_SNAPSHOT: SMBSettings = SMBSettings::new("SHOW_SNAPSHOT");
-
-    /// SMB setting to show previous versions
-    pub const SHOW_PREVIOUS_VERSIONS: SMBSettings = SMBSettings::new("SHOW_PREVIOUS_VERSIONS");
-
-    /// SMB setting to access volume based on enumerartion
-    pub const ACCESS_BASED_ENUMERATION: SMBSettings = SMBSettings::new("ACCESS_BASED_ENUMERATION");
-
-    /// Continuously available enumeration
-    pub const CONTINUOUSLY_AVAILABLE: SMBSettings = SMBSettings::new("CONTINUOUSLY_AVAILABLE");
-}
-
-impl std::convert::From<std::string::String> for SMBSettings {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SMBSettings {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SMBSettings {
     fn default() -> Self {
-        smb_settings::SMB_SETTINGS_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The security style of the volume, can be either UNIX or NTFS.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SecurityStyle(std::borrow::Cow<'static, str>);
+pub struct SecurityStyle(i32);
 
 impl SecurityStyle {
+    /// SecurityStyle is unspecified
+    pub const SECURITY_STYLE_UNSPECIFIED: SecurityStyle = SecurityStyle::new(0);
+
+    /// SecurityStyle uses NTFS
+    pub const NTFS: SecurityStyle = SecurityStyle::new(1);
+
+    /// SecurityStyle uses UNIX
+    pub const UNIX: SecurityStyle = SecurityStyle::new(2);
+
     /// Creates a new SecurityStyle instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SECURITY_STYLE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("NTFS"),
+            2 => std::borrow::Cow::Borrowed("UNIX"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SECURITY_STYLE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::SECURITY_STYLE_UNSPECIFIED)
+            }
+            "NTFS" => std::option::Option::Some(Self::NTFS),
+            "UNIX" => std::option::Option::Some(Self::UNIX),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [SecurityStyle](SecurityStyle)
-pub mod security_style {
-    use super::SecurityStyle;
-
-    /// SecurityStyle is unspecified
-    pub const SECURITY_STYLE_UNSPECIFIED: SecurityStyle =
-        SecurityStyle::new("SECURITY_STYLE_UNSPECIFIED");
-
-    /// SecurityStyle uses NTFS
-    pub const NTFS: SecurityStyle = SecurityStyle::new("NTFS");
-
-    /// SecurityStyle uses UNIX
-    pub const UNIX: SecurityStyle = SecurityStyle::new("UNIX");
-}
-
-impl std::convert::From<std::string::String> for SecurityStyle {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SecurityStyle {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SecurityStyle {
     fn default() -> Self {
-        security_style::SECURITY_STYLE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Actions to be restricted for a volume.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RestrictedAction(std::borrow::Cow<'static, str>);
+pub struct RestrictedAction(i32);
 
 impl RestrictedAction {
+    /// Unspecified restricted action
+    pub const RESTRICTED_ACTION_UNSPECIFIED: RestrictedAction = RestrictedAction::new(0);
+
+    /// Prevent volume from being deleted when mounted.
+    pub const DELETE: RestrictedAction = RestrictedAction::new(1);
+
     /// Creates a new RestrictedAction instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("RESTRICTED_ACTION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("DELETE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "RESTRICTED_ACTION_UNSPECIFIED" => {
+                std::option::Option::Some(Self::RESTRICTED_ACTION_UNSPECIFIED)
+            }
+            "DELETE" => std::option::Option::Some(Self::DELETE),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [RestrictedAction](RestrictedAction)
-pub mod restricted_action {
-    use super::RestrictedAction;
-
-    /// Unspecified restricted action
-    pub const RESTRICTED_ACTION_UNSPECIFIED: RestrictedAction =
-        RestrictedAction::new("RESTRICTED_ACTION_UNSPECIFIED");
-
-    /// Prevent volume from being deleted when mounted.
-    pub const DELETE: RestrictedAction = RestrictedAction::new("DELETE");
-}
-
-impl std::convert::From<std::string::String> for RestrictedAction {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for RestrictedAction {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for RestrictedAction {
     fn default() -> Self {
-        restricted_action::RESTRICTED_ACTION_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/netapp/v1/src/transport.rs
+++ b/src/generated/cloud/netapp/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::NetApp for NetApp {
                 reqwest::Method::GET,
                 format!("/v1/{}/storagePools", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -78,7 +78,7 @@ impl crate::stubs::NetApp for NetApp {
                 reqwest::Method::POST,
                 format!("/v1/{}/storagePools", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -98,7 +98,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -126,7 +126,7 @@ impl crate::stubs::NetApp for NetApp {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -155,7 +155,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -177,7 +177,7 @@ impl crate::stubs::NetApp for NetApp {
                 reqwest::Method::POST,
                 format!("/v1/{}:validateDirectoryService", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -194,7 +194,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:switch", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -211,7 +211,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/volumes", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -234,7 +234,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -253,7 +253,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/volumes", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -280,7 +280,7 @@ impl crate::stubs::NetApp for NetApp {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -307,7 +307,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -327,7 +327,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:revert", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -347,7 +347,7 @@ impl crate::stubs::NetApp for NetApp {
                 reqwest::Method::GET,
                 format!("/v1/{}/snapshots", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -370,7 +370,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -392,7 +392,7 @@ impl crate::stubs::NetApp for NetApp {
                 reqwest::Method::POST,
                 format!("/v1/{}/snapshots", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -412,7 +412,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -440,7 +440,7 @@ impl crate::stubs::NetApp for NetApp {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -472,7 +472,7 @@ impl crate::stubs::NetApp for NetApp {
                 reqwest::Method::GET,
                 format!("/v1/{}/activeDirectories", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -495,7 +495,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -517,7 +517,7 @@ impl crate::stubs::NetApp for NetApp {
                 reqwest::Method::POST,
                 format!("/v1/{}/activeDirectories", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -546,7 +546,7 @@ impl crate::stubs::NetApp for NetApp {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -575,7 +575,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -597,7 +597,7 @@ impl crate::stubs::NetApp for NetApp {
                 reqwest::Method::GET,
                 format!("/v1/{}/kmsConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -623,7 +623,7 @@ impl crate::stubs::NetApp for NetApp {
                 reqwest::Method::POST,
                 format!("/v1/{}/kmsConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -643,7 +643,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -671,7 +671,7 @@ impl crate::stubs::NetApp for NetApp {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -700,7 +700,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:encrypt", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -717,7 +717,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:verify", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -734,7 +734,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -756,7 +756,7 @@ impl crate::stubs::NetApp for NetApp {
                 reqwest::Method::GET,
                 format!("/v1/{}/replications", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -779,7 +779,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -801,7 +801,7 @@ impl crate::stubs::NetApp for NetApp {
                 reqwest::Method::POST,
                 format!("/v1/{}/replications", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -821,7 +821,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -849,7 +849,7 @@ impl crate::stubs::NetApp for NetApp {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -878,7 +878,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:stop", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -895,7 +895,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:resume", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -915,7 +915,7 @@ impl crate::stubs::NetApp for NetApp {
                 reqwest::Method::POST,
                 format!("/v1/{}:reverseDirection", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -935,7 +935,7 @@ impl crate::stubs::NetApp for NetApp {
                 reqwest::Method::POST,
                 format!("/v1/{}:establishPeering", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -952,7 +952,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:sync", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -972,7 +972,7 @@ impl crate::stubs::NetApp for NetApp {
                 reqwest::Method::POST,
                 format!("/v1/{}/backupVaults", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -992,7 +992,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1014,7 +1014,7 @@ impl crate::stubs::NetApp for NetApp {
                 reqwest::Method::GET,
                 format!("/v1/{}/backupVaults", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1046,7 +1046,7 @@ impl crate::stubs::NetApp for NetApp {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1075,7 +1075,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1094,7 +1094,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/backups", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1112,7 +1112,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1131,7 +1131,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/backups", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1154,7 +1154,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1182,7 +1182,7 @@ impl crate::stubs::NetApp for NetApp {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1212,7 +1212,7 @@ impl crate::stubs::NetApp for NetApp {
                 reqwest::Method::POST,
                 format!("/v1/{}/backupPolicies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1232,7 +1232,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1254,7 +1254,7 @@ impl crate::stubs::NetApp for NetApp {
                 reqwest::Method::GET,
                 format!("/v1/{}/backupPolicies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1286,7 +1286,7 @@ impl crate::stubs::NetApp for NetApp {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1315,7 +1315,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1337,7 +1337,7 @@ impl crate::stubs::NetApp for NetApp {
                 reqwest::Method::GET,
                 format!("/v1/{}/quotaRules", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1360,7 +1360,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1382,7 +1382,7 @@ impl crate::stubs::NetApp for NetApp {
                 reqwest::Method::POST,
                 format!("/v1/{}/quotaRules", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1411,7 +1411,7 @@ impl crate::stubs::NetApp for NetApp {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1440,7 +1440,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1459,7 +1459,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1481,7 +1481,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1500,7 +1500,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1522,7 +1522,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1541,7 +1541,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1560,7 +1560,7 @@ impl crate::stubs::NetApp for NetApp {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/networkconnectivity/v1/src/model.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/model.rs
@@ -696,50 +696,69 @@ pub mod spoke {
 
         /// The Code enum represents the various reasons a state can be `INACTIVE`.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Code(std::borrow::Cow<'static, str>);
+        pub struct Code(i32);
 
         impl Code {
-            /// Creates a new Code instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [Code](Code)
-        pub mod code {
-            use super::Code;
-
             /// No information available.
-            pub const CODE_UNSPECIFIED: Code = Code::new("CODE_UNSPECIFIED");
+            pub const CODE_UNSPECIFIED: Code = Code::new(0);
 
             /// The proposed spoke is pending review.
-            pub const PENDING_REVIEW: Code = Code::new("PENDING_REVIEW");
+            pub const PENDING_REVIEW: Code = Code::new(1);
 
             /// The proposed spoke has been rejected by the hub administrator.
-            pub const REJECTED: Code = Code::new("REJECTED");
+            pub const REJECTED: Code = Code::new(2);
 
             /// The spoke has been deactivated internally.
-            pub const PAUSED: Code = Code::new("PAUSED");
+            pub const PAUSED: Code = Code::new(3);
 
             /// Network Connectivity Center encountered errors while accepting
             /// the spoke.
-            pub const FAILED: Code = Code::new("FAILED");
+            pub const FAILED: Code = Code::new(4);
+
+            /// Creates a new Code instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("CODE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("PENDING_REVIEW"),
+                    2 => std::borrow::Cow::Borrowed("REJECTED"),
+                    3 => std::borrow::Cow::Borrowed("PAUSED"),
+                    4 => std::borrow::Cow::Borrowed("FAILED"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "CODE_UNSPECIFIED" => std::option::Option::Some(Self::CODE_UNSPECIFIED),
+                    "PENDING_REVIEW" => std::option::Option::Some(Self::PENDING_REVIEW),
+                    "REJECTED" => std::option::Option::Some(Self::REJECTED),
+                    "PAUSED" => std::option::Option::Some(Self::PAUSED),
+                    "FAILED" => std::option::Option::Some(Self::FAILED),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for Code {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Code {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Code {
             fn default() -> Self {
-                code::CODE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -1759,47 +1778,62 @@ pub mod list_hub_spokes_request {
 
     /// Enum that controls which spoke fields are included in the response.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SpokeView(std::borrow::Cow<'static, str>);
+    pub struct SpokeView(i32);
 
     impl SpokeView {
-        /// Creates a new SpokeView instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [SpokeView](SpokeView)
-    pub mod spoke_view {
-        use super::SpokeView;
-
         /// The spoke view is unspecified. When the spoke view is unspecified, the
         /// API returns the same fields as the `BASIC` view.
-        pub const SPOKE_VIEW_UNSPECIFIED: SpokeView = SpokeView::new("SPOKE_VIEW_UNSPECIFIED");
+        pub const SPOKE_VIEW_UNSPECIFIED: SpokeView = SpokeView::new(0);
 
         /// Includes `name`, `create_time`, `hub`, `unique_id`, `state`, `reasons`,
         /// and `spoke_type`. This is the default value.
-        pub const BASIC: SpokeView = SpokeView::new("BASIC");
+        pub const BASIC: SpokeView = SpokeView::new(1);
 
         /// Includes all spoke fields except `labels`.
         /// You can use the `DETAILED` view only when you set the `spoke_locations`
         /// field to `[global]`.
-        pub const DETAILED: SpokeView = SpokeView::new("DETAILED");
+        pub const DETAILED: SpokeView = SpokeView::new(2);
+
+        /// Creates a new SpokeView instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SPOKE_VIEW_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BASIC"),
+                2 => std::borrow::Cow::Borrowed("DETAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SPOKE_VIEW_UNSPECIFIED" => std::option::Option::Some(Self::SPOKE_VIEW_UNSPECIFIED),
+                "BASIC" => std::option::Option::Some(Self::BASIC),
+                "DETAILED" => std::option::Option::Some(Self::DETAILED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for SpokeView {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SpokeView {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SpokeView {
         fn default() -> Self {
-            spoke_view::SPOKE_VIEW_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2214,67 +2248,98 @@ pub mod psc_propagation_status {
     /// The Code enum represents the state of the Private Service Connect
     /// propagation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Code(std::borrow::Cow<'static, str>);
+    pub struct Code(i32);
 
     impl Code {
-        /// Creates a new Code instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Code](Code)
-    pub mod code {
-        use super::Code;
-
         /// The code is unspecified.
-        pub const CODE_UNSPECIFIED: Code = Code::new("CODE_UNSPECIFIED");
+        pub const CODE_UNSPECIFIED: Code = Code::new(0);
 
         /// The propagated Private Service Connect connection is ready.
-        pub const READY: Code = Code::new("READY");
+        pub const READY: Code = Code::new(1);
 
         /// The Private Service Connect connection is propagating. This is a
         /// transient state.
-        pub const PROPAGATING: Code = Code::new("PROPAGATING");
+        pub const PROPAGATING: Code = Code::new(2);
 
         /// The Private Service Connect connection propagation failed because the VPC
         /// network or the project of the target spoke has exceeded the connection
         /// limit set by the producer.
-        pub const ERROR_PRODUCER_PROPAGATED_CONNECTION_LIMIT_EXCEEDED: Code =
-            Code::new("ERROR_PRODUCER_PROPAGATED_CONNECTION_LIMIT_EXCEEDED");
+        pub const ERROR_PRODUCER_PROPAGATED_CONNECTION_LIMIT_EXCEEDED: Code = Code::new(3);
 
         /// The Private Service Connect connection propagation failed because the NAT
         /// IP subnet space has been exhausted. It is equivalent to the `Needs
         /// attention` status of the Private Service Connect connection. See
         /// <https://cloud.google.com/vpc/docs/about-accessing-vpc-hosted-services-endpoints#connection-statuses>.
-        pub const ERROR_PRODUCER_NAT_IP_SPACE_EXHAUSTED: Code =
-            Code::new("ERROR_PRODUCER_NAT_IP_SPACE_EXHAUSTED");
+        pub const ERROR_PRODUCER_NAT_IP_SPACE_EXHAUSTED: Code = Code::new(4);
 
         /// The Private Service Connect connection propagation failed because the
         /// `PSC_ILB_CONSUMER_FORWARDING_RULES_PER_PRODUCER_NETWORK` quota in the
         /// producer VPC network has been exceeded.
-        pub const ERROR_PRODUCER_QUOTA_EXCEEDED: Code = Code::new("ERROR_PRODUCER_QUOTA_EXCEEDED");
+        pub const ERROR_PRODUCER_QUOTA_EXCEEDED: Code = Code::new(5);
 
         /// The Private Service Connect connection propagation failed because the
         /// `PSC_PROPAGATED_CONNECTIONS_PER_VPC_NETWORK` quota in the consumer
         /// VPC network has been exceeded.
-        pub const ERROR_CONSUMER_QUOTA_EXCEEDED: Code = Code::new("ERROR_CONSUMER_QUOTA_EXCEEDED");
+        pub const ERROR_CONSUMER_QUOTA_EXCEEDED: Code = Code::new(6);
+
+        /// Creates a new Code instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("READY"),
+                2 => std::borrow::Cow::Borrowed("PROPAGATING"),
+                3 => std::borrow::Cow::Borrowed(
+                    "ERROR_PRODUCER_PROPAGATED_CONNECTION_LIMIT_EXCEEDED",
+                ),
+                4 => std::borrow::Cow::Borrowed("ERROR_PRODUCER_NAT_IP_SPACE_EXHAUSTED"),
+                5 => std::borrow::Cow::Borrowed("ERROR_PRODUCER_QUOTA_EXCEEDED"),
+                6 => std::borrow::Cow::Borrowed("ERROR_CONSUMER_QUOTA_EXCEEDED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CODE_UNSPECIFIED" => std::option::Option::Some(Self::CODE_UNSPECIFIED),
+                "READY" => std::option::Option::Some(Self::READY),
+                "PROPAGATING" => std::option::Option::Some(Self::PROPAGATING),
+                "ERROR_PRODUCER_PROPAGATED_CONNECTION_LIMIT_EXCEEDED" => std::option::Option::Some(
+                    Self::ERROR_PRODUCER_PROPAGATED_CONNECTION_LIMIT_EXCEEDED,
+                ),
+                "ERROR_PRODUCER_NAT_IP_SPACE_EXHAUSTED" => {
+                    std::option::Option::Some(Self::ERROR_PRODUCER_NAT_IP_SPACE_EXHAUSTED)
+                }
+                "ERROR_PRODUCER_QUOTA_EXCEEDED" => {
+                    std::option::Option::Some(Self::ERROR_PRODUCER_QUOTA_EXCEEDED)
+                }
+                "ERROR_CONSUMER_QUOTA_EXCEEDED" => {
+                    std::option::Option::Some(Self::ERROR_CONSUMER_QUOTA_EXCEEDED)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Code {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Code {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Code {
         fn default() -> Self {
-            code::CODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4826,41 +4891,55 @@ pub mod policy_based_route {
 
         /// The internet protocol version.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ProtocolVersion(std::borrow::Cow<'static, str>);
+        pub struct ProtocolVersion(i32);
 
         impl ProtocolVersion {
+            /// Default value.
+            pub const PROTOCOL_VERSION_UNSPECIFIED: ProtocolVersion = ProtocolVersion::new(0);
+
+            /// The PBR is for IPv4 internet protocol traffic.
+            pub const IPV4: ProtocolVersion = ProtocolVersion::new(1);
+
             /// Creates a new ProtocolVersion instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("PROTOCOL_VERSION_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("IPV4"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "PROTOCOL_VERSION_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::PROTOCOL_VERSION_UNSPECIFIED)
+                    }
+                    "IPV4" => std::option::Option::Some(Self::IPV4),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [ProtocolVersion](ProtocolVersion)
-        pub mod protocol_version {
-            use super::ProtocolVersion;
-
-            /// Default value.
-            pub const PROTOCOL_VERSION_UNSPECIFIED: ProtocolVersion =
-                ProtocolVersion::new("PROTOCOL_VERSION_UNSPECIFIED");
-
-            /// The PBR is for IPv4 internet protocol traffic.
-            pub const IPV4: ProtocolVersion = ProtocolVersion::new("IPV4");
-        }
-
-        impl std::convert::From<std::string::String> for ProtocolVersion {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for ProtocolVersion {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for ProtocolVersion {
             fn default() -> Self {
-                protocol_version::PROTOCOL_VERSION_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -4938,90 +5017,121 @@ pub mod policy_based_route {
         /// Warning code for Policy Based Routing. Expect to add values in the
         /// future.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Code(std::borrow::Cow<'static, str>);
+        pub struct Code(i32);
 
         impl Code {
-            /// Creates a new Code instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [Code](Code)
-        pub mod code {
-            use super::Code;
-
             /// Default value.
-            pub const WARNING_UNSPECIFIED: Code = Code::new("WARNING_UNSPECIFIED");
+            pub const WARNING_UNSPECIFIED: Code = Code::new(0);
 
             /// The policy based route is not active and functioning. Common causes are
             /// the dependent network was deleted or the resource project was turned
             /// off.
-            pub const RESOURCE_NOT_ACTIVE: Code = Code::new("RESOURCE_NOT_ACTIVE");
+            pub const RESOURCE_NOT_ACTIVE: Code = Code::new(1);
 
             /// The policy based route is being modified (e.g. created/deleted) at this
             /// time.
-            pub const RESOURCE_BEING_MODIFIED: Code = Code::new("RESOURCE_BEING_MODIFIED");
+            pub const RESOURCE_BEING_MODIFIED: Code = Code::new(2);
+
+            /// Creates a new Code instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("WARNING_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("RESOURCE_NOT_ACTIVE"),
+                    2 => std::borrow::Cow::Borrowed("RESOURCE_BEING_MODIFIED"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "WARNING_UNSPECIFIED" => std::option::Option::Some(Self::WARNING_UNSPECIFIED),
+                    "RESOURCE_NOT_ACTIVE" => std::option::Option::Some(Self::RESOURCE_NOT_ACTIVE),
+                    "RESOURCE_BEING_MODIFIED" => {
+                        std::option::Option::Some(Self::RESOURCE_BEING_MODIFIED)
+                    }
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for Code {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Code {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Code {
             fn default() -> Self {
-                code::WARNING_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// The other routing cases.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OtherRoutes(std::borrow::Cow<'static, str>);
+    pub struct OtherRoutes(i32);
 
     impl OtherRoutes {
-        /// Creates a new OtherRoutes instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [OtherRoutes](OtherRoutes)
-    pub mod other_routes {
-        use super::OtherRoutes;
-
         /// Default value.
-        pub const OTHER_ROUTES_UNSPECIFIED: OtherRoutes =
-            OtherRoutes::new("OTHER_ROUTES_UNSPECIFIED");
+        pub const OTHER_ROUTES_UNSPECIFIED: OtherRoutes = OtherRoutes::new(0);
 
         /// Use the routes from the default routing tables (system-generated routes,
         /// custom routes, peering route) to determine the next hop. This will
         /// effectively exclude matching packets being applied on other PBRs with a
         /// lower priority.
-        pub const DEFAULT_ROUTING: OtherRoutes = OtherRoutes::new("DEFAULT_ROUTING");
+        pub const DEFAULT_ROUTING: OtherRoutes = OtherRoutes::new(1);
+
+        /// Creates a new OtherRoutes instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("OTHER_ROUTES_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DEFAULT_ROUTING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "OTHER_ROUTES_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::OTHER_ROUTES_UNSPECIFIED)
+                }
+                "DEFAULT_ROUTING" => std::option::Option::Some(Self::DEFAULT_ROUTING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for OtherRoutes {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for OtherRoutes {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for OtherRoutes {
         fn default() -> Self {
-            other_routes::OTHER_ROUTES_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -5356,293 +5466,403 @@ impl wkt::message::Message for DeletePolicyBasedRouteRequest {
 
 /// Supported features for a location
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LocationFeature(std::borrow::Cow<'static, str>);
+pub struct LocationFeature(i32);
 
 impl LocationFeature {
+    /// No publicly supported feature in this location
+    pub const LOCATION_FEATURE_UNSPECIFIED: LocationFeature = LocationFeature::new(0);
+
+    /// Site-to-cloud spokes are supported in this location
+    pub const SITE_TO_CLOUD_SPOKES: LocationFeature = LocationFeature::new(1);
+
+    /// Site-to-site spokes are supported in this location
+    pub const SITE_TO_SITE_SPOKES: LocationFeature = LocationFeature::new(2);
+
     /// Creates a new LocationFeature instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("LOCATION_FEATURE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SITE_TO_CLOUD_SPOKES"),
+            2 => std::borrow::Cow::Borrowed("SITE_TO_SITE_SPOKES"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "LOCATION_FEATURE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::LOCATION_FEATURE_UNSPECIFIED)
+            }
+            "SITE_TO_CLOUD_SPOKES" => std::option::Option::Some(Self::SITE_TO_CLOUD_SPOKES),
+            "SITE_TO_SITE_SPOKES" => std::option::Option::Some(Self::SITE_TO_SITE_SPOKES),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [LocationFeature](LocationFeature)
-pub mod location_feature {
-    use super::LocationFeature;
-
-    /// No publicly supported feature in this location
-    pub const LOCATION_FEATURE_UNSPECIFIED: LocationFeature =
-        LocationFeature::new("LOCATION_FEATURE_UNSPECIFIED");
-
-    /// Site-to-cloud spokes are supported in this location
-    pub const SITE_TO_CLOUD_SPOKES: LocationFeature = LocationFeature::new("SITE_TO_CLOUD_SPOKES");
-
-    /// Site-to-site spokes are supported in this location
-    pub const SITE_TO_SITE_SPOKES: LocationFeature = LocationFeature::new("SITE_TO_SITE_SPOKES");
-}
-
-impl std::convert::From<std::string::String> for LocationFeature {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for LocationFeature {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for LocationFeature {
     fn default() -> Self {
-        location_feature::LOCATION_FEATURE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The route's type
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RouteType(std::borrow::Cow<'static, str>);
+pub struct RouteType(i32);
 
 impl RouteType {
-    /// Creates a new RouteType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [RouteType](RouteType)
-pub mod route_type {
-    use super::RouteType;
-
     /// No route type information specified
-    pub const ROUTE_TYPE_UNSPECIFIED: RouteType = RouteType::new("ROUTE_TYPE_UNSPECIFIED");
+    pub const ROUTE_TYPE_UNSPECIFIED: RouteType = RouteType::new(0);
 
     /// The route leads to a destination within the primary address range of the
     /// VPC network's subnet.
-    pub const VPC_PRIMARY_SUBNET: RouteType = RouteType::new("VPC_PRIMARY_SUBNET");
+    pub const VPC_PRIMARY_SUBNET: RouteType = RouteType::new(1);
 
     /// The route leads to a destination within the secondary address range of the
     /// VPC network's subnet.
-    pub const VPC_SECONDARY_SUBNET: RouteType = RouteType::new("VPC_SECONDARY_SUBNET");
+    pub const VPC_SECONDARY_SUBNET: RouteType = RouteType::new(2);
 
     /// The route leads to a destination in a dynamic route. Dynamic routes are
     /// derived from Border Gateway Protocol (BGP) advertisements received from an
     /// NCC hybrid spoke.
-    pub const DYNAMIC_ROUTE: RouteType = RouteType::new("DYNAMIC_ROUTE");
+    pub const DYNAMIC_ROUTE: RouteType = RouteType::new(3);
+
+    /// Creates a new RouteType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ROUTE_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("VPC_PRIMARY_SUBNET"),
+            2 => std::borrow::Cow::Borrowed("VPC_SECONDARY_SUBNET"),
+            3 => std::borrow::Cow::Borrowed("DYNAMIC_ROUTE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ROUTE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::ROUTE_TYPE_UNSPECIFIED),
+            "VPC_PRIMARY_SUBNET" => std::option::Option::Some(Self::VPC_PRIMARY_SUBNET),
+            "VPC_SECONDARY_SUBNET" => std::option::Option::Some(Self::VPC_SECONDARY_SUBNET),
+            "DYNAMIC_ROUTE" => std::option::Option::Some(Self::DYNAMIC_ROUTE),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for RouteType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for RouteType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for RouteType {
     fn default() -> Self {
-        route_type::ROUTE_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The State enum represents the lifecycle stage of a Network Connectivity
 /// Center resource.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct State(std::borrow::Cow<'static, str>);
+pub struct State(i32);
 
 impl State {
-    /// Creates a new State instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [State](State)
-pub mod state {
-    use super::State;
-
     /// No state information available
-    pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+    pub const STATE_UNSPECIFIED: State = State::new(0);
 
     /// The resource's create operation is in progress.
-    pub const CREATING: State = State::new("CREATING");
+    pub const CREATING: State = State::new(1);
 
     /// The resource is active
-    pub const ACTIVE: State = State::new("ACTIVE");
+    pub const ACTIVE: State = State::new(2);
 
     /// The resource's delete operation is in progress.
-    pub const DELETING: State = State::new("DELETING");
+    pub const DELETING: State = State::new(3);
 
     /// The resource's accept operation is in progress.
-    pub const ACCEPTING: State = State::new("ACCEPTING");
+    pub const ACCEPTING: State = State::new(8);
 
     /// The resource's reject operation is in progress.
-    pub const REJECTING: State = State::new("REJECTING");
+    pub const REJECTING: State = State::new(9);
 
     /// The resource's update operation is in progress.
-    pub const UPDATING: State = State::new("UPDATING");
+    pub const UPDATING: State = State::new(6);
 
     /// The resource is inactive.
-    pub const INACTIVE: State = State::new("INACTIVE");
+    pub const INACTIVE: State = State::new(7);
 
     /// The hub associated with this spoke resource has been deleted.
     /// This state applies to spoke resources only.
-    pub const OBSOLETE: State = State::new("OBSOLETE");
+    pub const OBSOLETE: State = State::new(10);
+
+    /// Creates a new State instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("CREATING"),
+            2 => std::borrow::Cow::Borrowed("ACTIVE"),
+            3 => std::borrow::Cow::Borrowed("DELETING"),
+            6 => std::borrow::Cow::Borrowed("UPDATING"),
+            7 => std::borrow::Cow::Borrowed("INACTIVE"),
+            8 => std::borrow::Cow::Borrowed("ACCEPTING"),
+            9 => std::borrow::Cow::Borrowed("REJECTING"),
+            10 => std::borrow::Cow::Borrowed("OBSOLETE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+            "CREATING" => std::option::Option::Some(Self::CREATING),
+            "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+            "DELETING" => std::option::Option::Some(Self::DELETING),
+            "ACCEPTING" => std::option::Option::Some(Self::ACCEPTING),
+            "REJECTING" => std::option::Option::Some(Self::REJECTING),
+            "UPDATING" => std::option::Option::Some(Self::UPDATING),
+            "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
+            "OBSOLETE" => std::option::Option::Some(Self::OBSOLETE),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for State {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for State {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for State {
     fn default() -> Self {
-        state::STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The SpokeType enum represents the type of spoke. The type
 /// reflects the kind of resource that a spoke is associated with.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SpokeType(std::borrow::Cow<'static, str>);
+pub struct SpokeType(i32);
 
 impl SpokeType {
+    /// Unspecified spoke type.
+    pub const SPOKE_TYPE_UNSPECIFIED: SpokeType = SpokeType::new(0);
+
+    /// Spokes associated with VPN tunnels.
+    pub const VPN_TUNNEL: SpokeType = SpokeType::new(1);
+
+    /// Spokes associated with VLAN attachments.
+    pub const INTERCONNECT_ATTACHMENT: SpokeType = SpokeType::new(2);
+
+    /// Spokes associated with router appliance instances.
+    pub const ROUTER_APPLIANCE: SpokeType = SpokeType::new(3);
+
+    /// Spokes associated with VPC networks.
+    pub const VPC_NETWORK: SpokeType = SpokeType::new(4);
+
+    /// Spokes that are backed by a producer VPC network.
+    pub const PRODUCER_VPC_NETWORK: SpokeType = SpokeType::new(7);
+
     /// Creates a new SpokeType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SPOKE_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("VPN_TUNNEL"),
+            2 => std::borrow::Cow::Borrowed("INTERCONNECT_ATTACHMENT"),
+            3 => std::borrow::Cow::Borrowed("ROUTER_APPLIANCE"),
+            4 => std::borrow::Cow::Borrowed("VPC_NETWORK"),
+            7 => std::borrow::Cow::Borrowed("PRODUCER_VPC_NETWORK"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SPOKE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SPOKE_TYPE_UNSPECIFIED),
+            "VPN_TUNNEL" => std::option::Option::Some(Self::VPN_TUNNEL),
+            "INTERCONNECT_ATTACHMENT" => std::option::Option::Some(Self::INTERCONNECT_ATTACHMENT),
+            "ROUTER_APPLIANCE" => std::option::Option::Some(Self::ROUTER_APPLIANCE),
+            "VPC_NETWORK" => std::option::Option::Some(Self::VPC_NETWORK),
+            "PRODUCER_VPC_NETWORK" => std::option::Option::Some(Self::PRODUCER_VPC_NETWORK),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [SpokeType](SpokeType)
-pub mod spoke_type {
-    use super::SpokeType;
-
-    /// Unspecified spoke type.
-    pub const SPOKE_TYPE_UNSPECIFIED: SpokeType = SpokeType::new("SPOKE_TYPE_UNSPECIFIED");
-
-    /// Spokes associated with VPN tunnels.
-    pub const VPN_TUNNEL: SpokeType = SpokeType::new("VPN_TUNNEL");
-
-    /// Spokes associated with VLAN attachments.
-    pub const INTERCONNECT_ATTACHMENT: SpokeType = SpokeType::new("INTERCONNECT_ATTACHMENT");
-
-    /// Spokes associated with router appliance instances.
-    pub const ROUTER_APPLIANCE: SpokeType = SpokeType::new("ROUTER_APPLIANCE");
-
-    /// Spokes associated with VPC networks.
-    pub const VPC_NETWORK: SpokeType = SpokeType::new("VPC_NETWORK");
-
-    /// Spokes that are backed by a producer VPC network.
-    pub const PRODUCER_VPC_NETWORK: SpokeType = SpokeType::new("PRODUCER_VPC_NETWORK");
-}
-
-impl std::convert::From<std::string::String> for SpokeType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SpokeType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SpokeType {
     fn default() -> Self {
-        spoke_type::SPOKE_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// This enum controls the policy mode used in a hub.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PolicyMode(std::borrow::Cow<'static, str>);
+pub struct PolicyMode(i32);
 
 impl PolicyMode {
+    /// Policy mode is unspecified. It defaults to PRESET
+    /// with preset_topology = MESH.
+    pub const POLICY_MODE_UNSPECIFIED: PolicyMode = PolicyMode::new(0);
+
+    /// Hub uses one of the preset topologies.
+    pub const PRESET: PolicyMode = PolicyMode::new(1);
+
     /// Creates a new PolicyMode instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("POLICY_MODE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PRESET"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "POLICY_MODE_UNSPECIFIED" => std::option::Option::Some(Self::POLICY_MODE_UNSPECIFIED),
+            "PRESET" => std::option::Option::Some(Self::PRESET),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [PolicyMode](PolicyMode)
-pub mod policy_mode {
-    use super::PolicyMode;
-
-    /// Policy mode is unspecified. It defaults to PRESET
-    /// with preset_topology = MESH.
-    pub const POLICY_MODE_UNSPECIFIED: PolicyMode = PolicyMode::new("POLICY_MODE_UNSPECIFIED");
-
-    /// Hub uses one of the preset topologies.
-    pub const PRESET: PolicyMode = PolicyMode::new("PRESET");
-}
-
-impl std::convert::From<std::string::String> for PolicyMode {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for PolicyMode {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for PolicyMode {
     fn default() -> Self {
-        policy_mode::POLICY_MODE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The list of available preset topologies.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PresetTopology(std::borrow::Cow<'static, str>);
+pub struct PresetTopology(i32);
 
 impl PresetTopology {
-    /// Creates a new PresetTopology instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [PresetTopology](PresetTopology)
-pub mod preset_topology {
-    use super::PresetTopology;
-
     /// Preset topology is unspecified. When policy_mode = PRESET,
     /// it defaults to MESH.
-    pub const PRESET_TOPOLOGY_UNSPECIFIED: PresetTopology =
-        PresetTopology::new("PRESET_TOPOLOGY_UNSPECIFIED");
+    pub const PRESET_TOPOLOGY_UNSPECIFIED: PresetTopology = PresetTopology::new(0);
 
     /// Mesh topology is implemented. Group `default` is automatically created.
     /// All spokes in the hub are added to group `default`.
-    pub const MESH: PresetTopology = PresetTopology::new("MESH");
+    pub const MESH: PresetTopology = PresetTopology::new(2);
 
     /// Star topology is implemented. Two groups, `center` and `edge`, are
     /// automatically created along with hub creation. Spokes have to join one of
     /// the groups during creation.
-    pub const STAR: PresetTopology = PresetTopology::new("STAR");
+    pub const STAR: PresetTopology = PresetTopology::new(3);
+
+    /// Creates a new PresetTopology instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("PRESET_TOPOLOGY_UNSPECIFIED"),
+            2 => std::borrow::Cow::Borrowed("MESH"),
+            3 => std::borrow::Cow::Borrowed("STAR"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "PRESET_TOPOLOGY_UNSPECIFIED" => {
+                std::option::Option::Some(Self::PRESET_TOPOLOGY_UNSPECIFIED)
+            }
+            "MESH" => std::option::Option::Some(Self::MESH),
+            "STAR" => std::option::Option::Some(Self::STAR),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for PresetTopology {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for PresetTopology {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for PresetTopology {
     fn default() -> Self {
-        preset_topology::PRESET_TOPOLOGY_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/networkconnectivity/v1/src/transport.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::HubService for HubService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/hubs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::HubService for HubService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -91,7 +91,7 @@ impl crate::stubs::HubService for HubService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/hubs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -119,7 +119,7 @@ impl crate::stubs::HubService for HubService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -147,7 +147,7 @@ impl crate::stubs::HubService for HubService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -167,7 +167,7 @@ impl crate::stubs::HubService for HubService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}:listSpokes", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -197,7 +197,7 @@ impl crate::stubs::HubService for HubService {
                 reqwest::Method::GET,
                 format!("/v1/{}:queryStatus", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -221,7 +221,7 @@ impl crate::stubs::HubService for HubService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/spokes", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -244,7 +244,7 @@ impl crate::stubs::HubService for HubService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -263,7 +263,7 @@ impl crate::stubs::HubService for HubService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/spokes", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -291,7 +291,7 @@ impl crate::stubs::HubService for HubService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -322,7 +322,7 @@ impl crate::stubs::HubService for HubService {
                 reqwest::Method::POST,
                 format!("/v1/{}:rejectSpoke", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -342,7 +342,7 @@ impl crate::stubs::HubService for HubService {
                 reqwest::Method::POST,
                 format!("/v1/{}:acceptSpoke", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -359,7 +359,7 @@ impl crate::stubs::HubService for HubService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -379,7 +379,7 @@ impl crate::stubs::HubService for HubService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -398,7 +398,7 @@ impl crate::stubs::HubService for HubService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -417,7 +417,7 @@ impl crate::stubs::HubService for HubService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/routes", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -443,7 +443,7 @@ impl crate::stubs::HubService for HubService {
                 reqwest::Method::GET,
                 format!("/v1/{}/routeTables", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -466,7 +466,7 @@ impl crate::stubs::HubService for HubService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -485,7 +485,7 @@ impl crate::stubs::HubService for HubService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/groups", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -517,7 +517,7 @@ impl crate::stubs::HubService for HubService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -545,7 +545,7 @@ impl crate::stubs::HubService for HubService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -567,7 +567,7 @@ impl crate::stubs::HubService for HubService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -589,7 +589,7 @@ impl crate::stubs::HubService for HubService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -609,7 +609,7 @@ impl crate::stubs::HubService for HubService {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -641,7 +641,7 @@ impl crate::stubs::HubService for HubService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -658,7 +658,7 @@ impl crate::stubs::HubService for HubService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -680,7 +680,7 @@ impl crate::stubs::HubService for HubService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -699,7 +699,7 @@ impl crate::stubs::HubService for HubService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -718,7 +718,7 @@ impl crate::stubs::HubService for HubService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -775,7 +775,7 @@ impl crate::stubs::PolicyBasedRoutingService for PolicyBasedRoutingService {
                 reqwest::Method::GET,
                 format!("/v1/{}/policyBasedRoutes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -798,7 +798,7 @@ impl crate::stubs::PolicyBasedRoutingService for PolicyBasedRoutingService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -820,7 +820,7 @@ impl crate::stubs::PolicyBasedRoutingService for PolicyBasedRoutingService {
                 reqwest::Method::POST,
                 format!("/v1/{}/policyBasedRoutes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -841,7 +841,7 @@ impl crate::stubs::PolicyBasedRoutingService for PolicyBasedRoutingService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -861,7 +861,7 @@ impl crate::stubs::PolicyBasedRoutingService for PolicyBasedRoutingService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -883,7 +883,7 @@ impl crate::stubs::PolicyBasedRoutingService for PolicyBasedRoutingService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -905,7 +905,7 @@ impl crate::stubs::PolicyBasedRoutingService for PolicyBasedRoutingService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -925,7 +925,7 @@ impl crate::stubs::PolicyBasedRoutingService for PolicyBasedRoutingService {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -957,7 +957,7 @@ impl crate::stubs::PolicyBasedRoutingService for PolicyBasedRoutingService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -974,7 +974,7 @@ impl crate::stubs::PolicyBasedRoutingService for PolicyBasedRoutingService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -996,7 +996,7 @@ impl crate::stubs::PolicyBasedRoutingService for PolicyBasedRoutingService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1015,7 +1015,7 @@ impl crate::stubs::PolicyBasedRoutingService for PolicyBasedRoutingService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1034,7 +1034,7 @@ impl crate::stubs::PolicyBasedRoutingService for PolicyBasedRoutingService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/networkmanagement/v1/src/model.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/model.rs
@@ -650,98 +650,135 @@ pub mod endpoint {
     /// The type definition of an endpoint's network. Use one of the
     /// following choices:
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NetworkType(std::borrow::Cow<'static, str>);
+    pub struct NetworkType(i32);
 
     impl NetworkType {
-        /// Creates a new NetworkType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [NetworkType](NetworkType)
-    pub mod network_type {
-        use super::NetworkType;
-
         /// Default type if unspecified.
-        pub const NETWORK_TYPE_UNSPECIFIED: NetworkType =
-            NetworkType::new("NETWORK_TYPE_UNSPECIFIED");
+        pub const NETWORK_TYPE_UNSPECIFIED: NetworkType = NetworkType::new(0);
 
         /// A network hosted within Google Cloud.
         /// To receive more detailed output, specify the URI for the source or
         /// destination network.
-        pub const GCP_NETWORK: NetworkType = NetworkType::new("GCP_NETWORK");
+        pub const GCP_NETWORK: NetworkType = NetworkType::new(1);
 
         /// A network hosted outside of Google Cloud.
         /// This can be an on-premises network, or a network hosted by another cloud
         /// provider.
-        pub const NON_GCP_NETWORK: NetworkType = NetworkType::new("NON_GCP_NETWORK");
+        pub const NON_GCP_NETWORK: NetworkType = NetworkType::new(2);
+
+        /// Creates a new NetworkType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("NETWORK_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GCP_NETWORK"),
+                2 => std::borrow::Cow::Borrowed("NON_GCP_NETWORK"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "NETWORK_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::NETWORK_TYPE_UNSPECIFIED)
+                }
+                "GCP_NETWORK" => std::option::Option::Some(Self::GCP_NETWORK),
+                "NON_GCP_NETWORK" => std::option::Option::Some(Self::NON_GCP_NETWORK),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for NetworkType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for NetworkType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for NetworkType {
         fn default() -> Self {
-            network_type::NETWORK_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Type of the target of a forwarding rule.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ForwardingRuleTarget(std::borrow::Cow<'static, str>);
+    pub struct ForwardingRuleTarget(i32);
 
     impl ForwardingRuleTarget {
-        /// Creates a new ForwardingRuleTarget instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ForwardingRuleTarget](ForwardingRuleTarget)
-    pub mod forwarding_rule_target {
-        use super::ForwardingRuleTarget;
-
         /// Forwarding rule target is unknown.
         pub const FORWARDING_RULE_TARGET_UNSPECIFIED: ForwardingRuleTarget =
-            ForwardingRuleTarget::new("FORWARDING_RULE_TARGET_UNSPECIFIED");
+            ForwardingRuleTarget::new(0);
 
         /// Compute Engine instance for protocol forwarding.
-        pub const INSTANCE: ForwardingRuleTarget = ForwardingRuleTarget::new("INSTANCE");
+        pub const INSTANCE: ForwardingRuleTarget = ForwardingRuleTarget::new(1);
 
         /// Load Balancer. The specific type can be found from [load_balancer_type]
         /// [google.cloud.networkmanagement.v1.Endpoint.load_balancer_type].
-        pub const LOAD_BALANCER: ForwardingRuleTarget = ForwardingRuleTarget::new("LOAD_BALANCER");
+        pub const LOAD_BALANCER: ForwardingRuleTarget = ForwardingRuleTarget::new(2);
 
         /// Classic Cloud VPN Gateway.
-        pub const VPN_GATEWAY: ForwardingRuleTarget = ForwardingRuleTarget::new("VPN_GATEWAY");
+        pub const VPN_GATEWAY: ForwardingRuleTarget = ForwardingRuleTarget::new(3);
 
         /// Forwarding Rule is a Private Service Connect endpoint.
-        pub const PSC: ForwardingRuleTarget = ForwardingRuleTarget::new("PSC");
+        pub const PSC: ForwardingRuleTarget = ForwardingRuleTarget::new(4);
+
+        /// Creates a new ForwardingRuleTarget instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FORWARDING_RULE_TARGET_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INSTANCE"),
+                2 => std::borrow::Cow::Borrowed("LOAD_BALANCER"),
+                3 => std::borrow::Cow::Borrowed("VPN_GATEWAY"),
+                4 => std::borrow::Cow::Borrowed("PSC"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FORWARDING_RULE_TARGET_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::FORWARDING_RULE_TARGET_UNSPECIFIED)
+                }
+                "INSTANCE" => std::option::Option::Some(Self::INSTANCE),
+                "LOAD_BALANCER" => std::option::Option::Some(Self::LOAD_BALANCER),
+                "VPN_GATEWAY" => std::option::Option::Some(Self::VPN_GATEWAY),
+                "PSC" => std::option::Option::Some(Self::PSC),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ForwardingRuleTarget {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ForwardingRuleTarget {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ForwardingRuleTarget {
         fn default() -> Self {
-            forwarding_rule_target::FORWARDING_RULE_TARGET_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -827,26 +864,11 @@ pub mod reachability_details {
 
     /// The overall result of the test's configuration analysis.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Result(std::borrow::Cow<'static, str>);
+    pub struct Result(i32);
 
     impl Result {
-        /// Creates a new Result instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Result](Result)
-    pub mod result {
-        use super::Result;
-
         /// No result was specified.
-        pub const RESULT_UNSPECIFIED: Result = Result::new("RESULT_UNSPECIFIED");
+        pub const RESULT_UNSPECIFIED: Result = Result::new(0);
 
         /// Possible scenarios are:
         ///
@@ -855,11 +877,11 @@ pub mod reachability_details {
         /// * The analysis didn't complete because the user lacks permission for
         ///   some of the resources in the trace. However, at the time the user's
         ///   permission became insufficient, the trace had been successful so far.
-        pub const REACHABLE: Result = Result::new("REACHABLE");
+        pub const REACHABLE: Result = Result::new(1);
 
         /// A packet originating from the source is expected to be dropped before
         /// reaching the destination.
-        pub const UNREACHABLE: Result = Result::new("UNREACHABLE");
+        pub const UNREACHABLE: Result = Result::new(2);
 
         /// The source and destination endpoints do not uniquely identify
         /// the test location in the network, and the reachability result contains
@@ -867,7 +889,7 @@ pub mod reachability_details {
         /// others, it would not be. This result is also assigned to
         /// configuration analysis of return path if on its own it should be
         /// REACHABLE, but configuration analysis of forward path is AMBIGUOUS.
-        pub const AMBIGUOUS: Result = Result::new("AMBIGUOUS");
+        pub const AMBIGUOUS: Result = Result::new(4);
 
         /// The configuration analysis did not complete. Possible reasons are:
         ///
@@ -876,18 +898,52 @@ pub mod reachability_details {
         /// * An internal error occurred.
         /// * The analyzer received an invalid or unsupported argument or was unable
         ///   to identify a known endpoint.
-        pub const UNDETERMINED: Result = Result::new("UNDETERMINED");
+        pub const UNDETERMINED: Result = Result::new(5);
+
+        /// Creates a new Result instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RESULT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REACHABLE"),
+                2 => std::borrow::Cow::Borrowed("UNREACHABLE"),
+                4 => std::borrow::Cow::Borrowed("AMBIGUOUS"),
+                5 => std::borrow::Cow::Borrowed("UNDETERMINED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RESULT_UNSPECIFIED" => std::option::Option::Some(Self::RESULT_UNSPECIFIED),
+                "REACHABLE" => std::option::Option::Some(Self::REACHABLE),
+                "UNREACHABLE" => std::option::Option::Some(Self::UNREACHABLE),
+                "AMBIGUOUS" => std::option::Option::Some(Self::AMBIGUOUS),
+                "UNDETERMINED" => std::option::Option::Some(Self::UNDETERMINED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Result {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Result {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Result {
         fn default() -> Self {
-            result::RESULT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1148,37 +1204,20 @@ pub mod probing_details {
 
     /// Overall probing result of the test.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ProbingResult(std::borrow::Cow<'static, str>);
+    pub struct ProbingResult(i32);
 
     impl ProbingResult {
-        /// Creates a new ProbingResult instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ProbingResult](ProbingResult)
-    pub mod probing_result {
-        use super::ProbingResult;
-
         /// No result was specified.
-        pub const PROBING_RESULT_UNSPECIFIED: ProbingResult =
-            ProbingResult::new("PROBING_RESULT_UNSPECIFIED");
+        pub const PROBING_RESULT_UNSPECIFIED: ProbingResult = ProbingResult::new(0);
 
         /// At least 95% of packets reached the destination.
-        pub const REACHABLE: ProbingResult = ProbingResult::new("REACHABLE");
+        pub const REACHABLE: ProbingResult = ProbingResult::new(1);
 
         /// No packets reached the destination.
-        pub const UNREACHABLE: ProbingResult = ProbingResult::new("UNREACHABLE");
+        pub const UNREACHABLE: ProbingResult = ProbingResult::new(2);
 
         /// Less than 95% of packets reached the destination.
-        pub const REACHABILITY_INCONSISTENT: ProbingResult =
-            ProbingResult::new("REACHABILITY_INCONSISTENT");
+        pub const REACHABILITY_INCONSISTENT: ProbingResult = ProbingResult::new(3);
 
         /// Reachability could not be determined. Possible reasons are:
         ///
@@ -1186,64 +1225,116 @@ pub mod probing_details {
         ///   required to run the test.
         /// * No valid source endpoint could be derived from the request.
         /// * An internal error occurred.
-        pub const UNDETERMINED: ProbingResult = ProbingResult::new("UNDETERMINED");
+        pub const UNDETERMINED: ProbingResult = ProbingResult::new(4);
+
+        /// Creates a new ProbingResult instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PROBING_RESULT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REACHABLE"),
+                2 => std::borrow::Cow::Borrowed("UNREACHABLE"),
+                3 => std::borrow::Cow::Borrowed("REACHABILITY_INCONSISTENT"),
+                4 => std::borrow::Cow::Borrowed("UNDETERMINED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PROBING_RESULT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PROBING_RESULT_UNSPECIFIED)
+                }
+                "REACHABLE" => std::option::Option::Some(Self::REACHABLE),
+                "UNREACHABLE" => std::option::Option::Some(Self::UNREACHABLE),
+                "REACHABILITY_INCONSISTENT" => {
+                    std::option::Option::Some(Self::REACHABILITY_INCONSISTENT)
+                }
+                "UNDETERMINED" => std::option::Option::Some(Self::UNDETERMINED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ProbingResult {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ProbingResult {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ProbingResult {
         fn default() -> Self {
-            probing_result::PROBING_RESULT_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Abort cause types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ProbingAbortCause(std::borrow::Cow<'static, str>);
+    pub struct ProbingAbortCause(i32);
 
     impl ProbingAbortCause {
-        /// Creates a new ProbingAbortCause instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ProbingAbortCause](ProbingAbortCause)
-    pub mod probing_abort_cause {
-        use super::ProbingAbortCause;
-
         /// No reason was specified.
-        pub const PROBING_ABORT_CAUSE_UNSPECIFIED: ProbingAbortCause =
-            ProbingAbortCause::new("PROBING_ABORT_CAUSE_UNSPECIFIED");
+        pub const PROBING_ABORT_CAUSE_UNSPECIFIED: ProbingAbortCause = ProbingAbortCause::new(0);
 
         /// The user lacks permission to access some of the
         /// network resources required to run the test.
-        pub const PERMISSION_DENIED: ProbingAbortCause =
-            ProbingAbortCause::new("PERMISSION_DENIED");
+        pub const PERMISSION_DENIED: ProbingAbortCause = ProbingAbortCause::new(1);
 
         /// No valid source endpoint could be derived from the request.
-        pub const NO_SOURCE_LOCATION: ProbingAbortCause =
-            ProbingAbortCause::new("NO_SOURCE_LOCATION");
+        pub const NO_SOURCE_LOCATION: ProbingAbortCause = ProbingAbortCause::new(2);
+
+        /// Creates a new ProbingAbortCause instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PROBING_ABORT_CAUSE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PERMISSION_DENIED"),
+                2 => std::borrow::Cow::Borrowed("NO_SOURCE_LOCATION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PROBING_ABORT_CAUSE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PROBING_ABORT_CAUSE_UNSPECIFIED)
+                }
+                "PERMISSION_DENIED" => std::option::Option::Some(Self::PERMISSION_DENIED),
+                "NO_SOURCE_LOCATION" => std::option::Option::Some(Self::NO_SOURCE_LOCATION),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ProbingAbortCause {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ProbingAbortCause {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ProbingAbortCause {
         fn default() -> Self {
-            probing_abort_cause::PROBING_ABORT_CAUSE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2608,165 +2699,271 @@ pub mod step {
     /// Type of states that are defined in the network state machine.
     /// Each step in the packet trace is in a specific state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Initial state: packet originating from a Compute Engine instance.
         /// An InstanceInfo is populated with starting instance information.
-        pub const START_FROM_INSTANCE: State = State::new("START_FROM_INSTANCE");
+        pub const START_FROM_INSTANCE: State = State::new(1);
 
         /// Initial state: packet originating from the internet.
         /// The endpoint information is populated.
-        pub const START_FROM_INTERNET: State = State::new("START_FROM_INTERNET");
+        pub const START_FROM_INTERNET: State = State::new(2);
 
         /// Initial state: packet originating from a Google service.
         /// The google_service information is populated.
-        pub const START_FROM_GOOGLE_SERVICE: State = State::new("START_FROM_GOOGLE_SERVICE");
+        pub const START_FROM_GOOGLE_SERVICE: State = State::new(27);
 
         /// Initial state: packet originating from a VPC or on-premises network
         /// with internal source IP.
         /// If the source is a VPC network visible to the user, a NetworkInfo
         /// is populated with details of the network.
-        pub const START_FROM_PRIVATE_NETWORK: State = State::new("START_FROM_PRIVATE_NETWORK");
+        pub const START_FROM_PRIVATE_NETWORK: State = State::new(3);
 
         /// Initial state: packet originating from a Google Kubernetes Engine cluster
         /// master. A GKEMasterInfo is populated with starting instance information.
-        pub const START_FROM_GKE_MASTER: State = State::new("START_FROM_GKE_MASTER");
+        pub const START_FROM_GKE_MASTER: State = State::new(21);
 
         /// Initial state: packet originating from a Cloud SQL instance.
         /// A CloudSQLInstanceInfo is populated with starting instance information.
-        pub const START_FROM_CLOUD_SQL_INSTANCE: State =
-            State::new("START_FROM_CLOUD_SQL_INSTANCE");
+        pub const START_FROM_CLOUD_SQL_INSTANCE: State = State::new(22);
 
         /// Initial state: packet originating from a Redis instance.
         /// A RedisInstanceInfo is populated with starting instance information.
-        pub const START_FROM_REDIS_INSTANCE: State = State::new("START_FROM_REDIS_INSTANCE");
+        pub const START_FROM_REDIS_INSTANCE: State = State::new(32);
 
         /// Initial state: packet originating from a Redis Cluster.
         /// A RedisClusterInfo is populated with starting Cluster information.
-        pub const START_FROM_REDIS_CLUSTER: State = State::new("START_FROM_REDIS_CLUSTER");
+        pub const START_FROM_REDIS_CLUSTER: State = State::new(33);
 
         /// Initial state: packet originating from a Cloud Function.
         /// A CloudFunctionInfo is populated with starting function information.
-        pub const START_FROM_CLOUD_FUNCTION: State = State::new("START_FROM_CLOUD_FUNCTION");
+        pub const START_FROM_CLOUD_FUNCTION: State = State::new(23);
 
         /// Initial state: packet originating from an App Engine service version.
         /// An AppEngineVersionInfo is populated with starting version information.
-        pub const START_FROM_APP_ENGINE_VERSION: State =
-            State::new("START_FROM_APP_ENGINE_VERSION");
+        pub const START_FROM_APP_ENGINE_VERSION: State = State::new(25);
 
         /// Initial state: packet originating from a Cloud Run revision.
         /// A CloudRunRevisionInfo is populated with starting revision information.
-        pub const START_FROM_CLOUD_RUN_REVISION: State =
-            State::new("START_FROM_CLOUD_RUN_REVISION");
+        pub const START_FROM_CLOUD_RUN_REVISION: State = State::new(26);
 
         /// Initial state: packet originating from a Storage Bucket. Used only for
         /// return traces.
         /// The storage_bucket information is populated.
-        pub const START_FROM_STORAGE_BUCKET: State = State::new("START_FROM_STORAGE_BUCKET");
+        pub const START_FROM_STORAGE_BUCKET: State = State::new(29);
 
         /// Initial state: packet originating from a published service that uses
         /// Private Service Connect. Used only for return traces.
-        pub const START_FROM_PSC_PUBLISHED_SERVICE: State =
-            State::new("START_FROM_PSC_PUBLISHED_SERVICE");
+        pub const START_FROM_PSC_PUBLISHED_SERVICE: State = State::new(30);
 
         /// Initial state: packet originating from a serverless network endpoint
         /// group backend. Used only for return traces.
         /// The serverless_neg information is populated.
-        pub const START_FROM_SERVERLESS_NEG: State = State::new("START_FROM_SERVERLESS_NEG");
+        pub const START_FROM_SERVERLESS_NEG: State = State::new(31);
 
         /// Config checking state: verify ingress firewall rule.
-        pub const APPLY_INGRESS_FIREWALL_RULE: State = State::new("APPLY_INGRESS_FIREWALL_RULE");
+        pub const APPLY_INGRESS_FIREWALL_RULE: State = State::new(4);
 
         /// Config checking state: verify egress firewall rule.
-        pub const APPLY_EGRESS_FIREWALL_RULE: State = State::new("APPLY_EGRESS_FIREWALL_RULE");
+        pub const APPLY_EGRESS_FIREWALL_RULE: State = State::new(5);
 
         /// Config checking state: verify route.
-        pub const APPLY_ROUTE: State = State::new("APPLY_ROUTE");
+        pub const APPLY_ROUTE: State = State::new(6);
 
         /// Config checking state: match forwarding rule.
-        pub const APPLY_FORWARDING_RULE: State = State::new("APPLY_FORWARDING_RULE");
+        pub const APPLY_FORWARDING_RULE: State = State::new(7);
 
         /// Config checking state: verify load balancer backend configuration.
-        pub const ANALYZE_LOAD_BALANCER_BACKEND: State =
-            State::new("ANALYZE_LOAD_BALANCER_BACKEND");
+        pub const ANALYZE_LOAD_BALANCER_BACKEND: State = State::new(28);
 
         /// Config checking state: packet sent or received under foreign IP
         /// address and allowed.
-        pub const SPOOFING_APPROVED: State = State::new("SPOOFING_APPROVED");
+        pub const SPOOFING_APPROVED: State = State::new(8);
 
         /// Forwarding state: arriving at a Compute Engine instance.
-        pub const ARRIVE_AT_INSTANCE: State = State::new("ARRIVE_AT_INSTANCE");
+        pub const ARRIVE_AT_INSTANCE: State = State::new(9);
 
         /// Forwarding state: arriving at a Compute Engine internal load balancer.
-        pub const ARRIVE_AT_INTERNAL_LOAD_BALANCER: State =
-            State::new("ARRIVE_AT_INTERNAL_LOAD_BALANCER");
+        pub const ARRIVE_AT_INTERNAL_LOAD_BALANCER: State = State::new(10);
 
         /// Forwarding state: arriving at a Compute Engine external load balancer.
-        pub const ARRIVE_AT_EXTERNAL_LOAD_BALANCER: State =
-            State::new("ARRIVE_AT_EXTERNAL_LOAD_BALANCER");
+        pub const ARRIVE_AT_EXTERNAL_LOAD_BALANCER: State = State::new(11);
 
         /// Forwarding state: arriving at a Cloud VPN gateway.
-        pub const ARRIVE_AT_VPN_GATEWAY: State = State::new("ARRIVE_AT_VPN_GATEWAY");
+        pub const ARRIVE_AT_VPN_GATEWAY: State = State::new(12);
 
         /// Forwarding state: arriving at a Cloud VPN tunnel.
-        pub const ARRIVE_AT_VPN_TUNNEL: State = State::new("ARRIVE_AT_VPN_TUNNEL");
+        pub const ARRIVE_AT_VPN_TUNNEL: State = State::new(13);
 
         /// Forwarding state: arriving at a VPC connector.
-        pub const ARRIVE_AT_VPC_CONNECTOR: State = State::new("ARRIVE_AT_VPC_CONNECTOR");
+        pub const ARRIVE_AT_VPC_CONNECTOR: State = State::new(24);
 
         /// Transition state: packet header translated.
-        pub const NAT: State = State::new("NAT");
+        pub const NAT: State = State::new(14);
 
         /// Transition state: original connection is terminated and a new proxied
         /// connection is initiated.
-        pub const PROXY_CONNECTION: State = State::new("PROXY_CONNECTION");
+        pub const PROXY_CONNECTION: State = State::new(15);
 
         /// Final state: packet could be delivered.
-        pub const DELIVER: State = State::new("DELIVER");
+        pub const DELIVER: State = State::new(16);
 
         /// Final state: packet could be dropped.
-        pub const DROP: State = State::new("DROP");
+        pub const DROP: State = State::new(17);
 
         /// Final state: packet could be forwarded to a network with an unknown
         /// configuration.
-        pub const FORWARD: State = State::new("FORWARD");
+        pub const FORWARD: State = State::new(18);
 
         /// Final state: analysis is aborted.
-        pub const ABORT: State = State::new("ABORT");
+        pub const ABORT: State = State::new(19);
 
         /// Special state: viewer of the test result does not have permission to
         /// see the configuration in this step.
-        pub const VIEWER_PERMISSION_MISSING: State = State::new("VIEWER_PERMISSION_MISSING");
+        pub const VIEWER_PERMISSION_MISSING: State = State::new(20);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("START_FROM_INSTANCE"),
+                2 => std::borrow::Cow::Borrowed("START_FROM_INTERNET"),
+                3 => std::borrow::Cow::Borrowed("START_FROM_PRIVATE_NETWORK"),
+                4 => std::borrow::Cow::Borrowed("APPLY_INGRESS_FIREWALL_RULE"),
+                5 => std::borrow::Cow::Borrowed("APPLY_EGRESS_FIREWALL_RULE"),
+                6 => std::borrow::Cow::Borrowed("APPLY_ROUTE"),
+                7 => std::borrow::Cow::Borrowed("APPLY_FORWARDING_RULE"),
+                8 => std::borrow::Cow::Borrowed("SPOOFING_APPROVED"),
+                9 => std::borrow::Cow::Borrowed("ARRIVE_AT_INSTANCE"),
+                10 => std::borrow::Cow::Borrowed("ARRIVE_AT_INTERNAL_LOAD_BALANCER"),
+                11 => std::borrow::Cow::Borrowed("ARRIVE_AT_EXTERNAL_LOAD_BALANCER"),
+                12 => std::borrow::Cow::Borrowed("ARRIVE_AT_VPN_GATEWAY"),
+                13 => std::borrow::Cow::Borrowed("ARRIVE_AT_VPN_TUNNEL"),
+                14 => std::borrow::Cow::Borrowed("NAT"),
+                15 => std::borrow::Cow::Borrowed("PROXY_CONNECTION"),
+                16 => std::borrow::Cow::Borrowed("DELIVER"),
+                17 => std::borrow::Cow::Borrowed("DROP"),
+                18 => std::borrow::Cow::Borrowed("FORWARD"),
+                19 => std::borrow::Cow::Borrowed("ABORT"),
+                20 => std::borrow::Cow::Borrowed("VIEWER_PERMISSION_MISSING"),
+                21 => std::borrow::Cow::Borrowed("START_FROM_GKE_MASTER"),
+                22 => std::borrow::Cow::Borrowed("START_FROM_CLOUD_SQL_INSTANCE"),
+                23 => std::borrow::Cow::Borrowed("START_FROM_CLOUD_FUNCTION"),
+                24 => std::borrow::Cow::Borrowed("ARRIVE_AT_VPC_CONNECTOR"),
+                25 => std::borrow::Cow::Borrowed("START_FROM_APP_ENGINE_VERSION"),
+                26 => std::borrow::Cow::Borrowed("START_FROM_CLOUD_RUN_REVISION"),
+                27 => std::borrow::Cow::Borrowed("START_FROM_GOOGLE_SERVICE"),
+                28 => std::borrow::Cow::Borrowed("ANALYZE_LOAD_BALANCER_BACKEND"),
+                29 => std::borrow::Cow::Borrowed("START_FROM_STORAGE_BUCKET"),
+                30 => std::borrow::Cow::Borrowed("START_FROM_PSC_PUBLISHED_SERVICE"),
+                31 => std::borrow::Cow::Borrowed("START_FROM_SERVERLESS_NEG"),
+                32 => std::borrow::Cow::Borrowed("START_FROM_REDIS_INSTANCE"),
+                33 => std::borrow::Cow::Borrowed("START_FROM_REDIS_CLUSTER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "START_FROM_INSTANCE" => std::option::Option::Some(Self::START_FROM_INSTANCE),
+                "START_FROM_INTERNET" => std::option::Option::Some(Self::START_FROM_INTERNET),
+                "START_FROM_GOOGLE_SERVICE" => {
+                    std::option::Option::Some(Self::START_FROM_GOOGLE_SERVICE)
+                }
+                "START_FROM_PRIVATE_NETWORK" => {
+                    std::option::Option::Some(Self::START_FROM_PRIVATE_NETWORK)
+                }
+                "START_FROM_GKE_MASTER" => std::option::Option::Some(Self::START_FROM_GKE_MASTER),
+                "START_FROM_CLOUD_SQL_INSTANCE" => {
+                    std::option::Option::Some(Self::START_FROM_CLOUD_SQL_INSTANCE)
+                }
+                "START_FROM_REDIS_INSTANCE" => {
+                    std::option::Option::Some(Self::START_FROM_REDIS_INSTANCE)
+                }
+                "START_FROM_REDIS_CLUSTER" => {
+                    std::option::Option::Some(Self::START_FROM_REDIS_CLUSTER)
+                }
+                "START_FROM_CLOUD_FUNCTION" => {
+                    std::option::Option::Some(Self::START_FROM_CLOUD_FUNCTION)
+                }
+                "START_FROM_APP_ENGINE_VERSION" => {
+                    std::option::Option::Some(Self::START_FROM_APP_ENGINE_VERSION)
+                }
+                "START_FROM_CLOUD_RUN_REVISION" => {
+                    std::option::Option::Some(Self::START_FROM_CLOUD_RUN_REVISION)
+                }
+                "START_FROM_STORAGE_BUCKET" => {
+                    std::option::Option::Some(Self::START_FROM_STORAGE_BUCKET)
+                }
+                "START_FROM_PSC_PUBLISHED_SERVICE" => {
+                    std::option::Option::Some(Self::START_FROM_PSC_PUBLISHED_SERVICE)
+                }
+                "START_FROM_SERVERLESS_NEG" => {
+                    std::option::Option::Some(Self::START_FROM_SERVERLESS_NEG)
+                }
+                "APPLY_INGRESS_FIREWALL_RULE" => {
+                    std::option::Option::Some(Self::APPLY_INGRESS_FIREWALL_RULE)
+                }
+                "APPLY_EGRESS_FIREWALL_RULE" => {
+                    std::option::Option::Some(Self::APPLY_EGRESS_FIREWALL_RULE)
+                }
+                "APPLY_ROUTE" => std::option::Option::Some(Self::APPLY_ROUTE),
+                "APPLY_FORWARDING_RULE" => std::option::Option::Some(Self::APPLY_FORWARDING_RULE),
+                "ANALYZE_LOAD_BALANCER_BACKEND" => {
+                    std::option::Option::Some(Self::ANALYZE_LOAD_BALANCER_BACKEND)
+                }
+                "SPOOFING_APPROVED" => std::option::Option::Some(Self::SPOOFING_APPROVED),
+                "ARRIVE_AT_INSTANCE" => std::option::Option::Some(Self::ARRIVE_AT_INSTANCE),
+                "ARRIVE_AT_INTERNAL_LOAD_BALANCER" => {
+                    std::option::Option::Some(Self::ARRIVE_AT_INTERNAL_LOAD_BALANCER)
+                }
+                "ARRIVE_AT_EXTERNAL_LOAD_BALANCER" => {
+                    std::option::Option::Some(Self::ARRIVE_AT_EXTERNAL_LOAD_BALANCER)
+                }
+                "ARRIVE_AT_VPN_GATEWAY" => std::option::Option::Some(Self::ARRIVE_AT_VPN_GATEWAY),
+                "ARRIVE_AT_VPN_TUNNEL" => std::option::Option::Some(Self::ARRIVE_AT_VPN_TUNNEL),
+                "ARRIVE_AT_VPC_CONNECTOR" => {
+                    std::option::Option::Some(Self::ARRIVE_AT_VPC_CONNECTOR)
+                }
+                "NAT" => std::option::Option::Some(Self::NAT),
+                "PROXY_CONNECTION" => std::option::Option::Some(Self::PROXY_CONNECTION),
+                "DELIVER" => std::option::Option::Some(Self::DELIVER),
+                "DROP" => std::option::Option::Some(Self::DROP),
+                "FORWARD" => std::option::Option::Some(Self::FORWARD),
+                "ABORT" => std::option::Option::Some(Self::ABORT),
+                "VIEWER_PERMISSION_MISSING" => {
+                    std::option::Option::Some(Self::VIEWER_PERMISSION_MISSING)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -3192,87 +3389,123 @@ pub mod firewall_info {
 
     /// The firewall rule's type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FirewallRuleType(std::borrow::Cow<'static, str>);
+    pub struct FirewallRuleType(i32);
 
     impl FirewallRuleType {
-        /// Creates a new FirewallRuleType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [FirewallRuleType](FirewallRuleType)
-    pub mod firewall_rule_type {
-        use super::FirewallRuleType;
-
         /// Unspecified type.
-        pub const FIREWALL_RULE_TYPE_UNSPECIFIED: FirewallRuleType =
-            FirewallRuleType::new("FIREWALL_RULE_TYPE_UNSPECIFIED");
+        pub const FIREWALL_RULE_TYPE_UNSPECIFIED: FirewallRuleType = FirewallRuleType::new(0);
 
         /// Hierarchical firewall policy rule. For details, see
         /// [Hierarchical firewall policies
         /// overview](https://cloud.google.com/vpc/docs/firewall-policies).
-        pub const HIERARCHICAL_FIREWALL_POLICY_RULE: FirewallRuleType =
-            FirewallRuleType::new("HIERARCHICAL_FIREWALL_POLICY_RULE");
+        pub const HIERARCHICAL_FIREWALL_POLICY_RULE: FirewallRuleType = FirewallRuleType::new(1);
 
         /// VPC firewall rule. For details, see
         /// [VPC firewall rules
         /// overview](https://cloud.google.com/vpc/docs/firewalls).
-        pub const VPC_FIREWALL_RULE: FirewallRuleType = FirewallRuleType::new("VPC_FIREWALL_RULE");
+        pub const VPC_FIREWALL_RULE: FirewallRuleType = FirewallRuleType::new(2);
 
         /// Implied VPC firewall rule. For details, see
         /// [Implied
         /// rules](https://cloud.google.com/vpc/docs/firewalls#default_firewall_rules).
-        pub const IMPLIED_VPC_FIREWALL_RULE: FirewallRuleType =
-            FirewallRuleType::new("IMPLIED_VPC_FIREWALL_RULE");
+        pub const IMPLIED_VPC_FIREWALL_RULE: FirewallRuleType = FirewallRuleType::new(3);
 
         /// Implicit firewall rules that are managed by serverless VPC access to
         /// allow ingress access. They are not visible in the Google Cloud console.
         /// For details, see [VPC connector's implicit
         /// rules](https://cloud.google.com/functions/docs/networking/connecting-vpc#restrict-access).
         pub const SERVERLESS_VPC_ACCESS_MANAGED_FIREWALL_RULE: FirewallRuleType =
-            FirewallRuleType::new("SERVERLESS_VPC_ACCESS_MANAGED_FIREWALL_RULE");
+            FirewallRuleType::new(4);
 
         /// Global network firewall policy rule.
         /// For details, see [Network firewall
         /// policies](https://cloud.google.com/vpc/docs/network-firewall-policies).
-        pub const NETWORK_FIREWALL_POLICY_RULE: FirewallRuleType =
-            FirewallRuleType::new("NETWORK_FIREWALL_POLICY_RULE");
+        pub const NETWORK_FIREWALL_POLICY_RULE: FirewallRuleType = FirewallRuleType::new(5);
 
         /// Regional network firewall policy rule.
         /// For details, see [Regional network firewall
         /// policies](https://cloud.google.com/firewall/docs/regional-firewall-policies).
         pub const NETWORK_REGIONAL_FIREWALL_POLICY_RULE: FirewallRuleType =
-            FirewallRuleType::new("NETWORK_REGIONAL_FIREWALL_POLICY_RULE");
+            FirewallRuleType::new(6);
 
         /// Firewall policy rule containing attributes not yet supported in
         /// Connectivity tests. Firewall analysis is skipped if such a rule can
         /// potentially be matched. Please see the [list of unsupported
         /// configurations](https://cloud.google.com/network-intelligence-center/docs/connectivity-tests/concepts/overview#unsupported-configs).
-        pub const UNSUPPORTED_FIREWALL_POLICY_RULE: FirewallRuleType =
-            FirewallRuleType::new("UNSUPPORTED_FIREWALL_POLICY_RULE");
+        pub const UNSUPPORTED_FIREWALL_POLICY_RULE: FirewallRuleType = FirewallRuleType::new(100);
 
         /// Tracking state for response traffic created when request traffic goes
         /// through allow firewall rule.
         /// For details, see [firewall rules
         /// specifications](https://cloud.google.com/firewall/docs/firewalls#specifications)
-        pub const TRACKING_STATE: FirewallRuleType = FirewallRuleType::new("TRACKING_STATE");
+        pub const TRACKING_STATE: FirewallRuleType = FirewallRuleType::new(101);
+
+        /// Creates a new FirewallRuleType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FIREWALL_RULE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("HIERARCHICAL_FIREWALL_POLICY_RULE"),
+                2 => std::borrow::Cow::Borrowed("VPC_FIREWALL_RULE"),
+                3 => std::borrow::Cow::Borrowed("IMPLIED_VPC_FIREWALL_RULE"),
+                4 => std::borrow::Cow::Borrowed("SERVERLESS_VPC_ACCESS_MANAGED_FIREWALL_RULE"),
+                5 => std::borrow::Cow::Borrowed("NETWORK_FIREWALL_POLICY_RULE"),
+                6 => std::borrow::Cow::Borrowed("NETWORK_REGIONAL_FIREWALL_POLICY_RULE"),
+                100 => std::borrow::Cow::Borrowed("UNSUPPORTED_FIREWALL_POLICY_RULE"),
+                101 => std::borrow::Cow::Borrowed("TRACKING_STATE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FIREWALL_RULE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::FIREWALL_RULE_TYPE_UNSPECIFIED)
+                }
+                "HIERARCHICAL_FIREWALL_POLICY_RULE" => {
+                    std::option::Option::Some(Self::HIERARCHICAL_FIREWALL_POLICY_RULE)
+                }
+                "VPC_FIREWALL_RULE" => std::option::Option::Some(Self::VPC_FIREWALL_RULE),
+                "IMPLIED_VPC_FIREWALL_RULE" => {
+                    std::option::Option::Some(Self::IMPLIED_VPC_FIREWALL_RULE)
+                }
+                "SERVERLESS_VPC_ACCESS_MANAGED_FIREWALL_RULE" => {
+                    std::option::Option::Some(Self::SERVERLESS_VPC_ACCESS_MANAGED_FIREWALL_RULE)
+                }
+                "NETWORK_FIREWALL_POLICY_RULE" => {
+                    std::option::Option::Some(Self::NETWORK_FIREWALL_POLICY_RULE)
+                }
+                "NETWORK_REGIONAL_FIREWALL_POLICY_RULE" => {
+                    std::option::Option::Some(Self::NETWORK_REGIONAL_FIREWALL_POLICY_RULE)
+                }
+                "UNSUPPORTED_FIREWALL_POLICY_RULE" => {
+                    std::option::Option::Some(Self::UNSUPPORTED_FIREWALL_POLICY_RULE)
+                }
+                "TRACKING_STATE" => std::option::Option::Some(Self::TRACKING_STATE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for FirewallRuleType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for FirewallRuleType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for FirewallRuleType {
         fn default() -> Self {
-            firewall_rule_type::FIREWALL_RULE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3538,186 +3771,268 @@ pub mod route_info {
 
     /// Type of route:
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RouteType(std::borrow::Cow<'static, str>);
+    pub struct RouteType(i32);
 
     impl RouteType {
-        /// Creates a new RouteType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RouteType](RouteType)
-    pub mod route_type {
-        use super::RouteType;
-
         /// Unspecified type. Default value.
-        pub const ROUTE_TYPE_UNSPECIFIED: RouteType = RouteType::new("ROUTE_TYPE_UNSPECIFIED");
+        pub const ROUTE_TYPE_UNSPECIFIED: RouteType = RouteType::new(0);
 
         /// Route is a subnet route automatically created by the system.
-        pub const SUBNET: RouteType = RouteType::new("SUBNET");
+        pub const SUBNET: RouteType = RouteType::new(1);
 
         /// Static route created by the user, including the default route to the
         /// internet.
-        pub const STATIC: RouteType = RouteType::new("STATIC");
+        pub const STATIC: RouteType = RouteType::new(2);
 
         /// Dynamic route exchanged between BGP peers.
-        pub const DYNAMIC: RouteType = RouteType::new("DYNAMIC");
+        pub const DYNAMIC: RouteType = RouteType::new(3);
 
         /// A subnet route received from peering network.
-        pub const PEERING_SUBNET: RouteType = RouteType::new("PEERING_SUBNET");
+        pub const PEERING_SUBNET: RouteType = RouteType::new(4);
 
         /// A static route received from peering network.
-        pub const PEERING_STATIC: RouteType = RouteType::new("PEERING_STATIC");
+        pub const PEERING_STATIC: RouteType = RouteType::new(5);
 
         /// A dynamic route received from peering network.
-        pub const PEERING_DYNAMIC: RouteType = RouteType::new("PEERING_DYNAMIC");
+        pub const PEERING_DYNAMIC: RouteType = RouteType::new(6);
 
         /// Policy based route.
-        pub const POLICY_BASED: RouteType = RouteType::new("POLICY_BASED");
+        pub const POLICY_BASED: RouteType = RouteType::new(7);
 
         /// Advertised route. Synthetic route which is used to transition from the
         /// StartFromPrivateNetwork state in Connectivity tests.
-        pub const ADVERTISED: RouteType = RouteType::new("ADVERTISED");
+        pub const ADVERTISED: RouteType = RouteType::new(101);
+
+        /// Creates a new RouteType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ROUTE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SUBNET"),
+                2 => std::borrow::Cow::Borrowed("STATIC"),
+                3 => std::borrow::Cow::Borrowed("DYNAMIC"),
+                4 => std::borrow::Cow::Borrowed("PEERING_SUBNET"),
+                5 => std::borrow::Cow::Borrowed("PEERING_STATIC"),
+                6 => std::borrow::Cow::Borrowed("PEERING_DYNAMIC"),
+                7 => std::borrow::Cow::Borrowed("POLICY_BASED"),
+                101 => std::borrow::Cow::Borrowed("ADVERTISED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ROUTE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::ROUTE_TYPE_UNSPECIFIED),
+                "SUBNET" => std::option::Option::Some(Self::SUBNET),
+                "STATIC" => std::option::Option::Some(Self::STATIC),
+                "DYNAMIC" => std::option::Option::Some(Self::DYNAMIC),
+                "PEERING_SUBNET" => std::option::Option::Some(Self::PEERING_SUBNET),
+                "PEERING_STATIC" => std::option::Option::Some(Self::PEERING_STATIC),
+                "PEERING_DYNAMIC" => std::option::Option::Some(Self::PEERING_DYNAMIC),
+                "POLICY_BASED" => std::option::Option::Some(Self::POLICY_BASED),
+                "ADVERTISED" => std::option::Option::Some(Self::ADVERTISED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RouteType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RouteType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RouteType {
         fn default() -> Self {
-            route_type::ROUTE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Type of next hop:
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NextHopType(std::borrow::Cow<'static, str>);
+    pub struct NextHopType(i32);
 
     impl NextHopType {
-        /// Creates a new NextHopType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [NextHopType](NextHopType)
-    pub mod next_hop_type {
-        use super::NextHopType;
-
         /// Unspecified type. Default value.
-        pub const NEXT_HOP_TYPE_UNSPECIFIED: NextHopType =
-            NextHopType::new("NEXT_HOP_TYPE_UNSPECIFIED");
+        pub const NEXT_HOP_TYPE_UNSPECIFIED: NextHopType = NextHopType::new(0);
 
         /// Next hop is an IP address.
-        pub const NEXT_HOP_IP: NextHopType = NextHopType::new("NEXT_HOP_IP");
+        pub const NEXT_HOP_IP: NextHopType = NextHopType::new(1);
 
         /// Next hop is a Compute Engine instance.
-        pub const NEXT_HOP_INSTANCE: NextHopType = NextHopType::new("NEXT_HOP_INSTANCE");
+        pub const NEXT_HOP_INSTANCE: NextHopType = NextHopType::new(2);
 
         /// Next hop is a VPC network gateway.
-        pub const NEXT_HOP_NETWORK: NextHopType = NextHopType::new("NEXT_HOP_NETWORK");
+        pub const NEXT_HOP_NETWORK: NextHopType = NextHopType::new(3);
 
         /// Next hop is a peering VPC.
-        pub const NEXT_HOP_PEERING: NextHopType = NextHopType::new("NEXT_HOP_PEERING");
+        pub const NEXT_HOP_PEERING: NextHopType = NextHopType::new(4);
 
         /// Next hop is an interconnect.
-        pub const NEXT_HOP_INTERCONNECT: NextHopType = NextHopType::new("NEXT_HOP_INTERCONNECT");
+        pub const NEXT_HOP_INTERCONNECT: NextHopType = NextHopType::new(5);
 
         /// Next hop is a VPN tunnel.
-        pub const NEXT_HOP_VPN_TUNNEL: NextHopType = NextHopType::new("NEXT_HOP_VPN_TUNNEL");
+        pub const NEXT_HOP_VPN_TUNNEL: NextHopType = NextHopType::new(6);
 
         /// Next hop is a VPN gateway. This scenario only happens when tracing
         /// connectivity from an on-premises network to Google Cloud through a VPN.
         /// The analysis simulates a packet departing from the on-premises network
         /// through a VPN tunnel and arriving at a Cloud VPN gateway.
-        pub const NEXT_HOP_VPN_GATEWAY: NextHopType = NextHopType::new("NEXT_HOP_VPN_GATEWAY");
+        pub const NEXT_HOP_VPN_GATEWAY: NextHopType = NextHopType::new(7);
 
         /// Next hop is an internet gateway.
-        pub const NEXT_HOP_INTERNET_GATEWAY: NextHopType =
-            NextHopType::new("NEXT_HOP_INTERNET_GATEWAY");
+        pub const NEXT_HOP_INTERNET_GATEWAY: NextHopType = NextHopType::new(8);
 
         /// Next hop is blackhole; that is, the next hop either does not exist or is
         /// not running.
-        pub const NEXT_HOP_BLACKHOLE: NextHopType = NextHopType::new("NEXT_HOP_BLACKHOLE");
+        pub const NEXT_HOP_BLACKHOLE: NextHopType = NextHopType::new(9);
 
         /// Next hop is the forwarding rule of an Internal Load Balancer.
-        pub const NEXT_HOP_ILB: NextHopType = NextHopType::new("NEXT_HOP_ILB");
+        pub const NEXT_HOP_ILB: NextHopType = NextHopType::new(10);
 
         /// Next hop is a
         /// [router appliance
         /// instance](https://cloud.google.com/network-connectivity/docs/network-connectivity-center/concepts/ra-overview).
-        pub const NEXT_HOP_ROUTER_APPLIANCE: NextHopType =
-            NextHopType::new("NEXT_HOP_ROUTER_APPLIANCE");
+        pub const NEXT_HOP_ROUTER_APPLIANCE: NextHopType = NextHopType::new(11);
 
         /// Next hop is an NCC hub.
-        pub const NEXT_HOP_NCC_HUB: NextHopType = NextHopType::new("NEXT_HOP_NCC_HUB");
+        pub const NEXT_HOP_NCC_HUB: NextHopType = NextHopType::new(12);
+
+        /// Creates a new NextHopType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("NEXT_HOP_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NEXT_HOP_IP"),
+                2 => std::borrow::Cow::Borrowed("NEXT_HOP_INSTANCE"),
+                3 => std::borrow::Cow::Borrowed("NEXT_HOP_NETWORK"),
+                4 => std::borrow::Cow::Borrowed("NEXT_HOP_PEERING"),
+                5 => std::borrow::Cow::Borrowed("NEXT_HOP_INTERCONNECT"),
+                6 => std::borrow::Cow::Borrowed("NEXT_HOP_VPN_TUNNEL"),
+                7 => std::borrow::Cow::Borrowed("NEXT_HOP_VPN_GATEWAY"),
+                8 => std::borrow::Cow::Borrowed("NEXT_HOP_INTERNET_GATEWAY"),
+                9 => std::borrow::Cow::Borrowed("NEXT_HOP_BLACKHOLE"),
+                10 => std::borrow::Cow::Borrowed("NEXT_HOP_ILB"),
+                11 => std::borrow::Cow::Borrowed("NEXT_HOP_ROUTER_APPLIANCE"),
+                12 => std::borrow::Cow::Borrowed("NEXT_HOP_NCC_HUB"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "NEXT_HOP_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::NEXT_HOP_TYPE_UNSPECIFIED)
+                }
+                "NEXT_HOP_IP" => std::option::Option::Some(Self::NEXT_HOP_IP),
+                "NEXT_HOP_INSTANCE" => std::option::Option::Some(Self::NEXT_HOP_INSTANCE),
+                "NEXT_HOP_NETWORK" => std::option::Option::Some(Self::NEXT_HOP_NETWORK),
+                "NEXT_HOP_PEERING" => std::option::Option::Some(Self::NEXT_HOP_PEERING),
+                "NEXT_HOP_INTERCONNECT" => std::option::Option::Some(Self::NEXT_HOP_INTERCONNECT),
+                "NEXT_HOP_VPN_TUNNEL" => std::option::Option::Some(Self::NEXT_HOP_VPN_TUNNEL),
+                "NEXT_HOP_VPN_GATEWAY" => std::option::Option::Some(Self::NEXT_HOP_VPN_GATEWAY),
+                "NEXT_HOP_INTERNET_GATEWAY" => {
+                    std::option::Option::Some(Self::NEXT_HOP_INTERNET_GATEWAY)
+                }
+                "NEXT_HOP_BLACKHOLE" => std::option::Option::Some(Self::NEXT_HOP_BLACKHOLE),
+                "NEXT_HOP_ILB" => std::option::Option::Some(Self::NEXT_HOP_ILB),
+                "NEXT_HOP_ROUTER_APPLIANCE" => {
+                    std::option::Option::Some(Self::NEXT_HOP_ROUTER_APPLIANCE)
+                }
+                "NEXT_HOP_NCC_HUB" => std::option::Option::Some(Self::NEXT_HOP_NCC_HUB),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for NextHopType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for NextHopType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for NextHopType {
         fn default() -> Self {
-            next_hop_type::NEXT_HOP_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Indicates where routes are applicable.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RouteScope(std::borrow::Cow<'static, str>);
+    pub struct RouteScope(i32);
 
     impl RouteScope {
+        /// Unspecified scope. Default value.
+        pub const ROUTE_SCOPE_UNSPECIFIED: RouteScope = RouteScope::new(0);
+
+        /// Route is applicable to packets in Network.
+        pub const NETWORK: RouteScope = RouteScope::new(1);
+
+        /// Route is applicable to packets using NCC Hub's routing table.
+        pub const NCC_HUB: RouteScope = RouteScope::new(2);
+
         /// Creates a new RouteScope instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ROUTE_SCOPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NETWORK"),
+                2 => std::borrow::Cow::Borrowed("NCC_HUB"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ROUTE_SCOPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ROUTE_SCOPE_UNSPECIFIED)
+                }
+                "NETWORK" => std::option::Option::Some(Self::NETWORK),
+                "NCC_HUB" => std::option::Option::Some(Self::NCC_HUB),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RouteScope](RouteScope)
-    pub mod route_scope {
-        use super::RouteScope;
-
-        /// Unspecified scope. Default value.
-        pub const ROUTE_SCOPE_UNSPECIFIED: RouteScope = RouteScope::new("ROUTE_SCOPE_UNSPECIFIED");
-
-        /// Route is applicable to packets in Network.
-        pub const NETWORK: RouteScope = RouteScope::new("NETWORK");
-
-        /// Route is applicable to packets using NCC Hub's routing table.
-        pub const NCC_HUB: RouteScope = RouteScope::new("NCC_HUB");
-    }
-
-    impl std::convert::From<std::string::String> for RouteScope {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RouteScope {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RouteScope {
         fn default() -> Self {
-            route_scope::ROUTE_SCOPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3776,68 +4091,92 @@ pub mod google_service_info {
 
     /// Recognized type of a Google Service.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct GoogleServiceType(std::borrow::Cow<'static, str>);
+    pub struct GoogleServiceType(i32);
 
     impl GoogleServiceType {
-        /// Creates a new GoogleServiceType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [GoogleServiceType](GoogleServiceType)
-    pub mod google_service_type {
-        use super::GoogleServiceType;
-
         /// Unspecified Google Service.
-        pub const GOOGLE_SERVICE_TYPE_UNSPECIFIED: GoogleServiceType =
-            GoogleServiceType::new("GOOGLE_SERVICE_TYPE_UNSPECIFIED");
+        pub const GOOGLE_SERVICE_TYPE_UNSPECIFIED: GoogleServiceType = GoogleServiceType::new(0);
 
         /// Identity aware proxy.
         /// <https://cloud.google.com/iap/docs/using-tcp-forwarding>
-        pub const IAP: GoogleServiceType = GoogleServiceType::new("IAP");
+        pub const IAP: GoogleServiceType = GoogleServiceType::new(1);
 
         /// One of two services sharing IP ranges:
         ///
         /// * Load Balancer proxy
         /// * Centralized Health Check prober
         ///   <https://cloud.google.com/load-balancing/docs/firewall-rules>
-        pub const GFE_PROXY_OR_HEALTH_CHECK_PROBER: GoogleServiceType =
-            GoogleServiceType::new("GFE_PROXY_OR_HEALTH_CHECK_PROBER");
+        pub const GFE_PROXY_OR_HEALTH_CHECK_PROBER: GoogleServiceType = GoogleServiceType::new(2);
 
         /// Connectivity from Cloud DNS to forwarding targets or alternate name
         /// servers that use private routing.
         /// <https://cloud.google.com/dns/docs/zones/forwarding-zones#firewall-rules>
         /// <https://cloud.google.com/dns/docs/policies#firewall-rules>
-        pub const CLOUD_DNS: GoogleServiceType = GoogleServiceType::new("CLOUD_DNS");
+        pub const CLOUD_DNS: GoogleServiceType = GoogleServiceType::new(3);
 
         /// private.googleapis.com and restricted.googleapis.com
-        pub const GOOGLE_API: GoogleServiceType = GoogleServiceType::new("GOOGLE_API");
+        pub const GOOGLE_API: GoogleServiceType = GoogleServiceType::new(4);
 
         /// Google API via Private Service Connect.
         /// <https://cloud.google.com/vpc/docs/configure-private-service-connect-apis>
-        pub const GOOGLE_API_PSC: GoogleServiceType = GoogleServiceType::new("GOOGLE_API_PSC");
+        pub const GOOGLE_API_PSC: GoogleServiceType = GoogleServiceType::new(5);
 
         /// Google API via VPC Service Controls.
         /// <https://cloud.google.com/vpc/docs/configure-private-service-connect-apis>
-        pub const GOOGLE_API_VPC_SC: GoogleServiceType =
-            GoogleServiceType::new("GOOGLE_API_VPC_SC");
+        pub const GOOGLE_API_VPC_SC: GoogleServiceType = GoogleServiceType::new(6);
+
+        /// Creates a new GoogleServiceType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("GOOGLE_SERVICE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IAP"),
+                2 => std::borrow::Cow::Borrowed("GFE_PROXY_OR_HEALTH_CHECK_PROBER"),
+                3 => std::borrow::Cow::Borrowed("CLOUD_DNS"),
+                4 => std::borrow::Cow::Borrowed("GOOGLE_API"),
+                5 => std::borrow::Cow::Borrowed("GOOGLE_API_PSC"),
+                6 => std::borrow::Cow::Borrowed("GOOGLE_API_VPC_SC"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "GOOGLE_SERVICE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::GOOGLE_SERVICE_TYPE_UNSPECIFIED)
+                }
+                "IAP" => std::option::Option::Some(Self::IAP),
+                "GFE_PROXY_OR_HEALTH_CHECK_PROBER" => {
+                    std::option::Option::Some(Self::GFE_PROXY_OR_HEALTH_CHECK_PROBER)
+                }
+                "CLOUD_DNS" => std::option::Option::Some(Self::CLOUD_DNS),
+                "GOOGLE_API" => std::option::Option::Some(Self::GOOGLE_API),
+                "GOOGLE_API_PSC" => std::option::Option::Some(Self::GOOGLE_API_PSC),
+                "GOOGLE_API_VPC_SC" => std::option::Option::Some(Self::GOOGLE_API_VPC_SC),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for GoogleServiceType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for GoogleServiceType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for GoogleServiceType {
         fn default() -> Self {
-            google_service_type::GOOGLE_SERVICE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4082,99 +4421,139 @@ pub mod load_balancer_info {
 
     /// The type definition for a load balancer:
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LoadBalancerType(std::borrow::Cow<'static, str>);
+    pub struct LoadBalancerType(i32);
 
     impl LoadBalancerType {
+        /// Type is unspecified.
+        pub const LOAD_BALANCER_TYPE_UNSPECIFIED: LoadBalancerType = LoadBalancerType::new(0);
+
+        /// Internal TCP/UDP load balancer.
+        pub const INTERNAL_TCP_UDP: LoadBalancerType = LoadBalancerType::new(1);
+
+        /// Network TCP/UDP load balancer.
+        pub const NETWORK_TCP_UDP: LoadBalancerType = LoadBalancerType::new(2);
+
+        /// HTTP(S) proxy load balancer.
+        pub const HTTP_PROXY: LoadBalancerType = LoadBalancerType::new(3);
+
+        /// TCP proxy load balancer.
+        pub const TCP_PROXY: LoadBalancerType = LoadBalancerType::new(4);
+
+        /// SSL proxy load balancer.
+        pub const SSL_PROXY: LoadBalancerType = LoadBalancerType::new(5);
+
         /// Creates a new LoadBalancerType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LOAD_BALANCER_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INTERNAL_TCP_UDP"),
+                2 => std::borrow::Cow::Borrowed("NETWORK_TCP_UDP"),
+                3 => std::borrow::Cow::Borrowed("HTTP_PROXY"),
+                4 => std::borrow::Cow::Borrowed("TCP_PROXY"),
+                5 => std::borrow::Cow::Borrowed("SSL_PROXY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LOAD_BALANCER_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::LOAD_BALANCER_TYPE_UNSPECIFIED)
+                }
+                "INTERNAL_TCP_UDP" => std::option::Option::Some(Self::INTERNAL_TCP_UDP),
+                "NETWORK_TCP_UDP" => std::option::Option::Some(Self::NETWORK_TCP_UDP),
+                "HTTP_PROXY" => std::option::Option::Some(Self::HTTP_PROXY),
+                "TCP_PROXY" => std::option::Option::Some(Self::TCP_PROXY),
+                "SSL_PROXY" => std::option::Option::Some(Self::SSL_PROXY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [LoadBalancerType](LoadBalancerType)
-    pub mod load_balancer_type {
-        use super::LoadBalancerType;
-
-        /// Type is unspecified.
-        pub const LOAD_BALANCER_TYPE_UNSPECIFIED: LoadBalancerType =
-            LoadBalancerType::new("LOAD_BALANCER_TYPE_UNSPECIFIED");
-
-        /// Internal TCP/UDP load balancer.
-        pub const INTERNAL_TCP_UDP: LoadBalancerType = LoadBalancerType::new("INTERNAL_TCP_UDP");
-
-        /// Network TCP/UDP load balancer.
-        pub const NETWORK_TCP_UDP: LoadBalancerType = LoadBalancerType::new("NETWORK_TCP_UDP");
-
-        /// HTTP(S) proxy load balancer.
-        pub const HTTP_PROXY: LoadBalancerType = LoadBalancerType::new("HTTP_PROXY");
-
-        /// TCP proxy load balancer.
-        pub const TCP_PROXY: LoadBalancerType = LoadBalancerType::new("TCP_PROXY");
-
-        /// SSL proxy load balancer.
-        pub const SSL_PROXY: LoadBalancerType = LoadBalancerType::new("SSL_PROXY");
-    }
-
-    impl std::convert::From<std::string::String> for LoadBalancerType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LoadBalancerType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LoadBalancerType {
         fn default() -> Self {
-            load_balancer_type::LOAD_BALANCER_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The type definition for a load balancer backend configuration:
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BackendType(std::borrow::Cow<'static, str>);
+    pub struct BackendType(i32);
 
     impl BackendType {
+        /// Type is unspecified.
+        pub const BACKEND_TYPE_UNSPECIFIED: BackendType = BackendType::new(0);
+
+        /// Backend Service as the load balancer's backend.
+        pub const BACKEND_SERVICE: BackendType = BackendType::new(1);
+
+        /// Target Pool as the load balancer's backend.
+        pub const TARGET_POOL: BackendType = BackendType::new(2);
+
+        /// Target Instance as the load balancer's backend.
+        pub const TARGET_INSTANCE: BackendType = BackendType::new(3);
+
         /// Creates a new BackendType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("BACKEND_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BACKEND_SERVICE"),
+                2 => std::borrow::Cow::Borrowed("TARGET_POOL"),
+                3 => std::borrow::Cow::Borrowed("TARGET_INSTANCE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "BACKEND_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::BACKEND_TYPE_UNSPECIFIED)
+                }
+                "BACKEND_SERVICE" => std::option::Option::Some(Self::BACKEND_SERVICE),
+                "TARGET_POOL" => std::option::Option::Some(Self::TARGET_POOL),
+                "TARGET_INSTANCE" => std::option::Option::Some(Self::TARGET_INSTANCE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [BackendType](BackendType)
-    pub mod backend_type {
-        use super::BackendType;
-
-        /// Type is unspecified.
-        pub const BACKEND_TYPE_UNSPECIFIED: BackendType =
-            BackendType::new("BACKEND_TYPE_UNSPECIFIED");
-
-        /// Backend Service as the load balancer's backend.
-        pub const BACKEND_SERVICE: BackendType = BackendType::new("BACKEND_SERVICE");
-
-        /// Target Pool as the load balancer's backend.
-        pub const TARGET_POOL: BackendType = BackendType::new("TARGET_POOL");
-
-        /// Target Instance as the load balancer's backend.
-        pub const TARGET_INSTANCE: BackendType = BackendType::new("TARGET_INSTANCE");
-    }
-
-    impl std::convert::From<std::string::String> for BackendType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for BackendType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for BackendType {
         fn default() -> Self {
-            backend_type::BACKEND_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4269,51 +4648,66 @@ pub mod load_balancer_backend {
 
     /// State of a health check firewall configuration:
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HealthCheckFirewallState(std::borrow::Cow<'static, str>);
+    pub struct HealthCheckFirewallState(i32);
 
     impl HealthCheckFirewallState {
-        /// Creates a new HealthCheckFirewallState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [HealthCheckFirewallState](HealthCheckFirewallState)
-    pub mod health_check_firewall_state {
-        use super::HealthCheckFirewallState;
-
         /// State is unspecified. Default state if not populated.
         pub const HEALTH_CHECK_FIREWALL_STATE_UNSPECIFIED: HealthCheckFirewallState =
-            HealthCheckFirewallState::new("HEALTH_CHECK_FIREWALL_STATE_UNSPECIFIED");
+            HealthCheckFirewallState::new(0);
 
         /// There are configured firewall rules to allow health check probes to the
         /// backend.
-        pub const CONFIGURED: HealthCheckFirewallState =
-            HealthCheckFirewallState::new("CONFIGURED");
+        pub const CONFIGURED: HealthCheckFirewallState = HealthCheckFirewallState::new(1);
 
         /// There are firewall rules configured to allow partial health check ranges
         /// or block all health check ranges.
         /// If a health check probe is sent from denied IP ranges,
         /// the health check to the backend will fail. Then, the backend will be
         /// marked unhealthy and will not receive traffic sent to the load balancer.
-        pub const MISCONFIGURED: HealthCheckFirewallState =
-            HealthCheckFirewallState::new("MISCONFIGURED");
+        pub const MISCONFIGURED: HealthCheckFirewallState = HealthCheckFirewallState::new(2);
+
+        /// Creates a new HealthCheckFirewallState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("HEALTH_CHECK_FIREWALL_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CONFIGURED"),
+                2 => std::borrow::Cow::Borrowed("MISCONFIGURED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "HEALTH_CHECK_FIREWALL_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::HEALTH_CHECK_FIREWALL_STATE_UNSPECIFIED)
+                }
+                "CONFIGURED" => std::option::Option::Some(Self::CONFIGURED),
+                "MISCONFIGURED" => std::option::Option::Some(Self::MISCONFIGURED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for HealthCheckFirewallState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for HealthCheckFirewallState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for HealthCheckFirewallState {
         fn default() -> Self {
-            health_check_firewall_state::HEALTH_CHECK_FIREWALL_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4524,47 +4918,65 @@ pub mod vpn_tunnel_info {
     /// Types of VPN routing policy. For details, refer to [Networks and Tunnel
     /// routing](https://cloud.google.com/network-connectivity/docs/vpn/concepts/choosing-networks-routing/).
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RoutingType(std::borrow::Cow<'static, str>);
+    pub struct RoutingType(i32);
 
     impl RoutingType {
+        /// Unspecified type. Default value.
+        pub const ROUTING_TYPE_UNSPECIFIED: RoutingType = RoutingType::new(0);
+
+        /// Route based VPN.
+        pub const ROUTE_BASED: RoutingType = RoutingType::new(1);
+
+        /// Policy based routing.
+        pub const POLICY_BASED: RoutingType = RoutingType::new(2);
+
+        /// Dynamic (BGP) routing.
+        pub const DYNAMIC: RoutingType = RoutingType::new(3);
+
         /// Creates a new RoutingType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ROUTING_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ROUTE_BASED"),
+                2 => std::borrow::Cow::Borrowed("POLICY_BASED"),
+                3 => std::borrow::Cow::Borrowed("DYNAMIC"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ROUTING_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ROUTING_TYPE_UNSPECIFIED)
+                }
+                "ROUTE_BASED" => std::option::Option::Some(Self::ROUTE_BASED),
+                "POLICY_BASED" => std::option::Option::Some(Self::POLICY_BASED),
+                "DYNAMIC" => std::option::Option::Some(Self::DYNAMIC),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RoutingType](RoutingType)
-    pub mod routing_type {
-        use super::RoutingType;
-
-        /// Unspecified type. Default value.
-        pub const ROUTING_TYPE_UNSPECIFIED: RoutingType =
-            RoutingType::new("ROUTING_TYPE_UNSPECIFIED");
-
-        /// Route based VPN.
-        pub const ROUTE_BASED: RoutingType = RoutingType::new("ROUTE_BASED");
-
-        /// Policy based routing.
-        pub const POLICY_BASED: RoutingType = RoutingType::new("POLICY_BASED");
-
-        /// Dynamic (BGP) routing.
-        pub const DYNAMIC: RoutingType = RoutingType::new("DYNAMIC");
-    }
-
-    impl std::convert::From<std::string::String> for RoutingType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RoutingType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RoutingType {
         fn default() -> Self {
-            routing_type::ROUTING_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4759,91 +5171,136 @@ pub mod deliver_info {
 
     /// Deliver target types:
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Target(std::borrow::Cow<'static, str>);
+    pub struct Target(i32);
 
     impl Target {
-        /// Creates a new Target instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Target](Target)
-    pub mod target {
-        use super::Target;
-
         /// Target not specified.
-        pub const TARGET_UNSPECIFIED: Target = Target::new("TARGET_UNSPECIFIED");
+        pub const TARGET_UNSPECIFIED: Target = Target::new(0);
 
         /// Target is a Compute Engine instance.
-        pub const INSTANCE: Target = Target::new("INSTANCE");
+        pub const INSTANCE: Target = Target::new(1);
 
         /// Target is the internet.
-        pub const INTERNET: Target = Target::new("INTERNET");
+        pub const INTERNET: Target = Target::new(2);
 
         /// Target is a Google API.
-        pub const GOOGLE_API: Target = Target::new("GOOGLE_API");
+        pub const GOOGLE_API: Target = Target::new(3);
 
         /// Target is a Google Kubernetes Engine cluster master.
-        pub const GKE_MASTER: Target = Target::new("GKE_MASTER");
+        pub const GKE_MASTER: Target = Target::new(4);
 
         /// Target is a Cloud SQL instance.
-        pub const CLOUD_SQL_INSTANCE: Target = Target::new("CLOUD_SQL_INSTANCE");
+        pub const CLOUD_SQL_INSTANCE: Target = Target::new(5);
 
         /// Target is a published service that uses [Private Service
         /// Connect](https://cloud.google.com/vpc/docs/configure-private-service-connect-services).
-        pub const PSC_PUBLISHED_SERVICE: Target = Target::new("PSC_PUBLISHED_SERVICE");
+        pub const PSC_PUBLISHED_SERVICE: Target = Target::new(6);
 
         /// Target is Google APIs that use [Private Service
         /// Connect](https://cloud.google.com/vpc/docs/configure-private-service-connect-apis).
-        pub const PSC_GOOGLE_API: Target = Target::new("PSC_GOOGLE_API");
+        pub const PSC_GOOGLE_API: Target = Target::new(7);
 
         /// Target is a VPC-SC that uses [Private Service
         /// Connect](https://cloud.google.com/vpc/docs/configure-private-service-connect-apis).
-        pub const PSC_VPC_SC: Target = Target::new("PSC_VPC_SC");
+        pub const PSC_VPC_SC: Target = Target::new(8);
 
         /// Target is a serverless network endpoint group.
-        pub const SERVERLESS_NEG: Target = Target::new("SERVERLESS_NEG");
+        pub const SERVERLESS_NEG: Target = Target::new(9);
 
         /// Target is a Cloud Storage bucket.
-        pub const STORAGE_BUCKET: Target = Target::new("STORAGE_BUCKET");
+        pub const STORAGE_BUCKET: Target = Target::new(10);
 
         /// Target is a private network. Used only for return traces.
-        pub const PRIVATE_NETWORK: Target = Target::new("PRIVATE_NETWORK");
+        pub const PRIVATE_NETWORK: Target = Target::new(11);
 
         /// Target is a Cloud Function. Used only for return traces.
-        pub const CLOUD_FUNCTION: Target = Target::new("CLOUD_FUNCTION");
+        pub const CLOUD_FUNCTION: Target = Target::new(12);
 
         /// Target is a App Engine service version. Used only for return traces.
-        pub const APP_ENGINE_VERSION: Target = Target::new("APP_ENGINE_VERSION");
+        pub const APP_ENGINE_VERSION: Target = Target::new(13);
 
         /// Target is a Cloud Run revision. Used only for return traces.
-        pub const CLOUD_RUN_REVISION: Target = Target::new("CLOUD_RUN_REVISION");
+        pub const CLOUD_RUN_REVISION: Target = Target::new(14);
 
         /// Target is a Google-managed service. Used only for return traces.
-        pub const GOOGLE_MANAGED_SERVICE: Target = Target::new("GOOGLE_MANAGED_SERVICE");
+        pub const GOOGLE_MANAGED_SERVICE: Target = Target::new(15);
 
         /// Target is a Redis Instance.
-        pub const REDIS_INSTANCE: Target = Target::new("REDIS_INSTANCE");
+        pub const REDIS_INSTANCE: Target = Target::new(16);
 
         /// Target is a Redis Cluster.
-        pub const REDIS_CLUSTER: Target = Target::new("REDIS_CLUSTER");
+        pub const REDIS_CLUSTER: Target = Target::new(17);
+
+        /// Creates a new Target instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TARGET_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INSTANCE"),
+                2 => std::borrow::Cow::Borrowed("INTERNET"),
+                3 => std::borrow::Cow::Borrowed("GOOGLE_API"),
+                4 => std::borrow::Cow::Borrowed("GKE_MASTER"),
+                5 => std::borrow::Cow::Borrowed("CLOUD_SQL_INSTANCE"),
+                6 => std::borrow::Cow::Borrowed("PSC_PUBLISHED_SERVICE"),
+                7 => std::borrow::Cow::Borrowed("PSC_GOOGLE_API"),
+                8 => std::borrow::Cow::Borrowed("PSC_VPC_SC"),
+                9 => std::borrow::Cow::Borrowed("SERVERLESS_NEG"),
+                10 => std::borrow::Cow::Borrowed("STORAGE_BUCKET"),
+                11 => std::borrow::Cow::Borrowed("PRIVATE_NETWORK"),
+                12 => std::borrow::Cow::Borrowed("CLOUD_FUNCTION"),
+                13 => std::borrow::Cow::Borrowed("APP_ENGINE_VERSION"),
+                14 => std::borrow::Cow::Borrowed("CLOUD_RUN_REVISION"),
+                15 => std::borrow::Cow::Borrowed("GOOGLE_MANAGED_SERVICE"),
+                16 => std::borrow::Cow::Borrowed("REDIS_INSTANCE"),
+                17 => std::borrow::Cow::Borrowed("REDIS_CLUSTER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TARGET_UNSPECIFIED" => std::option::Option::Some(Self::TARGET_UNSPECIFIED),
+                "INSTANCE" => std::option::Option::Some(Self::INSTANCE),
+                "INTERNET" => std::option::Option::Some(Self::INTERNET),
+                "GOOGLE_API" => std::option::Option::Some(Self::GOOGLE_API),
+                "GKE_MASTER" => std::option::Option::Some(Self::GKE_MASTER),
+                "CLOUD_SQL_INSTANCE" => std::option::Option::Some(Self::CLOUD_SQL_INSTANCE),
+                "PSC_PUBLISHED_SERVICE" => std::option::Option::Some(Self::PSC_PUBLISHED_SERVICE),
+                "PSC_GOOGLE_API" => std::option::Option::Some(Self::PSC_GOOGLE_API),
+                "PSC_VPC_SC" => std::option::Option::Some(Self::PSC_VPC_SC),
+                "SERVERLESS_NEG" => std::option::Option::Some(Self::SERVERLESS_NEG),
+                "STORAGE_BUCKET" => std::option::Option::Some(Self::STORAGE_BUCKET),
+                "PRIVATE_NETWORK" => std::option::Option::Some(Self::PRIVATE_NETWORK),
+                "CLOUD_FUNCTION" => std::option::Option::Some(Self::CLOUD_FUNCTION),
+                "APP_ENGINE_VERSION" => std::option::Option::Some(Self::APP_ENGINE_VERSION),
+                "CLOUD_RUN_REVISION" => std::option::Option::Some(Self::CLOUD_RUN_REVISION),
+                "GOOGLE_MANAGED_SERVICE" => std::option::Option::Some(Self::GOOGLE_MANAGED_SERVICE),
+                "REDIS_INSTANCE" => std::option::Option::Some(Self::REDIS_INSTANCE),
+                "REDIS_CLUSTER" => std::option::Option::Some(Self::REDIS_CLUSTER),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Target {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Target {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Target {
         fn default() -> Self {
-            target::TARGET_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4906,65 +5363,95 @@ pub mod forward_info {
 
     /// Forward target types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Target(std::borrow::Cow<'static, str>);
+    pub struct Target(i32);
 
     impl Target {
+        /// Target not specified.
+        pub const TARGET_UNSPECIFIED: Target = Target::new(0);
+
+        /// Forwarded to a VPC peering network.
+        pub const PEERING_VPC: Target = Target::new(1);
+
+        /// Forwarded to a Cloud VPN gateway.
+        pub const VPN_GATEWAY: Target = Target::new(2);
+
+        /// Forwarded to a Cloud Interconnect connection.
+        pub const INTERCONNECT: Target = Target::new(3);
+
+        /// Forwarded to a Google Kubernetes Engine Container cluster master.
+        pub const GKE_MASTER: Target = Target::new(4);
+
+        /// Forwarded to the next hop of a custom route imported from a peering VPC.
+        pub const IMPORTED_CUSTOM_ROUTE_NEXT_HOP: Target = Target::new(5);
+
+        /// Forwarded to a Cloud SQL instance.
+        pub const CLOUD_SQL_INSTANCE: Target = Target::new(6);
+
+        /// Forwarded to a VPC network in another project.
+        pub const ANOTHER_PROJECT: Target = Target::new(7);
+
+        /// Forwarded to an NCC Hub.
+        pub const NCC_HUB: Target = Target::new(8);
+
+        /// Forwarded to a router appliance.
+        pub const ROUTER_APPLIANCE: Target = Target::new(9);
+
         /// Creates a new Target instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TARGET_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PEERING_VPC"),
+                2 => std::borrow::Cow::Borrowed("VPN_GATEWAY"),
+                3 => std::borrow::Cow::Borrowed("INTERCONNECT"),
+                4 => std::borrow::Cow::Borrowed("GKE_MASTER"),
+                5 => std::borrow::Cow::Borrowed("IMPORTED_CUSTOM_ROUTE_NEXT_HOP"),
+                6 => std::borrow::Cow::Borrowed("CLOUD_SQL_INSTANCE"),
+                7 => std::borrow::Cow::Borrowed("ANOTHER_PROJECT"),
+                8 => std::borrow::Cow::Borrowed("NCC_HUB"),
+                9 => std::borrow::Cow::Borrowed("ROUTER_APPLIANCE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TARGET_UNSPECIFIED" => std::option::Option::Some(Self::TARGET_UNSPECIFIED),
+                "PEERING_VPC" => std::option::Option::Some(Self::PEERING_VPC),
+                "VPN_GATEWAY" => std::option::Option::Some(Self::VPN_GATEWAY),
+                "INTERCONNECT" => std::option::Option::Some(Self::INTERCONNECT),
+                "GKE_MASTER" => std::option::Option::Some(Self::GKE_MASTER),
+                "IMPORTED_CUSTOM_ROUTE_NEXT_HOP" => {
+                    std::option::Option::Some(Self::IMPORTED_CUSTOM_ROUTE_NEXT_HOP)
+                }
+                "CLOUD_SQL_INSTANCE" => std::option::Option::Some(Self::CLOUD_SQL_INSTANCE),
+                "ANOTHER_PROJECT" => std::option::Option::Some(Self::ANOTHER_PROJECT),
+                "NCC_HUB" => std::option::Option::Some(Self::NCC_HUB),
+                "ROUTER_APPLIANCE" => std::option::Option::Some(Self::ROUTER_APPLIANCE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Target](Target)
-    pub mod target {
-        use super::Target;
-
-        /// Target not specified.
-        pub const TARGET_UNSPECIFIED: Target = Target::new("TARGET_UNSPECIFIED");
-
-        /// Forwarded to a VPC peering network.
-        pub const PEERING_VPC: Target = Target::new("PEERING_VPC");
-
-        /// Forwarded to a Cloud VPN gateway.
-        pub const VPN_GATEWAY: Target = Target::new("VPN_GATEWAY");
-
-        /// Forwarded to a Cloud Interconnect connection.
-        pub const INTERCONNECT: Target = Target::new("INTERCONNECT");
-
-        /// Forwarded to a Google Kubernetes Engine Container cluster master.
-        pub const GKE_MASTER: Target = Target::new("GKE_MASTER");
-
-        /// Forwarded to the next hop of a custom route imported from a peering VPC.
-        pub const IMPORTED_CUSTOM_ROUTE_NEXT_HOP: Target =
-            Target::new("IMPORTED_CUSTOM_ROUTE_NEXT_HOP");
-
-        /// Forwarded to a Cloud SQL instance.
-        pub const CLOUD_SQL_INSTANCE: Target = Target::new("CLOUD_SQL_INSTANCE");
-
-        /// Forwarded to a VPC network in another project.
-        pub const ANOTHER_PROJECT: Target = Target::new("ANOTHER_PROJECT");
-
-        /// Forwarded to an NCC Hub.
-        pub const NCC_HUB: Target = Target::new("NCC_HUB");
-
-        /// Forwarded to a router appliance.
-        pub const ROUTER_APPLIANCE: Target = Target::new("ROUTER_APPLIANCE");
-    }
-
-    impl std::convert::From<std::string::String> for Target {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Target {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Target {
         fn default() -> Self {
-            target::TARGET_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5043,97 +5530,75 @@ pub mod abort_info {
 
     /// Abort cause types:
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Cause(std::borrow::Cow<'static, str>);
+    pub struct Cause(i32);
 
     impl Cause {
-        /// Creates a new Cause instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Cause](Cause)
-    pub mod cause {
-        use super::Cause;
-
         /// Cause is unspecified.
-        pub const CAUSE_UNSPECIFIED: Cause = Cause::new("CAUSE_UNSPECIFIED");
+        pub const CAUSE_UNSPECIFIED: Cause = Cause::new(0);
 
         /// Aborted due to unknown network. Deprecated, not used in the new tests.
-        pub const UNKNOWN_NETWORK: Cause = Cause::new("UNKNOWN_NETWORK");
+        pub const UNKNOWN_NETWORK: Cause = Cause::new(1);
 
         /// Aborted because no project information can be derived from the test
         /// input. Deprecated, not used in the new tests.
-        pub const UNKNOWN_PROJECT: Cause = Cause::new("UNKNOWN_PROJECT");
+        pub const UNKNOWN_PROJECT: Cause = Cause::new(3);
 
         /// Aborted because traffic is sent from a public IP to an instance without
         /// an external IP. Deprecated, not used in the new tests.
-        pub const NO_EXTERNAL_IP: Cause = Cause::new("NO_EXTERNAL_IP");
+        pub const NO_EXTERNAL_IP: Cause = Cause::new(7);
 
         /// Aborted because none of the traces matches destination information
         /// specified in the input test request. Deprecated, not used in the new
         /// tests.
-        pub const UNINTENDED_DESTINATION: Cause = Cause::new("UNINTENDED_DESTINATION");
+        pub const UNINTENDED_DESTINATION: Cause = Cause::new(8);
 
         /// Aborted because the source endpoint could not be found. Deprecated, not
         /// used in the new tests.
-        pub const SOURCE_ENDPOINT_NOT_FOUND: Cause = Cause::new("SOURCE_ENDPOINT_NOT_FOUND");
+        pub const SOURCE_ENDPOINT_NOT_FOUND: Cause = Cause::new(11);
 
         /// Aborted because the source network does not match the source endpoint.
         /// Deprecated, not used in the new tests.
-        pub const MISMATCHED_SOURCE_NETWORK: Cause = Cause::new("MISMATCHED_SOURCE_NETWORK");
+        pub const MISMATCHED_SOURCE_NETWORK: Cause = Cause::new(12);
 
         /// Aborted because the destination endpoint could not be found. Deprecated,
         /// not used in the new tests.
-        pub const DESTINATION_ENDPOINT_NOT_FOUND: Cause =
-            Cause::new("DESTINATION_ENDPOINT_NOT_FOUND");
+        pub const DESTINATION_ENDPOINT_NOT_FOUND: Cause = Cause::new(13);
 
         /// Aborted because the destination network does not match the destination
         /// endpoint. Deprecated, not used in the new tests.
-        pub const MISMATCHED_DESTINATION_NETWORK: Cause =
-            Cause::new("MISMATCHED_DESTINATION_NETWORK");
+        pub const MISMATCHED_DESTINATION_NETWORK: Cause = Cause::new(14);
 
         /// Aborted because no endpoint with the packet's destination IP address is
         /// found.
-        pub const UNKNOWN_IP: Cause = Cause::new("UNKNOWN_IP");
+        pub const UNKNOWN_IP: Cause = Cause::new(2);
 
         /// Aborted because no endpoint with the packet's destination IP is found in
         /// the Google-managed project.
-        pub const GOOGLE_MANAGED_SERVICE_UNKNOWN_IP: Cause =
-            Cause::new("GOOGLE_MANAGED_SERVICE_UNKNOWN_IP");
+        pub const GOOGLE_MANAGED_SERVICE_UNKNOWN_IP: Cause = Cause::new(32);
 
         /// Aborted because the source IP address doesn't belong to any of the
         /// subnets of the source VPC network.
-        pub const SOURCE_IP_ADDRESS_NOT_IN_SOURCE_NETWORK: Cause =
-            Cause::new("SOURCE_IP_ADDRESS_NOT_IN_SOURCE_NETWORK");
+        pub const SOURCE_IP_ADDRESS_NOT_IN_SOURCE_NETWORK: Cause = Cause::new(23);
 
         /// Aborted because user lacks permission to access all or part of the
         /// network configurations required to run the test.
-        pub const PERMISSION_DENIED: Cause = Cause::new("PERMISSION_DENIED");
+        pub const PERMISSION_DENIED: Cause = Cause::new(4);
 
         /// Aborted because user lacks permission to access Cloud NAT configs
         /// required to run the test.
-        pub const PERMISSION_DENIED_NO_CLOUD_NAT_CONFIGS: Cause =
-            Cause::new("PERMISSION_DENIED_NO_CLOUD_NAT_CONFIGS");
+        pub const PERMISSION_DENIED_NO_CLOUD_NAT_CONFIGS: Cause = Cause::new(28);
 
         /// Aborted because user lacks permission to access Network endpoint group
         /// endpoint configs required to run the test.
-        pub const PERMISSION_DENIED_NO_NEG_ENDPOINT_CONFIGS: Cause =
-            Cause::new("PERMISSION_DENIED_NO_NEG_ENDPOINT_CONFIGS");
+        pub const PERMISSION_DENIED_NO_NEG_ENDPOINT_CONFIGS: Cause = Cause::new(29);
 
         /// Aborted because user lacks permission to access Cloud Router configs
         /// required to run the test.
-        pub const PERMISSION_DENIED_NO_CLOUD_ROUTER_CONFIGS: Cause =
-            Cause::new("PERMISSION_DENIED_NO_CLOUD_ROUTER_CONFIGS");
+        pub const PERMISSION_DENIED_NO_CLOUD_ROUTER_CONFIGS: Cause = Cause::new(36);
 
         /// Aborted because no valid source or destination endpoint is derived from
         /// the input test request.
-        pub const NO_SOURCE_LOCATION: Cause = Cause::new("NO_SOURCE_LOCATION");
+        pub const NO_SOURCE_LOCATION: Cause = Cause::new(5);
 
         /// Aborted because the source or destination endpoint specified in
         /// the request is invalid. Some examples:
@@ -5143,90 +5608,222 @@ pub mod abort_info {
         /// - The request might contain inconsistent information (for example, the
         ///   request might include both the instance and the network, but the instance
         ///   might not have a NIC in that network).
-        pub const INVALID_ARGUMENT: Cause = Cause::new("INVALID_ARGUMENT");
+        pub const INVALID_ARGUMENT: Cause = Cause::new(6);
 
         /// Aborted because the number of steps in the trace exceeds a certain
         /// limit. It might be caused by a routing loop.
-        pub const TRACE_TOO_LONG: Cause = Cause::new("TRACE_TOO_LONG");
+        pub const TRACE_TOO_LONG: Cause = Cause::new(9);
 
         /// Aborted due to internal server error.
-        pub const INTERNAL_ERROR: Cause = Cause::new("INTERNAL_ERROR");
+        pub const INTERNAL_ERROR: Cause = Cause::new(10);
 
         /// Aborted because the test scenario is not supported.
-        pub const UNSUPPORTED: Cause = Cause::new("UNSUPPORTED");
+        pub const UNSUPPORTED: Cause = Cause::new(15);
 
         /// Aborted because the source and destination resources have no common IP
         /// version.
-        pub const MISMATCHED_IP_VERSION: Cause = Cause::new("MISMATCHED_IP_VERSION");
+        pub const MISMATCHED_IP_VERSION: Cause = Cause::new(16);
 
         /// Aborted because the connection between the control plane and the node of
         /// the source cluster is initiated by the node and managed by the
         /// Konnectivity proxy.
-        pub const GKE_KONNECTIVITY_PROXY_UNSUPPORTED: Cause =
-            Cause::new("GKE_KONNECTIVITY_PROXY_UNSUPPORTED");
+        pub const GKE_KONNECTIVITY_PROXY_UNSUPPORTED: Cause = Cause::new(17);
 
         /// Aborted because expected resource configuration was missing.
-        pub const RESOURCE_CONFIG_NOT_FOUND: Cause = Cause::new("RESOURCE_CONFIG_NOT_FOUND");
+        pub const RESOURCE_CONFIG_NOT_FOUND: Cause = Cause::new(18);
 
         /// Aborted because expected VM instance configuration was missing.
-        pub const VM_INSTANCE_CONFIG_NOT_FOUND: Cause = Cause::new("VM_INSTANCE_CONFIG_NOT_FOUND");
+        pub const VM_INSTANCE_CONFIG_NOT_FOUND: Cause = Cause::new(24);
 
         /// Aborted because expected network configuration was missing.
-        pub const NETWORK_CONFIG_NOT_FOUND: Cause = Cause::new("NETWORK_CONFIG_NOT_FOUND");
+        pub const NETWORK_CONFIG_NOT_FOUND: Cause = Cause::new(25);
 
         /// Aborted because expected firewall configuration was missing.
-        pub const FIREWALL_CONFIG_NOT_FOUND: Cause = Cause::new("FIREWALL_CONFIG_NOT_FOUND");
+        pub const FIREWALL_CONFIG_NOT_FOUND: Cause = Cause::new(26);
 
         /// Aborted because expected route configuration was missing.
-        pub const ROUTE_CONFIG_NOT_FOUND: Cause = Cause::new("ROUTE_CONFIG_NOT_FOUND");
+        pub const ROUTE_CONFIG_NOT_FOUND: Cause = Cause::new(27);
 
         /// Aborted because a PSC endpoint selection for the Google-managed service
         /// is ambiguous (several PSC endpoints satisfy test input).
-        pub const GOOGLE_MANAGED_SERVICE_AMBIGUOUS_PSC_ENDPOINT: Cause =
-            Cause::new("GOOGLE_MANAGED_SERVICE_AMBIGUOUS_PSC_ENDPOINT");
+        pub const GOOGLE_MANAGED_SERVICE_AMBIGUOUS_PSC_ENDPOINT: Cause = Cause::new(19);
 
         /// Aborted because tests with a PSC-based Cloud SQL instance as a source are
         /// not supported.
-        pub const SOURCE_PSC_CLOUD_SQL_UNSUPPORTED: Cause =
-            Cause::new("SOURCE_PSC_CLOUD_SQL_UNSUPPORTED");
+        pub const SOURCE_PSC_CLOUD_SQL_UNSUPPORTED: Cause = Cause::new(20);
 
         /// Aborted because tests with a Redis Cluster as a source are not supported.
-        pub const SOURCE_REDIS_CLUSTER_UNSUPPORTED: Cause =
-            Cause::new("SOURCE_REDIS_CLUSTER_UNSUPPORTED");
+        pub const SOURCE_REDIS_CLUSTER_UNSUPPORTED: Cause = Cause::new(34);
 
         /// Aborted because tests with a Redis Instance as a source are not
         /// supported.
-        pub const SOURCE_REDIS_INSTANCE_UNSUPPORTED: Cause =
-            Cause::new("SOURCE_REDIS_INSTANCE_UNSUPPORTED");
+        pub const SOURCE_REDIS_INSTANCE_UNSUPPORTED: Cause = Cause::new(35);
 
         /// Aborted because tests with a forwarding rule as a source are not
         /// supported.
-        pub const SOURCE_FORWARDING_RULE_UNSUPPORTED: Cause =
-            Cause::new("SOURCE_FORWARDING_RULE_UNSUPPORTED");
+        pub const SOURCE_FORWARDING_RULE_UNSUPPORTED: Cause = Cause::new(21);
 
         /// Aborted because one of the endpoints is a non-routable IP address
         /// (loopback, link-local, etc).
-        pub const NON_ROUTABLE_IP_ADDRESS: Cause = Cause::new("NON_ROUTABLE_IP_ADDRESS");
+        pub const NON_ROUTABLE_IP_ADDRESS: Cause = Cause::new(22);
 
         /// Aborted due to an unknown issue in the Google-managed project.
-        pub const UNKNOWN_ISSUE_IN_GOOGLE_MANAGED_PROJECT: Cause =
-            Cause::new("UNKNOWN_ISSUE_IN_GOOGLE_MANAGED_PROJECT");
+        pub const UNKNOWN_ISSUE_IN_GOOGLE_MANAGED_PROJECT: Cause = Cause::new(30);
 
         /// Aborted due to an unsupported configuration of the Google-managed
         /// project.
-        pub const UNSUPPORTED_GOOGLE_MANAGED_PROJECT_CONFIG: Cause =
-            Cause::new("UNSUPPORTED_GOOGLE_MANAGED_PROJECT_CONFIG");
+        pub const UNSUPPORTED_GOOGLE_MANAGED_PROJECT_CONFIG: Cause = Cause::new(31);
+
+        /// Creates a new Cause instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CAUSE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("UNKNOWN_NETWORK"),
+                2 => std::borrow::Cow::Borrowed("UNKNOWN_IP"),
+                3 => std::borrow::Cow::Borrowed("UNKNOWN_PROJECT"),
+                4 => std::borrow::Cow::Borrowed("PERMISSION_DENIED"),
+                5 => std::borrow::Cow::Borrowed("NO_SOURCE_LOCATION"),
+                6 => std::borrow::Cow::Borrowed("INVALID_ARGUMENT"),
+                7 => std::borrow::Cow::Borrowed("NO_EXTERNAL_IP"),
+                8 => std::borrow::Cow::Borrowed("UNINTENDED_DESTINATION"),
+                9 => std::borrow::Cow::Borrowed("TRACE_TOO_LONG"),
+                10 => std::borrow::Cow::Borrowed("INTERNAL_ERROR"),
+                11 => std::borrow::Cow::Borrowed("SOURCE_ENDPOINT_NOT_FOUND"),
+                12 => std::borrow::Cow::Borrowed("MISMATCHED_SOURCE_NETWORK"),
+                13 => std::borrow::Cow::Borrowed("DESTINATION_ENDPOINT_NOT_FOUND"),
+                14 => std::borrow::Cow::Borrowed("MISMATCHED_DESTINATION_NETWORK"),
+                15 => std::borrow::Cow::Borrowed("UNSUPPORTED"),
+                16 => std::borrow::Cow::Borrowed("MISMATCHED_IP_VERSION"),
+                17 => std::borrow::Cow::Borrowed("GKE_KONNECTIVITY_PROXY_UNSUPPORTED"),
+                18 => std::borrow::Cow::Borrowed("RESOURCE_CONFIG_NOT_FOUND"),
+                19 => std::borrow::Cow::Borrowed("GOOGLE_MANAGED_SERVICE_AMBIGUOUS_PSC_ENDPOINT"),
+                20 => std::borrow::Cow::Borrowed("SOURCE_PSC_CLOUD_SQL_UNSUPPORTED"),
+                21 => std::borrow::Cow::Borrowed("SOURCE_FORWARDING_RULE_UNSUPPORTED"),
+                22 => std::borrow::Cow::Borrowed("NON_ROUTABLE_IP_ADDRESS"),
+                23 => std::borrow::Cow::Borrowed("SOURCE_IP_ADDRESS_NOT_IN_SOURCE_NETWORK"),
+                24 => std::borrow::Cow::Borrowed("VM_INSTANCE_CONFIG_NOT_FOUND"),
+                25 => std::borrow::Cow::Borrowed("NETWORK_CONFIG_NOT_FOUND"),
+                26 => std::borrow::Cow::Borrowed("FIREWALL_CONFIG_NOT_FOUND"),
+                27 => std::borrow::Cow::Borrowed("ROUTE_CONFIG_NOT_FOUND"),
+                28 => std::borrow::Cow::Borrowed("PERMISSION_DENIED_NO_CLOUD_NAT_CONFIGS"),
+                29 => std::borrow::Cow::Borrowed("PERMISSION_DENIED_NO_NEG_ENDPOINT_CONFIGS"),
+                30 => std::borrow::Cow::Borrowed("UNKNOWN_ISSUE_IN_GOOGLE_MANAGED_PROJECT"),
+                31 => std::borrow::Cow::Borrowed("UNSUPPORTED_GOOGLE_MANAGED_PROJECT_CONFIG"),
+                32 => std::borrow::Cow::Borrowed("GOOGLE_MANAGED_SERVICE_UNKNOWN_IP"),
+                34 => std::borrow::Cow::Borrowed("SOURCE_REDIS_CLUSTER_UNSUPPORTED"),
+                35 => std::borrow::Cow::Borrowed("SOURCE_REDIS_INSTANCE_UNSUPPORTED"),
+                36 => std::borrow::Cow::Borrowed("PERMISSION_DENIED_NO_CLOUD_ROUTER_CONFIGS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CAUSE_UNSPECIFIED" => std::option::Option::Some(Self::CAUSE_UNSPECIFIED),
+                "UNKNOWN_NETWORK" => std::option::Option::Some(Self::UNKNOWN_NETWORK),
+                "UNKNOWN_PROJECT" => std::option::Option::Some(Self::UNKNOWN_PROJECT),
+                "NO_EXTERNAL_IP" => std::option::Option::Some(Self::NO_EXTERNAL_IP),
+                "UNINTENDED_DESTINATION" => std::option::Option::Some(Self::UNINTENDED_DESTINATION),
+                "SOURCE_ENDPOINT_NOT_FOUND" => {
+                    std::option::Option::Some(Self::SOURCE_ENDPOINT_NOT_FOUND)
+                }
+                "MISMATCHED_SOURCE_NETWORK" => {
+                    std::option::Option::Some(Self::MISMATCHED_SOURCE_NETWORK)
+                }
+                "DESTINATION_ENDPOINT_NOT_FOUND" => {
+                    std::option::Option::Some(Self::DESTINATION_ENDPOINT_NOT_FOUND)
+                }
+                "MISMATCHED_DESTINATION_NETWORK" => {
+                    std::option::Option::Some(Self::MISMATCHED_DESTINATION_NETWORK)
+                }
+                "UNKNOWN_IP" => std::option::Option::Some(Self::UNKNOWN_IP),
+                "GOOGLE_MANAGED_SERVICE_UNKNOWN_IP" => {
+                    std::option::Option::Some(Self::GOOGLE_MANAGED_SERVICE_UNKNOWN_IP)
+                }
+                "SOURCE_IP_ADDRESS_NOT_IN_SOURCE_NETWORK" => {
+                    std::option::Option::Some(Self::SOURCE_IP_ADDRESS_NOT_IN_SOURCE_NETWORK)
+                }
+                "PERMISSION_DENIED" => std::option::Option::Some(Self::PERMISSION_DENIED),
+                "PERMISSION_DENIED_NO_CLOUD_NAT_CONFIGS" => {
+                    std::option::Option::Some(Self::PERMISSION_DENIED_NO_CLOUD_NAT_CONFIGS)
+                }
+                "PERMISSION_DENIED_NO_NEG_ENDPOINT_CONFIGS" => {
+                    std::option::Option::Some(Self::PERMISSION_DENIED_NO_NEG_ENDPOINT_CONFIGS)
+                }
+                "PERMISSION_DENIED_NO_CLOUD_ROUTER_CONFIGS" => {
+                    std::option::Option::Some(Self::PERMISSION_DENIED_NO_CLOUD_ROUTER_CONFIGS)
+                }
+                "NO_SOURCE_LOCATION" => std::option::Option::Some(Self::NO_SOURCE_LOCATION),
+                "INVALID_ARGUMENT" => std::option::Option::Some(Self::INVALID_ARGUMENT),
+                "TRACE_TOO_LONG" => std::option::Option::Some(Self::TRACE_TOO_LONG),
+                "INTERNAL_ERROR" => std::option::Option::Some(Self::INTERNAL_ERROR),
+                "UNSUPPORTED" => std::option::Option::Some(Self::UNSUPPORTED),
+                "MISMATCHED_IP_VERSION" => std::option::Option::Some(Self::MISMATCHED_IP_VERSION),
+                "GKE_KONNECTIVITY_PROXY_UNSUPPORTED" => {
+                    std::option::Option::Some(Self::GKE_KONNECTIVITY_PROXY_UNSUPPORTED)
+                }
+                "RESOURCE_CONFIG_NOT_FOUND" => {
+                    std::option::Option::Some(Self::RESOURCE_CONFIG_NOT_FOUND)
+                }
+                "VM_INSTANCE_CONFIG_NOT_FOUND" => {
+                    std::option::Option::Some(Self::VM_INSTANCE_CONFIG_NOT_FOUND)
+                }
+                "NETWORK_CONFIG_NOT_FOUND" => {
+                    std::option::Option::Some(Self::NETWORK_CONFIG_NOT_FOUND)
+                }
+                "FIREWALL_CONFIG_NOT_FOUND" => {
+                    std::option::Option::Some(Self::FIREWALL_CONFIG_NOT_FOUND)
+                }
+                "ROUTE_CONFIG_NOT_FOUND" => std::option::Option::Some(Self::ROUTE_CONFIG_NOT_FOUND),
+                "GOOGLE_MANAGED_SERVICE_AMBIGUOUS_PSC_ENDPOINT" => {
+                    std::option::Option::Some(Self::GOOGLE_MANAGED_SERVICE_AMBIGUOUS_PSC_ENDPOINT)
+                }
+                "SOURCE_PSC_CLOUD_SQL_UNSUPPORTED" => {
+                    std::option::Option::Some(Self::SOURCE_PSC_CLOUD_SQL_UNSUPPORTED)
+                }
+                "SOURCE_REDIS_CLUSTER_UNSUPPORTED" => {
+                    std::option::Option::Some(Self::SOURCE_REDIS_CLUSTER_UNSUPPORTED)
+                }
+                "SOURCE_REDIS_INSTANCE_UNSUPPORTED" => {
+                    std::option::Option::Some(Self::SOURCE_REDIS_INSTANCE_UNSUPPORTED)
+                }
+                "SOURCE_FORWARDING_RULE_UNSUPPORTED" => {
+                    std::option::Option::Some(Self::SOURCE_FORWARDING_RULE_UNSUPPORTED)
+                }
+                "NON_ROUTABLE_IP_ADDRESS" => {
+                    std::option::Option::Some(Self::NON_ROUTABLE_IP_ADDRESS)
+                }
+                "UNKNOWN_ISSUE_IN_GOOGLE_MANAGED_PROJECT" => {
+                    std::option::Option::Some(Self::UNKNOWN_ISSUE_IN_GOOGLE_MANAGED_PROJECT)
+                }
+                "UNSUPPORTED_GOOGLE_MANAGED_PROJECT_CONFIG" => {
+                    std::option::Option::Some(Self::UNSUPPORTED_GOOGLE_MANAGED_PROJECT_CONFIG)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Cause {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Cause {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Cause {
         fn default() -> Self {
-            cause::CAUSE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5309,420 +5906,701 @@ pub mod drop_info {
 
     /// Drop cause types:
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Cause(std::borrow::Cow<'static, str>);
+    pub struct Cause(i32);
 
     impl Cause {
-        /// Creates a new Cause instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Cause](Cause)
-    pub mod cause {
-        use super::Cause;
-
         /// Cause is unspecified.
-        pub const CAUSE_UNSPECIFIED: Cause = Cause::new("CAUSE_UNSPECIFIED");
+        pub const CAUSE_UNSPECIFIED: Cause = Cause::new(0);
 
         /// Destination external address cannot be resolved to a known target. If
         /// the address is used in a Google Cloud project, provide the project ID
         /// as test input.
-        pub const UNKNOWN_EXTERNAL_ADDRESS: Cause = Cause::new("UNKNOWN_EXTERNAL_ADDRESS");
+        pub const UNKNOWN_EXTERNAL_ADDRESS: Cause = Cause::new(1);
 
         /// A Compute Engine instance can only send or receive a packet with a
         /// foreign IP address if ip_forward is enabled.
-        pub const FOREIGN_IP_DISALLOWED: Cause = Cause::new("FOREIGN_IP_DISALLOWED");
+        pub const FOREIGN_IP_DISALLOWED: Cause = Cause::new(2);
 
         /// Dropped due to a firewall rule, unless allowed due to connection
         /// tracking.
-        pub const FIREWALL_RULE: Cause = Cause::new("FIREWALL_RULE");
+        pub const FIREWALL_RULE: Cause = Cause::new(3);
 
         /// Dropped due to no matching routes.
-        pub const NO_ROUTE: Cause = Cause::new("NO_ROUTE");
+        pub const NO_ROUTE: Cause = Cause::new(4);
 
         /// Dropped due to invalid route. Route's next hop is a blackhole.
-        pub const ROUTE_BLACKHOLE: Cause = Cause::new("ROUTE_BLACKHOLE");
+        pub const ROUTE_BLACKHOLE: Cause = Cause::new(5);
 
         /// Packet is sent to a wrong (unintended) network. Example: you trace a
         /// packet from VM1:Network1 to VM2:Network2, however, the route configured
         /// in Network1 sends the packet destined for VM2's IP address to Network3.
-        pub const ROUTE_WRONG_NETWORK: Cause = Cause::new("ROUTE_WRONG_NETWORK");
+        pub const ROUTE_WRONG_NETWORK: Cause = Cause::new(6);
 
         /// Route's next hop IP address cannot be resolved to a GCP resource.
-        pub const ROUTE_NEXT_HOP_IP_ADDRESS_NOT_RESOLVED: Cause =
-            Cause::new("ROUTE_NEXT_HOP_IP_ADDRESS_NOT_RESOLVED");
+        pub const ROUTE_NEXT_HOP_IP_ADDRESS_NOT_RESOLVED: Cause = Cause::new(42);
 
         /// Route's next hop resource is not found.
-        pub const ROUTE_NEXT_HOP_RESOURCE_NOT_FOUND: Cause =
-            Cause::new("ROUTE_NEXT_HOP_RESOURCE_NOT_FOUND");
+        pub const ROUTE_NEXT_HOP_RESOURCE_NOT_FOUND: Cause = Cause::new(43);
 
         /// Route's next hop instance doesn't have a NIC in the route's network.
-        pub const ROUTE_NEXT_HOP_INSTANCE_WRONG_NETWORK: Cause =
-            Cause::new("ROUTE_NEXT_HOP_INSTANCE_WRONG_NETWORK");
+        pub const ROUTE_NEXT_HOP_INSTANCE_WRONG_NETWORK: Cause = Cause::new(49);
 
         /// Route's next hop IP address is not a primary IP address of the next hop
         /// instance.
-        pub const ROUTE_NEXT_HOP_INSTANCE_NON_PRIMARY_IP: Cause =
-            Cause::new("ROUTE_NEXT_HOP_INSTANCE_NON_PRIMARY_IP");
+        pub const ROUTE_NEXT_HOP_INSTANCE_NON_PRIMARY_IP: Cause = Cause::new(50);
 
         /// Route's next hop forwarding rule doesn't match next hop IP address.
-        pub const ROUTE_NEXT_HOP_FORWARDING_RULE_IP_MISMATCH: Cause =
-            Cause::new("ROUTE_NEXT_HOP_FORWARDING_RULE_IP_MISMATCH");
+        pub const ROUTE_NEXT_HOP_FORWARDING_RULE_IP_MISMATCH: Cause = Cause::new(51);
 
         /// Route's next hop VPN tunnel is down (does not have valid IKE SAs).
-        pub const ROUTE_NEXT_HOP_VPN_TUNNEL_NOT_ESTABLISHED: Cause =
-            Cause::new("ROUTE_NEXT_HOP_VPN_TUNNEL_NOT_ESTABLISHED");
+        pub const ROUTE_NEXT_HOP_VPN_TUNNEL_NOT_ESTABLISHED: Cause = Cause::new(52);
 
         /// Route's next hop forwarding rule type is invalid (it's not a forwarding
         /// rule of the internal passthrough load balancer).
-        pub const ROUTE_NEXT_HOP_FORWARDING_RULE_TYPE_INVALID: Cause =
-            Cause::new("ROUTE_NEXT_HOP_FORWARDING_RULE_TYPE_INVALID");
+        pub const ROUTE_NEXT_HOP_FORWARDING_RULE_TYPE_INVALID: Cause = Cause::new(53);
 
         /// Packet is sent from the Internet to the private IPv6 address.
-        pub const NO_ROUTE_FROM_INTERNET_TO_PRIVATE_IPV6_ADDRESS: Cause =
-            Cause::new("NO_ROUTE_FROM_INTERNET_TO_PRIVATE_IPV6_ADDRESS");
+        pub const NO_ROUTE_FROM_INTERNET_TO_PRIVATE_IPV6_ADDRESS: Cause = Cause::new(44);
 
         /// The packet does not match a policy-based VPN tunnel local selector.
-        pub const VPN_TUNNEL_LOCAL_SELECTOR_MISMATCH: Cause =
-            Cause::new("VPN_TUNNEL_LOCAL_SELECTOR_MISMATCH");
+        pub const VPN_TUNNEL_LOCAL_SELECTOR_MISMATCH: Cause = Cause::new(45);
 
         /// The packet does not match a policy-based VPN tunnel remote selector.
-        pub const VPN_TUNNEL_REMOTE_SELECTOR_MISMATCH: Cause =
-            Cause::new("VPN_TUNNEL_REMOTE_SELECTOR_MISMATCH");
+        pub const VPN_TUNNEL_REMOTE_SELECTOR_MISMATCH: Cause = Cause::new(46);
 
         /// Packet with internal destination address sent to the internet gateway.
-        pub const PRIVATE_TRAFFIC_TO_INTERNET: Cause = Cause::new("PRIVATE_TRAFFIC_TO_INTERNET");
+        pub const PRIVATE_TRAFFIC_TO_INTERNET: Cause = Cause::new(7);
 
         /// Instance with only an internal IP address tries to access Google API and
         /// services, but private Google access is not enabled in the subnet.
-        pub const PRIVATE_GOOGLE_ACCESS_DISALLOWED: Cause =
-            Cause::new("PRIVATE_GOOGLE_ACCESS_DISALLOWED");
+        pub const PRIVATE_GOOGLE_ACCESS_DISALLOWED: Cause = Cause::new(8);
 
         /// Source endpoint tries to access Google API and services through the VPN
         /// tunnel to another network, but Private Google Access needs to be enabled
         /// in the source endpoint network.
-        pub const PRIVATE_GOOGLE_ACCESS_VIA_VPN_TUNNEL_UNSUPPORTED: Cause =
-            Cause::new("PRIVATE_GOOGLE_ACCESS_VIA_VPN_TUNNEL_UNSUPPORTED");
+        pub const PRIVATE_GOOGLE_ACCESS_VIA_VPN_TUNNEL_UNSUPPORTED: Cause = Cause::new(47);
 
         /// Instance with only an internal IP address tries to access external hosts,
         /// but Cloud NAT is not enabled in the subnet, unless special configurations
         /// on a VM allow this connection.
-        pub const NO_EXTERNAL_ADDRESS: Cause = Cause::new("NO_EXTERNAL_ADDRESS");
+        pub const NO_EXTERNAL_ADDRESS: Cause = Cause::new(9);
 
         /// Destination internal address cannot be resolved to a known target. If
         /// this is a shared VPC scenario, verify if the service project ID is
         /// provided as test input. Otherwise, verify if the IP address is being
         /// used in the project.
-        pub const UNKNOWN_INTERNAL_ADDRESS: Cause = Cause::new("UNKNOWN_INTERNAL_ADDRESS");
+        pub const UNKNOWN_INTERNAL_ADDRESS: Cause = Cause::new(10);
 
         /// Forwarding rule's protocol and ports do not match the packet header.
-        pub const FORWARDING_RULE_MISMATCH: Cause = Cause::new("FORWARDING_RULE_MISMATCH");
+        pub const FORWARDING_RULE_MISMATCH: Cause = Cause::new(11);
 
         /// Forwarding rule does not have backends configured.
-        pub const FORWARDING_RULE_NO_INSTANCES: Cause = Cause::new("FORWARDING_RULE_NO_INSTANCES");
+        pub const FORWARDING_RULE_NO_INSTANCES: Cause = Cause::new(12);
 
         /// Firewalls block the health check probes to the backends and cause
         /// the backends to be unavailable for traffic from the load balancer.
         /// For more details, see [Health check firewall
         /// rules](https://cloud.google.com/load-balancing/docs/health-checks#firewall_rules).
-        pub const FIREWALL_BLOCKING_LOAD_BALANCER_BACKEND_HEALTH_CHECK: Cause =
-            Cause::new("FIREWALL_BLOCKING_LOAD_BALANCER_BACKEND_HEALTH_CHECK");
+        pub const FIREWALL_BLOCKING_LOAD_BALANCER_BACKEND_HEALTH_CHECK: Cause = Cause::new(13);
 
         /// Packet is sent from or to a Compute Engine instance that is not in a
         /// running state.
-        pub const INSTANCE_NOT_RUNNING: Cause = Cause::new("INSTANCE_NOT_RUNNING");
+        pub const INSTANCE_NOT_RUNNING: Cause = Cause::new(14);
 
         /// Packet sent from or to a GKE cluster that is not in running state.
-        pub const GKE_CLUSTER_NOT_RUNNING: Cause = Cause::new("GKE_CLUSTER_NOT_RUNNING");
+        pub const GKE_CLUSTER_NOT_RUNNING: Cause = Cause::new(27);
 
         /// Packet sent from or to a Cloud SQL instance that is not in running state.
-        pub const CLOUD_SQL_INSTANCE_NOT_RUNNING: Cause =
-            Cause::new("CLOUD_SQL_INSTANCE_NOT_RUNNING");
+        pub const CLOUD_SQL_INSTANCE_NOT_RUNNING: Cause = Cause::new(28);
 
         /// Packet sent from or to a Redis Instance that is not in running state.
-        pub const REDIS_INSTANCE_NOT_RUNNING: Cause = Cause::new("REDIS_INSTANCE_NOT_RUNNING");
+        pub const REDIS_INSTANCE_NOT_RUNNING: Cause = Cause::new(68);
 
         /// Packet sent from or to a Redis Cluster that is not in running state.
-        pub const REDIS_CLUSTER_NOT_RUNNING: Cause = Cause::new("REDIS_CLUSTER_NOT_RUNNING");
+        pub const REDIS_CLUSTER_NOT_RUNNING: Cause = Cause::new(69);
 
         /// The type of traffic is blocked and the user cannot configure a firewall
         /// rule to enable it. See [Always blocked
         /// traffic](https://cloud.google.com/vpc/docs/firewalls#blockedtraffic) for
         /// more details.
-        pub const TRAFFIC_TYPE_BLOCKED: Cause = Cause::new("TRAFFIC_TYPE_BLOCKED");
+        pub const TRAFFIC_TYPE_BLOCKED: Cause = Cause::new(15);
 
         /// Access to Google Kubernetes Engine cluster master's endpoint is not
         /// authorized. See [Access to the cluster
         /// endpoints](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#access_to_the_cluster_endpoints)
         /// for more details.
-        pub const GKE_MASTER_UNAUTHORIZED_ACCESS: Cause =
-            Cause::new("GKE_MASTER_UNAUTHORIZED_ACCESS");
+        pub const GKE_MASTER_UNAUTHORIZED_ACCESS: Cause = Cause::new(16);
 
         /// Access to the Cloud SQL instance endpoint is not authorized.
         /// See [Authorizing with authorized
         /// networks](https://cloud.google.com/sql/docs/mysql/authorize-networks) for
         /// more details.
-        pub const CLOUD_SQL_INSTANCE_UNAUTHORIZED_ACCESS: Cause =
-            Cause::new("CLOUD_SQL_INSTANCE_UNAUTHORIZED_ACCESS");
+        pub const CLOUD_SQL_INSTANCE_UNAUTHORIZED_ACCESS: Cause = Cause::new(17);
 
         /// Packet was dropped inside Google Kubernetes Engine Service.
-        pub const DROPPED_INSIDE_GKE_SERVICE: Cause = Cause::new("DROPPED_INSIDE_GKE_SERVICE");
+        pub const DROPPED_INSIDE_GKE_SERVICE: Cause = Cause::new(18);
 
         /// Packet was dropped inside Cloud SQL Service.
-        pub const DROPPED_INSIDE_CLOUD_SQL_SERVICE: Cause =
-            Cause::new("DROPPED_INSIDE_CLOUD_SQL_SERVICE");
+        pub const DROPPED_INSIDE_CLOUD_SQL_SERVICE: Cause = Cause::new(19);
 
         /// Packet was dropped because there is no peering between the originating
         /// network and the Google Managed Services Network.
-        pub const GOOGLE_MANAGED_SERVICE_NO_PEERING: Cause =
-            Cause::new("GOOGLE_MANAGED_SERVICE_NO_PEERING");
+        pub const GOOGLE_MANAGED_SERVICE_NO_PEERING: Cause = Cause::new(20);
 
         /// Packet was dropped because the Google-managed service uses Private
         /// Service Connect (PSC), but the PSC endpoint is not found in the project.
-        pub const GOOGLE_MANAGED_SERVICE_NO_PSC_ENDPOINT: Cause =
-            Cause::new("GOOGLE_MANAGED_SERVICE_NO_PSC_ENDPOINT");
+        pub const GOOGLE_MANAGED_SERVICE_NO_PSC_ENDPOINT: Cause = Cause::new(38);
 
         /// Packet was dropped because the GKE cluster uses Private Service Connect
         /// (PSC), but the PSC endpoint is not found in the project.
-        pub const GKE_PSC_ENDPOINT_MISSING: Cause = Cause::new("GKE_PSC_ENDPOINT_MISSING");
+        pub const GKE_PSC_ENDPOINT_MISSING: Cause = Cause::new(36);
 
         /// Packet was dropped because the Cloud SQL instance has neither a private
         /// nor a public IP address.
-        pub const CLOUD_SQL_INSTANCE_NO_IP_ADDRESS: Cause =
-            Cause::new("CLOUD_SQL_INSTANCE_NO_IP_ADDRESS");
+        pub const CLOUD_SQL_INSTANCE_NO_IP_ADDRESS: Cause = Cause::new(21);
 
         /// Packet was dropped because a GKE cluster private endpoint is
         /// unreachable from a region different from the cluster's region.
-        pub const GKE_CONTROL_PLANE_REGION_MISMATCH: Cause =
-            Cause::new("GKE_CONTROL_PLANE_REGION_MISMATCH");
+        pub const GKE_CONTROL_PLANE_REGION_MISMATCH: Cause = Cause::new(30);
 
         /// Packet sent from a public GKE cluster control plane to a private
         /// IP address.
-        pub const PUBLIC_GKE_CONTROL_PLANE_TO_PRIVATE_DESTINATION: Cause =
-            Cause::new("PUBLIC_GKE_CONTROL_PLANE_TO_PRIVATE_DESTINATION");
+        pub const PUBLIC_GKE_CONTROL_PLANE_TO_PRIVATE_DESTINATION: Cause = Cause::new(31);
 
         /// Packet was dropped because there is no route from a GKE cluster
         /// control plane to a destination network.
-        pub const GKE_CONTROL_PLANE_NO_ROUTE: Cause = Cause::new("GKE_CONTROL_PLANE_NO_ROUTE");
+        pub const GKE_CONTROL_PLANE_NO_ROUTE: Cause = Cause::new(32);
 
         /// Packet sent from a Cloud SQL instance to an external IP address is not
         /// allowed. The Cloud SQL instance is not configured to send packets to
         /// external IP addresses.
-        pub const CLOUD_SQL_INSTANCE_NOT_CONFIGURED_FOR_EXTERNAL_TRAFFIC: Cause =
-            Cause::new("CLOUD_SQL_INSTANCE_NOT_CONFIGURED_FOR_EXTERNAL_TRAFFIC");
+        pub const CLOUD_SQL_INSTANCE_NOT_CONFIGURED_FOR_EXTERNAL_TRAFFIC: Cause = Cause::new(33);
 
         /// Packet sent from a Cloud SQL instance with only a public IP address to a
         /// private IP address.
-        pub const PUBLIC_CLOUD_SQL_INSTANCE_TO_PRIVATE_DESTINATION: Cause =
-            Cause::new("PUBLIC_CLOUD_SQL_INSTANCE_TO_PRIVATE_DESTINATION");
+        pub const PUBLIC_CLOUD_SQL_INSTANCE_TO_PRIVATE_DESTINATION: Cause = Cause::new(34);
 
         /// Packet was dropped because there is no route from a Cloud SQL
         /// instance to a destination network.
-        pub const CLOUD_SQL_INSTANCE_NO_ROUTE: Cause = Cause::new("CLOUD_SQL_INSTANCE_NO_ROUTE");
+        pub const CLOUD_SQL_INSTANCE_NO_ROUTE: Cause = Cause::new(35);
 
         /// Packet was dropped because the Cloud SQL instance requires all
         /// connections to use Cloud SQL connectors and to target the Cloud SQL proxy
         /// port (3307).
-        pub const CLOUD_SQL_CONNECTOR_REQUIRED: Cause = Cause::new("CLOUD_SQL_CONNECTOR_REQUIRED");
+        pub const CLOUD_SQL_CONNECTOR_REQUIRED: Cause = Cause::new(63);
 
         /// Packet could be dropped because the Cloud Function is not in an active
         /// status.
-        pub const CLOUD_FUNCTION_NOT_ACTIVE: Cause = Cause::new("CLOUD_FUNCTION_NOT_ACTIVE");
+        pub const CLOUD_FUNCTION_NOT_ACTIVE: Cause = Cause::new(22);
 
         /// Packet could be dropped because no VPC connector is set.
-        pub const VPC_CONNECTOR_NOT_SET: Cause = Cause::new("VPC_CONNECTOR_NOT_SET");
+        pub const VPC_CONNECTOR_NOT_SET: Cause = Cause::new(23);
 
         /// Packet could be dropped because the VPC connector is not in a running
         /// state.
-        pub const VPC_CONNECTOR_NOT_RUNNING: Cause = Cause::new("VPC_CONNECTOR_NOT_RUNNING");
+        pub const VPC_CONNECTOR_NOT_RUNNING: Cause = Cause::new(24);
 
         /// Packet could be dropped because the traffic from the serverless service
         /// to the VPC connector is not allowed.
-        pub const VPC_CONNECTOR_SERVERLESS_TRAFFIC_BLOCKED: Cause =
-            Cause::new("VPC_CONNECTOR_SERVERLESS_TRAFFIC_BLOCKED");
+        pub const VPC_CONNECTOR_SERVERLESS_TRAFFIC_BLOCKED: Cause = Cause::new(60);
 
         /// Packet could be dropped because the health check traffic to the VPC
         /// connector is not allowed.
-        pub const VPC_CONNECTOR_HEALTH_CHECK_TRAFFIC_BLOCKED: Cause =
-            Cause::new("VPC_CONNECTOR_HEALTH_CHECK_TRAFFIC_BLOCKED");
+        pub const VPC_CONNECTOR_HEALTH_CHECK_TRAFFIC_BLOCKED: Cause = Cause::new(61);
 
         /// Packet could be dropped because it was sent from a different region
         /// to a regional forwarding without global access.
-        pub const FORWARDING_RULE_REGION_MISMATCH: Cause =
-            Cause::new("FORWARDING_RULE_REGION_MISMATCH");
+        pub const FORWARDING_RULE_REGION_MISMATCH: Cause = Cause::new(25);
 
         /// The Private Service Connect endpoint is in a project that is not approved
         /// to connect to the service.
-        pub const PSC_CONNECTION_NOT_ACCEPTED: Cause = Cause::new("PSC_CONNECTION_NOT_ACCEPTED");
+        pub const PSC_CONNECTION_NOT_ACCEPTED: Cause = Cause::new(26);
 
         /// The packet is sent to the Private Service Connect endpoint over the
         /// peering, but [it's not
         /// supported](https://cloud.google.com/vpc/docs/configure-private-service-connect-services#on-premises).
-        pub const PSC_ENDPOINT_ACCESSED_FROM_PEERED_NETWORK: Cause =
-            Cause::new("PSC_ENDPOINT_ACCESSED_FROM_PEERED_NETWORK");
+        pub const PSC_ENDPOINT_ACCESSED_FROM_PEERED_NETWORK: Cause = Cause::new(41);
 
         /// The packet is sent to the Private Service Connect backend (network
         /// endpoint group), but the producer PSC forwarding rule does not have
         /// global access enabled.
-        pub const PSC_NEG_PRODUCER_ENDPOINT_NO_GLOBAL_ACCESS: Cause =
-            Cause::new("PSC_NEG_PRODUCER_ENDPOINT_NO_GLOBAL_ACCESS");
+        pub const PSC_NEG_PRODUCER_ENDPOINT_NO_GLOBAL_ACCESS: Cause = Cause::new(48);
 
         /// The packet is sent to the Private Service Connect backend (network
         /// endpoint group), but the producer PSC forwarding rule has multiple ports
         /// specified.
-        pub const PSC_NEG_PRODUCER_FORWARDING_RULE_MULTIPLE_PORTS: Cause =
-            Cause::new("PSC_NEG_PRODUCER_FORWARDING_RULE_MULTIPLE_PORTS");
+        pub const PSC_NEG_PRODUCER_FORWARDING_RULE_MULTIPLE_PORTS: Cause = Cause::new(54);
 
         /// The packet is sent to the Private Service Connect backend (network
         /// endpoint group) targeting a Cloud SQL service attachment, but this
         /// configuration is not supported.
-        pub const CLOUD_SQL_PSC_NEG_UNSUPPORTED: Cause =
-            Cause::new("CLOUD_SQL_PSC_NEG_UNSUPPORTED");
+        pub const CLOUD_SQL_PSC_NEG_UNSUPPORTED: Cause = Cause::new(58);
 
         /// No NAT subnets are defined for the PSC service attachment.
-        pub const NO_NAT_SUBNETS_FOR_PSC_SERVICE_ATTACHMENT: Cause =
-            Cause::new("NO_NAT_SUBNETS_FOR_PSC_SERVICE_ATTACHMENT");
+        pub const NO_NAT_SUBNETS_FOR_PSC_SERVICE_ATTACHMENT: Cause = Cause::new(57);
 
         /// PSC endpoint is accessed via NCC, but PSC transitivity configuration is
         /// not yet propagated.
-        pub const PSC_TRANSITIVITY_NOT_PROPAGATED: Cause =
-            Cause::new("PSC_TRANSITIVITY_NOT_PROPAGATED");
+        pub const PSC_TRANSITIVITY_NOT_PROPAGATED: Cause = Cause::new(64);
 
         /// The packet sent from the hybrid NEG proxy matches a non-dynamic route,
         /// but such a configuration is not supported.
-        pub const HYBRID_NEG_NON_DYNAMIC_ROUTE_MATCHED: Cause =
-            Cause::new("HYBRID_NEG_NON_DYNAMIC_ROUTE_MATCHED");
+        pub const HYBRID_NEG_NON_DYNAMIC_ROUTE_MATCHED: Cause = Cause::new(55);
 
         /// The packet sent from the hybrid NEG proxy matches a dynamic route with a
         /// next hop in a different region, but such a configuration is not
         /// supported.
-        pub const HYBRID_NEG_NON_LOCAL_DYNAMIC_ROUTE_MATCHED: Cause =
-            Cause::new("HYBRID_NEG_NON_LOCAL_DYNAMIC_ROUTE_MATCHED");
+        pub const HYBRID_NEG_NON_LOCAL_DYNAMIC_ROUTE_MATCHED: Cause = Cause::new(56);
 
         /// Packet sent from a Cloud Run revision that is not ready.
-        pub const CLOUD_RUN_REVISION_NOT_READY: Cause = Cause::new("CLOUD_RUN_REVISION_NOT_READY");
+        pub const CLOUD_RUN_REVISION_NOT_READY: Cause = Cause::new(29);
 
         /// Packet was dropped inside Private Service Connect service producer.
-        pub const DROPPED_INSIDE_PSC_SERVICE_PRODUCER: Cause =
-            Cause::new("DROPPED_INSIDE_PSC_SERVICE_PRODUCER");
+        pub const DROPPED_INSIDE_PSC_SERVICE_PRODUCER: Cause = Cause::new(37);
 
         /// Packet sent to a load balancer, which requires a proxy-only subnet and
         /// the subnet is not found.
-        pub const LOAD_BALANCER_HAS_NO_PROXY_SUBNET: Cause =
-            Cause::new("LOAD_BALANCER_HAS_NO_PROXY_SUBNET");
+        pub const LOAD_BALANCER_HAS_NO_PROXY_SUBNET: Cause = Cause::new(39);
 
         /// Packet sent to Cloud Nat without active NAT IPs.
-        pub const CLOUD_NAT_NO_ADDRESSES: Cause = Cause::new("CLOUD_NAT_NO_ADDRESSES");
+        pub const CLOUD_NAT_NO_ADDRESSES: Cause = Cause::new(40);
 
         /// Packet is stuck in a routing loop.
-        pub const ROUTING_LOOP: Cause = Cause::new("ROUTING_LOOP");
+        pub const ROUTING_LOOP: Cause = Cause::new(59);
 
         /// Packet is dropped inside a Google-managed service due to being delivered
         /// in return trace to an endpoint that doesn't match the endpoint the packet
         /// was sent from in forward trace. Used only for return traces.
-        pub const DROPPED_INSIDE_GOOGLE_MANAGED_SERVICE: Cause =
-            Cause::new("DROPPED_INSIDE_GOOGLE_MANAGED_SERVICE");
+        pub const DROPPED_INSIDE_GOOGLE_MANAGED_SERVICE: Cause = Cause::new(62);
 
         /// Packet is dropped due to a load balancer backend instance not having a
         /// network interface in the network expected by the load balancer.
-        pub const LOAD_BALANCER_BACKEND_INVALID_NETWORK: Cause =
-            Cause::new("LOAD_BALANCER_BACKEND_INVALID_NETWORK");
+        pub const LOAD_BALANCER_BACKEND_INVALID_NETWORK: Cause = Cause::new(65);
 
         /// Packet is dropped due to a backend service named port not being defined
         /// on the instance group level.
-        pub const BACKEND_SERVICE_NAMED_PORT_NOT_DEFINED: Cause =
-            Cause::new("BACKEND_SERVICE_NAMED_PORT_NOT_DEFINED");
+        pub const BACKEND_SERVICE_NAMED_PORT_NOT_DEFINED: Cause = Cause::new(66);
 
         /// Packet is dropped due to a destination IP range being part of a Private
         /// NAT IP range.
-        pub const DESTINATION_IS_PRIVATE_NAT_IP_RANGE: Cause =
-            Cause::new("DESTINATION_IS_PRIVATE_NAT_IP_RANGE");
+        pub const DESTINATION_IS_PRIVATE_NAT_IP_RANGE: Cause = Cause::new(67);
 
         /// Generic drop cause for a packet being dropped inside a Redis Instance
         /// service project.
-        pub const DROPPED_INSIDE_REDIS_INSTANCE_SERVICE: Cause =
-            Cause::new("DROPPED_INSIDE_REDIS_INSTANCE_SERVICE");
+        pub const DROPPED_INSIDE_REDIS_INSTANCE_SERVICE: Cause = Cause::new(70);
 
         /// Packet is dropped due to an unsupported port being used to connect to a
         /// Redis Instance. Port 6379 should be used to connect to a Redis Instance.
-        pub const REDIS_INSTANCE_UNSUPPORTED_PORT: Cause =
-            Cause::new("REDIS_INSTANCE_UNSUPPORTED_PORT");
+        pub const REDIS_INSTANCE_UNSUPPORTED_PORT: Cause = Cause::new(71);
 
         /// Packet is dropped due to connecting from PUPI address to a PSA based
         /// Redis Instance.
-        pub const REDIS_INSTANCE_CONNECTING_FROM_PUPI_ADDRESS: Cause =
-            Cause::new("REDIS_INSTANCE_CONNECTING_FROM_PUPI_ADDRESS");
+        pub const REDIS_INSTANCE_CONNECTING_FROM_PUPI_ADDRESS: Cause = Cause::new(72);
 
         /// Packet is dropped due to no route to the destination network.
-        pub const REDIS_INSTANCE_NO_ROUTE_TO_DESTINATION_NETWORK: Cause =
-            Cause::new("REDIS_INSTANCE_NO_ROUTE_TO_DESTINATION_NETWORK");
+        pub const REDIS_INSTANCE_NO_ROUTE_TO_DESTINATION_NETWORK: Cause = Cause::new(73);
 
         /// Redis Instance does not have an external IP address.
-        pub const REDIS_INSTANCE_NO_EXTERNAL_IP: Cause =
-            Cause::new("REDIS_INSTANCE_NO_EXTERNAL_IP");
+        pub const REDIS_INSTANCE_NO_EXTERNAL_IP: Cause = Cause::new(74);
 
         /// Packet is dropped due to an unsupported protocol being used to connect to
         /// a Redis Instance. Only TCP connections are accepted by a Redis Instance.
-        pub const REDIS_INSTANCE_UNSUPPORTED_PROTOCOL: Cause =
-            Cause::new("REDIS_INSTANCE_UNSUPPORTED_PROTOCOL");
+        pub const REDIS_INSTANCE_UNSUPPORTED_PROTOCOL: Cause = Cause::new(78);
 
         /// Generic drop cause for a packet being dropped inside a Redis Cluster
         /// service project.
-        pub const DROPPED_INSIDE_REDIS_CLUSTER_SERVICE: Cause =
-            Cause::new("DROPPED_INSIDE_REDIS_CLUSTER_SERVICE");
+        pub const DROPPED_INSIDE_REDIS_CLUSTER_SERVICE: Cause = Cause::new(75);
 
         /// Packet is dropped due to an unsupported port being used to connect to a
         /// Redis Cluster. Ports 6379 and 11000 to 13047 should be used to connect to
         /// a Redis Cluster.
-        pub const REDIS_CLUSTER_UNSUPPORTED_PORT: Cause =
-            Cause::new("REDIS_CLUSTER_UNSUPPORTED_PORT");
+        pub const REDIS_CLUSTER_UNSUPPORTED_PORT: Cause = Cause::new(76);
 
         /// Redis Cluster does not have an external IP address.
-        pub const REDIS_CLUSTER_NO_EXTERNAL_IP: Cause = Cause::new("REDIS_CLUSTER_NO_EXTERNAL_IP");
+        pub const REDIS_CLUSTER_NO_EXTERNAL_IP: Cause = Cause::new(77);
 
         /// Packet is dropped due to an unsupported protocol being used to connect to
         /// a Redis Cluster. Only TCP connections are accepted by a Redis Cluster.
-        pub const REDIS_CLUSTER_UNSUPPORTED_PROTOCOL: Cause =
-            Cause::new("REDIS_CLUSTER_UNSUPPORTED_PROTOCOL");
+        pub const REDIS_CLUSTER_UNSUPPORTED_PROTOCOL: Cause = Cause::new(79);
 
         /// Packet from the non-GCP (on-prem) or unknown GCP network is dropped due
         /// to the destination IP address not belonging to any IP prefix advertised
         /// via BGP by the Cloud Router.
-        pub const NO_ADVERTISED_ROUTE_TO_GCP_DESTINATION: Cause =
-            Cause::new("NO_ADVERTISED_ROUTE_TO_GCP_DESTINATION");
+        pub const NO_ADVERTISED_ROUTE_TO_GCP_DESTINATION: Cause = Cause::new(80);
 
         /// Packet from the non-GCP (on-prem) or unknown GCP network is dropped due
         /// to the destination IP address not belonging to any IP prefix included to
         /// the local traffic selector of the VPN tunnel.
-        pub const NO_TRAFFIC_SELECTOR_TO_GCP_DESTINATION: Cause =
-            Cause::new("NO_TRAFFIC_SELECTOR_TO_GCP_DESTINATION");
+        pub const NO_TRAFFIC_SELECTOR_TO_GCP_DESTINATION: Cause = Cause::new(81);
 
         /// Packet from the unknown peered network is dropped due to no known route
         /// from the source network to the destination IP address.
-        pub const NO_KNOWN_ROUTE_FROM_PEERED_NETWORK_TO_DESTINATION: Cause =
-            Cause::new("NO_KNOWN_ROUTE_FROM_PEERED_NETWORK_TO_DESTINATION");
+        pub const NO_KNOWN_ROUTE_FROM_PEERED_NETWORK_TO_DESTINATION: Cause = Cause::new(82);
 
         /// Sending packets processed by the Private NAT Gateways to the Private
         /// Service Connect endpoints is not supported.
-        pub const PRIVATE_NAT_TO_PSC_ENDPOINT_UNSUPPORTED: Cause =
-            Cause::new("PRIVATE_NAT_TO_PSC_ENDPOINT_UNSUPPORTED");
+        pub const PRIVATE_NAT_TO_PSC_ENDPOINT_UNSUPPORTED: Cause = Cause::new(83);
+
+        /// Creates a new Cause instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CAUSE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("UNKNOWN_EXTERNAL_ADDRESS"),
+                2 => std::borrow::Cow::Borrowed("FOREIGN_IP_DISALLOWED"),
+                3 => std::borrow::Cow::Borrowed("FIREWALL_RULE"),
+                4 => std::borrow::Cow::Borrowed("NO_ROUTE"),
+                5 => std::borrow::Cow::Borrowed("ROUTE_BLACKHOLE"),
+                6 => std::borrow::Cow::Borrowed("ROUTE_WRONG_NETWORK"),
+                7 => std::borrow::Cow::Borrowed("PRIVATE_TRAFFIC_TO_INTERNET"),
+                8 => std::borrow::Cow::Borrowed("PRIVATE_GOOGLE_ACCESS_DISALLOWED"),
+                9 => std::borrow::Cow::Borrowed("NO_EXTERNAL_ADDRESS"),
+                10 => std::borrow::Cow::Borrowed("UNKNOWN_INTERNAL_ADDRESS"),
+                11 => std::borrow::Cow::Borrowed("FORWARDING_RULE_MISMATCH"),
+                12 => std::borrow::Cow::Borrowed("FORWARDING_RULE_NO_INSTANCES"),
+                13 => std::borrow::Cow::Borrowed(
+                    "FIREWALL_BLOCKING_LOAD_BALANCER_BACKEND_HEALTH_CHECK",
+                ),
+                14 => std::borrow::Cow::Borrowed("INSTANCE_NOT_RUNNING"),
+                15 => std::borrow::Cow::Borrowed("TRAFFIC_TYPE_BLOCKED"),
+                16 => std::borrow::Cow::Borrowed("GKE_MASTER_UNAUTHORIZED_ACCESS"),
+                17 => std::borrow::Cow::Borrowed("CLOUD_SQL_INSTANCE_UNAUTHORIZED_ACCESS"),
+                18 => std::borrow::Cow::Borrowed("DROPPED_INSIDE_GKE_SERVICE"),
+                19 => std::borrow::Cow::Borrowed("DROPPED_INSIDE_CLOUD_SQL_SERVICE"),
+                20 => std::borrow::Cow::Borrowed("GOOGLE_MANAGED_SERVICE_NO_PEERING"),
+                21 => std::borrow::Cow::Borrowed("CLOUD_SQL_INSTANCE_NO_IP_ADDRESS"),
+                22 => std::borrow::Cow::Borrowed("CLOUD_FUNCTION_NOT_ACTIVE"),
+                23 => std::borrow::Cow::Borrowed("VPC_CONNECTOR_NOT_SET"),
+                24 => std::borrow::Cow::Borrowed("VPC_CONNECTOR_NOT_RUNNING"),
+                25 => std::borrow::Cow::Borrowed("FORWARDING_RULE_REGION_MISMATCH"),
+                26 => std::borrow::Cow::Borrowed("PSC_CONNECTION_NOT_ACCEPTED"),
+                27 => std::borrow::Cow::Borrowed("GKE_CLUSTER_NOT_RUNNING"),
+                28 => std::borrow::Cow::Borrowed("CLOUD_SQL_INSTANCE_NOT_RUNNING"),
+                29 => std::borrow::Cow::Borrowed("CLOUD_RUN_REVISION_NOT_READY"),
+                30 => std::borrow::Cow::Borrowed("GKE_CONTROL_PLANE_REGION_MISMATCH"),
+                31 => std::borrow::Cow::Borrowed("PUBLIC_GKE_CONTROL_PLANE_TO_PRIVATE_DESTINATION"),
+                32 => std::borrow::Cow::Borrowed("GKE_CONTROL_PLANE_NO_ROUTE"),
+                33 => std::borrow::Cow::Borrowed(
+                    "CLOUD_SQL_INSTANCE_NOT_CONFIGURED_FOR_EXTERNAL_TRAFFIC",
+                ),
+                34 => {
+                    std::borrow::Cow::Borrowed("PUBLIC_CLOUD_SQL_INSTANCE_TO_PRIVATE_DESTINATION")
+                }
+                35 => std::borrow::Cow::Borrowed("CLOUD_SQL_INSTANCE_NO_ROUTE"),
+                36 => std::borrow::Cow::Borrowed("GKE_PSC_ENDPOINT_MISSING"),
+                37 => std::borrow::Cow::Borrowed("DROPPED_INSIDE_PSC_SERVICE_PRODUCER"),
+                38 => std::borrow::Cow::Borrowed("GOOGLE_MANAGED_SERVICE_NO_PSC_ENDPOINT"),
+                39 => std::borrow::Cow::Borrowed("LOAD_BALANCER_HAS_NO_PROXY_SUBNET"),
+                40 => std::borrow::Cow::Borrowed("CLOUD_NAT_NO_ADDRESSES"),
+                41 => std::borrow::Cow::Borrowed("PSC_ENDPOINT_ACCESSED_FROM_PEERED_NETWORK"),
+                42 => std::borrow::Cow::Borrowed("ROUTE_NEXT_HOP_IP_ADDRESS_NOT_RESOLVED"),
+                43 => std::borrow::Cow::Borrowed("ROUTE_NEXT_HOP_RESOURCE_NOT_FOUND"),
+                44 => std::borrow::Cow::Borrowed("NO_ROUTE_FROM_INTERNET_TO_PRIVATE_IPV6_ADDRESS"),
+                45 => std::borrow::Cow::Borrowed("VPN_TUNNEL_LOCAL_SELECTOR_MISMATCH"),
+                46 => std::borrow::Cow::Borrowed("VPN_TUNNEL_REMOTE_SELECTOR_MISMATCH"),
+                47 => {
+                    std::borrow::Cow::Borrowed("PRIVATE_GOOGLE_ACCESS_VIA_VPN_TUNNEL_UNSUPPORTED")
+                }
+                48 => std::borrow::Cow::Borrowed("PSC_NEG_PRODUCER_ENDPOINT_NO_GLOBAL_ACCESS"),
+                49 => std::borrow::Cow::Borrowed("ROUTE_NEXT_HOP_INSTANCE_WRONG_NETWORK"),
+                50 => std::borrow::Cow::Borrowed("ROUTE_NEXT_HOP_INSTANCE_NON_PRIMARY_IP"),
+                51 => std::borrow::Cow::Borrowed("ROUTE_NEXT_HOP_FORWARDING_RULE_IP_MISMATCH"),
+                52 => std::borrow::Cow::Borrowed("ROUTE_NEXT_HOP_VPN_TUNNEL_NOT_ESTABLISHED"),
+                53 => std::borrow::Cow::Borrowed("ROUTE_NEXT_HOP_FORWARDING_RULE_TYPE_INVALID"),
+                54 => std::borrow::Cow::Borrowed("PSC_NEG_PRODUCER_FORWARDING_RULE_MULTIPLE_PORTS"),
+                55 => std::borrow::Cow::Borrowed("HYBRID_NEG_NON_DYNAMIC_ROUTE_MATCHED"),
+                56 => std::borrow::Cow::Borrowed("HYBRID_NEG_NON_LOCAL_DYNAMIC_ROUTE_MATCHED"),
+                57 => std::borrow::Cow::Borrowed("NO_NAT_SUBNETS_FOR_PSC_SERVICE_ATTACHMENT"),
+                58 => std::borrow::Cow::Borrowed("CLOUD_SQL_PSC_NEG_UNSUPPORTED"),
+                59 => std::borrow::Cow::Borrowed("ROUTING_LOOP"),
+                60 => std::borrow::Cow::Borrowed("VPC_CONNECTOR_SERVERLESS_TRAFFIC_BLOCKED"),
+                61 => std::borrow::Cow::Borrowed("VPC_CONNECTOR_HEALTH_CHECK_TRAFFIC_BLOCKED"),
+                62 => std::borrow::Cow::Borrowed("DROPPED_INSIDE_GOOGLE_MANAGED_SERVICE"),
+                63 => std::borrow::Cow::Borrowed("CLOUD_SQL_CONNECTOR_REQUIRED"),
+                64 => std::borrow::Cow::Borrowed("PSC_TRANSITIVITY_NOT_PROPAGATED"),
+                65 => std::borrow::Cow::Borrowed("LOAD_BALANCER_BACKEND_INVALID_NETWORK"),
+                66 => std::borrow::Cow::Borrowed("BACKEND_SERVICE_NAMED_PORT_NOT_DEFINED"),
+                67 => std::borrow::Cow::Borrowed("DESTINATION_IS_PRIVATE_NAT_IP_RANGE"),
+                68 => std::borrow::Cow::Borrowed("REDIS_INSTANCE_NOT_RUNNING"),
+                69 => std::borrow::Cow::Borrowed("REDIS_CLUSTER_NOT_RUNNING"),
+                70 => std::borrow::Cow::Borrowed("DROPPED_INSIDE_REDIS_INSTANCE_SERVICE"),
+                71 => std::borrow::Cow::Borrowed("REDIS_INSTANCE_UNSUPPORTED_PORT"),
+                72 => std::borrow::Cow::Borrowed("REDIS_INSTANCE_CONNECTING_FROM_PUPI_ADDRESS"),
+                73 => std::borrow::Cow::Borrowed("REDIS_INSTANCE_NO_ROUTE_TO_DESTINATION_NETWORK"),
+                74 => std::borrow::Cow::Borrowed("REDIS_INSTANCE_NO_EXTERNAL_IP"),
+                75 => std::borrow::Cow::Borrowed("DROPPED_INSIDE_REDIS_CLUSTER_SERVICE"),
+                76 => std::borrow::Cow::Borrowed("REDIS_CLUSTER_UNSUPPORTED_PORT"),
+                77 => std::borrow::Cow::Borrowed("REDIS_CLUSTER_NO_EXTERNAL_IP"),
+                78 => std::borrow::Cow::Borrowed("REDIS_INSTANCE_UNSUPPORTED_PROTOCOL"),
+                79 => std::borrow::Cow::Borrowed("REDIS_CLUSTER_UNSUPPORTED_PROTOCOL"),
+                80 => std::borrow::Cow::Borrowed("NO_ADVERTISED_ROUTE_TO_GCP_DESTINATION"),
+                81 => std::borrow::Cow::Borrowed("NO_TRAFFIC_SELECTOR_TO_GCP_DESTINATION"),
+                82 => {
+                    std::borrow::Cow::Borrowed("NO_KNOWN_ROUTE_FROM_PEERED_NETWORK_TO_DESTINATION")
+                }
+                83 => std::borrow::Cow::Borrowed("PRIVATE_NAT_TO_PSC_ENDPOINT_UNSUPPORTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CAUSE_UNSPECIFIED" => std::option::Option::Some(Self::CAUSE_UNSPECIFIED),
+                "UNKNOWN_EXTERNAL_ADDRESS" => {
+                    std::option::Option::Some(Self::UNKNOWN_EXTERNAL_ADDRESS)
+                }
+                "FOREIGN_IP_DISALLOWED" => std::option::Option::Some(Self::FOREIGN_IP_DISALLOWED),
+                "FIREWALL_RULE" => std::option::Option::Some(Self::FIREWALL_RULE),
+                "NO_ROUTE" => std::option::Option::Some(Self::NO_ROUTE),
+                "ROUTE_BLACKHOLE" => std::option::Option::Some(Self::ROUTE_BLACKHOLE),
+                "ROUTE_WRONG_NETWORK" => std::option::Option::Some(Self::ROUTE_WRONG_NETWORK),
+                "ROUTE_NEXT_HOP_IP_ADDRESS_NOT_RESOLVED" => {
+                    std::option::Option::Some(Self::ROUTE_NEXT_HOP_IP_ADDRESS_NOT_RESOLVED)
+                }
+                "ROUTE_NEXT_HOP_RESOURCE_NOT_FOUND" => {
+                    std::option::Option::Some(Self::ROUTE_NEXT_HOP_RESOURCE_NOT_FOUND)
+                }
+                "ROUTE_NEXT_HOP_INSTANCE_WRONG_NETWORK" => {
+                    std::option::Option::Some(Self::ROUTE_NEXT_HOP_INSTANCE_WRONG_NETWORK)
+                }
+                "ROUTE_NEXT_HOP_INSTANCE_NON_PRIMARY_IP" => {
+                    std::option::Option::Some(Self::ROUTE_NEXT_HOP_INSTANCE_NON_PRIMARY_IP)
+                }
+                "ROUTE_NEXT_HOP_FORWARDING_RULE_IP_MISMATCH" => {
+                    std::option::Option::Some(Self::ROUTE_NEXT_HOP_FORWARDING_RULE_IP_MISMATCH)
+                }
+                "ROUTE_NEXT_HOP_VPN_TUNNEL_NOT_ESTABLISHED" => {
+                    std::option::Option::Some(Self::ROUTE_NEXT_HOP_VPN_TUNNEL_NOT_ESTABLISHED)
+                }
+                "ROUTE_NEXT_HOP_FORWARDING_RULE_TYPE_INVALID" => {
+                    std::option::Option::Some(Self::ROUTE_NEXT_HOP_FORWARDING_RULE_TYPE_INVALID)
+                }
+                "NO_ROUTE_FROM_INTERNET_TO_PRIVATE_IPV6_ADDRESS" => {
+                    std::option::Option::Some(Self::NO_ROUTE_FROM_INTERNET_TO_PRIVATE_IPV6_ADDRESS)
+                }
+                "VPN_TUNNEL_LOCAL_SELECTOR_MISMATCH" => {
+                    std::option::Option::Some(Self::VPN_TUNNEL_LOCAL_SELECTOR_MISMATCH)
+                }
+                "VPN_TUNNEL_REMOTE_SELECTOR_MISMATCH" => {
+                    std::option::Option::Some(Self::VPN_TUNNEL_REMOTE_SELECTOR_MISMATCH)
+                }
+                "PRIVATE_TRAFFIC_TO_INTERNET" => {
+                    std::option::Option::Some(Self::PRIVATE_TRAFFIC_TO_INTERNET)
+                }
+                "PRIVATE_GOOGLE_ACCESS_DISALLOWED" => {
+                    std::option::Option::Some(Self::PRIVATE_GOOGLE_ACCESS_DISALLOWED)
+                }
+                "PRIVATE_GOOGLE_ACCESS_VIA_VPN_TUNNEL_UNSUPPORTED" => std::option::Option::Some(
+                    Self::PRIVATE_GOOGLE_ACCESS_VIA_VPN_TUNNEL_UNSUPPORTED,
+                ),
+                "NO_EXTERNAL_ADDRESS" => std::option::Option::Some(Self::NO_EXTERNAL_ADDRESS),
+                "UNKNOWN_INTERNAL_ADDRESS" => {
+                    std::option::Option::Some(Self::UNKNOWN_INTERNAL_ADDRESS)
+                }
+                "FORWARDING_RULE_MISMATCH" => {
+                    std::option::Option::Some(Self::FORWARDING_RULE_MISMATCH)
+                }
+                "FORWARDING_RULE_NO_INSTANCES" => {
+                    std::option::Option::Some(Self::FORWARDING_RULE_NO_INSTANCES)
+                }
+                "FIREWALL_BLOCKING_LOAD_BALANCER_BACKEND_HEALTH_CHECK" => {
+                    std::option::Option::Some(
+                        Self::FIREWALL_BLOCKING_LOAD_BALANCER_BACKEND_HEALTH_CHECK,
+                    )
+                }
+                "INSTANCE_NOT_RUNNING" => std::option::Option::Some(Self::INSTANCE_NOT_RUNNING),
+                "GKE_CLUSTER_NOT_RUNNING" => {
+                    std::option::Option::Some(Self::GKE_CLUSTER_NOT_RUNNING)
+                }
+                "CLOUD_SQL_INSTANCE_NOT_RUNNING" => {
+                    std::option::Option::Some(Self::CLOUD_SQL_INSTANCE_NOT_RUNNING)
+                }
+                "REDIS_INSTANCE_NOT_RUNNING" => {
+                    std::option::Option::Some(Self::REDIS_INSTANCE_NOT_RUNNING)
+                }
+                "REDIS_CLUSTER_NOT_RUNNING" => {
+                    std::option::Option::Some(Self::REDIS_CLUSTER_NOT_RUNNING)
+                }
+                "TRAFFIC_TYPE_BLOCKED" => std::option::Option::Some(Self::TRAFFIC_TYPE_BLOCKED),
+                "GKE_MASTER_UNAUTHORIZED_ACCESS" => {
+                    std::option::Option::Some(Self::GKE_MASTER_UNAUTHORIZED_ACCESS)
+                }
+                "CLOUD_SQL_INSTANCE_UNAUTHORIZED_ACCESS" => {
+                    std::option::Option::Some(Self::CLOUD_SQL_INSTANCE_UNAUTHORIZED_ACCESS)
+                }
+                "DROPPED_INSIDE_GKE_SERVICE" => {
+                    std::option::Option::Some(Self::DROPPED_INSIDE_GKE_SERVICE)
+                }
+                "DROPPED_INSIDE_CLOUD_SQL_SERVICE" => {
+                    std::option::Option::Some(Self::DROPPED_INSIDE_CLOUD_SQL_SERVICE)
+                }
+                "GOOGLE_MANAGED_SERVICE_NO_PEERING" => {
+                    std::option::Option::Some(Self::GOOGLE_MANAGED_SERVICE_NO_PEERING)
+                }
+                "GOOGLE_MANAGED_SERVICE_NO_PSC_ENDPOINT" => {
+                    std::option::Option::Some(Self::GOOGLE_MANAGED_SERVICE_NO_PSC_ENDPOINT)
+                }
+                "GKE_PSC_ENDPOINT_MISSING" => {
+                    std::option::Option::Some(Self::GKE_PSC_ENDPOINT_MISSING)
+                }
+                "CLOUD_SQL_INSTANCE_NO_IP_ADDRESS" => {
+                    std::option::Option::Some(Self::CLOUD_SQL_INSTANCE_NO_IP_ADDRESS)
+                }
+                "GKE_CONTROL_PLANE_REGION_MISMATCH" => {
+                    std::option::Option::Some(Self::GKE_CONTROL_PLANE_REGION_MISMATCH)
+                }
+                "PUBLIC_GKE_CONTROL_PLANE_TO_PRIVATE_DESTINATION" => {
+                    std::option::Option::Some(Self::PUBLIC_GKE_CONTROL_PLANE_TO_PRIVATE_DESTINATION)
+                }
+                "GKE_CONTROL_PLANE_NO_ROUTE" => {
+                    std::option::Option::Some(Self::GKE_CONTROL_PLANE_NO_ROUTE)
+                }
+                "CLOUD_SQL_INSTANCE_NOT_CONFIGURED_FOR_EXTERNAL_TRAFFIC" => {
+                    std::option::Option::Some(
+                        Self::CLOUD_SQL_INSTANCE_NOT_CONFIGURED_FOR_EXTERNAL_TRAFFIC,
+                    )
+                }
+                "PUBLIC_CLOUD_SQL_INSTANCE_TO_PRIVATE_DESTINATION" => std::option::Option::Some(
+                    Self::PUBLIC_CLOUD_SQL_INSTANCE_TO_PRIVATE_DESTINATION,
+                ),
+                "CLOUD_SQL_INSTANCE_NO_ROUTE" => {
+                    std::option::Option::Some(Self::CLOUD_SQL_INSTANCE_NO_ROUTE)
+                }
+                "CLOUD_SQL_CONNECTOR_REQUIRED" => {
+                    std::option::Option::Some(Self::CLOUD_SQL_CONNECTOR_REQUIRED)
+                }
+                "CLOUD_FUNCTION_NOT_ACTIVE" => {
+                    std::option::Option::Some(Self::CLOUD_FUNCTION_NOT_ACTIVE)
+                }
+                "VPC_CONNECTOR_NOT_SET" => std::option::Option::Some(Self::VPC_CONNECTOR_NOT_SET),
+                "VPC_CONNECTOR_NOT_RUNNING" => {
+                    std::option::Option::Some(Self::VPC_CONNECTOR_NOT_RUNNING)
+                }
+                "VPC_CONNECTOR_SERVERLESS_TRAFFIC_BLOCKED" => {
+                    std::option::Option::Some(Self::VPC_CONNECTOR_SERVERLESS_TRAFFIC_BLOCKED)
+                }
+                "VPC_CONNECTOR_HEALTH_CHECK_TRAFFIC_BLOCKED" => {
+                    std::option::Option::Some(Self::VPC_CONNECTOR_HEALTH_CHECK_TRAFFIC_BLOCKED)
+                }
+                "FORWARDING_RULE_REGION_MISMATCH" => {
+                    std::option::Option::Some(Self::FORWARDING_RULE_REGION_MISMATCH)
+                }
+                "PSC_CONNECTION_NOT_ACCEPTED" => {
+                    std::option::Option::Some(Self::PSC_CONNECTION_NOT_ACCEPTED)
+                }
+                "PSC_ENDPOINT_ACCESSED_FROM_PEERED_NETWORK" => {
+                    std::option::Option::Some(Self::PSC_ENDPOINT_ACCESSED_FROM_PEERED_NETWORK)
+                }
+                "PSC_NEG_PRODUCER_ENDPOINT_NO_GLOBAL_ACCESS" => {
+                    std::option::Option::Some(Self::PSC_NEG_PRODUCER_ENDPOINT_NO_GLOBAL_ACCESS)
+                }
+                "PSC_NEG_PRODUCER_FORWARDING_RULE_MULTIPLE_PORTS" => {
+                    std::option::Option::Some(Self::PSC_NEG_PRODUCER_FORWARDING_RULE_MULTIPLE_PORTS)
+                }
+                "CLOUD_SQL_PSC_NEG_UNSUPPORTED" => {
+                    std::option::Option::Some(Self::CLOUD_SQL_PSC_NEG_UNSUPPORTED)
+                }
+                "NO_NAT_SUBNETS_FOR_PSC_SERVICE_ATTACHMENT" => {
+                    std::option::Option::Some(Self::NO_NAT_SUBNETS_FOR_PSC_SERVICE_ATTACHMENT)
+                }
+                "PSC_TRANSITIVITY_NOT_PROPAGATED" => {
+                    std::option::Option::Some(Self::PSC_TRANSITIVITY_NOT_PROPAGATED)
+                }
+                "HYBRID_NEG_NON_DYNAMIC_ROUTE_MATCHED" => {
+                    std::option::Option::Some(Self::HYBRID_NEG_NON_DYNAMIC_ROUTE_MATCHED)
+                }
+                "HYBRID_NEG_NON_LOCAL_DYNAMIC_ROUTE_MATCHED" => {
+                    std::option::Option::Some(Self::HYBRID_NEG_NON_LOCAL_DYNAMIC_ROUTE_MATCHED)
+                }
+                "CLOUD_RUN_REVISION_NOT_READY" => {
+                    std::option::Option::Some(Self::CLOUD_RUN_REVISION_NOT_READY)
+                }
+                "DROPPED_INSIDE_PSC_SERVICE_PRODUCER" => {
+                    std::option::Option::Some(Self::DROPPED_INSIDE_PSC_SERVICE_PRODUCER)
+                }
+                "LOAD_BALANCER_HAS_NO_PROXY_SUBNET" => {
+                    std::option::Option::Some(Self::LOAD_BALANCER_HAS_NO_PROXY_SUBNET)
+                }
+                "CLOUD_NAT_NO_ADDRESSES" => std::option::Option::Some(Self::CLOUD_NAT_NO_ADDRESSES),
+                "ROUTING_LOOP" => std::option::Option::Some(Self::ROUTING_LOOP),
+                "DROPPED_INSIDE_GOOGLE_MANAGED_SERVICE" => {
+                    std::option::Option::Some(Self::DROPPED_INSIDE_GOOGLE_MANAGED_SERVICE)
+                }
+                "LOAD_BALANCER_BACKEND_INVALID_NETWORK" => {
+                    std::option::Option::Some(Self::LOAD_BALANCER_BACKEND_INVALID_NETWORK)
+                }
+                "BACKEND_SERVICE_NAMED_PORT_NOT_DEFINED" => {
+                    std::option::Option::Some(Self::BACKEND_SERVICE_NAMED_PORT_NOT_DEFINED)
+                }
+                "DESTINATION_IS_PRIVATE_NAT_IP_RANGE" => {
+                    std::option::Option::Some(Self::DESTINATION_IS_PRIVATE_NAT_IP_RANGE)
+                }
+                "DROPPED_INSIDE_REDIS_INSTANCE_SERVICE" => {
+                    std::option::Option::Some(Self::DROPPED_INSIDE_REDIS_INSTANCE_SERVICE)
+                }
+                "REDIS_INSTANCE_UNSUPPORTED_PORT" => {
+                    std::option::Option::Some(Self::REDIS_INSTANCE_UNSUPPORTED_PORT)
+                }
+                "REDIS_INSTANCE_CONNECTING_FROM_PUPI_ADDRESS" => {
+                    std::option::Option::Some(Self::REDIS_INSTANCE_CONNECTING_FROM_PUPI_ADDRESS)
+                }
+                "REDIS_INSTANCE_NO_ROUTE_TO_DESTINATION_NETWORK" => {
+                    std::option::Option::Some(Self::REDIS_INSTANCE_NO_ROUTE_TO_DESTINATION_NETWORK)
+                }
+                "REDIS_INSTANCE_NO_EXTERNAL_IP" => {
+                    std::option::Option::Some(Self::REDIS_INSTANCE_NO_EXTERNAL_IP)
+                }
+                "REDIS_INSTANCE_UNSUPPORTED_PROTOCOL" => {
+                    std::option::Option::Some(Self::REDIS_INSTANCE_UNSUPPORTED_PROTOCOL)
+                }
+                "DROPPED_INSIDE_REDIS_CLUSTER_SERVICE" => {
+                    std::option::Option::Some(Self::DROPPED_INSIDE_REDIS_CLUSTER_SERVICE)
+                }
+                "REDIS_CLUSTER_UNSUPPORTED_PORT" => {
+                    std::option::Option::Some(Self::REDIS_CLUSTER_UNSUPPORTED_PORT)
+                }
+                "REDIS_CLUSTER_NO_EXTERNAL_IP" => {
+                    std::option::Option::Some(Self::REDIS_CLUSTER_NO_EXTERNAL_IP)
+                }
+                "REDIS_CLUSTER_UNSUPPORTED_PROTOCOL" => {
+                    std::option::Option::Some(Self::REDIS_CLUSTER_UNSUPPORTED_PROTOCOL)
+                }
+                "NO_ADVERTISED_ROUTE_TO_GCP_DESTINATION" => {
+                    std::option::Option::Some(Self::NO_ADVERTISED_ROUTE_TO_GCP_DESTINATION)
+                }
+                "NO_TRAFFIC_SELECTOR_TO_GCP_DESTINATION" => {
+                    std::option::Option::Some(Self::NO_TRAFFIC_SELECTOR_TO_GCP_DESTINATION)
+                }
+                "NO_KNOWN_ROUTE_FROM_PEERED_NETWORK_TO_DESTINATION" => std::option::Option::Some(
+                    Self::NO_KNOWN_ROUTE_FROM_PEERED_NETWORK_TO_DESTINATION,
+                ),
+                "PRIVATE_NAT_TO_PSC_ENDPOINT_UNSUPPORTED" => {
+                    std::option::Option::Some(Self::PRIVATE_NAT_TO_PSC_ENDPOINT_UNSUPPORTED)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Cause {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Cause {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Cause {
         fn default() -> Self {
-            cause::CAUSE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6442,49 +7320,70 @@ pub mod nat_info {
 
     /// Types of NAT.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Type is unspecified.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// From Compute Engine instance's internal address to external address.
+        pub const INTERNAL_TO_EXTERNAL: Type = Type::new(1);
+
+        /// From Compute Engine instance's external address to internal address.
+        pub const EXTERNAL_TO_INTERNAL: Type = Type::new(2);
+
+        /// Cloud NAT Gateway.
+        pub const CLOUD_NAT: Type = Type::new(3);
+
+        /// Private service connect NAT.
+        pub const PRIVATE_SERVICE_CONNECT: Type = Type::new(4);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INTERNAL_TO_EXTERNAL"),
+                2 => std::borrow::Cow::Borrowed("EXTERNAL_TO_INTERNAL"),
+                3 => std::borrow::Cow::Borrowed("CLOUD_NAT"),
+                4 => std::borrow::Cow::Borrowed("PRIVATE_SERVICE_CONNECT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "INTERNAL_TO_EXTERNAL" => std::option::Option::Some(Self::INTERNAL_TO_EXTERNAL),
+                "EXTERNAL_TO_INTERNAL" => std::option::Option::Some(Self::EXTERNAL_TO_INTERNAL),
+                "CLOUD_NAT" => std::option::Option::Some(Self::CLOUD_NAT),
+                "PRIVATE_SERVICE_CONNECT" => {
+                    std::option::Option::Some(Self::PRIVATE_SERVICE_CONNECT)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Type is unspecified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// From Compute Engine instance's internal address to external address.
-        pub const INTERNAL_TO_EXTERNAL: Type = Type::new("INTERNAL_TO_EXTERNAL");
-
-        /// From Compute Engine instance's external address to internal address.
-        pub const EXTERNAL_TO_INTERNAL: Type = Type::new("EXTERNAL_TO_INTERNAL");
-
-        /// Cloud NAT Gateway.
-        pub const CLOUD_NAT: Type = Type::new("CLOUD_NAT");
-
-        /// Private service connect NAT.
-        pub const PRIVATE_SERVICE_CONNECT: Type = Type::new("PRIVATE_SERVICE_CONNECT");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6786,62 +7685,87 @@ pub mod load_balancer_backend_info {
 
     /// Health check firewalls configuration state enum.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HealthCheckFirewallsConfigState(std::borrow::Cow<'static, str>);
+    pub struct HealthCheckFirewallsConfigState(i32);
 
     impl HealthCheckFirewallsConfigState {
-        /// Creates a new HealthCheckFirewallsConfigState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [HealthCheckFirewallsConfigState](HealthCheckFirewallsConfigState)
-    pub mod health_check_firewalls_config_state {
-        use super::HealthCheckFirewallsConfigState;
-
         /// Configuration state unspecified. It usually means that the backend has
         /// no health check attached, or there was an unexpected configuration error
         /// preventing Connectivity tests from verifying health check configuration.
         pub const HEALTH_CHECK_FIREWALLS_CONFIG_STATE_UNSPECIFIED: HealthCheckFirewallsConfigState =
-            HealthCheckFirewallsConfigState::new("HEALTH_CHECK_FIREWALLS_CONFIG_STATE_UNSPECIFIED");
+            HealthCheckFirewallsConfigState::new(0);
 
         /// Firewall rules (policies) allowing health check traffic from all required
         /// IP ranges to the backend are configured.
         pub const FIREWALLS_CONFIGURED: HealthCheckFirewallsConfigState =
-            HealthCheckFirewallsConfigState::new("FIREWALLS_CONFIGURED");
+            HealthCheckFirewallsConfigState::new(1);
 
         /// Firewall rules (policies) allow health check traffic only from a part of
         /// required IP ranges.
         pub const FIREWALLS_PARTIALLY_CONFIGURED: HealthCheckFirewallsConfigState =
-            HealthCheckFirewallsConfigState::new("FIREWALLS_PARTIALLY_CONFIGURED");
+            HealthCheckFirewallsConfigState::new(2);
 
         /// Firewall rules (policies) deny health check traffic from all required
         /// IP ranges to the backend.
         pub const FIREWALLS_NOT_CONFIGURED: HealthCheckFirewallsConfigState =
-            HealthCheckFirewallsConfigState::new("FIREWALLS_NOT_CONFIGURED");
+            HealthCheckFirewallsConfigState::new(3);
 
         /// The network contains firewall rules of unsupported types, so Connectivity
         /// tests were not able to verify health check configuration status. Please
         /// refer to the documentation for the list of unsupported configurations:
         /// <https://cloud.google.com/network-intelligence-center/docs/connectivity-tests/concepts/overview#unsupported-configs>
         pub const FIREWALLS_UNSUPPORTED: HealthCheckFirewallsConfigState =
-            HealthCheckFirewallsConfigState::new("FIREWALLS_UNSUPPORTED");
+            HealthCheckFirewallsConfigState::new(4);
+
+        /// Creates a new HealthCheckFirewallsConfigState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("HEALTH_CHECK_FIREWALLS_CONFIG_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FIREWALLS_CONFIGURED"),
+                2 => std::borrow::Cow::Borrowed("FIREWALLS_PARTIALLY_CONFIGURED"),
+                3 => std::borrow::Cow::Borrowed("FIREWALLS_NOT_CONFIGURED"),
+                4 => std::borrow::Cow::Borrowed("FIREWALLS_UNSUPPORTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "HEALTH_CHECK_FIREWALLS_CONFIG_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::HEALTH_CHECK_FIREWALLS_CONFIG_STATE_UNSPECIFIED)
+                }
+                "FIREWALLS_CONFIGURED" => std::option::Option::Some(Self::FIREWALLS_CONFIGURED),
+                "FIREWALLS_PARTIALLY_CONFIGURED" => {
+                    std::option::Option::Some(Self::FIREWALLS_PARTIALLY_CONFIGURED)
+                }
+                "FIREWALLS_NOT_CONFIGURED" => {
+                    std::option::Option::Some(Self::FIREWALLS_NOT_CONFIGURED)
+                }
+                "FIREWALLS_UNSUPPORTED" => std::option::Option::Some(Self::FIREWALLS_UNSUPPORTED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for HealthCheckFirewallsConfigState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for HealthCheckFirewallsConfigState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for HealthCheckFirewallsConfigState {
         fn default() -> Self {
-            health_check_firewalls_config_state::HEALTH_CHECK_FIREWALLS_CONFIG_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7496,192 +8420,263 @@ pub mod vpc_flow_logs_config {
     /// Determines whether this configuration will be generating logs.
     /// Setting state=DISABLED will pause the log generation for this config.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// If not specified, will default to ENABLED.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// When ENABLED, this configuration will generate logs.
+        pub const ENABLED: State = State::new(1);
+
+        /// When DISABLED, this configuration will not generate logs.
+        pub const DISABLED: State = State::new(2);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENABLED"),
+                2 => std::borrow::Cow::Borrowed("DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// If not specified, will default to ENABLED.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// When ENABLED, this configuration will generate logs.
-        pub const ENABLED: State = State::new("ENABLED");
-
-        /// When DISABLED, this configuration will not generate logs.
-        pub const DISABLED: State = State::new("DISABLED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Toggles the aggregation interval for collecting flow logs by 5-tuple.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AggregationInterval(std::borrow::Cow<'static, str>);
+    pub struct AggregationInterval(i32);
 
     impl AggregationInterval {
+        /// If not specified, will default to INTERVAL_5_SEC.
+        pub const AGGREGATION_INTERVAL_UNSPECIFIED: AggregationInterval =
+            AggregationInterval::new(0);
+
+        /// Aggregate logs in 5s intervals.
+        pub const INTERVAL_5_SEC: AggregationInterval = AggregationInterval::new(1);
+
+        /// Aggregate logs in 30s intervals.
+        pub const INTERVAL_30_SEC: AggregationInterval = AggregationInterval::new(2);
+
+        /// Aggregate logs in 1m intervals.
+        pub const INTERVAL_1_MIN: AggregationInterval = AggregationInterval::new(3);
+
+        /// Aggregate logs in 5m intervals.
+        pub const INTERVAL_5_MIN: AggregationInterval = AggregationInterval::new(4);
+
+        /// Aggregate logs in 10m intervals.
+        pub const INTERVAL_10_MIN: AggregationInterval = AggregationInterval::new(5);
+
+        /// Aggregate logs in 15m intervals.
+        pub const INTERVAL_15_MIN: AggregationInterval = AggregationInterval::new(6);
+
         /// Creates a new AggregationInterval instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("AGGREGATION_INTERVAL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INTERVAL_5_SEC"),
+                2 => std::borrow::Cow::Borrowed("INTERVAL_30_SEC"),
+                3 => std::borrow::Cow::Borrowed("INTERVAL_1_MIN"),
+                4 => std::borrow::Cow::Borrowed("INTERVAL_5_MIN"),
+                5 => std::borrow::Cow::Borrowed("INTERVAL_10_MIN"),
+                6 => std::borrow::Cow::Borrowed("INTERVAL_15_MIN"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "AGGREGATION_INTERVAL_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::AGGREGATION_INTERVAL_UNSPECIFIED)
+                }
+                "INTERVAL_5_SEC" => std::option::Option::Some(Self::INTERVAL_5_SEC),
+                "INTERVAL_30_SEC" => std::option::Option::Some(Self::INTERVAL_30_SEC),
+                "INTERVAL_1_MIN" => std::option::Option::Some(Self::INTERVAL_1_MIN),
+                "INTERVAL_5_MIN" => std::option::Option::Some(Self::INTERVAL_5_MIN),
+                "INTERVAL_10_MIN" => std::option::Option::Some(Self::INTERVAL_10_MIN),
+                "INTERVAL_15_MIN" => std::option::Option::Some(Self::INTERVAL_15_MIN),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AggregationInterval](AggregationInterval)
-    pub mod aggregation_interval {
-        use super::AggregationInterval;
-
-        /// If not specified, will default to INTERVAL_5_SEC.
-        pub const AGGREGATION_INTERVAL_UNSPECIFIED: AggregationInterval =
-            AggregationInterval::new("AGGREGATION_INTERVAL_UNSPECIFIED");
-
-        /// Aggregate logs in 5s intervals.
-        pub const INTERVAL_5_SEC: AggregationInterval = AggregationInterval::new("INTERVAL_5_SEC");
-
-        /// Aggregate logs in 30s intervals.
-        pub const INTERVAL_30_SEC: AggregationInterval =
-            AggregationInterval::new("INTERVAL_30_SEC");
-
-        /// Aggregate logs in 1m intervals.
-        pub const INTERVAL_1_MIN: AggregationInterval = AggregationInterval::new("INTERVAL_1_MIN");
-
-        /// Aggregate logs in 5m intervals.
-        pub const INTERVAL_5_MIN: AggregationInterval = AggregationInterval::new("INTERVAL_5_MIN");
-
-        /// Aggregate logs in 10m intervals.
-        pub const INTERVAL_10_MIN: AggregationInterval =
-            AggregationInterval::new("INTERVAL_10_MIN");
-
-        /// Aggregate logs in 15m intervals.
-        pub const INTERVAL_15_MIN: AggregationInterval =
-            AggregationInterval::new("INTERVAL_15_MIN");
-    }
-
-    impl std::convert::From<std::string::String> for AggregationInterval {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AggregationInterval {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AggregationInterval {
         fn default() -> Self {
-            aggregation_interval::AGGREGATION_INTERVAL_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Configures which log fields would be included.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Metadata(std::borrow::Cow<'static, str>);
+    pub struct Metadata(i32);
 
     impl Metadata {
+        /// If not specified, will default to INCLUDE_ALL_METADATA.
+        pub const METADATA_UNSPECIFIED: Metadata = Metadata::new(0);
+
+        /// Include all metadata fields.
+        pub const INCLUDE_ALL_METADATA: Metadata = Metadata::new(1);
+
+        /// Exclude all metadata fields.
+        pub const EXCLUDE_ALL_METADATA: Metadata = Metadata::new(2);
+
+        /// Include only custom fields (specified in metadata_fields).
+        pub const CUSTOM_METADATA: Metadata = Metadata::new(3);
+
         /// Creates a new Metadata instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("METADATA_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INCLUDE_ALL_METADATA"),
+                2 => std::borrow::Cow::Borrowed("EXCLUDE_ALL_METADATA"),
+                3 => std::borrow::Cow::Borrowed("CUSTOM_METADATA"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "METADATA_UNSPECIFIED" => std::option::Option::Some(Self::METADATA_UNSPECIFIED),
+                "INCLUDE_ALL_METADATA" => std::option::Option::Some(Self::INCLUDE_ALL_METADATA),
+                "EXCLUDE_ALL_METADATA" => std::option::Option::Some(Self::EXCLUDE_ALL_METADATA),
+                "CUSTOM_METADATA" => std::option::Option::Some(Self::CUSTOM_METADATA),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Metadata](Metadata)
-    pub mod metadata {
-        use super::Metadata;
-
-        /// If not specified, will default to INCLUDE_ALL_METADATA.
-        pub const METADATA_UNSPECIFIED: Metadata = Metadata::new("METADATA_UNSPECIFIED");
-
-        /// Include all metadata fields.
-        pub const INCLUDE_ALL_METADATA: Metadata = Metadata::new("INCLUDE_ALL_METADATA");
-
-        /// Exclude all metadata fields.
-        pub const EXCLUDE_ALL_METADATA: Metadata = Metadata::new("EXCLUDE_ALL_METADATA");
-
-        /// Include only custom fields (specified in metadata_fields).
-        pub const CUSTOM_METADATA: Metadata = Metadata::new("CUSTOM_METADATA");
-    }
-
-    impl std::convert::From<std::string::String> for Metadata {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Metadata {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Metadata {
         fn default() -> Self {
-            metadata::METADATA_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Optional states of the target resource that are used as part of the
     /// diagnostic bit.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TargetResourceState(std::borrow::Cow<'static, str>);
+    pub struct TargetResourceState(i32);
 
     impl TargetResourceState {
+        /// Unspecified target resource state.
+        pub const TARGET_RESOURCE_STATE_UNSPECIFIED: TargetResourceState =
+            TargetResourceState::new(0);
+
+        /// Indicates that the target resource exists.
+        pub const TARGET_RESOURCE_EXISTS: TargetResourceState = TargetResourceState::new(1);
+
+        /// Indicates that the target resource does not exist.
+        pub const TARGET_RESOURCE_DOES_NOT_EXIST: TargetResourceState = TargetResourceState::new(2);
+
         /// Creates a new TargetResourceState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TARGET_RESOURCE_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TARGET_RESOURCE_EXISTS"),
+                2 => std::borrow::Cow::Borrowed("TARGET_RESOURCE_DOES_NOT_EXIST"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TARGET_RESOURCE_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::TARGET_RESOURCE_STATE_UNSPECIFIED)
+                }
+                "TARGET_RESOURCE_EXISTS" => std::option::Option::Some(Self::TARGET_RESOURCE_EXISTS),
+                "TARGET_RESOURCE_DOES_NOT_EXIST" => {
+                    std::option::Option::Some(Self::TARGET_RESOURCE_DOES_NOT_EXIST)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [TargetResourceState](TargetResourceState)
-    pub mod target_resource_state {
-        use super::TargetResourceState;
-
-        /// Unspecified target resource state.
-        pub const TARGET_RESOURCE_STATE_UNSPECIFIED: TargetResourceState =
-            TargetResourceState::new("TARGET_RESOURCE_STATE_UNSPECIFIED");
-
-        /// Indicates that the target resource exists.
-        pub const TARGET_RESOURCE_EXISTS: TargetResourceState =
-            TargetResourceState::new("TARGET_RESOURCE_EXISTS");
-
-        /// Indicates that the target resource does not exist.
-        pub const TARGET_RESOURCE_DOES_NOT_EXIST: TargetResourceState =
-            TargetResourceState::new("TARGET_RESOURCE_DOES_NOT_EXIST");
-    }
-
-    impl std::convert::From<std::string::String> for TargetResourceState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TargetResourceState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TargetResourceState {
         fn default() -> Self {
-            target_resource_state::TARGET_RESOURCE_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -7706,77 +8701,112 @@ pub mod vpc_flow_logs_config {
 /// load
 /// balancers](https://cloud.google.com/load-balancing/docs/load-balancing-overview#summary-of-google-cloud-load-balancers).
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LoadBalancerType(std::borrow::Cow<'static, str>);
+pub struct LoadBalancerType(i32);
 
 impl LoadBalancerType {
+    /// Forwarding rule points to a different target than a load balancer or a
+    /// load balancer type is unknown.
+    pub const LOAD_BALANCER_TYPE_UNSPECIFIED: LoadBalancerType = LoadBalancerType::new(0);
+
+    /// Global external HTTP(S) load balancer.
+    pub const HTTPS_ADVANCED_LOAD_BALANCER: LoadBalancerType = LoadBalancerType::new(1);
+
+    /// Global external HTTP(S) load balancer (classic)
+    pub const HTTPS_LOAD_BALANCER: LoadBalancerType = LoadBalancerType::new(2);
+
+    /// Regional external HTTP(S) load balancer.
+    pub const REGIONAL_HTTPS_LOAD_BALANCER: LoadBalancerType = LoadBalancerType::new(3);
+
+    /// Internal HTTP(S) load balancer.
+    pub const INTERNAL_HTTPS_LOAD_BALANCER: LoadBalancerType = LoadBalancerType::new(4);
+
+    /// External SSL proxy load balancer.
+    pub const SSL_PROXY_LOAD_BALANCER: LoadBalancerType = LoadBalancerType::new(5);
+
+    /// External TCP proxy load balancer.
+    pub const TCP_PROXY_LOAD_BALANCER: LoadBalancerType = LoadBalancerType::new(6);
+
+    /// Internal regional TCP proxy load balancer.
+    pub const INTERNAL_TCP_PROXY_LOAD_BALANCER: LoadBalancerType = LoadBalancerType::new(7);
+
+    /// External TCP/UDP Network load balancer.
+    pub const NETWORK_LOAD_BALANCER: LoadBalancerType = LoadBalancerType::new(8);
+
+    /// Target-pool based external TCP/UDP Network load balancer.
+    pub const LEGACY_NETWORK_LOAD_BALANCER: LoadBalancerType = LoadBalancerType::new(9);
+
+    /// Internal TCP/UDP load balancer.
+    pub const TCP_UDP_INTERNAL_LOAD_BALANCER: LoadBalancerType = LoadBalancerType::new(10);
+
     /// Creates a new LoadBalancerType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("LOAD_BALANCER_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("HTTPS_ADVANCED_LOAD_BALANCER"),
+            2 => std::borrow::Cow::Borrowed("HTTPS_LOAD_BALANCER"),
+            3 => std::borrow::Cow::Borrowed("REGIONAL_HTTPS_LOAD_BALANCER"),
+            4 => std::borrow::Cow::Borrowed("INTERNAL_HTTPS_LOAD_BALANCER"),
+            5 => std::borrow::Cow::Borrowed("SSL_PROXY_LOAD_BALANCER"),
+            6 => std::borrow::Cow::Borrowed("TCP_PROXY_LOAD_BALANCER"),
+            7 => std::borrow::Cow::Borrowed("INTERNAL_TCP_PROXY_LOAD_BALANCER"),
+            8 => std::borrow::Cow::Borrowed("NETWORK_LOAD_BALANCER"),
+            9 => std::borrow::Cow::Borrowed("LEGACY_NETWORK_LOAD_BALANCER"),
+            10 => std::borrow::Cow::Borrowed("TCP_UDP_INTERNAL_LOAD_BALANCER"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "LOAD_BALANCER_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::LOAD_BALANCER_TYPE_UNSPECIFIED)
+            }
+            "HTTPS_ADVANCED_LOAD_BALANCER" => {
+                std::option::Option::Some(Self::HTTPS_ADVANCED_LOAD_BALANCER)
+            }
+            "HTTPS_LOAD_BALANCER" => std::option::Option::Some(Self::HTTPS_LOAD_BALANCER),
+            "REGIONAL_HTTPS_LOAD_BALANCER" => {
+                std::option::Option::Some(Self::REGIONAL_HTTPS_LOAD_BALANCER)
+            }
+            "INTERNAL_HTTPS_LOAD_BALANCER" => {
+                std::option::Option::Some(Self::INTERNAL_HTTPS_LOAD_BALANCER)
+            }
+            "SSL_PROXY_LOAD_BALANCER" => std::option::Option::Some(Self::SSL_PROXY_LOAD_BALANCER),
+            "TCP_PROXY_LOAD_BALANCER" => std::option::Option::Some(Self::TCP_PROXY_LOAD_BALANCER),
+            "INTERNAL_TCP_PROXY_LOAD_BALANCER" => {
+                std::option::Option::Some(Self::INTERNAL_TCP_PROXY_LOAD_BALANCER)
+            }
+            "NETWORK_LOAD_BALANCER" => std::option::Option::Some(Self::NETWORK_LOAD_BALANCER),
+            "LEGACY_NETWORK_LOAD_BALANCER" => {
+                std::option::Option::Some(Self::LEGACY_NETWORK_LOAD_BALANCER)
+            }
+            "TCP_UDP_INTERNAL_LOAD_BALANCER" => {
+                std::option::Option::Some(Self::TCP_UDP_INTERNAL_LOAD_BALANCER)
+            }
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [LoadBalancerType](LoadBalancerType)
-pub mod load_balancer_type {
-    use super::LoadBalancerType;
-
-    /// Forwarding rule points to a different target than a load balancer or a
-    /// load balancer type is unknown.
-    pub const LOAD_BALANCER_TYPE_UNSPECIFIED: LoadBalancerType =
-        LoadBalancerType::new("LOAD_BALANCER_TYPE_UNSPECIFIED");
-
-    /// Global external HTTP(S) load balancer.
-    pub const HTTPS_ADVANCED_LOAD_BALANCER: LoadBalancerType =
-        LoadBalancerType::new("HTTPS_ADVANCED_LOAD_BALANCER");
-
-    /// Global external HTTP(S) load balancer (classic)
-    pub const HTTPS_LOAD_BALANCER: LoadBalancerType = LoadBalancerType::new("HTTPS_LOAD_BALANCER");
-
-    /// Regional external HTTP(S) load balancer.
-    pub const REGIONAL_HTTPS_LOAD_BALANCER: LoadBalancerType =
-        LoadBalancerType::new("REGIONAL_HTTPS_LOAD_BALANCER");
-
-    /// Internal HTTP(S) load balancer.
-    pub const INTERNAL_HTTPS_LOAD_BALANCER: LoadBalancerType =
-        LoadBalancerType::new("INTERNAL_HTTPS_LOAD_BALANCER");
-
-    /// External SSL proxy load balancer.
-    pub const SSL_PROXY_LOAD_BALANCER: LoadBalancerType =
-        LoadBalancerType::new("SSL_PROXY_LOAD_BALANCER");
-
-    /// External TCP proxy load balancer.
-    pub const TCP_PROXY_LOAD_BALANCER: LoadBalancerType =
-        LoadBalancerType::new("TCP_PROXY_LOAD_BALANCER");
-
-    /// Internal regional TCP proxy load balancer.
-    pub const INTERNAL_TCP_PROXY_LOAD_BALANCER: LoadBalancerType =
-        LoadBalancerType::new("INTERNAL_TCP_PROXY_LOAD_BALANCER");
-
-    /// External TCP/UDP Network load balancer.
-    pub const NETWORK_LOAD_BALANCER: LoadBalancerType =
-        LoadBalancerType::new("NETWORK_LOAD_BALANCER");
-
-    /// Target-pool based external TCP/UDP Network load balancer.
-    pub const LEGACY_NETWORK_LOAD_BALANCER: LoadBalancerType =
-        LoadBalancerType::new("LEGACY_NETWORK_LOAD_BALANCER");
-
-    /// Internal TCP/UDP load balancer.
-    pub const TCP_UDP_INTERNAL_LOAD_BALANCER: LoadBalancerType =
-        LoadBalancerType::new("TCP_UDP_INTERNAL_LOAD_BALANCER");
-}
-
-impl std::convert::From<std::string::String> for LoadBalancerType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for LoadBalancerType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for LoadBalancerType {
     fn default() -> Self {
-        load_balancer_type::LOAD_BALANCER_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/networkmanagement/v1/src/transport.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::ReachabilityService for ReachabilityService {
                 reqwest::Method::GET,
                 format!("/v1/{}/connectivityTests", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::ReachabilityService for ReachabilityService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::ReachabilityService for ReachabilityService {
                 reqwest::Method::POST,
                 format!("/v1/{}/connectivityTests", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -126,7 +126,7 @@ impl crate::stubs::ReachabilityService for ReachabilityService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -155,7 +155,7 @@ impl crate::stubs::ReachabilityService for ReachabilityService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:rerun", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -172,7 +172,7 @@ impl crate::stubs::ReachabilityService for ReachabilityService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -191,7 +191,7 @@ impl crate::stubs::ReachabilityService for ReachabilityService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -213,7 +213,7 @@ impl crate::stubs::ReachabilityService for ReachabilityService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -235,7 +235,7 @@ impl crate::stubs::ReachabilityService for ReachabilityService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -255,7 +255,7 @@ impl crate::stubs::ReachabilityService for ReachabilityService {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -287,7 +287,7 @@ impl crate::stubs::ReachabilityService for ReachabilityService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -304,7 +304,7 @@ impl crate::stubs::ReachabilityService for ReachabilityService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -326,7 +326,7 @@ impl crate::stubs::ReachabilityService for ReachabilityService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -345,7 +345,7 @@ impl crate::stubs::ReachabilityService for ReachabilityService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -364,7 +364,7 @@ impl crate::stubs::ReachabilityService for ReachabilityService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -421,7 +421,7 @@ impl crate::stubs::VpcFlowLogsService for VpcFlowLogsService {
                 reqwest::Method::GET,
                 format!("/v1/{}/vpcFlowLogsConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -444,7 +444,7 @@ impl crate::stubs::VpcFlowLogsService for VpcFlowLogsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -466,7 +466,7 @@ impl crate::stubs::VpcFlowLogsService for VpcFlowLogsService {
                 reqwest::Method::POST,
                 format!("/v1/{}/vpcFlowLogsConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -495,7 +495,7 @@ impl crate::stubs::VpcFlowLogsService for VpcFlowLogsService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -524,7 +524,7 @@ impl crate::stubs::VpcFlowLogsService for VpcFlowLogsService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -543,7 +543,7 @@ impl crate::stubs::VpcFlowLogsService for VpcFlowLogsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -565,7 +565,7 @@ impl crate::stubs::VpcFlowLogsService for VpcFlowLogsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -587,7 +587,7 @@ impl crate::stubs::VpcFlowLogsService for VpcFlowLogsService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -607,7 +607,7 @@ impl crate::stubs::VpcFlowLogsService for VpcFlowLogsService {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -639,7 +639,7 @@ impl crate::stubs::VpcFlowLogsService for VpcFlowLogsService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -656,7 +656,7 @@ impl crate::stubs::VpcFlowLogsService for VpcFlowLogsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -678,7 +678,7 @@ impl crate::stubs::VpcFlowLogsService for VpcFlowLogsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -697,7 +697,7 @@ impl crate::stubs::VpcFlowLogsService for VpcFlowLogsService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -716,7 +716,7 @@ impl crate::stubs::VpcFlowLogsService for VpcFlowLogsService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/networksecurity/v1/src/model.rs
+++ b/src/generated/cloud/networksecurity/v1/src/model.rs
@@ -470,45 +470,60 @@ pub mod authorization_policy {
 
     /// Possible values that define what action to take.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(std::borrow::Cow<'static, str>);
+    pub struct Action(i32);
 
     impl Action {
-        /// Creates a new Action instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Action](Action)
-    pub mod action {
-        use super::Action;
-
         /// Default value.
-        pub const ACTION_UNSPECIFIED: Action = Action::new("ACTION_UNSPECIFIED");
+        pub const ACTION_UNSPECIFIED: Action = Action::new(0);
 
         /// Grant access.
-        pub const ALLOW: Action = Action::new("ALLOW");
+        pub const ALLOW: Action = Action::new(1);
 
         /// Deny access.
         /// Deny rules should be avoided unless they are used to provide a default
         /// "deny all" fallback.
-        pub const DENY: Action = Action::new("DENY");
+        pub const DENY: Action = Action::new(2);
+
+        /// Creates a new Action instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ACTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALLOW"),
+                2 => std::borrow::Cow::Borrowed("DENY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ACTION_UNSPECIFIED" => std::option::Option::Some(Self::ACTION_UNSPECIFIED),
+                "ALLOW" => std::option::Option::Some(Self::ALLOW),
+                "DENY" => std::option::Option::Some(Self::DENY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Action {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            action::ACTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/networksecurity/v1/src/transport.rs
+++ b/src/generated/cloud/networksecurity/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
                 reqwest::Method::GET,
                 format!("/v1/{}/authorizationPolicies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -73,7 +73,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -95,7 +95,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
                 reqwest::Method::POST,
                 format!("/v1/{}/authorizationPolicies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -124,7 +124,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -153,7 +153,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -175,7 +175,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
                 reqwest::Method::GET,
                 format!("/v1/{}/serverTlsPolicies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -196,7 +196,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -218,7 +218,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
                 reqwest::Method::POST,
                 format!("/v1/{}/serverTlsPolicies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -247,7 +247,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -276,7 +276,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -298,7 +298,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
                 reqwest::Method::GET,
                 format!("/v1/{}/clientTlsPolicies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -319,7 +319,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -341,7 +341,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
                 reqwest::Method::POST,
                 format!("/v1/{}/clientTlsPolicies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -370,7 +370,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -399,7 +399,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -418,7 +418,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -440,7 +440,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -462,7 +462,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -482,7 +482,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -514,7 +514,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -531,7 +531,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -553,7 +553,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -572,7 +572,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -591,7 +591,7 @@ impl crate::stubs::NetworkSecurity for NetworkSecurity {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/networkservices/v1/src/model.rs
+++ b/src/generated/cloud/networkservices/v1/src/model.rs
@@ -379,48 +379,63 @@ pub mod endpoint_matcher {
 
         /// Possible criteria values that define logic of how matching is made.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct MetadataLabelMatchCriteria(std::borrow::Cow<'static, str>);
+        pub struct MetadataLabelMatchCriteria(i32);
 
         impl MetadataLabelMatchCriteria {
-            /// Creates a new MetadataLabelMatchCriteria instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [MetadataLabelMatchCriteria](MetadataLabelMatchCriteria)
-        pub mod metadata_label_match_criteria {
-            use super::MetadataLabelMatchCriteria;
-
             /// Default value. Should not be used.
             pub const METADATA_LABEL_MATCH_CRITERIA_UNSPECIFIED: MetadataLabelMatchCriteria =
-                MetadataLabelMatchCriteria::new("METADATA_LABEL_MATCH_CRITERIA_UNSPECIFIED");
+                MetadataLabelMatchCriteria::new(0);
 
             /// At least one of the Labels specified in the matcher should match the
             /// metadata presented by xDS client.
-            pub const MATCH_ANY: MetadataLabelMatchCriteria =
-                MetadataLabelMatchCriteria::new("MATCH_ANY");
+            pub const MATCH_ANY: MetadataLabelMatchCriteria = MetadataLabelMatchCriteria::new(1);
 
             /// The metadata presented by the xDS client should contain all of the
             /// labels specified here.
-            pub const MATCH_ALL: MetadataLabelMatchCriteria =
-                MetadataLabelMatchCriteria::new("MATCH_ALL");
+            pub const MATCH_ALL: MetadataLabelMatchCriteria = MetadataLabelMatchCriteria::new(2);
+
+            /// Creates a new MetadataLabelMatchCriteria instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("METADATA_LABEL_MATCH_CRITERIA_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("MATCH_ANY"),
+                    2 => std::borrow::Cow::Borrowed("MATCH_ALL"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "METADATA_LABEL_MATCH_CRITERIA_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::METADATA_LABEL_MATCH_CRITERIA_UNSPECIFIED)
+                    }
+                    "MATCH_ANY" => std::option::Option::Some(Self::MATCH_ANY),
+                    "MATCH_ALL" => std::option::Option::Some(Self::MATCH_ALL),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for MetadataLabelMatchCriteria {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for MetadataLabelMatchCriteria {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for MetadataLabelMatchCriteria {
             fn default() -> Self {
-                metadata_label_match_criteria::METADATA_LABEL_MATCH_CRITERIA_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -1965,44 +1980,60 @@ pub mod endpoint_policy {
 
     /// The type of endpoint policy.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EndpointPolicyType(std::borrow::Cow<'static, str>);
+    pub struct EndpointPolicyType(i32);
 
     impl EndpointPolicyType {
+        /// Default value. Must not be used.
+        pub const ENDPOINT_POLICY_TYPE_UNSPECIFIED: EndpointPolicyType = EndpointPolicyType::new(0);
+
+        /// Represents a proxy deployed as a sidecar.
+        pub const SIDECAR_PROXY: EndpointPolicyType = EndpointPolicyType::new(1);
+
+        /// Represents a proxyless gRPC backend.
+        pub const GRPC_SERVER: EndpointPolicyType = EndpointPolicyType::new(2);
+
         /// Creates a new EndpointPolicyType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ENDPOINT_POLICY_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SIDECAR_PROXY"),
+                2 => std::borrow::Cow::Borrowed("GRPC_SERVER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ENDPOINT_POLICY_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ENDPOINT_POLICY_TYPE_UNSPECIFIED)
+                }
+                "SIDECAR_PROXY" => std::option::Option::Some(Self::SIDECAR_PROXY),
+                "GRPC_SERVER" => std::option::Option::Some(Self::GRPC_SERVER),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [EndpointPolicyType](EndpointPolicyType)
-    pub mod endpoint_policy_type {
-        use super::EndpointPolicyType;
-
-        /// Default value. Must not be used.
-        pub const ENDPOINT_POLICY_TYPE_UNSPECIFIED: EndpointPolicyType =
-            EndpointPolicyType::new("ENDPOINT_POLICY_TYPE_UNSPECIFIED");
-
-        /// Represents a proxy deployed as a sidecar.
-        pub const SIDECAR_PROXY: EndpointPolicyType = EndpointPolicyType::new("SIDECAR_PROXY");
-
-        /// Represents a proxyless gRPC backend.
-        pub const GRPC_SERVER: EndpointPolicyType = EndpointPolicyType::new("GRPC_SERVER");
-    }
-
-    impl std::convert::From<std::string::String> for EndpointPolicyType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EndpointPolicyType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EndpointPolicyType {
         fn default() -> Self {
-            endpoint_policy_type::ENDPOINT_POLICY_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2454,44 +2485,59 @@ pub mod gateway {
     /// * OPEN_MESH
     /// * SECURE_WEB_GATEWAY
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// The type of the customer managed gateway is unspecified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// The type of the customer managed gateway is TrafficDirector Open
         /// Mesh.
-        pub const OPEN_MESH: Type = Type::new("OPEN_MESH");
+        pub const OPEN_MESH: Type = Type::new(1);
 
         /// The type of the customer managed gateway is SecureWebGateway (SWG).
-        pub const SECURE_WEB_GATEWAY: Type = Type::new("SECURE_WEB_GATEWAY");
+        pub const SECURE_WEB_GATEWAY: Type = Type::new(2);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("OPEN_MESH"),
+                2 => std::borrow::Cow::Borrowed("SECURE_WEB_GATEWAY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "OPEN_MESH" => std::option::Option::Some(Self::OPEN_MESH),
+                "SECURE_WEB_GATEWAY" => std::option::Option::Some(Self::SECURE_WEB_GATEWAY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3051,44 +3097,59 @@ pub mod grpc_route {
 
         /// The type of the match.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(std::borrow::Cow<'static, str>);
+        pub struct Type(i32);
 
         impl Type {
-            /// Creates a new Type instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [Type](Type)
-        pub mod r#type {
-            use super::Type;
-
             /// Unspecified.
-            pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
             /// Will only match the exact name provided.
-            pub const EXACT: Type = Type::new("EXACT");
+            pub const EXACT: Type = Type::new(1);
 
             /// Will interpret grpc_method and grpc_service as regexes. RE2 syntax is
             /// supported.
-            pub const REGULAR_EXPRESSION: Type = Type::new("REGULAR_EXPRESSION");
+            pub const REGULAR_EXPRESSION: Type = Type::new(2);
+
+            /// Creates a new Type instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("EXACT"),
+                    2 => std::borrow::Cow::Borrowed("REGULAR_EXPRESSION"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                    "EXACT" => std::option::Option::Some(Self::EXACT),
+                    "REGULAR_EXPRESSION" => std::option::Option::Some(Self::REGULAR_EXPRESSION),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for Type {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                r#type::TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -3153,44 +3214,59 @@ pub mod grpc_route {
 
         /// The type of match.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(std::borrow::Cow<'static, str>);
+        pub struct Type(i32);
 
         impl Type {
-            /// Creates a new Type instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [Type](Type)
-        pub mod r#type {
-            use super::Type;
-
             /// Unspecified.
-            pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
             /// Will only match the exact value provided.
-            pub const EXACT: Type = Type::new("EXACT");
+            pub const EXACT: Type = Type::new(1);
 
             /// Will match paths conforming to the prefix specified by value. RE2
             /// syntax is supported.
-            pub const REGULAR_EXPRESSION: Type = Type::new("REGULAR_EXPRESSION");
+            pub const REGULAR_EXPRESSION: Type = Type::new(2);
+
+            /// Creates a new Type instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("EXACT"),
+                    2 => std::borrow::Cow::Borrowed("REGULAR_EXPRESSION"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                    "EXACT" => std::option::Option::Some(Self::EXACT),
+                    "REGULAR_EXPRESSION" => std::option::Option::Some(Self::REGULAR_EXPRESSION),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for Type {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                r#type::TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -4994,54 +5070,77 @@ pub mod http_route {
 
         /// Supported HTTP response code.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ResponseCode(std::borrow::Cow<'static, str>);
+        pub struct ResponseCode(i32);
 
         impl ResponseCode {
+            /// Default value
+            pub const RESPONSE_CODE_UNSPECIFIED: ResponseCode = ResponseCode::new(0);
+
+            /// Corresponds to 301.
+            pub const MOVED_PERMANENTLY_DEFAULT: ResponseCode = ResponseCode::new(1);
+
+            /// Corresponds to 302.
+            pub const FOUND: ResponseCode = ResponseCode::new(2);
+
+            /// Corresponds to 303.
+            pub const SEE_OTHER: ResponseCode = ResponseCode::new(3);
+
+            /// Corresponds to 307. In this case, the request method will be retained.
+            pub const TEMPORARY_REDIRECT: ResponseCode = ResponseCode::new(4);
+
+            /// Corresponds to 308. In this case, the request method will be retained.
+            pub const PERMANENT_REDIRECT: ResponseCode = ResponseCode::new(5);
+
             /// Creates a new ResponseCode instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("RESPONSE_CODE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("MOVED_PERMANENTLY_DEFAULT"),
+                    2 => std::borrow::Cow::Borrowed("FOUND"),
+                    3 => std::borrow::Cow::Borrowed("SEE_OTHER"),
+                    4 => std::borrow::Cow::Borrowed("TEMPORARY_REDIRECT"),
+                    5 => std::borrow::Cow::Borrowed("PERMANENT_REDIRECT"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "RESPONSE_CODE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::RESPONSE_CODE_UNSPECIFIED)
+                    }
+                    "MOVED_PERMANENTLY_DEFAULT" => {
+                        std::option::Option::Some(Self::MOVED_PERMANENTLY_DEFAULT)
+                    }
+                    "FOUND" => std::option::Option::Some(Self::FOUND),
+                    "SEE_OTHER" => std::option::Option::Some(Self::SEE_OTHER),
+                    "TEMPORARY_REDIRECT" => std::option::Option::Some(Self::TEMPORARY_REDIRECT),
+                    "PERMANENT_REDIRECT" => std::option::Option::Some(Self::PERMANENT_REDIRECT),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [ResponseCode](ResponseCode)
-        pub mod response_code {
-            use super::ResponseCode;
-
-            /// Default value
-            pub const RESPONSE_CODE_UNSPECIFIED: ResponseCode =
-                ResponseCode::new("RESPONSE_CODE_UNSPECIFIED");
-
-            /// Corresponds to 301.
-            pub const MOVED_PERMANENTLY_DEFAULT: ResponseCode =
-                ResponseCode::new("MOVED_PERMANENTLY_DEFAULT");
-
-            /// Corresponds to 302.
-            pub const FOUND: ResponseCode = ResponseCode::new("FOUND");
-
-            /// Corresponds to 303.
-            pub const SEE_OTHER: ResponseCode = ResponseCode::new("SEE_OTHER");
-
-            /// Corresponds to 307. In this case, the request method will be retained.
-            pub const TEMPORARY_REDIRECT: ResponseCode = ResponseCode::new("TEMPORARY_REDIRECT");
-
-            /// Corresponds to 308. In this case, the request method will be retained.
-            pub const PERMANENT_REDIRECT: ResponseCode = ResponseCode::new("PERMANENT_REDIRECT");
-        }
-
-        impl std::convert::From<std::string::String> for ResponseCode {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for ResponseCode {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for ResponseCode {
             fn default() -> Self {
-                response_code::RESPONSE_CODE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -8028,61 +8127,84 @@ impl wkt::message::Message for DeleteTlsRouteRequest {
 
 /// The part of the request or response for which the extension is called.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EventType(std::borrow::Cow<'static, str>);
+pub struct EventType(i32);
 
 impl EventType {
-    /// Creates a new EventType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [EventType](EventType)
-pub mod event_type {
-    use super::EventType;
-
     /// Unspecified value. Do not use.
-    pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new("EVENT_TYPE_UNSPECIFIED");
+    pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new(0);
 
     /// If included in `supported_events`,
     /// the extension is called when the HTTP request headers arrive.
-    pub const REQUEST_HEADERS: EventType = EventType::new("REQUEST_HEADERS");
+    pub const REQUEST_HEADERS: EventType = EventType::new(1);
 
     /// If included in `supported_events`,
     /// the extension is called when the HTTP request body arrives.
-    pub const REQUEST_BODY: EventType = EventType::new("REQUEST_BODY");
+    pub const REQUEST_BODY: EventType = EventType::new(2);
 
     /// If included in `supported_events`,
     /// the extension is called when the HTTP response headers arrive.
-    pub const RESPONSE_HEADERS: EventType = EventType::new("RESPONSE_HEADERS");
+    pub const RESPONSE_HEADERS: EventType = EventType::new(3);
 
     /// If included in `supported_events`,
     /// the extension is called when the HTTP response body arrives.
-    pub const RESPONSE_BODY: EventType = EventType::new("RESPONSE_BODY");
+    pub const RESPONSE_BODY: EventType = EventType::new(4);
 
     /// If included in `supported_events`,
     /// the extension is called when the HTTP request trailers arrives.
-    pub const REQUEST_TRAILERS: EventType = EventType::new("REQUEST_TRAILERS");
+    pub const REQUEST_TRAILERS: EventType = EventType::new(5);
 
     /// If included in `supported_events`,
     /// the extension is called when the HTTP response trailers arrives.
-    pub const RESPONSE_TRAILERS: EventType = EventType::new("RESPONSE_TRAILERS");
+    pub const RESPONSE_TRAILERS: EventType = EventType::new(6);
+
+    /// Creates a new EventType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("EVENT_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("REQUEST_HEADERS"),
+            2 => std::borrow::Cow::Borrowed("REQUEST_BODY"),
+            3 => std::borrow::Cow::Borrowed("RESPONSE_HEADERS"),
+            4 => std::borrow::Cow::Borrowed("RESPONSE_BODY"),
+            5 => std::borrow::Cow::Borrowed("REQUEST_TRAILERS"),
+            6 => std::borrow::Cow::Borrowed("RESPONSE_TRAILERS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "EVENT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::EVENT_TYPE_UNSPECIFIED),
+            "REQUEST_HEADERS" => std::option::Option::Some(Self::REQUEST_HEADERS),
+            "REQUEST_BODY" => std::option::Option::Some(Self::REQUEST_BODY),
+            "RESPONSE_HEADERS" => std::option::Option::Some(Self::RESPONSE_HEADERS),
+            "RESPONSE_BODY" => std::option::Option::Some(Self::RESPONSE_BODY),
+            "REQUEST_TRAILERS" => std::option::Option::Some(Self::REQUEST_TRAILERS),
+            "RESPONSE_TRAILERS" => std::option::Option::Some(Self::RESPONSE_TRAILERS),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for EventType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for EventType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for EventType {
     fn default() -> Self {
-        event_type::EVENT_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -8091,44 +8213,60 @@ impl std::default::Default for EventType {
 /// For more information, refer to [Choosing a load
 /// balancer](https://cloud.google.com/load-balancing/docs/backend-service).
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LoadBalancingScheme(std::borrow::Cow<'static, str>);
+pub struct LoadBalancingScheme(i32);
 
 impl LoadBalancingScheme {
-    /// Creates a new LoadBalancingScheme instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [LoadBalancingScheme](LoadBalancingScheme)
-pub mod load_balancing_scheme {
-    use super::LoadBalancingScheme;
-
     /// Default value. Do not use.
-    pub const LOAD_BALANCING_SCHEME_UNSPECIFIED: LoadBalancingScheme =
-        LoadBalancingScheme::new("LOAD_BALANCING_SCHEME_UNSPECIFIED");
+    pub const LOAD_BALANCING_SCHEME_UNSPECIFIED: LoadBalancingScheme = LoadBalancingScheme::new(0);
 
     /// Signifies that this is used for Internal HTTP(S) Load Balancing.
-    pub const INTERNAL_MANAGED: LoadBalancingScheme = LoadBalancingScheme::new("INTERNAL_MANAGED");
+    pub const INTERNAL_MANAGED: LoadBalancingScheme = LoadBalancingScheme::new(1);
 
     /// Signifies that this is used for External Managed HTTP(S) Load
     /// Balancing.
-    pub const EXTERNAL_MANAGED: LoadBalancingScheme = LoadBalancingScheme::new("EXTERNAL_MANAGED");
+    pub const EXTERNAL_MANAGED: LoadBalancingScheme = LoadBalancingScheme::new(2);
+
+    /// Creates a new LoadBalancingScheme instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("LOAD_BALANCING_SCHEME_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("INTERNAL_MANAGED"),
+            2 => std::borrow::Cow::Borrowed("EXTERNAL_MANAGED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "LOAD_BALANCING_SCHEME_UNSPECIFIED" => {
+                std::option::Option::Some(Self::LOAD_BALANCING_SCHEME_UNSPECIFIED)
+            }
+            "INTERNAL_MANAGED" => std::option::Option::Some(Self::INTERNAL_MANAGED),
+            "EXTERNAL_MANAGED" => std::option::Option::Some(Self::EXTERNAL_MANAGED),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for LoadBalancingScheme {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for LoadBalancingScheme {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for LoadBalancingScheme {
     fn default() -> Self {
-        load_balancing_scheme::LOAD_BALANCING_SCHEME_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/networkservices/v1/src/transport.rs
+++ b/src/generated/cloud/networkservices/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::DepService for DepService {
                 reqwest::Method::GET,
                 format!("/v1/{}/lbTrafficExtensions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::DepService for DepService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::DepService for DepService {
                 reqwest::Method::POST,
                 format!("/v1/{}/lbTrafficExtensions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -127,7 +127,7 @@ impl crate::stubs::DepService for DepService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -157,7 +157,7 @@ impl crate::stubs::DepService for DepService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -180,7 +180,7 @@ impl crate::stubs::DepService for DepService {
                 reqwest::Method::GET,
                 format!("/v1/{}/lbRouteExtensions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -203,7 +203,7 @@ impl crate::stubs::DepService for DepService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -225,7 +225,7 @@ impl crate::stubs::DepService for DepService {
                 reqwest::Method::POST,
                 format!("/v1/{}/lbRouteExtensions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -255,7 +255,7 @@ impl crate::stubs::DepService for DepService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -285,7 +285,7 @@ impl crate::stubs::DepService for DepService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -305,7 +305,7 @@ impl crate::stubs::DepService for DepService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -327,7 +327,7 @@ impl crate::stubs::DepService for DepService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -349,7 +349,7 @@ impl crate::stubs::DepService for DepService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -369,7 +369,7 @@ impl crate::stubs::DepService for DepService {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -401,7 +401,7 @@ impl crate::stubs::DepService for DepService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -418,7 +418,7 @@ impl crate::stubs::DepService for DepService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -440,7 +440,7 @@ impl crate::stubs::DepService for DepService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -459,7 +459,7 @@ impl crate::stubs::DepService for DepService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -478,7 +478,7 @@ impl crate::stubs::DepService for DepService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -535,7 +535,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
                 reqwest::Method::GET,
                 format!("/v1/{}/endpointPolicies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -556,7 +556,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -578,7 +578,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
                 reqwest::Method::POST,
                 format!("/v1/{}/endpointPolicies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -607,7 +607,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -636,7 +636,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -655,7 +655,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/gateways", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -676,7 +676,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -698,7 +698,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
                 reqwest::Method::POST,
                 format!("/v1/{}/gateways", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -727,7 +727,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -756,7 +756,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -778,7 +778,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
                 reqwest::Method::GET,
                 format!("/v1/{}/grpcRoutes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -799,7 +799,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -821,7 +821,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
                 reqwest::Method::POST,
                 format!("/v1/{}/grpcRoutes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -850,7 +850,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -879,7 +879,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -901,7 +901,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
                 reqwest::Method::GET,
                 format!("/v1/{}/httpRoutes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -922,7 +922,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -944,7 +944,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
                 reqwest::Method::POST,
                 format!("/v1/{}/httpRoutes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -973,7 +973,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1002,7 +1002,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1024,7 +1024,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
                 reqwest::Method::GET,
                 format!("/v1/{}/tcpRoutes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1045,7 +1045,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1067,7 +1067,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
                 reqwest::Method::POST,
                 format!("/v1/{}/tcpRoutes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1096,7 +1096,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1125,7 +1125,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1147,7 +1147,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
                 reqwest::Method::GET,
                 format!("/v1/{}/tlsRoutes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1168,7 +1168,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1190,7 +1190,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
                 reqwest::Method::POST,
                 format!("/v1/{}/tlsRoutes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1219,7 +1219,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1248,7 +1248,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1270,7 +1270,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
                 reqwest::Method::GET,
                 format!("/v1/{}/serviceBindings", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1291,7 +1291,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1313,7 +1313,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
                 reqwest::Method::POST,
                 format!("/v1/{}/serviceBindings", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1333,7 +1333,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1352,7 +1352,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/meshes", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1373,7 +1373,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1392,7 +1392,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/meshes", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1419,7 +1419,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1446,7 +1446,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1465,7 +1465,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1487,7 +1487,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1509,7 +1509,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1529,7 +1529,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1561,7 +1561,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1578,7 +1578,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1600,7 +1600,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1619,7 +1619,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1638,7 +1638,7 @@ impl crate::stubs::NetworkServices for NetworkServices {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/notebooks/v2/src/model.rs
+++ b/src/generated/cloud/notebooks/v2/src/model.rs
@@ -181,60 +181,81 @@ pub mod event {
 
     /// The definition of the event types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EventType(std::borrow::Cow<'static, str>);
+    pub struct EventType(i32);
 
     impl EventType {
-        /// Creates a new EventType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [EventType](EventType)
-    pub mod event_type {
-        use super::EventType;
-
         /// Event is not specified.
-        pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new("EVENT_TYPE_UNSPECIFIED");
+        pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new(0);
 
         /// The instance / runtime is idle
-        pub const IDLE: EventType = EventType::new("IDLE");
+        pub const IDLE: EventType = EventType::new(1);
 
         /// The instance / runtime is available.
         /// This event indicates that instance / runtime underlying compute is
         /// operational.
-        pub const HEARTBEAT: EventType = EventType::new("HEARTBEAT");
+        pub const HEARTBEAT: EventType = EventType::new(2);
 
         /// The instance / runtime health is available.
         /// This event indicates that instance / runtime health information.
-        pub const HEALTH: EventType = EventType::new("HEALTH");
+        pub const HEALTH: EventType = EventType::new(3);
 
         /// The instance / runtime is available.
         /// This event allows instance / runtime to send Host maintenance
         /// information to Control Plane.
         /// <https://cloud.google.com/compute/docs/gpus/gpu-host-maintenance>
-        pub const MAINTENANCE: EventType = EventType::new("MAINTENANCE");
+        pub const MAINTENANCE: EventType = EventType::new(4);
 
         /// The instance / runtime is available.
         /// This event indicates that the instance had metadata that needs to be
         /// modified.
-        pub const METADATA_CHANGE: EventType = EventType::new("METADATA_CHANGE");
+        pub const METADATA_CHANGE: EventType = EventType::new(5);
+
+        /// Creates a new EventType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EVENT_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IDLE"),
+                2 => std::borrow::Cow::Borrowed("HEARTBEAT"),
+                3 => std::borrow::Cow::Borrowed("HEALTH"),
+                4 => std::borrow::Cow::Borrowed("MAINTENANCE"),
+                5 => std::borrow::Cow::Borrowed("METADATA_CHANGE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EVENT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::EVENT_TYPE_UNSPECIFIED),
+                "IDLE" => std::option::Option::Some(Self::IDLE),
+                "HEARTBEAT" => std::option::Option::Some(Self::HEARTBEAT),
+                "HEALTH" => std::option::Option::Some(Self::HEALTH),
+                "MAINTENANCE" => std::option::Option::Some(Self::MAINTENANCE),
+                "METADATA_CHANGE" => std::option::Option::Some(Self::METADATA_CHANGE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for EventType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EventType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EventType {
         fn default() -> Self {
-            event_type::EVENT_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -303,43 +324,58 @@ pub mod network_interface {
     /// The type of vNIC driver.
     /// Default should be NIC_TYPE_UNSPECIFIED.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NicType(std::borrow::Cow<'static, str>);
+    pub struct NicType(i32);
 
     impl NicType {
+        /// No type specified.
+        pub const NIC_TYPE_UNSPECIFIED: NicType = NicType::new(0);
+
+        /// VIRTIO
+        pub const VIRTIO_NET: NicType = NicType::new(1);
+
+        /// GVNIC
+        pub const GVNIC: NicType = NicType::new(2);
+
         /// Creates a new NicType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("NIC_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("VIRTIO_NET"),
+                2 => std::borrow::Cow::Borrowed("GVNIC"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "NIC_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::NIC_TYPE_UNSPECIFIED),
+                "VIRTIO_NET" => std::option::Option::Some(Self::VIRTIO_NET),
+                "GVNIC" => std::option::Option::Some(Self::GVNIC),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [NicType](NicType)
-    pub mod nic_type {
-        use super::NicType;
-
-        /// No type specified.
-        pub const NIC_TYPE_UNSPECIFIED: NicType = NicType::new("NIC_TYPE_UNSPECIFIED");
-
-        /// VIRTIO
-        pub const VIRTIO_NET: NicType = NicType::new("VIRTIO_NET");
-
-        /// GVNIC
-        pub const GVNIC: NicType = NicType::new("GVNIC");
-    }
-
-    impl std::convert::From<std::string::String> for NicType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for NicType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for NicType {
         fn default() -> Self {
-            nic_type::NIC_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -545,71 +581,100 @@ pub mod accelerator_config {
     /// Definition of the types of hardware accelerators that can be used on
     /// this instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AcceleratorType(std::borrow::Cow<'static, str>);
+    pub struct AcceleratorType(i32);
 
     impl AcceleratorType {
+        /// Accelerator type is not specified.
+        pub const ACCELERATOR_TYPE_UNSPECIFIED: AcceleratorType = AcceleratorType::new(0);
+
+        /// Accelerator type is Nvidia Tesla P100.
+        pub const NVIDIA_TESLA_P100: AcceleratorType = AcceleratorType::new(2);
+
+        /// Accelerator type is Nvidia Tesla V100.
+        pub const NVIDIA_TESLA_V100: AcceleratorType = AcceleratorType::new(3);
+
+        /// Accelerator type is Nvidia Tesla P4.
+        pub const NVIDIA_TESLA_P4: AcceleratorType = AcceleratorType::new(4);
+
+        /// Accelerator type is Nvidia Tesla T4.
+        pub const NVIDIA_TESLA_T4: AcceleratorType = AcceleratorType::new(5);
+
+        /// Accelerator type is Nvidia Tesla A100 - 40GB.
+        pub const NVIDIA_TESLA_A100: AcceleratorType = AcceleratorType::new(11);
+
+        /// Accelerator type is Nvidia Tesla A100 - 80GB.
+        pub const NVIDIA_A100_80GB: AcceleratorType = AcceleratorType::new(12);
+
+        /// Accelerator type is Nvidia Tesla L4.
+        pub const NVIDIA_L4: AcceleratorType = AcceleratorType::new(13);
+
+        /// Accelerator type is NVIDIA Tesla T4 Virtual Workstations.
+        pub const NVIDIA_TESLA_T4_VWS: AcceleratorType = AcceleratorType::new(8);
+
+        /// Accelerator type is NVIDIA Tesla P100 Virtual Workstations.
+        pub const NVIDIA_TESLA_P100_VWS: AcceleratorType = AcceleratorType::new(9);
+
+        /// Accelerator type is NVIDIA Tesla P4 Virtual Workstations.
+        pub const NVIDIA_TESLA_P4_VWS: AcceleratorType = AcceleratorType::new(10);
+
         /// Creates a new AcceleratorType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ACCELERATOR_TYPE_UNSPECIFIED"),
+                2 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_P100"),
+                3 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_V100"),
+                4 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_P4"),
+                5 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_T4"),
+                8 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_T4_VWS"),
+                9 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_P100_VWS"),
+                10 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_P4_VWS"),
+                11 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_A100"),
+                12 => std::borrow::Cow::Borrowed("NVIDIA_A100_80GB"),
+                13 => std::borrow::Cow::Borrowed("NVIDIA_L4"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ACCELERATOR_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ACCELERATOR_TYPE_UNSPECIFIED)
+                }
+                "NVIDIA_TESLA_P100" => std::option::Option::Some(Self::NVIDIA_TESLA_P100),
+                "NVIDIA_TESLA_V100" => std::option::Option::Some(Self::NVIDIA_TESLA_V100),
+                "NVIDIA_TESLA_P4" => std::option::Option::Some(Self::NVIDIA_TESLA_P4),
+                "NVIDIA_TESLA_T4" => std::option::Option::Some(Self::NVIDIA_TESLA_T4),
+                "NVIDIA_TESLA_A100" => std::option::Option::Some(Self::NVIDIA_TESLA_A100),
+                "NVIDIA_A100_80GB" => std::option::Option::Some(Self::NVIDIA_A100_80GB),
+                "NVIDIA_L4" => std::option::Option::Some(Self::NVIDIA_L4),
+                "NVIDIA_TESLA_T4_VWS" => std::option::Option::Some(Self::NVIDIA_TESLA_T4_VWS),
+                "NVIDIA_TESLA_P100_VWS" => std::option::Option::Some(Self::NVIDIA_TESLA_P100_VWS),
+                "NVIDIA_TESLA_P4_VWS" => std::option::Option::Some(Self::NVIDIA_TESLA_P4_VWS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AcceleratorType](AcceleratorType)
-    pub mod accelerator_type {
-        use super::AcceleratorType;
-
-        /// Accelerator type is not specified.
-        pub const ACCELERATOR_TYPE_UNSPECIFIED: AcceleratorType =
-            AcceleratorType::new("ACCELERATOR_TYPE_UNSPECIFIED");
-
-        /// Accelerator type is Nvidia Tesla P100.
-        pub const NVIDIA_TESLA_P100: AcceleratorType = AcceleratorType::new("NVIDIA_TESLA_P100");
-
-        /// Accelerator type is Nvidia Tesla V100.
-        pub const NVIDIA_TESLA_V100: AcceleratorType = AcceleratorType::new("NVIDIA_TESLA_V100");
-
-        /// Accelerator type is Nvidia Tesla P4.
-        pub const NVIDIA_TESLA_P4: AcceleratorType = AcceleratorType::new("NVIDIA_TESLA_P4");
-
-        /// Accelerator type is Nvidia Tesla T4.
-        pub const NVIDIA_TESLA_T4: AcceleratorType = AcceleratorType::new("NVIDIA_TESLA_T4");
-
-        /// Accelerator type is Nvidia Tesla A100 - 40GB.
-        pub const NVIDIA_TESLA_A100: AcceleratorType = AcceleratorType::new("NVIDIA_TESLA_A100");
-
-        /// Accelerator type is Nvidia Tesla A100 - 80GB.
-        pub const NVIDIA_A100_80GB: AcceleratorType = AcceleratorType::new("NVIDIA_A100_80GB");
-
-        /// Accelerator type is Nvidia Tesla L4.
-        pub const NVIDIA_L4: AcceleratorType = AcceleratorType::new("NVIDIA_L4");
-
-        /// Accelerator type is NVIDIA Tesla T4 Virtual Workstations.
-        pub const NVIDIA_TESLA_T4_VWS: AcceleratorType =
-            AcceleratorType::new("NVIDIA_TESLA_T4_VWS");
-
-        /// Accelerator type is NVIDIA Tesla P100 Virtual Workstations.
-        pub const NVIDIA_TESLA_P100_VWS: AcceleratorType =
-            AcceleratorType::new("NVIDIA_TESLA_P100_VWS");
-
-        /// Accelerator type is NVIDIA Tesla P4 Virtual Workstations.
-        pub const NVIDIA_TESLA_P4_VWS: AcceleratorType =
-            AcceleratorType::new("NVIDIA_TESLA_P4_VWS");
-    }
-
-    impl std::convert::From<std::string::String> for AcceleratorType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AcceleratorType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AcceleratorType {
         fn default() -> Self {
-            accelerator_type::ACCELERATOR_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1297,88 +1362,120 @@ pub mod upgrade_history_entry {
 
     /// The definition of the states of this upgrade history entry.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State is not specified.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The instance upgrade is started.
+        pub const STARTED: State = State::new(1);
+
+        /// The instance upgrade is succeeded.
+        pub const SUCCEEDED: State = State::new(2);
+
+        /// The instance upgrade is failed.
+        pub const FAILED: State = State::new(3);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STARTED"),
+                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "STARTED" => std::option::Option::Some(Self::STARTED),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State is not specified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The instance upgrade is started.
-        pub const STARTED: State = State::new("STARTED");
-
-        /// The instance upgrade is succeeded.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-        /// The instance upgrade is failed.
-        pub const FAILED: State = State::new("FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The definition of operations of this upgrade history entry.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(std::borrow::Cow<'static, str>);
+    pub struct Action(i32);
 
     impl Action {
+        /// Operation is not specified.
+        pub const ACTION_UNSPECIFIED: Action = Action::new(0);
+
+        /// Upgrade.
+        pub const UPGRADE: Action = Action::new(1);
+
+        /// Rollback.
+        pub const ROLLBACK: Action = Action::new(2);
+
         /// Creates a new Action instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ACTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("UPGRADE"),
+                2 => std::borrow::Cow::Borrowed("ROLLBACK"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ACTION_UNSPECIFIED" => std::option::Option::Some(Self::ACTION_UNSPECIFIED),
+                "UPGRADE" => std::option::Option::Some(Self::UPGRADE),
+                "ROLLBACK" => std::option::Option::Some(Self::ROLLBACK),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Action](Action)
-    pub mod action {
-        use super::Action;
-
-        /// Operation is not specified.
-        pub const ACTION_UNSPECIFIED: Action = Action::new("ACTION_UNSPECIFIED");
-
-        /// Upgrade.
-        pub const UPGRADE: Action = Action::new("UPGRADE");
-
-        /// Rollback.
-        pub const ROLLBACK: Action = Action::new("ROLLBACK");
-    }
-
-    impl std::convert::From<std::string::String> for Action {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            action::ACTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2401,212 +2498,297 @@ impl wkt::message::Message for DiagnoseInstanceRequest {
 
 /// Definition of the disk encryption options.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DiskEncryption(std::borrow::Cow<'static, str>);
+pub struct DiskEncryption(i32);
 
 impl DiskEncryption {
+    /// Disk encryption is not specified.
+    pub const DISK_ENCRYPTION_UNSPECIFIED: DiskEncryption = DiskEncryption::new(0);
+
+    /// Use Google managed encryption keys to encrypt the boot disk.
+    pub const GMEK: DiskEncryption = DiskEncryption::new(1);
+
+    /// Use customer managed encryption keys to encrypt the boot disk.
+    pub const CMEK: DiskEncryption = DiskEncryption::new(2);
+
     /// Creates a new DiskEncryption instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DISK_ENCRYPTION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("GMEK"),
+            2 => std::borrow::Cow::Borrowed("CMEK"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DISK_ENCRYPTION_UNSPECIFIED" => {
+                std::option::Option::Some(Self::DISK_ENCRYPTION_UNSPECIFIED)
+            }
+            "GMEK" => std::option::Option::Some(Self::GMEK),
+            "CMEK" => std::option::Option::Some(Self::CMEK),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [DiskEncryption](DiskEncryption)
-pub mod disk_encryption {
-    use super::DiskEncryption;
-
-    /// Disk encryption is not specified.
-    pub const DISK_ENCRYPTION_UNSPECIFIED: DiskEncryption =
-        DiskEncryption::new("DISK_ENCRYPTION_UNSPECIFIED");
-
-    /// Use Google managed encryption keys to encrypt the boot disk.
-    pub const GMEK: DiskEncryption = DiskEncryption::new("GMEK");
-
-    /// Use customer managed encryption keys to encrypt the boot disk.
-    pub const CMEK: DiskEncryption = DiskEncryption::new("CMEK");
-}
-
-impl std::convert::From<std::string::String> for DiskEncryption {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DiskEncryption {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DiskEncryption {
     fn default() -> Self {
-        disk_encryption::DISK_ENCRYPTION_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Possible disk types.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DiskType(std::borrow::Cow<'static, str>);
+pub struct DiskType(i32);
 
 impl DiskType {
+    /// Disk type not set.
+    pub const DISK_TYPE_UNSPECIFIED: DiskType = DiskType::new(0);
+
+    /// Standard persistent disk type.
+    pub const PD_STANDARD: DiskType = DiskType::new(1);
+
+    /// SSD persistent disk type.
+    pub const PD_SSD: DiskType = DiskType::new(2);
+
+    /// Balanced persistent disk type.
+    pub const PD_BALANCED: DiskType = DiskType::new(3);
+
+    /// Extreme persistent disk type.
+    pub const PD_EXTREME: DiskType = DiskType::new(4);
+
     /// Creates a new DiskType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DISK_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PD_STANDARD"),
+            2 => std::borrow::Cow::Borrowed("PD_SSD"),
+            3 => std::borrow::Cow::Borrowed("PD_BALANCED"),
+            4 => std::borrow::Cow::Borrowed("PD_EXTREME"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DISK_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::DISK_TYPE_UNSPECIFIED),
+            "PD_STANDARD" => std::option::Option::Some(Self::PD_STANDARD),
+            "PD_SSD" => std::option::Option::Some(Self::PD_SSD),
+            "PD_BALANCED" => std::option::Option::Some(Self::PD_BALANCED),
+            "PD_EXTREME" => std::option::Option::Some(Self::PD_EXTREME),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [DiskType](DiskType)
-pub mod disk_type {
-    use super::DiskType;
-
-    /// Disk type not set.
-    pub const DISK_TYPE_UNSPECIFIED: DiskType = DiskType::new("DISK_TYPE_UNSPECIFIED");
-
-    /// Standard persistent disk type.
-    pub const PD_STANDARD: DiskType = DiskType::new("PD_STANDARD");
-
-    /// SSD persistent disk type.
-    pub const PD_SSD: DiskType = DiskType::new("PD_SSD");
-
-    /// Balanced persistent disk type.
-    pub const PD_BALANCED: DiskType = DiskType::new("PD_BALANCED");
-
-    /// Extreme persistent disk type.
-    pub const PD_EXTREME: DiskType = DiskType::new("PD_EXTREME");
-}
-
-impl std::convert::From<std::string::String> for DiskType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DiskType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DiskType {
     fn default() -> Self {
-        disk_type::DISK_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The definition of the states of this instance.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct State(std::borrow::Cow<'static, str>);
+pub struct State(i32);
 
 impl State {
-    /// Creates a new State instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [State](State)
-pub mod state {
-    use super::State;
-
     /// State is not specified.
-    pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+    pub const STATE_UNSPECIFIED: State = State::new(0);
 
     /// The control logic is starting the instance.
-    pub const STARTING: State = State::new("STARTING");
+    pub const STARTING: State = State::new(1);
 
     /// The control logic is installing required frameworks and registering the
     /// instance with notebook proxy
-    pub const PROVISIONING: State = State::new("PROVISIONING");
+    pub const PROVISIONING: State = State::new(2);
 
     /// The instance is running.
-    pub const ACTIVE: State = State::new("ACTIVE");
+    pub const ACTIVE: State = State::new(3);
 
     /// The control logic is stopping the instance.
-    pub const STOPPING: State = State::new("STOPPING");
+    pub const STOPPING: State = State::new(4);
 
     /// The instance is stopped.
-    pub const STOPPED: State = State::new("STOPPED");
+    pub const STOPPED: State = State::new(5);
 
     /// The instance is deleted.
-    pub const DELETED: State = State::new("DELETED");
+    pub const DELETED: State = State::new(6);
 
     /// The instance is upgrading.
-    pub const UPGRADING: State = State::new("UPGRADING");
+    pub const UPGRADING: State = State::new(7);
 
     /// The instance is being created.
-    pub const INITIALIZING: State = State::new("INITIALIZING");
+    pub const INITIALIZING: State = State::new(8);
 
     /// The instance is suspending.
-    pub const SUSPENDING: State = State::new("SUSPENDING");
+    pub const SUSPENDING: State = State::new(9);
 
     /// The instance is suspended.
-    pub const SUSPENDED: State = State::new("SUSPENDED");
+    pub const SUSPENDED: State = State::new(10);
+
+    /// Creates a new State instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("STARTING"),
+            2 => std::borrow::Cow::Borrowed("PROVISIONING"),
+            3 => std::borrow::Cow::Borrowed("ACTIVE"),
+            4 => std::borrow::Cow::Borrowed("STOPPING"),
+            5 => std::borrow::Cow::Borrowed("STOPPED"),
+            6 => std::borrow::Cow::Borrowed("DELETED"),
+            7 => std::borrow::Cow::Borrowed("UPGRADING"),
+            8 => std::borrow::Cow::Borrowed("INITIALIZING"),
+            9 => std::borrow::Cow::Borrowed("SUSPENDING"),
+            10 => std::borrow::Cow::Borrowed("SUSPENDED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+            "STARTING" => std::option::Option::Some(Self::STARTING),
+            "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
+            "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+            "STOPPING" => std::option::Option::Some(Self::STOPPING),
+            "STOPPED" => std::option::Option::Some(Self::STOPPED),
+            "DELETED" => std::option::Option::Some(Self::DELETED),
+            "UPGRADING" => std::option::Option::Some(Self::UPGRADING),
+            "INITIALIZING" => std::option::Option::Some(Self::INITIALIZING),
+            "SUSPENDING" => std::option::Option::Some(Self::SUSPENDING),
+            "SUSPENDED" => std::option::Option::Some(Self::SUSPENDED),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for State {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for State {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for State {
     fn default() -> Self {
-        state::STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The instance health state.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct HealthState(std::borrow::Cow<'static, str>);
+pub struct HealthState(i32);
 
 impl HealthState {
-    /// Creates a new HealthState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [HealthState](HealthState)
-pub mod health_state {
-    use super::HealthState;
-
     /// The instance substate is unknown.
-    pub const HEALTH_STATE_UNSPECIFIED: HealthState = HealthState::new("HEALTH_STATE_UNSPECIFIED");
+    pub const HEALTH_STATE_UNSPECIFIED: HealthState = HealthState::new(0);
 
     /// The instance is known to be in an healthy state
     /// (for example, critical daemons are running)
     /// Applies to ACTIVE state.
-    pub const HEALTHY: HealthState = HealthState::new("HEALTHY");
+    pub const HEALTHY: HealthState = HealthState::new(1);
 
     /// The instance is known to be in an unhealthy state
     /// (for example, critical daemons are not running)
     /// Applies to ACTIVE state.
-    pub const UNHEALTHY: HealthState = HealthState::new("UNHEALTHY");
+    pub const UNHEALTHY: HealthState = HealthState::new(2);
 
     /// The instance has not installed health monitoring agent.
     /// Applies to ACTIVE state.
-    pub const AGENT_NOT_INSTALLED: HealthState = HealthState::new("AGENT_NOT_INSTALLED");
+    pub const AGENT_NOT_INSTALLED: HealthState = HealthState::new(3);
 
     /// The instance health monitoring agent is not running.
     /// Applies to ACTIVE state.
-    pub const AGENT_NOT_RUNNING: HealthState = HealthState::new("AGENT_NOT_RUNNING");
+    pub const AGENT_NOT_RUNNING: HealthState = HealthState::new(4);
+
+    /// Creates a new HealthState instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("HEALTH_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("HEALTHY"),
+            2 => std::borrow::Cow::Borrowed("UNHEALTHY"),
+            3 => std::borrow::Cow::Borrowed("AGENT_NOT_INSTALLED"),
+            4 => std::borrow::Cow::Borrowed("AGENT_NOT_RUNNING"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "HEALTH_STATE_UNSPECIFIED" => std::option::Option::Some(Self::HEALTH_STATE_UNSPECIFIED),
+            "HEALTHY" => std::option::Option::Some(Self::HEALTHY),
+            "UNHEALTHY" => std::option::Option::Some(Self::UNHEALTHY),
+            "AGENT_NOT_INSTALLED" => std::option::Option::Some(Self::AGENT_NOT_INSTALLED),
+            "AGENT_NOT_RUNNING" => std::option::Option::Some(Self::AGENT_NOT_RUNNING),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for HealthState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for HealthState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for HealthState {
     fn default() -> Self {
-        health_state::HEALTH_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/notebooks/v2/src/transport.rs
+++ b/src/generated/cloud/notebooks/v2/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::NotebookService for NotebookService {
                 reqwest::Method::GET,
                 format!("/v2/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::NotebookService for NotebookService {
                 reqwest::Method::POST,
                 format!("/v2/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -127,7 +127,7 @@ impl crate::stubs::NotebookService for NotebookService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -157,7 +157,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -177,7 +177,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:start", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -194,7 +194,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:stop", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -211,7 +211,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:reset", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -231,7 +231,7 @@ impl crate::stubs::NotebookService for NotebookService {
                 reqwest::Method::GET,
                 format!("/v2/{}:checkUpgradability", req.notebook_instance),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -250,7 +250,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:upgrade", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -267,7 +267,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:rollback", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -284,7 +284,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:diagnose", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -301,7 +301,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -323,7 +323,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -345,7 +345,7 @@ impl crate::stubs::NotebookService for NotebookService {
                 reqwest::Method::POST,
                 format!("/v2/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -365,7 +365,7 @@ impl crate::stubs::NotebookService for NotebookService {
                 reqwest::Method::GET,
                 format!("/v2/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -397,7 +397,7 @@ impl crate::stubs::NotebookService for NotebookService {
                 reqwest::Method::POST,
                 format!("/v2/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -414,7 +414,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -436,7 +436,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -455,7 +455,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -474,7 +474,7 @@ impl crate::stubs::NotebookService for NotebookService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/optimization/v1/src/model.rs
+++ b/src/generated/cloud/optimization/v1/src/model.rs
@@ -349,49 +349,68 @@ pub mod async_model_metadata {
 
     /// Possible states of the operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The default value. This value is used if the state is omitted.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Request is being processed.
+        pub const RUNNING: State = State::new(1);
+
+        /// The operation completed successfully.
+        pub const SUCCEEDED: State = State::new(2);
+
+        /// The operation was cancelled.
+        pub const CANCELLED: State = State::new(3);
+
+        /// The operation has failed.
+        pub const FAILED: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RUNNING"),
+                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                3 => std::borrow::Cow::Borrowed("CANCELLED"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Request is being processed.
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// The operation completed successfully.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-        /// The operation was cancelled.
-        pub const CANCELLED: State = State::new("CANCELLED");
-
-        /// The operation has failed.
-        pub const FAILED: State = State::new("FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -821,33 +840,18 @@ pub mod optimize_tours_request {
     ///
     /// [google.cloud.optimization.v1.OptimizeToursRequest.max_validation_errors]: crate::model::OptimizeToursRequest::max_validation_errors
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SolvingMode(std::borrow::Cow<'static, str>);
+    pub struct SolvingMode(i32);
 
     impl SolvingMode {
-        /// Creates a new SolvingMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [SolvingMode](SolvingMode)
-    pub mod solving_mode {
-        use super::SolvingMode;
-
         /// Solve the model.
-        pub const DEFAULT_SOLVE: SolvingMode = SolvingMode::new("DEFAULT_SOLVE");
+        pub const DEFAULT_SOLVE: SolvingMode = SolvingMode::new(0);
 
         /// Only validates the model without solving it: populates as many
         /// [OptimizeToursResponse.validation_errors][google.cloud.optimization.v1.OptimizeToursResponse.validation_errors]
         /// as possible.
         ///
         /// [google.cloud.optimization.v1.OptimizeToursResponse.validation_errors]: crate::model::OptimizeToursResponse::validation_errors
-        pub const VALIDATE_ONLY: SolvingMode = SolvingMode::new("VALIDATE_ONLY");
+        pub const VALIDATE_ONLY: SolvingMode = SolvingMode::new(1);
 
         /// Only populates
         /// [OptimizeToursResponse.validation_errors][google.cloud.optimization.v1.OptimizeToursResponse.validation_errors]
@@ -867,63 +871,112 @@ pub mod optimize_tours_request {
         ///
         /// [google.cloud.optimization.v1.OptimizeToursResponse.skipped_shipments]: crate::model::OptimizeToursResponse::skipped_shipments
         /// [google.cloud.optimization.v1.OptimizeToursResponse.validation_errors]: crate::model::OptimizeToursResponse::validation_errors
-        pub const DETECT_SOME_INFEASIBLE_SHIPMENTS: SolvingMode =
-            SolvingMode::new("DETECT_SOME_INFEASIBLE_SHIPMENTS");
+        pub const DETECT_SOME_INFEASIBLE_SHIPMENTS: SolvingMode = SolvingMode::new(2);
+
+        /// Creates a new SolvingMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DEFAULT_SOLVE"),
+                1 => std::borrow::Cow::Borrowed("VALIDATE_ONLY"),
+                2 => std::borrow::Cow::Borrowed("DETECT_SOME_INFEASIBLE_SHIPMENTS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DEFAULT_SOLVE" => std::option::Option::Some(Self::DEFAULT_SOLVE),
+                "VALIDATE_ONLY" => std::option::Option::Some(Self::VALIDATE_ONLY),
+                "DETECT_SOME_INFEASIBLE_SHIPMENTS" => {
+                    std::option::Option::Some(Self::DETECT_SOME_INFEASIBLE_SHIPMENTS)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for SolvingMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SolvingMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SolvingMode {
         fn default() -> Self {
-            solving_mode::DEFAULT_SOLVE
+            Self::new(0)
         }
     }
 
     /// Mode defining the behavior of the search, trading off latency versus
     /// solution quality. In all modes, the global request deadline is enforced.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SearchMode(std::borrow::Cow<'static, str>);
+    pub struct SearchMode(i32);
 
     impl SearchMode {
+        /// Unspecified search mode, equivalent to `RETURN_FAST`.
+        pub const SEARCH_MODE_UNSPECIFIED: SearchMode = SearchMode::new(0);
+
+        /// Stop the search after finding the first good solution.
+        pub const RETURN_FAST: SearchMode = SearchMode::new(1);
+
+        /// Spend all the available time to search for better solutions.
+        pub const CONSUME_ALL_AVAILABLE_TIME: SearchMode = SearchMode::new(2);
+
         /// Creates a new SearchMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SEARCH_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RETURN_FAST"),
+                2 => std::borrow::Cow::Borrowed("CONSUME_ALL_AVAILABLE_TIME"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SEARCH_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SEARCH_MODE_UNSPECIFIED)
+                }
+                "RETURN_FAST" => std::option::Option::Some(Self::RETURN_FAST),
+                "CONSUME_ALL_AVAILABLE_TIME" => {
+                    std::option::Option::Some(Self::CONSUME_ALL_AVAILABLE_TIME)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SearchMode](SearchMode)
-    pub mod search_mode {
-        use super::SearchMode;
-
-        /// Unspecified search mode, equivalent to `RETURN_FAST`.
-        pub const SEARCH_MODE_UNSPECIFIED: SearchMode = SearchMode::new("SEARCH_MODE_UNSPECIFIED");
-
-        /// Stop the search after finding the first good solution.
-        pub const RETURN_FAST: SearchMode = SearchMode::new("RETURN_FAST");
-
-        /// Spend all the available time to search for better solutions.
-        pub const CONSUME_ALL_AVAILABLE_TIME: SearchMode =
-            SearchMode::new("CONSUME_ALL_AVAILABLE_TIME");
-    }
-
-    impl std::convert::From<std::string::String> for SearchMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SearchMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SearchMode {
         fn default() -> Self {
-            search_mode::SEARCH_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2799,32 +2852,16 @@ pub mod shipment_type_incompatibility {
     /// Modes defining how the appearance of incompatible shipments are restricted
     /// on the same route.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IncompatibilityMode(std::borrow::Cow<'static, str>);
+    pub struct IncompatibilityMode(i32);
 
     impl IncompatibilityMode {
-        /// Creates a new IncompatibilityMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [IncompatibilityMode](IncompatibilityMode)
-    pub mod incompatibility_mode {
-        use super::IncompatibilityMode;
-
         /// Unspecified incompatibility mode. This value should never be used.
         pub const INCOMPATIBILITY_MODE_UNSPECIFIED: IncompatibilityMode =
-            IncompatibilityMode::new("INCOMPATIBILITY_MODE_UNSPECIFIED");
+            IncompatibilityMode::new(0);
 
         /// In this mode, two shipments with incompatible types can never share the
         /// same vehicle.
-        pub const NOT_PERFORMED_BY_SAME_VEHICLE: IncompatibilityMode =
-            IncompatibilityMode::new("NOT_PERFORMED_BY_SAME_VEHICLE");
+        pub const NOT_PERFORMED_BY_SAME_VEHICLE: IncompatibilityMode = IncompatibilityMode::new(1);
 
         /// For two shipments with incompatible types with the
         /// `NOT_IN_SAME_VEHICLE_SIMULTANEOUSLY` incompatibility mode:
@@ -2835,18 +2872,54 @@ pub mod shipment_type_incompatibility {
         ///   shipments can share the same vehicle iff the former shipment is
         ///   delivered before the latter is picked up.
         pub const NOT_IN_SAME_VEHICLE_SIMULTANEOUSLY: IncompatibilityMode =
-            IncompatibilityMode::new("NOT_IN_SAME_VEHICLE_SIMULTANEOUSLY");
+            IncompatibilityMode::new(2);
+
+        /// Creates a new IncompatibilityMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("INCOMPATIBILITY_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NOT_PERFORMED_BY_SAME_VEHICLE"),
+                2 => std::borrow::Cow::Borrowed("NOT_IN_SAME_VEHICLE_SIMULTANEOUSLY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "INCOMPATIBILITY_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::INCOMPATIBILITY_MODE_UNSPECIFIED)
+                }
+                "NOT_PERFORMED_BY_SAME_VEHICLE" => {
+                    std::option::Option::Some(Self::NOT_PERFORMED_BY_SAME_VEHICLE)
+                }
+                "NOT_IN_SAME_VEHICLE_SIMULTANEOUSLY" => {
+                    std::option::Option::Some(Self::NOT_IN_SAME_VEHICLE_SIMULTANEOUSLY)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for IncompatibilityMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for IncompatibilityMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for IncompatibilityMode {
         fn default() -> Self {
-            incompatibility_mode::INCOMPATIBILITY_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2928,32 +3001,15 @@ pub mod shipment_type_requirement {
 
     /// Modes defining the appearance of dependent shipments on a route.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RequirementMode(std::borrow::Cow<'static, str>);
+    pub struct RequirementMode(i32);
 
     impl RequirementMode {
-        /// Creates a new RequirementMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RequirementMode](RequirementMode)
-    pub mod requirement_mode {
-        use super::RequirementMode;
-
         /// Unspecified requirement mode. This value should never be used.
-        pub const REQUIREMENT_MODE_UNSPECIFIED: RequirementMode =
-            RequirementMode::new("REQUIREMENT_MODE_UNSPECIFIED");
+        pub const REQUIREMENT_MODE_UNSPECIFIED: RequirementMode = RequirementMode::new(0);
 
         /// In this mode, all "dependent" shipments must share the same vehicle as at
         /// least one of their "required" shipments.
-        pub const PERFORMED_BY_SAME_VEHICLE: RequirementMode =
-            RequirementMode::new("PERFORMED_BY_SAME_VEHICLE");
+        pub const PERFORMED_BY_SAME_VEHICLE: RequirementMode = RequirementMode::new(1);
 
         /// With the `IN_SAME_VEHICLE_AT_PICKUP_TIME` mode, all "dependent"
         /// shipments need to have at least one "required" shipment on their vehicle
@@ -2965,24 +3021,62 @@ pub mod shipment_type_requirement {
         /// * A "required" shipment picked up on the route before it, and if the
         ///   "required" shipment has a delivery, this delivery must be performed
         ///   after the "dependent" shipment's pickup.
-        pub const IN_SAME_VEHICLE_AT_PICKUP_TIME: RequirementMode =
-            RequirementMode::new("IN_SAME_VEHICLE_AT_PICKUP_TIME");
+        pub const IN_SAME_VEHICLE_AT_PICKUP_TIME: RequirementMode = RequirementMode::new(2);
 
         /// Same as before, except the "dependent" shipments need to have a
         /// "required" shipment on their vehicle at the time of their *delivery*.
-        pub const IN_SAME_VEHICLE_AT_DELIVERY_TIME: RequirementMode =
-            RequirementMode::new("IN_SAME_VEHICLE_AT_DELIVERY_TIME");
+        pub const IN_SAME_VEHICLE_AT_DELIVERY_TIME: RequirementMode = RequirementMode::new(3);
+
+        /// Creates a new RequirementMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("REQUIREMENT_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PERFORMED_BY_SAME_VEHICLE"),
+                2 => std::borrow::Cow::Borrowed("IN_SAME_VEHICLE_AT_PICKUP_TIME"),
+                3 => std::borrow::Cow::Borrowed("IN_SAME_VEHICLE_AT_DELIVERY_TIME"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "REQUIREMENT_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::REQUIREMENT_MODE_UNSPECIFIED)
+                }
+                "PERFORMED_BY_SAME_VEHICLE" => {
+                    std::option::Option::Some(Self::PERFORMED_BY_SAME_VEHICLE)
+                }
+                "IN_SAME_VEHICLE_AT_PICKUP_TIME" => {
+                    std::option::Option::Some(Self::IN_SAME_VEHICLE_AT_PICKUP_TIME)
+                }
+                "IN_SAME_VEHICLE_AT_DELIVERY_TIME" => {
+                    std::option::Option::Some(Self::IN_SAME_VEHICLE_AT_DELIVERY_TIME)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RequirementMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RequirementMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RequirementMode {
         fn default() -> Self {
-            requirement_mode::REQUIREMENT_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3914,43 +4008,60 @@ pub mod vehicle {
     /// travel modes, see:
     /// <https://developers.google.com/maps/documentation/routes_preferred/reference/rest/Shared.Types/RouteTravelMode>.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TravelMode(std::borrow::Cow<'static, str>);
+    pub struct TravelMode(i32);
 
     impl TravelMode {
+        /// Unspecified travel mode, equivalent to `DRIVING`.
+        pub const TRAVEL_MODE_UNSPECIFIED: TravelMode = TravelMode::new(0);
+
+        /// Travel mode corresponding to driving directions (car, ...).
+        pub const DRIVING: TravelMode = TravelMode::new(1);
+
+        /// Travel mode corresponding to walking directions.
+        pub const WALKING: TravelMode = TravelMode::new(2);
+
         /// Creates a new TravelMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TRAVEL_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DRIVING"),
+                2 => std::borrow::Cow::Borrowed("WALKING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TRAVEL_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::TRAVEL_MODE_UNSPECIFIED)
+                }
+                "DRIVING" => std::option::Option::Some(Self::DRIVING),
+                "WALKING" => std::option::Option::Some(Self::WALKING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [TravelMode](TravelMode)
-    pub mod travel_mode {
-        use super::TravelMode;
-
-        /// Unspecified travel mode, equivalent to `DRIVING`.
-        pub const TRAVEL_MODE_UNSPECIFIED: TravelMode = TravelMode::new("TRAVEL_MODE_UNSPECIFIED");
-
-        /// Travel mode corresponding to driving directions (car, ...).
-        pub const DRIVING: TravelMode = TravelMode::new("DRIVING");
-
-        /// Travel mode corresponding to walking directions.
-        pub const WALKING: TravelMode = TravelMode::new("WALKING");
-    }
-
-    impl std::convert::From<std::string::String> for TravelMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TravelMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TravelMode {
         fn default() -> Self {
-            travel_mode::TRAVEL_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -3960,45 +4071,61 @@ pub mod vehicle {
     /// Other shipments are free to occur anywhere on the route independent of
     /// `unloading_policy`.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct UnloadingPolicy(std::borrow::Cow<'static, str>);
+    pub struct UnloadingPolicy(i32);
 
     impl UnloadingPolicy {
+        /// Unspecified unloading policy; deliveries must just occur after their
+        /// corresponding pickups.
+        pub const UNLOADING_POLICY_UNSPECIFIED: UnloadingPolicy = UnloadingPolicy::new(0);
+
+        /// Deliveries must occur in reverse order of pickups
+        pub const LAST_IN_FIRST_OUT: UnloadingPolicy = UnloadingPolicy::new(1);
+
+        /// Deliveries must occur in the same order as pickups
+        pub const FIRST_IN_FIRST_OUT: UnloadingPolicy = UnloadingPolicy::new(2);
+
         /// Creates a new UnloadingPolicy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNLOADING_POLICY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LAST_IN_FIRST_OUT"),
+                2 => std::borrow::Cow::Borrowed("FIRST_IN_FIRST_OUT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNLOADING_POLICY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::UNLOADING_POLICY_UNSPECIFIED)
+                }
+                "LAST_IN_FIRST_OUT" => std::option::Option::Some(Self::LAST_IN_FIRST_OUT),
+                "FIRST_IN_FIRST_OUT" => std::option::Option::Some(Self::FIRST_IN_FIRST_OUT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [UnloadingPolicy](UnloadingPolicy)
-    pub mod unloading_policy {
-        use super::UnloadingPolicy;
-
-        /// Unspecified unloading policy; deliveries must just occur after their
-        /// corresponding pickups.
-        pub const UNLOADING_POLICY_UNSPECIFIED: UnloadingPolicy =
-            UnloadingPolicy::new("UNLOADING_POLICY_UNSPECIFIED");
-
-        /// Deliveries must occur in reverse order of pickups
-        pub const LAST_IN_FIRST_OUT: UnloadingPolicy = UnloadingPolicy::new("LAST_IN_FIRST_OUT");
-
-        /// Deliveries must occur in the same order as pickups
-        pub const FIRST_IN_FIRST_OUT: UnloadingPolicy = UnloadingPolicy::new("FIRST_IN_FIRST_OUT");
-    }
-
-    impl std::convert::From<std::string::String> for UnloadingPolicy {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for UnloadingPolicy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for UnloadingPolicy {
         fn default() -> Self {
-            unloading_policy::UNLOADING_POLICY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6109,35 +6236,19 @@ pub mod skipped_shipment {
         /// particular, it gives no indication of whether a given reason will
         /// appear before another in the solution, if both apply.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Code(std::borrow::Cow<'static, str>);
+        pub struct Code(i32);
 
         impl Code {
-            /// Creates a new Code instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [Code](Code)
-        pub mod code {
-            use super::Code;
-
             /// This should never be used. If we are unable to understand why a
             /// shipment was skipped, we simply return an empty set of reasons.
-            pub const CODE_UNSPECIFIED: Code = Code::new("CODE_UNSPECIFIED");
+            pub const CODE_UNSPECIFIED: Code = Code::new(0);
 
             /// There is no vehicle in the model making all shipments infeasible.
-            pub const NO_VEHICLE: Code = Code::new("NO_VEHICLE");
+            pub const NO_VEHICLE: Code = Code::new(1);
 
             /// The demand of the shipment exceeds a vehicle's capacity for some
             /// capacity types, one of which is `example_exceeded_capacity_type`.
-            pub const DEMAND_EXCEEDS_VEHICLE_CAPACITY: Code =
-                Code::new("DEMAND_EXCEEDS_VEHICLE_CAPACITY");
+            pub const DEMAND_EXCEEDS_VEHICLE_CAPACITY: Code = Code::new(2);
 
             /// The minimum distance necessary to perform this shipment, i.e. from
             /// the vehicle's `start_location` to the shipment's pickup and/or delivery
@@ -6145,8 +6256,7 @@ pub mod skipped_shipment {
             /// `route_distance_limit`.
             ///
             /// Note that for this computation we use the geodesic distances.
-            pub const CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DISTANCE_LIMIT: Code =
-                Code::new("CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DISTANCE_LIMIT");
+            pub const CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DISTANCE_LIMIT: Code = Code::new(3);
 
             /// The minimum time necessary to perform this shipment, including travel
             /// time, wait time and service time exceeds the vehicle's
@@ -6154,35 +6264,96 @@ pub mod skipped_shipment {
             ///
             /// Note: travel time is computed in the best-case scenario, namely as
             /// geodesic distance x 36 m/s (roughly 130 km/hour).
-            pub const CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DURATION_LIMIT: Code =
-                Code::new("CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DURATION_LIMIT");
+            pub const CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DURATION_LIMIT: Code = Code::new(4);
 
             /// Same as above but we only compare minimum travel time and the
             /// vehicle's `travel_duration_limit`.
-            pub const CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TRAVEL_DURATION_LIMIT: Code =
-                Code::new("CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TRAVEL_DURATION_LIMIT");
+            pub const CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TRAVEL_DURATION_LIMIT: Code = Code::new(5);
 
             /// The vehicle cannot perform this shipment in the best-case scenario
             /// (see `CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DURATION_LIMIT` for time
             /// computation) if it starts at its earliest start time: the total time
             /// would make the vehicle end after its latest end time.
-            pub const CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TIME_WINDOWS: Code =
-                Code::new("CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TIME_WINDOWS");
+            pub const CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TIME_WINDOWS: Code = Code::new(6);
 
             /// The `allowed_vehicle_indices` field of the shipment is not empty and
             /// this vehicle does not belong to it.
-            pub const VEHICLE_NOT_ALLOWED: Code = Code::new("VEHICLE_NOT_ALLOWED");
+            pub const VEHICLE_NOT_ALLOWED: Code = Code::new(7);
+
+            /// Creates a new Code instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("CODE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("NO_VEHICLE"),
+                    2 => std::borrow::Cow::Borrowed("DEMAND_EXCEEDS_VEHICLE_CAPACITY"),
+                    3 => std::borrow::Cow::Borrowed(
+                        "CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DISTANCE_LIMIT",
+                    ),
+                    4 => std::borrow::Cow::Borrowed(
+                        "CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DURATION_LIMIT",
+                    ),
+                    5 => std::borrow::Cow::Borrowed(
+                        "CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TRAVEL_DURATION_LIMIT",
+                    ),
+                    6 => std::borrow::Cow::Borrowed(
+                        "CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TIME_WINDOWS",
+                    ),
+                    7 => std::borrow::Cow::Borrowed("VEHICLE_NOT_ALLOWED"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "CODE_UNSPECIFIED" => std::option::Option::Some(Self::CODE_UNSPECIFIED),
+                    "NO_VEHICLE" => std::option::Option::Some(Self::NO_VEHICLE),
+                    "DEMAND_EXCEEDS_VEHICLE_CAPACITY" => {
+                        std::option::Option::Some(Self::DEMAND_EXCEEDS_VEHICLE_CAPACITY)
+                    }
+                    "CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DISTANCE_LIMIT" => {
+                        std::option::Option::Some(
+                            Self::CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DISTANCE_LIMIT,
+                        )
+                    }
+                    "CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DURATION_LIMIT" => {
+                        std::option::Option::Some(
+                            Self::CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DURATION_LIMIT,
+                        )
+                    }
+                    "CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TRAVEL_DURATION_LIMIT" => {
+                        std::option::Option::Some(
+                            Self::CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TRAVEL_DURATION_LIMIT,
+                        )
+                    }
+                    "CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TIME_WINDOWS" => std::option::Option::Some(
+                        Self::CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TIME_WINDOWS,
+                    ),
+                    "VEHICLE_NOT_ALLOWED" => std::option::Option::Some(Self::VEHICLE_NOT_ALLOWED),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for Code {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Code {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Code {
             fn default() -> Self {
-                code::CODE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -6642,59 +6813,83 @@ pub mod injected_solution_constraint {
             ///
             /// The enumeration below is in order of increasing relaxation.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct Level(std::borrow::Cow<'static, str>);
+            pub struct Level(i32);
 
             impl Level {
-                /// Creates a new Level instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [Level](Level)
-            pub mod level {
-                use super::Level;
-
                 /// Implicit default relaxation level: no constraints are relaxed,
                 /// i.e., all visits are fully constrained.
                 ///
                 /// This value must not be explicitly used in `level`.
-                pub const LEVEL_UNSPECIFIED: Level = Level::new("LEVEL_UNSPECIFIED");
+                pub const LEVEL_UNSPECIFIED: Level = Level::new(0);
 
                 /// Visit start times and vehicle start/end times will be relaxed, but
                 /// each visit remains bound to the same vehicle and the visit sequence
                 /// must be observed: no visit can be inserted between them or before
                 /// them.
-                pub const RELAX_VISIT_TIMES_AFTER_THRESHOLD: Level =
-                    Level::new("RELAX_VISIT_TIMES_AFTER_THRESHOLD");
+                pub const RELAX_VISIT_TIMES_AFTER_THRESHOLD: Level = Level::new(1);
 
                 /// Same as `RELAX_VISIT_TIMES_AFTER_THRESHOLD`, but the visit sequence
                 /// is also relaxed: visits can only be performed by this vehicle, but
                 /// can potentially become unperformed.
-                pub const RELAX_VISIT_TIMES_AND_SEQUENCE_AFTER_THRESHOLD: Level =
-                    Level::new("RELAX_VISIT_TIMES_AND_SEQUENCE_AFTER_THRESHOLD");
+                pub const RELAX_VISIT_TIMES_AND_SEQUENCE_AFTER_THRESHOLD: Level = Level::new(2);
 
                 /// Same as `RELAX_VISIT_TIMES_AND_SEQUENCE_AFTER_THRESHOLD`, but the
                 /// vehicle is also relaxed: visits are completely free at or after the
                 /// threshold time and can potentially become unperformed.
-                pub const RELAX_ALL_AFTER_THRESHOLD: Level =
-                    Level::new("RELAX_ALL_AFTER_THRESHOLD");
+                pub const RELAX_ALL_AFTER_THRESHOLD: Level = Level::new(3);
+
+                /// Creates a new Level instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("LEVEL_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("RELAX_VISIT_TIMES_AFTER_THRESHOLD"),
+                        2 => std::borrow::Cow::Borrowed(
+                            "RELAX_VISIT_TIMES_AND_SEQUENCE_AFTER_THRESHOLD",
+                        ),
+                        3 => std::borrow::Cow::Borrowed("RELAX_ALL_AFTER_THRESHOLD"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "LEVEL_UNSPECIFIED" => std::option::Option::Some(Self::LEVEL_UNSPECIFIED),
+                        "RELAX_VISIT_TIMES_AFTER_THRESHOLD" => {
+                            std::option::Option::Some(Self::RELAX_VISIT_TIMES_AFTER_THRESHOLD)
+                        }
+                        "RELAX_VISIT_TIMES_AND_SEQUENCE_AFTER_THRESHOLD" => {
+                            std::option::Option::Some(
+                                Self::RELAX_VISIT_TIMES_AND_SEQUENCE_AFTER_THRESHOLD,
+                            )
+                        }
+                        "RELAX_ALL_AFTER_THRESHOLD" => {
+                            std::option::Option::Some(Self::RELAX_ALL_AFTER_THRESHOLD)
+                        }
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for Level {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for Level {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for Level {
                 fn default() -> Self {
-                    level::LEVEL_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -7214,42 +7409,57 @@ pub mod optimize_tours_validation_error {
 
 /// Data formats for input and output files.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DataFormat(std::borrow::Cow<'static, str>);
+pub struct DataFormat(i32);
 
 impl DataFormat {
+    /// Default value.
+    pub const DATA_FORMAT_UNSPECIFIED: DataFormat = DataFormat::new(0);
+
+    /// Input data in json format.
+    pub const JSON: DataFormat = DataFormat::new(1);
+
+    /// Input data in string format.
+    pub const STRING: DataFormat = DataFormat::new(2);
+
     /// Creates a new DataFormat instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DATA_FORMAT_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("JSON"),
+            2 => std::borrow::Cow::Borrowed("STRING"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DATA_FORMAT_UNSPECIFIED" => std::option::Option::Some(Self::DATA_FORMAT_UNSPECIFIED),
+            "JSON" => std::option::Option::Some(Self::JSON),
+            "STRING" => std::option::Option::Some(Self::STRING),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [DataFormat](DataFormat)
-pub mod data_format {
-    use super::DataFormat;
-
-    /// Default value.
-    pub const DATA_FORMAT_UNSPECIFIED: DataFormat = DataFormat::new("DATA_FORMAT_UNSPECIFIED");
-
-    /// Input data in json format.
-    pub const JSON: DataFormat = DataFormat::new("JSON");
-
-    /// Input data in string format.
-    pub const STRING: DataFormat = DataFormat::new("STRING");
-}
-
-impl std::convert::From<std::string::String> for DataFormat {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DataFormat {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DataFormat {
     fn default() -> Self {
-        data_format::DATA_FORMAT_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/optimization/v1/src/transport.rs
+++ b/src/generated/cloud/optimization/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::FleetRouting for FleetRouting {
                 reqwest::Method::POST,
                 format!("/v1/{}:optimizeTours", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::FleetRouting for FleetRouting {
                 reqwest::Method::POST,
                 format!("/v1/{}:batchOptimizeTours", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -89,7 +89,7 @@ impl crate::stubs::FleetRouting for FleetRouting {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/oracledatabase/v1/src/model.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/model.rs
@@ -939,509 +939,702 @@ pub mod autonomous_database_properties {
 
     /// The editions available for the Autonomous Database.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DatabaseEdition(std::borrow::Cow<'static, str>);
+    pub struct DatabaseEdition(i32);
 
     impl DatabaseEdition {
+        /// Default unspecified value.
+        pub const DATABASE_EDITION_UNSPECIFIED: DatabaseEdition = DatabaseEdition::new(0);
+
+        /// Standard Database Edition
+        pub const STANDARD_EDITION: DatabaseEdition = DatabaseEdition::new(1);
+
+        /// Enterprise Database Edition
+        pub const ENTERPRISE_EDITION: DatabaseEdition = DatabaseEdition::new(2);
+
         /// Creates a new DatabaseEdition instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATABASE_EDITION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STANDARD_EDITION"),
+                2 => std::borrow::Cow::Borrowed("ENTERPRISE_EDITION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATABASE_EDITION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DATABASE_EDITION_UNSPECIFIED)
+                }
+                "STANDARD_EDITION" => std::option::Option::Some(Self::STANDARD_EDITION),
+                "ENTERPRISE_EDITION" => std::option::Option::Some(Self::ENTERPRISE_EDITION),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DatabaseEdition](DatabaseEdition)
-    pub mod database_edition {
-        use super::DatabaseEdition;
-
-        /// Default unspecified value.
-        pub const DATABASE_EDITION_UNSPECIFIED: DatabaseEdition =
-            DatabaseEdition::new("DATABASE_EDITION_UNSPECIFIED");
-
-        /// Standard Database Edition
-        pub const STANDARD_EDITION: DatabaseEdition = DatabaseEdition::new("STANDARD_EDITION");
-
-        /// Enterprise Database Edition
-        pub const ENTERPRISE_EDITION: DatabaseEdition = DatabaseEdition::new("ENTERPRISE_EDITION");
-    }
-
-    impl std::convert::From<std::string::String> for DatabaseEdition {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DatabaseEdition {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DatabaseEdition {
         fn default() -> Self {
-            database_edition::DATABASE_EDITION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The license types available for the Autonomous Database.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LicenseType(std::borrow::Cow<'static, str>);
+    pub struct LicenseType(i32);
 
     impl LicenseType {
+        /// Unspecified
+        pub const LICENSE_TYPE_UNSPECIFIED: LicenseType = LicenseType::new(0);
+
+        /// License included part of offer
+        pub const LICENSE_INCLUDED: LicenseType = LicenseType::new(1);
+
+        /// Bring your own license
+        pub const BRING_YOUR_OWN_LICENSE: LicenseType = LicenseType::new(2);
+
         /// Creates a new LicenseType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LICENSE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LICENSE_INCLUDED"),
+                2 => std::borrow::Cow::Borrowed("BRING_YOUR_OWN_LICENSE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LICENSE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::LICENSE_TYPE_UNSPECIFIED)
+                }
+                "LICENSE_INCLUDED" => std::option::Option::Some(Self::LICENSE_INCLUDED),
+                "BRING_YOUR_OWN_LICENSE" => std::option::Option::Some(Self::BRING_YOUR_OWN_LICENSE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [LicenseType](LicenseType)
-    pub mod license_type {
-        use super::LicenseType;
-
-        /// Unspecified
-        pub const LICENSE_TYPE_UNSPECIFIED: LicenseType =
-            LicenseType::new("LICENSE_TYPE_UNSPECIFIED");
-
-        /// License included part of offer
-        pub const LICENSE_INCLUDED: LicenseType = LicenseType::new("LICENSE_INCLUDED");
-
-        /// Bring your own license
-        pub const BRING_YOUR_OWN_LICENSE: LicenseType = LicenseType::new("BRING_YOUR_OWN_LICENSE");
-    }
-
-    impl std::convert::From<std::string::String> for LicenseType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LicenseType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LicenseType {
         fn default() -> Self {
-            license_type::LICENSE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The available maintenance schedules for the Autonomous Database.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MaintenanceScheduleType(std::borrow::Cow<'static, str>);
+    pub struct MaintenanceScheduleType(i32);
 
     impl MaintenanceScheduleType {
-        /// Creates a new MaintenanceScheduleType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [MaintenanceScheduleType](MaintenanceScheduleType)
-    pub mod maintenance_schedule_type {
-        use super::MaintenanceScheduleType;
-
         /// Default unspecified value.
         pub const MAINTENANCE_SCHEDULE_TYPE_UNSPECIFIED: MaintenanceScheduleType =
-            MaintenanceScheduleType::new("MAINTENANCE_SCHEDULE_TYPE_UNSPECIFIED");
+            MaintenanceScheduleType::new(0);
 
         /// An EARLY maintenance schedule patches the database before
         /// the regular scheduled maintenance.
-        pub const EARLY: MaintenanceScheduleType = MaintenanceScheduleType::new("EARLY");
+        pub const EARLY: MaintenanceScheduleType = MaintenanceScheduleType::new(1);
 
         /// A REGULAR maintenance schedule follows the normal maintenance cycle.
-        pub const REGULAR: MaintenanceScheduleType = MaintenanceScheduleType::new("REGULAR");
+        pub const REGULAR: MaintenanceScheduleType = MaintenanceScheduleType::new(2);
+
+        /// Creates a new MaintenanceScheduleType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MAINTENANCE_SCHEDULE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("EARLY"),
+                2 => std::borrow::Cow::Borrowed("REGULAR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MAINTENANCE_SCHEDULE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MAINTENANCE_SCHEDULE_TYPE_UNSPECIFIED)
+                }
+                "EARLY" => std::option::Option::Some(Self::EARLY),
+                "REGULAR" => std::option::Option::Some(Self::REGULAR),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for MaintenanceScheduleType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MaintenanceScheduleType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MaintenanceScheduleType {
         fn default() -> Self {
-            maintenance_schedule_type::MAINTENANCE_SCHEDULE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The types of local disaster recovery available for an Autonomous Database.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LocalDisasterRecoveryType(std::borrow::Cow<'static, str>);
+    pub struct LocalDisasterRecoveryType(i32);
 
     impl LocalDisasterRecoveryType {
+        /// Default unspecified value.
+        pub const LOCAL_DISASTER_RECOVERY_TYPE_UNSPECIFIED: LocalDisasterRecoveryType =
+            LocalDisasterRecoveryType::new(0);
+
+        /// Autonomous Data Guard recovery.
+        pub const ADG: LocalDisasterRecoveryType = LocalDisasterRecoveryType::new(1);
+
+        /// Backup based recovery.
+        pub const BACKUP_BASED: LocalDisasterRecoveryType = LocalDisasterRecoveryType::new(2);
+
         /// Creates a new LocalDisasterRecoveryType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LOCAL_DISASTER_RECOVERY_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ADG"),
+                2 => std::borrow::Cow::Borrowed("BACKUP_BASED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LOCAL_DISASTER_RECOVERY_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::LOCAL_DISASTER_RECOVERY_TYPE_UNSPECIFIED)
+                }
+                "ADG" => std::option::Option::Some(Self::ADG),
+                "BACKUP_BASED" => std::option::Option::Some(Self::BACKUP_BASED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [LocalDisasterRecoveryType](LocalDisasterRecoveryType)
-    pub mod local_disaster_recovery_type {
-        use super::LocalDisasterRecoveryType;
-
-        /// Default unspecified value.
-        pub const LOCAL_DISASTER_RECOVERY_TYPE_UNSPECIFIED: LocalDisasterRecoveryType =
-            LocalDisasterRecoveryType::new("LOCAL_DISASTER_RECOVERY_TYPE_UNSPECIFIED");
-
-        /// Autonomous Data Guard recovery.
-        pub const ADG: LocalDisasterRecoveryType = LocalDisasterRecoveryType::new("ADG");
-
-        /// Backup based recovery.
-        pub const BACKUP_BASED: LocalDisasterRecoveryType =
-            LocalDisasterRecoveryType::new("BACKUP_BASED");
-    }
-
-    impl std::convert::From<std::string::String> for LocalDisasterRecoveryType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LocalDisasterRecoveryType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LocalDisasterRecoveryType {
         fn default() -> Self {
-            local_disaster_recovery_type::LOCAL_DISASTER_RECOVERY_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Varies states of the Data Safe registration for the Autonomous Database.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataSafeState(std::borrow::Cow<'static, str>);
+    pub struct DataSafeState(i32);
 
     impl DataSafeState {
+        /// Default unspecified value.
+        pub const DATA_SAFE_STATE_UNSPECIFIED: DataSafeState = DataSafeState::new(0);
+
+        /// Registering data safe state.
+        pub const REGISTERING: DataSafeState = DataSafeState::new(1);
+
+        /// Registered data safe state.
+        pub const REGISTERED: DataSafeState = DataSafeState::new(2);
+
+        /// Deregistering data safe state.
+        pub const DEREGISTERING: DataSafeState = DataSafeState::new(3);
+
+        /// Not registered data safe state.
+        pub const NOT_REGISTERED: DataSafeState = DataSafeState::new(4);
+
+        /// Failed data safe state.
+        pub const FAILED: DataSafeState = DataSafeState::new(5);
+
         /// Creates a new DataSafeState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATA_SAFE_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REGISTERING"),
+                2 => std::borrow::Cow::Borrowed("REGISTERED"),
+                3 => std::borrow::Cow::Borrowed("DEREGISTERING"),
+                4 => std::borrow::Cow::Borrowed("NOT_REGISTERED"),
+                5 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATA_SAFE_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DATA_SAFE_STATE_UNSPECIFIED)
+                }
+                "REGISTERING" => std::option::Option::Some(Self::REGISTERING),
+                "REGISTERED" => std::option::Option::Some(Self::REGISTERED),
+                "DEREGISTERING" => std::option::Option::Some(Self::DEREGISTERING),
+                "NOT_REGISTERED" => std::option::Option::Some(Self::NOT_REGISTERED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DataSafeState](DataSafeState)
-    pub mod data_safe_state {
-        use super::DataSafeState;
-
-        /// Default unspecified value.
-        pub const DATA_SAFE_STATE_UNSPECIFIED: DataSafeState =
-            DataSafeState::new("DATA_SAFE_STATE_UNSPECIFIED");
-
-        /// Registering data safe state.
-        pub const REGISTERING: DataSafeState = DataSafeState::new("REGISTERING");
-
-        /// Registered data safe state.
-        pub const REGISTERED: DataSafeState = DataSafeState::new("REGISTERED");
-
-        /// Deregistering data safe state.
-        pub const DEREGISTERING: DataSafeState = DataSafeState::new("DEREGISTERING");
-
-        /// Not registered data safe state.
-        pub const NOT_REGISTERED: DataSafeState = DataSafeState::new("NOT_REGISTERED");
-
-        /// Failed data safe state.
-        pub const FAILED: DataSafeState = DataSafeState::new("FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for DataSafeState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DataSafeState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DataSafeState {
         fn default() -> Self {
-            data_safe_state::DATA_SAFE_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The different states of database management for an Autonomous Database.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DatabaseManagementState(std::borrow::Cow<'static, str>);
+    pub struct DatabaseManagementState(i32);
 
     impl DatabaseManagementState {
+        /// Default unspecified value.
+        pub const DATABASE_MANAGEMENT_STATE_UNSPECIFIED: DatabaseManagementState =
+            DatabaseManagementState::new(0);
+
+        /// Enabling Database Management state
+        pub const ENABLING: DatabaseManagementState = DatabaseManagementState::new(1);
+
+        /// Enabled Database Management state
+        pub const ENABLED: DatabaseManagementState = DatabaseManagementState::new(2);
+
+        /// Disabling Database Management state
+        pub const DISABLING: DatabaseManagementState = DatabaseManagementState::new(3);
+
+        /// Not Enabled Database Management state
+        pub const NOT_ENABLED: DatabaseManagementState = DatabaseManagementState::new(4);
+
+        /// Failed enabling Database Management state
+        pub const FAILED_ENABLING: DatabaseManagementState = DatabaseManagementState::new(5);
+
+        /// Failed disabling Database Management state
+        pub const FAILED_DISABLING: DatabaseManagementState = DatabaseManagementState::new(6);
+
         /// Creates a new DatabaseManagementState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATABASE_MANAGEMENT_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENABLING"),
+                2 => std::borrow::Cow::Borrowed("ENABLED"),
+                3 => std::borrow::Cow::Borrowed("DISABLING"),
+                4 => std::borrow::Cow::Borrowed("NOT_ENABLED"),
+                5 => std::borrow::Cow::Borrowed("FAILED_ENABLING"),
+                6 => std::borrow::Cow::Borrowed("FAILED_DISABLING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATABASE_MANAGEMENT_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DATABASE_MANAGEMENT_STATE_UNSPECIFIED)
+                }
+                "ENABLING" => std::option::Option::Some(Self::ENABLING),
+                "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                "DISABLING" => std::option::Option::Some(Self::DISABLING),
+                "NOT_ENABLED" => std::option::Option::Some(Self::NOT_ENABLED),
+                "FAILED_ENABLING" => std::option::Option::Some(Self::FAILED_ENABLING),
+                "FAILED_DISABLING" => std::option::Option::Some(Self::FAILED_DISABLING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DatabaseManagementState](DatabaseManagementState)
-    pub mod database_management_state {
-        use super::DatabaseManagementState;
-
-        /// Default unspecified value.
-        pub const DATABASE_MANAGEMENT_STATE_UNSPECIFIED: DatabaseManagementState =
-            DatabaseManagementState::new("DATABASE_MANAGEMENT_STATE_UNSPECIFIED");
-
-        /// Enabling Database Management state
-        pub const ENABLING: DatabaseManagementState = DatabaseManagementState::new("ENABLING");
-
-        /// Enabled Database Management state
-        pub const ENABLED: DatabaseManagementState = DatabaseManagementState::new("ENABLED");
-
-        /// Disabling Database Management state
-        pub const DISABLING: DatabaseManagementState = DatabaseManagementState::new("DISABLING");
-
-        /// Not Enabled Database Management state
-        pub const NOT_ENABLED: DatabaseManagementState =
-            DatabaseManagementState::new("NOT_ENABLED");
-
-        /// Failed enabling Database Management state
-        pub const FAILED_ENABLING: DatabaseManagementState =
-            DatabaseManagementState::new("FAILED_ENABLING");
-
-        /// Failed disabling Database Management state
-        pub const FAILED_DISABLING: DatabaseManagementState =
-            DatabaseManagementState::new("FAILED_DISABLING");
-    }
-
-    impl std::convert::From<std::string::String> for DatabaseManagementState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DatabaseManagementState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DatabaseManagementState {
         fn default() -> Self {
-            database_management_state::DATABASE_MANAGEMENT_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// This field indicates the modes of an Autonomous Database.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OpenMode(std::borrow::Cow<'static, str>);
+    pub struct OpenMode(i32);
 
     impl OpenMode {
+        /// Default unspecified value.
+        pub const OPEN_MODE_UNSPECIFIED: OpenMode = OpenMode::new(0);
+
+        /// Read Only Mode
+        pub const READ_ONLY: OpenMode = OpenMode::new(1);
+
+        /// Read Write Mode
+        pub const READ_WRITE: OpenMode = OpenMode::new(2);
+
         /// Creates a new OpenMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("OPEN_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("READ_ONLY"),
+                2 => std::borrow::Cow::Borrowed("READ_WRITE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "OPEN_MODE_UNSPECIFIED" => std::option::Option::Some(Self::OPEN_MODE_UNSPECIFIED),
+                "READ_ONLY" => std::option::Option::Some(Self::READ_ONLY),
+                "READ_WRITE" => std::option::Option::Some(Self::READ_WRITE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [OpenMode](OpenMode)
-    pub mod open_mode {
-        use super::OpenMode;
-
-        /// Default unspecified value.
-        pub const OPEN_MODE_UNSPECIFIED: OpenMode = OpenMode::new("OPEN_MODE_UNSPECIFIED");
-
-        /// Read Only Mode
-        pub const READ_ONLY: OpenMode = OpenMode::new("READ_ONLY");
-
-        /// Read Write Mode
-        pub const READ_WRITE: OpenMode = OpenMode::new("READ_WRITE");
-    }
-
-    impl std::convert::From<std::string::String> for OpenMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for OpenMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for OpenMode {
         fn default() -> Self {
-            open_mode::OPEN_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The types of permission levels for an Autonomous Database.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PermissionLevel(std::borrow::Cow<'static, str>);
+    pub struct PermissionLevel(i32);
 
     impl PermissionLevel {
+        /// Default unspecified value.
+        pub const PERMISSION_LEVEL_UNSPECIFIED: PermissionLevel = PermissionLevel::new(0);
+
+        /// Restricted mode allows access only by admin users.
+        pub const RESTRICTED: PermissionLevel = PermissionLevel::new(1);
+
+        /// Normal access.
+        pub const UNRESTRICTED: PermissionLevel = PermissionLevel::new(2);
+
         /// Creates a new PermissionLevel instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PERMISSION_LEVEL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RESTRICTED"),
+                2 => std::borrow::Cow::Borrowed("UNRESTRICTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PERMISSION_LEVEL_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PERMISSION_LEVEL_UNSPECIFIED)
+                }
+                "RESTRICTED" => std::option::Option::Some(Self::RESTRICTED),
+                "UNRESTRICTED" => std::option::Option::Some(Self::UNRESTRICTED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [PermissionLevel](PermissionLevel)
-    pub mod permission_level {
-        use super::PermissionLevel;
-
-        /// Default unspecified value.
-        pub const PERMISSION_LEVEL_UNSPECIFIED: PermissionLevel =
-            PermissionLevel::new("PERMISSION_LEVEL_UNSPECIFIED");
-
-        /// Restricted mode allows access only by admin users.
-        pub const RESTRICTED: PermissionLevel = PermissionLevel::new("RESTRICTED");
-
-        /// Normal access.
-        pub const UNRESTRICTED: PermissionLevel = PermissionLevel::new("UNRESTRICTED");
-    }
-
-    impl std::convert::From<std::string::String> for PermissionLevel {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PermissionLevel {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PermissionLevel {
         fn default() -> Self {
-            permission_level::PERMISSION_LEVEL_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The refresh mode of the cloned Autonomous Database.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RefreshableMode(std::borrow::Cow<'static, str>);
+    pub struct RefreshableMode(i32);
 
     impl RefreshableMode {
-        /// Creates a new RefreshableMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RefreshableMode](RefreshableMode)
-    pub mod refreshable_mode {
-        use super::RefreshableMode;
-
         /// The default unspecified value.
-        pub const REFRESHABLE_MODE_UNSPECIFIED: RefreshableMode =
-            RefreshableMode::new("REFRESHABLE_MODE_UNSPECIFIED");
+        pub const REFRESHABLE_MODE_UNSPECIFIED: RefreshableMode = RefreshableMode::new(0);
 
         /// AUTOMATIC indicates that the cloned database is automatically
         /// refreshed with data from the source Autonomous Database.
-        pub const AUTOMATIC: RefreshableMode = RefreshableMode::new("AUTOMATIC");
+        pub const AUTOMATIC: RefreshableMode = RefreshableMode::new(1);
 
         /// MANUAL indicates that the cloned database is manually refreshed with
         /// data from the source Autonomous Database.
-        pub const MANUAL: RefreshableMode = RefreshableMode::new("MANUAL");
+        pub const MANUAL: RefreshableMode = RefreshableMode::new(2);
+
+        /// Creates a new RefreshableMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("REFRESHABLE_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AUTOMATIC"),
+                2 => std::borrow::Cow::Borrowed("MANUAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "REFRESHABLE_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::REFRESHABLE_MODE_UNSPECIFIED)
+                }
+                "AUTOMATIC" => std::option::Option::Some(Self::AUTOMATIC),
+                "MANUAL" => std::option::Option::Some(Self::MANUAL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RefreshableMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RefreshableMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RefreshableMode {
         fn default() -> Self {
-            refreshable_mode::REFRESHABLE_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The refresh state of the cloned Autonomous Database.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RefreshableState(std::borrow::Cow<'static, str>);
+    pub struct RefreshableState(i32);
 
     impl RefreshableState {
+        /// Default unspecified value.
+        pub const REFRESHABLE_STATE_UNSPECIFIED: RefreshableState = RefreshableState::new(0);
+
+        /// Refreshing
+        pub const REFRESHING: RefreshableState = RefreshableState::new(1);
+
+        /// Not refreshed
+        pub const NOT_REFRESHING: RefreshableState = RefreshableState::new(2);
+
         /// Creates a new RefreshableState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("REFRESHABLE_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REFRESHING"),
+                2 => std::borrow::Cow::Borrowed("NOT_REFRESHING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "REFRESHABLE_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::REFRESHABLE_STATE_UNSPECIFIED)
+                }
+                "REFRESHING" => std::option::Option::Some(Self::REFRESHING),
+                "NOT_REFRESHING" => std::option::Option::Some(Self::NOT_REFRESHING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RefreshableState](RefreshableState)
-    pub mod refreshable_state {
-        use super::RefreshableState;
-
-        /// Default unspecified value.
-        pub const REFRESHABLE_STATE_UNSPECIFIED: RefreshableState =
-            RefreshableState::new("REFRESHABLE_STATE_UNSPECIFIED");
-
-        /// Refreshing
-        pub const REFRESHING: RefreshableState = RefreshableState::new("REFRESHING");
-
-        /// Not refreshed
-        pub const NOT_REFRESHING: RefreshableState = RefreshableState::new("NOT_REFRESHING");
-    }
-
-    impl std::convert::From<std::string::String> for RefreshableState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RefreshableState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RefreshableState {
         fn default() -> Self {
-            refreshable_state::REFRESHABLE_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The Data Guard role of the Autonomous Database.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Role(std::borrow::Cow<'static, str>);
+    pub struct Role(i32);
 
     impl Role {
+        /// Default unspecified value.
+        pub const ROLE_UNSPECIFIED: Role = Role::new(0);
+
+        /// Primary role
+        pub const PRIMARY: Role = Role::new(1);
+
+        /// Standby role
+        pub const STANDBY: Role = Role::new(2);
+
+        /// Disabled standby role
+        pub const DISABLED_STANDBY: Role = Role::new(3);
+
+        /// Backup copy role
+        pub const BACKUP_COPY: Role = Role::new(4);
+
+        /// Snapshot standby role
+        pub const SNAPSHOT_STANDBY: Role = Role::new(5);
+
         /// Creates a new Role instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ROLE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PRIMARY"),
+                2 => std::borrow::Cow::Borrowed("STANDBY"),
+                3 => std::borrow::Cow::Borrowed("DISABLED_STANDBY"),
+                4 => std::borrow::Cow::Borrowed("BACKUP_COPY"),
+                5 => std::borrow::Cow::Borrowed("SNAPSHOT_STANDBY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ROLE_UNSPECIFIED" => std::option::Option::Some(Self::ROLE_UNSPECIFIED),
+                "PRIMARY" => std::option::Option::Some(Self::PRIMARY),
+                "STANDBY" => std::option::Option::Some(Self::STANDBY),
+                "DISABLED_STANDBY" => std::option::Option::Some(Self::DISABLED_STANDBY),
+                "BACKUP_COPY" => std::option::Option::Some(Self::BACKUP_COPY),
+                "SNAPSHOT_STANDBY" => std::option::Option::Some(Self::SNAPSHOT_STANDBY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Role](Role)
-    pub mod role {
-        use super::Role;
-
-        /// Default unspecified value.
-        pub const ROLE_UNSPECIFIED: Role = Role::new("ROLE_UNSPECIFIED");
-
-        /// Primary role
-        pub const PRIMARY: Role = Role::new("PRIMARY");
-
-        /// Standby role
-        pub const STANDBY: Role = Role::new("STANDBY");
-
-        /// Disabled standby role
-        pub const DISABLED_STANDBY: Role = Role::new("DISABLED_STANDBY");
-
-        /// Backup copy role
-        pub const BACKUP_COPY: Role = Role::new("BACKUP_COPY");
-
-        /// Snapshot standby role
-        pub const SNAPSHOT_STANDBY: Role = Role::new("SNAPSHOT_STANDBY");
-    }
-
-    impl std::convert::From<std::string::String> for Role {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Role {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Role {
         fn default() -> Self {
-            role::ROLE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1726,269 +1919,373 @@ pub mod database_connection_string_profile {
 
     /// The various consumer groups available in the connection string profile.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConsumerGroup(std::borrow::Cow<'static, str>);
+    pub struct ConsumerGroup(i32);
 
     impl ConsumerGroup {
+        /// Default unspecified value.
+        pub const CONSUMER_GROUP_UNSPECIFIED: ConsumerGroup = ConsumerGroup::new(0);
+
+        /// High consumer group.
+        pub const HIGH: ConsumerGroup = ConsumerGroup::new(1);
+
+        /// Medium consumer group.
+        pub const MEDIUM: ConsumerGroup = ConsumerGroup::new(2);
+
+        /// Low consumer group.
+        pub const LOW: ConsumerGroup = ConsumerGroup::new(3);
+
+        /// TP consumer group.
+        pub const TP: ConsumerGroup = ConsumerGroup::new(4);
+
+        /// TPURGENT consumer group.
+        pub const TPURGENT: ConsumerGroup = ConsumerGroup::new(5);
+
         /// Creates a new ConsumerGroup instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CONSUMER_GROUP_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("HIGH"),
+                2 => std::borrow::Cow::Borrowed("MEDIUM"),
+                3 => std::borrow::Cow::Borrowed("LOW"),
+                4 => std::borrow::Cow::Borrowed("TP"),
+                5 => std::borrow::Cow::Borrowed("TPURGENT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CONSUMER_GROUP_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CONSUMER_GROUP_UNSPECIFIED)
+                }
+                "HIGH" => std::option::Option::Some(Self::HIGH),
+                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
+                "LOW" => std::option::Option::Some(Self::LOW),
+                "TP" => std::option::Option::Some(Self::TP),
+                "TPURGENT" => std::option::Option::Some(Self::TPURGENT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ConsumerGroup](ConsumerGroup)
-    pub mod consumer_group {
-        use super::ConsumerGroup;
-
-        /// Default unspecified value.
-        pub const CONSUMER_GROUP_UNSPECIFIED: ConsumerGroup =
-            ConsumerGroup::new("CONSUMER_GROUP_UNSPECIFIED");
-
-        /// High consumer group.
-        pub const HIGH: ConsumerGroup = ConsumerGroup::new("HIGH");
-
-        /// Medium consumer group.
-        pub const MEDIUM: ConsumerGroup = ConsumerGroup::new("MEDIUM");
-
-        /// Low consumer group.
-        pub const LOW: ConsumerGroup = ConsumerGroup::new("LOW");
-
-        /// TP consumer group.
-        pub const TP: ConsumerGroup = ConsumerGroup::new("TP");
-
-        /// TPURGENT consumer group.
-        pub const TPURGENT: ConsumerGroup = ConsumerGroup::new("TPURGENT");
-    }
-
-    impl std::convert::From<std::string::String> for ConsumerGroup {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ConsumerGroup {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ConsumerGroup {
         fn default() -> Self {
-            consumer_group::CONSUMER_GROUP_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The host name format being used in the connection string.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HostFormat(std::borrow::Cow<'static, str>);
+    pub struct HostFormat(i32);
 
     impl HostFormat {
+        /// Default unspecified value.
+        pub const HOST_FORMAT_UNSPECIFIED: HostFormat = HostFormat::new(0);
+
+        /// FQDN
+        pub const FQDN: HostFormat = HostFormat::new(1);
+
+        /// IP
+        pub const IP: HostFormat = HostFormat::new(2);
+
         /// Creates a new HostFormat instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("HOST_FORMAT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FQDN"),
+                2 => std::borrow::Cow::Borrowed("IP"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "HOST_FORMAT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::HOST_FORMAT_UNSPECIFIED)
+                }
+                "FQDN" => std::option::Option::Some(Self::FQDN),
+                "IP" => std::option::Option::Some(Self::IP),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [HostFormat](HostFormat)
-    pub mod host_format {
-        use super::HostFormat;
-
-        /// Default unspecified value.
-        pub const HOST_FORMAT_UNSPECIFIED: HostFormat = HostFormat::new("HOST_FORMAT_UNSPECIFIED");
-
-        /// FQDN
-        pub const FQDN: HostFormat = HostFormat::new("FQDN");
-
-        /// IP
-        pub const IP: HostFormat = HostFormat::new("IP");
-    }
-
-    impl std::convert::From<std::string::String> for HostFormat {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for HostFormat {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for HostFormat {
         fn default() -> Self {
-            host_format::HOST_FORMAT_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The protocol being used by the connection.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Protocol(std::borrow::Cow<'static, str>);
+    pub struct Protocol(i32);
 
     impl Protocol {
+        /// Default unspecified value.
+        pub const PROTOCOL_UNSPECIFIED: Protocol = Protocol::new(0);
+
+        /// Tcp
+        pub const TCP: Protocol = Protocol::new(1);
+
+        /// Tcps
+        pub const TCPS: Protocol = Protocol::new(2);
+
         /// Creates a new Protocol instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PROTOCOL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TCP"),
+                2 => std::borrow::Cow::Borrowed("TCPS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PROTOCOL_UNSPECIFIED" => std::option::Option::Some(Self::PROTOCOL_UNSPECIFIED),
+                "TCP" => std::option::Option::Some(Self::TCP),
+                "TCPS" => std::option::Option::Some(Self::TCPS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Protocol](Protocol)
-    pub mod protocol {
-        use super::Protocol;
-
-        /// Default unspecified value.
-        pub const PROTOCOL_UNSPECIFIED: Protocol = Protocol::new("PROTOCOL_UNSPECIFIED");
-
-        /// Tcp
-        pub const TCP: Protocol = Protocol::new("TCP");
-
-        /// Tcps
-        pub const TCPS: Protocol = Protocol::new("TCPS");
-    }
-
-    impl std::convert::From<std::string::String> for Protocol {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Protocol {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Protocol {
         fn default() -> Self {
-            protocol::PROTOCOL_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The session mode of the connection.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SessionMode(std::borrow::Cow<'static, str>);
+    pub struct SessionMode(i32);
 
     impl SessionMode {
+        /// Default unspecified value.
+        pub const SESSION_MODE_UNSPECIFIED: SessionMode = SessionMode::new(0);
+
+        /// Direct
+        pub const DIRECT: SessionMode = SessionMode::new(1);
+
+        /// Indirect
+        pub const INDIRECT: SessionMode = SessionMode::new(2);
+
         /// Creates a new SessionMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SESSION_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DIRECT"),
+                2 => std::borrow::Cow::Borrowed("INDIRECT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SESSION_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SESSION_MODE_UNSPECIFIED)
+                }
+                "DIRECT" => std::option::Option::Some(Self::DIRECT),
+                "INDIRECT" => std::option::Option::Some(Self::INDIRECT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SessionMode](SessionMode)
-    pub mod session_mode {
-        use super::SessionMode;
-
-        /// Default unspecified value.
-        pub const SESSION_MODE_UNSPECIFIED: SessionMode =
-            SessionMode::new("SESSION_MODE_UNSPECIFIED");
-
-        /// Direct
-        pub const DIRECT: SessionMode = SessionMode::new("DIRECT");
-
-        /// Indirect
-        pub const INDIRECT: SessionMode = SessionMode::new("INDIRECT");
-    }
-
-    impl std::convert::From<std::string::String> for SessionMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SessionMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SessionMode {
         fn default() -> Self {
-            session_mode::SESSION_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Specifies syntax of the connection string.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SyntaxFormat(std::borrow::Cow<'static, str>);
+    pub struct SyntaxFormat(i32);
 
     impl SyntaxFormat {
+        /// Default unspecified value.
+        pub const SYNTAX_FORMAT_UNSPECIFIED: SyntaxFormat = SyntaxFormat::new(0);
+
+        /// Long
+        pub const LONG: SyntaxFormat = SyntaxFormat::new(1);
+
+        /// Ezconnect
+        pub const EZCONNECT: SyntaxFormat = SyntaxFormat::new(2);
+
+        /// Ezconnectplus
+        pub const EZCONNECTPLUS: SyntaxFormat = SyntaxFormat::new(3);
+
         /// Creates a new SyntaxFormat instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SYNTAX_FORMAT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LONG"),
+                2 => std::borrow::Cow::Borrowed("EZCONNECT"),
+                3 => std::borrow::Cow::Borrowed("EZCONNECTPLUS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SYNTAX_FORMAT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SYNTAX_FORMAT_UNSPECIFIED)
+                }
+                "LONG" => std::option::Option::Some(Self::LONG),
+                "EZCONNECT" => std::option::Option::Some(Self::EZCONNECT),
+                "EZCONNECTPLUS" => std::option::Option::Some(Self::EZCONNECTPLUS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SyntaxFormat](SyntaxFormat)
-    pub mod syntax_format {
-        use super::SyntaxFormat;
-
-        /// Default unspecified value.
-        pub const SYNTAX_FORMAT_UNSPECIFIED: SyntaxFormat =
-            SyntaxFormat::new("SYNTAX_FORMAT_UNSPECIFIED");
-
-        /// Long
-        pub const LONG: SyntaxFormat = SyntaxFormat::new("LONG");
-
-        /// Ezconnect
-        pub const EZCONNECT: SyntaxFormat = SyntaxFormat::new("EZCONNECT");
-
-        /// Ezconnectplus
-        pub const EZCONNECTPLUS: SyntaxFormat = SyntaxFormat::new("EZCONNECTPLUS");
-    }
-
-    impl std::convert::From<std::string::String> for SyntaxFormat {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SyntaxFormat {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SyntaxFormat {
         fn default() -> Self {
-            syntax_format::SYNTAX_FORMAT_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// This field indicates the TLS authentication type of the connection.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TLSAuthentication(std::borrow::Cow<'static, str>);
+    pub struct TLSAuthentication(i32);
 
     impl TLSAuthentication {
+        /// Default unspecified value.
+        pub const TLS_AUTHENTICATION_UNSPECIFIED: TLSAuthentication = TLSAuthentication::new(0);
+
+        /// Server
+        pub const SERVER: TLSAuthentication = TLSAuthentication::new(1);
+
+        /// Mutual
+        pub const MUTUAL: TLSAuthentication = TLSAuthentication::new(2);
+
         /// Creates a new TLSAuthentication instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TLS_AUTHENTICATION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SERVER"),
+                2 => std::borrow::Cow::Borrowed("MUTUAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TLS_AUTHENTICATION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::TLS_AUTHENTICATION_UNSPECIFIED)
+                }
+                "SERVER" => std::option::Option::Some(Self::SERVER),
+                "MUTUAL" => std::option::Option::Some(Self::MUTUAL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [TLSAuthentication](TLSAuthentication)
-    pub mod tls_authentication {
-        use super::TLSAuthentication;
-
-        /// Default unspecified value.
-        pub const TLS_AUTHENTICATION_UNSPECIFIED: TLSAuthentication =
-            TLSAuthentication::new("TLS_AUTHENTICATION_UNSPECIFIED");
-
-        /// Server
-        pub const SERVER: TLSAuthentication = TLSAuthentication::new("SERVER");
-
-        /// Mutual
-        pub const MUTUAL: TLSAuthentication = TLSAuthentication::new("MUTUAL");
-    }
-
-    impl std::convert::From<std::string::String> for TLSAuthentication {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TLSAuthentication {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TLSAuthentication {
         fn default() -> Self {
-            tls_authentication::TLS_AUTHENTICATION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2372,44 +2669,60 @@ pub mod autonomous_database_character_set {
 
     /// The type of character set an Autonomous Database can have.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CharacterSetType(std::borrow::Cow<'static, str>);
+    pub struct CharacterSetType(i32);
 
     impl CharacterSetType {
+        /// Character set type is not specified.
+        pub const CHARACTER_SET_TYPE_UNSPECIFIED: CharacterSetType = CharacterSetType::new(0);
+
+        /// Character set type is set to database.
+        pub const DATABASE: CharacterSetType = CharacterSetType::new(1);
+
+        /// Character set type is set to national.
+        pub const NATIONAL: CharacterSetType = CharacterSetType::new(2);
+
         /// Creates a new CharacterSetType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CHARACTER_SET_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DATABASE"),
+                2 => std::borrow::Cow::Borrowed("NATIONAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CHARACTER_SET_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CHARACTER_SET_TYPE_UNSPECIFIED)
+                }
+                "DATABASE" => std::option::Option::Some(Self::DATABASE),
+                "NATIONAL" => std::option::Option::Some(Self::NATIONAL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [CharacterSetType](CharacterSetType)
-    pub mod character_set_type {
-        use super::CharacterSetType;
-
-        /// Character set type is not specified.
-        pub const CHARACTER_SET_TYPE_UNSPECIFIED: CharacterSetType =
-            CharacterSetType::new("CHARACTER_SET_TYPE_UNSPECIFIED");
-
-        /// Character set type is set to database.
-        pub const DATABASE: CharacterSetType = CharacterSetType::new("DATABASE");
-
-        /// Character set type is set to national.
-        pub const NATIONAL: CharacterSetType = CharacterSetType::new("NATIONAL");
-    }
-
-    impl std::convert::From<std::string::String> for CharacterSetType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CharacterSetType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CharacterSetType {
         fn default() -> Self {
-            character_set_type::CHARACTER_SET_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2758,100 +3071,140 @@ pub mod autonomous_database_backup_properties {
 
     /// // The various lifecycle states of the Autonomous Database Backup.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Default unspecified value.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Indicates that the resource is in creating state.
+        pub const CREATING: State = State::new(1);
+
+        /// Indicates that the resource is in active state.
+        pub const ACTIVE: State = State::new(2);
+
+        /// Indicates that the resource is in deleting state.
+        pub const DELETING: State = State::new(3);
+
+        /// Indicates that the resource is in deleted state.
+        pub const DELETED: State = State::new(4);
+
+        /// Indicates that the resource is in failed state.
+        pub const FAILED: State = State::new(6);
+
+        /// Indicates that the resource is in updating state.
+        pub const UPDATING: State = State::new(7);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("DELETED"),
+                6 => std::borrow::Cow::Borrowed("FAILED"),
+                7 => std::borrow::Cow::Borrowed("UPDATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "DELETED" => std::option::Option::Some(Self::DELETED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Default unspecified value.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Indicates that the resource is in creating state.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// Indicates that the resource is in active state.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// Indicates that the resource is in deleting state.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// Indicates that the resource is in deleted state.
-        pub const DELETED: State = State::new("DELETED");
-
-        /// Indicates that the resource is in failed state.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// Indicates that the resource is in updating state.
-        pub const UPDATING: State = State::new("UPDATING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The type of the backup.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Default unspecified value.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// Incremental backups.
+        pub const INCREMENTAL: Type = Type::new(1);
+
+        /// Full backups.
+        pub const FULL: Type = Type::new(2);
+
+        /// Long term backups.
+        pub const LONG_TERM: Type = Type::new(3);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INCREMENTAL"),
+                2 => std::borrow::Cow::Borrowed("FULL"),
+                3 => std::borrow::Cow::Borrowed("LONG_TERM"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "INCREMENTAL" => std::option::Option::Some(Self::INCREMENTAL),
+                "FULL" => std::option::Option::Some(Self::FULL),
+                "LONG_TERM" => std::option::Option::Some(Self::LONG_TERM),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Default unspecified value.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// Incremental backups.
-        pub const INCREMENTAL: Type = Type::new("INCREMENTAL");
-
-        /// Full backups.
-        pub const FULL: Type = Type::new("FULL");
-
-        /// Long term backups.
-        pub const LONG_TERM: Type = Type::new("LONG_TERM");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3102,64 +3455,93 @@ pub mod db_node_properties {
 
     /// The various lifecycle states of the database node.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Default unspecified value.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Indicates that the resource is in provisioning state.
+        pub const PROVISIONING: State = State::new(1);
+
+        /// Indicates that the resource is in available state.
+        pub const AVAILABLE: State = State::new(2);
+
+        /// Indicates that the resource is in updating state.
+        pub const UPDATING: State = State::new(3);
+
+        /// Indicates that the resource is in stopping state.
+        pub const STOPPING: State = State::new(4);
+
+        /// Indicates that the resource is in stopped state.
+        pub const STOPPED: State = State::new(5);
+
+        /// Indicates that the resource is in starting state.
+        pub const STARTING: State = State::new(6);
+
+        /// Indicates that the resource is in terminating state.
+        pub const TERMINATING: State = State::new(7);
+
+        /// Indicates that the resource is in terminated state.
+        pub const TERMINATED: State = State::new(8);
+
+        /// Indicates that the resource is in failed state.
+        pub const FAILED: State = State::new(9);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
+                2 => std::borrow::Cow::Borrowed("AVAILABLE"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("STOPPING"),
+                5 => std::borrow::Cow::Borrowed("STOPPED"),
+                6 => std::borrow::Cow::Borrowed("STARTING"),
+                7 => std::borrow::Cow::Borrowed("TERMINATING"),
+                8 => std::borrow::Cow::Borrowed("TERMINATED"),
+                9 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
+                "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "STOPPING" => std::option::Option::Some(Self::STOPPING),
+                "STOPPED" => std::option::Option::Some(Self::STOPPED),
+                "STARTING" => std::option::Option::Some(Self::STARTING),
+                "TERMINATING" => std::option::Option::Some(Self::TERMINATING),
+                "TERMINATED" => std::option::Option::Some(Self::TERMINATED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Default unspecified value.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Indicates that the resource is in provisioning state.
-        pub const PROVISIONING: State = State::new("PROVISIONING");
-
-        /// Indicates that the resource is in available state.
-        pub const AVAILABLE: State = State::new("AVAILABLE");
-
-        /// Indicates that the resource is in updating state.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// Indicates that the resource is in stopping state.
-        pub const STOPPING: State = State::new("STOPPING");
-
-        /// Indicates that the resource is in stopped state.
-        pub const STOPPED: State = State::new("STOPPED");
-
-        /// Indicates that the resource is in starting state.
-        pub const STARTING: State = State::new("STARTING");
-
-        /// Indicates that the resource is in terminating state.
-        pub const TERMINATING: State = State::new("TERMINATING");
-
-        /// Indicates that the resource is in terminated state.
-        pub const TERMINATED: State = State::new("TERMINATED");
-
-        /// Indicates that the resource is in failed state.
-        pub const FAILED: State = State::new("FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3346,52 +3728,73 @@ pub mod db_server_properties {
 
     /// The various lifecycle states of the database server.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Default unspecified value.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Indicates that the resource is in creating state.
+        pub const CREATING: State = State::new(1);
+
+        /// Indicates that the resource is in available state.
+        pub const AVAILABLE: State = State::new(2);
+
+        /// Indicates that the resource is in unavailable state.
+        pub const UNAVAILABLE: State = State::new(3);
+
+        /// Indicates that the resource is in deleting state.
+        pub const DELETING: State = State::new(4);
+
+        /// Indicates that the resource is in deleted state.
+        pub const DELETED: State = State::new(5);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("AVAILABLE"),
+                3 => std::borrow::Cow::Borrowed("UNAVAILABLE"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("DELETED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
+                "UNAVAILABLE" => std::option::Option::Some(Self::UNAVAILABLE),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "DELETED" => std::option::Option::Some(Self::DELETED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Default unspecified value.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Indicates that the resource is in creating state.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// Indicates that the resource is in available state.
-        pub const AVAILABLE: State = State::new("AVAILABLE");
-
-        /// Indicates that the resource is in unavailable state.
-        pub const UNAVAILABLE: State = State::new("UNAVAILABLE");
-
-        /// Indicates that the resource is in deleting state.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// Indicates that the resource is in deleted state.
-        pub const DELETED: State = State::new("DELETED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3601,49 +4004,68 @@ pub mod entitlement {
 
     /// The various lifecycle states of the subscription.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Default unspecified value.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Account not linked.
+        pub const ACCOUNT_NOT_LINKED: State = State::new(1);
+
+        /// Account is linked but not active.
+        pub const ACCOUNT_NOT_ACTIVE: State = State::new(2);
+
+        /// Entitlement and Account are active.
+        pub const ACTIVE: State = State::new(3);
+
+        /// Account is suspended.
+        pub const ACCOUNT_SUSPENDED: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACCOUNT_NOT_LINKED"),
+                2 => std::borrow::Cow::Borrowed("ACCOUNT_NOT_ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("ACTIVE"),
+                4 => std::borrow::Cow::Borrowed("ACCOUNT_SUSPENDED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACCOUNT_NOT_LINKED" => std::option::Option::Some(Self::ACCOUNT_NOT_LINKED),
+                "ACCOUNT_NOT_ACTIVE" => std::option::Option::Some(Self::ACCOUNT_NOT_ACTIVE),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "ACCOUNT_SUSPENDED" => std::option::Option::Some(Self::ACCOUNT_SUSPENDED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Default unspecified value.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Account not linked.
-        pub const ACCOUNT_NOT_LINKED: State = State::new("ACCOUNT_NOT_LINKED");
-
-        /// Account is linked but not active.
-        pub const ACCOUNT_NOT_ACTIVE: State = State::new("ACCOUNT_NOT_ACTIVE");
-
-        /// Entitlement and Account are active.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// Account is suspended.
-        pub const ACCOUNT_SUSPENDED: State = State::new("ACCOUNT_SUSPENDED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4159,58 +4581,85 @@ pub mod cloud_exadata_infrastructure_properties {
 
     /// The various lifecycle states of the Exadata Infrastructure.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Default unspecified value.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The Exadata Infrastructure is being provisioned.
+        pub const PROVISIONING: State = State::new(1);
+
+        /// The Exadata Infrastructure is available for use.
+        pub const AVAILABLE: State = State::new(2);
+
+        /// The Exadata Infrastructure is being updated.
+        pub const UPDATING: State = State::new(3);
+
+        /// The Exadata Infrastructure is being terminated.
+        pub const TERMINATING: State = State::new(4);
+
+        /// The Exadata Infrastructure is terminated.
+        pub const TERMINATED: State = State::new(5);
+
+        /// The Exadata Infrastructure is in failed state.
+        pub const FAILED: State = State::new(6);
+
+        /// The Exadata Infrastructure is in maintenance.
+        pub const MAINTENANCE_IN_PROGRESS: State = State::new(7);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
+                2 => std::borrow::Cow::Borrowed("AVAILABLE"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("TERMINATING"),
+                5 => std::borrow::Cow::Borrowed("TERMINATED"),
+                6 => std::borrow::Cow::Borrowed("FAILED"),
+                7 => std::borrow::Cow::Borrowed("MAINTENANCE_IN_PROGRESS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
+                "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "TERMINATING" => std::option::Option::Some(Self::TERMINATING),
+                "TERMINATED" => std::option::Option::Some(Self::TERMINATED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "MAINTENANCE_IN_PROGRESS" => {
+                    std::option::Option::Some(Self::MAINTENANCE_IN_PROGRESS)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Default unspecified value.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The Exadata Infrastructure is being provisioned.
-        pub const PROVISIONING: State = State::new("PROVISIONING");
-
-        /// The Exadata Infrastructure is available for use.
-        pub const AVAILABLE: State = State::new("AVAILABLE");
-
-        /// The Exadata Infrastructure is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// The Exadata Infrastructure is being terminated.
-        pub const TERMINATING: State = State::new("TERMINATING");
-
-        /// The Exadata Infrastructure is terminated.
-        pub const TERMINATED: State = State::new("TERMINATED");
-
-        /// The Exadata Infrastructure is in failed state.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// The Exadata Infrastructure is in maintenance.
-        pub const MAINTENANCE_IN_PROGRESS: State = State::new("MAINTENANCE_IN_PROGRESS");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4376,90 +4825,122 @@ pub mod maintenance_window {
 
     /// Maintenance window preference.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MaintenanceWindowPreference(std::borrow::Cow<'static, str>);
+    pub struct MaintenanceWindowPreference(i32);
 
     impl MaintenanceWindowPreference {
-        /// Creates a new MaintenanceWindowPreference instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [MaintenanceWindowPreference](MaintenanceWindowPreference)
-    pub mod maintenance_window_preference {
-        use super::MaintenanceWindowPreference;
-
         /// Default unspecified value.
         pub const MAINTENANCE_WINDOW_PREFERENCE_UNSPECIFIED: MaintenanceWindowPreference =
-            MaintenanceWindowPreference::new("MAINTENANCE_WINDOW_PREFERENCE_UNSPECIFIED");
+            MaintenanceWindowPreference::new(0);
 
         /// Custom preference.
         pub const CUSTOM_PREFERENCE: MaintenanceWindowPreference =
-            MaintenanceWindowPreference::new("CUSTOM_PREFERENCE");
+            MaintenanceWindowPreference::new(1);
 
         /// No preference.
-        pub const NO_PREFERENCE: MaintenanceWindowPreference =
-            MaintenanceWindowPreference::new("NO_PREFERENCE");
+        pub const NO_PREFERENCE: MaintenanceWindowPreference = MaintenanceWindowPreference::new(2);
+
+        /// Creates a new MaintenanceWindowPreference instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MAINTENANCE_WINDOW_PREFERENCE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CUSTOM_PREFERENCE"),
+                2 => std::borrow::Cow::Borrowed("NO_PREFERENCE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MAINTENANCE_WINDOW_PREFERENCE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MAINTENANCE_WINDOW_PREFERENCE_UNSPECIFIED)
+                }
+                "CUSTOM_PREFERENCE" => std::option::Option::Some(Self::CUSTOM_PREFERENCE),
+                "NO_PREFERENCE" => std::option::Option::Some(Self::NO_PREFERENCE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for MaintenanceWindowPreference {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MaintenanceWindowPreference {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MaintenanceWindowPreference {
         fn default() -> Self {
-            maintenance_window_preference::MAINTENANCE_WINDOW_PREFERENCE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Patching mode.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PatchingMode(std::borrow::Cow<'static, str>);
+    pub struct PatchingMode(i32);
 
     impl PatchingMode {
-        /// Creates a new PatchingMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PatchingMode](PatchingMode)
-    pub mod patching_mode {
-        use super::PatchingMode;
-
         /// Default unspecified value.
-        pub const PATCHING_MODE_UNSPECIFIED: PatchingMode =
-            PatchingMode::new("PATCHING_MODE_UNSPECIFIED");
+        pub const PATCHING_MODE_UNSPECIFIED: PatchingMode = PatchingMode::new(0);
 
         /// Updates the Cloud Exadata database server hosts in a rolling fashion.
-        pub const ROLLING: PatchingMode = PatchingMode::new("ROLLING");
+        pub const ROLLING: PatchingMode = PatchingMode::new(1);
 
         /// The non-rolling maintenance method first updates your storage servers at
         /// the same time, then your database servers at the same time.
-        pub const NON_ROLLING: PatchingMode = PatchingMode::new("NON_ROLLING");
+        pub const NON_ROLLING: PatchingMode = PatchingMode::new(2);
+
+        /// Creates a new PatchingMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PATCHING_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ROLLING"),
+                2 => std::borrow::Cow::Borrowed("NON_ROLLING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PATCHING_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PATCHING_MODE_UNSPECIFIED)
+                }
+                "ROLLING" => std::option::Option::Some(Self::ROLLING),
+                "NON_ROLLING" => std::option::Option::Some(Self::NON_ROLLING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PatchingMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PatchingMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PatchingMode {
         fn default() -> Self {
-            patching_mode::PATCHING_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7046,144 +7527,203 @@ pub mod cloud_vm_cluster_properties {
 
     /// Different licenses supported.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LicenseType(std::borrow::Cow<'static, str>);
+    pub struct LicenseType(i32);
 
     impl LicenseType {
+        /// Unspecified
+        pub const LICENSE_TYPE_UNSPECIFIED: LicenseType = LicenseType::new(0);
+
+        /// License included part of offer
+        pub const LICENSE_INCLUDED: LicenseType = LicenseType::new(1);
+
+        /// Bring your own license
+        pub const BRING_YOUR_OWN_LICENSE: LicenseType = LicenseType::new(2);
+
         /// Creates a new LicenseType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LICENSE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LICENSE_INCLUDED"),
+                2 => std::borrow::Cow::Borrowed("BRING_YOUR_OWN_LICENSE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LICENSE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::LICENSE_TYPE_UNSPECIFIED)
+                }
+                "LICENSE_INCLUDED" => std::option::Option::Some(Self::LICENSE_INCLUDED),
+                "BRING_YOUR_OWN_LICENSE" => std::option::Option::Some(Self::BRING_YOUR_OWN_LICENSE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [LicenseType](LicenseType)
-    pub mod license_type {
-        use super::LicenseType;
-
-        /// Unspecified
-        pub const LICENSE_TYPE_UNSPECIFIED: LicenseType =
-            LicenseType::new("LICENSE_TYPE_UNSPECIFIED");
-
-        /// License included part of offer
-        pub const LICENSE_INCLUDED: LicenseType = LicenseType::new("LICENSE_INCLUDED");
-
-        /// Bring your own license
-        pub const BRING_YOUR_OWN_LICENSE: LicenseType = LicenseType::new("BRING_YOUR_OWN_LICENSE");
-    }
-
-    impl std::convert::From<std::string::String> for LicenseType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LicenseType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LicenseType {
         fn default() -> Self {
-            license_type::LICENSE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Types of disk redundancy provided by Oracle.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DiskRedundancy(std::borrow::Cow<'static, str>);
+    pub struct DiskRedundancy(i32);
 
     impl DiskRedundancy {
+        /// Unspecified.
+        pub const DISK_REDUNDANCY_UNSPECIFIED: DiskRedundancy = DiskRedundancy::new(0);
+
+        /// High -  3 way mirror.
+        pub const HIGH: DiskRedundancy = DiskRedundancy::new(1);
+
+        /// Normal - 2 way mirror.
+        pub const NORMAL: DiskRedundancy = DiskRedundancy::new(2);
+
         /// Creates a new DiskRedundancy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DISK_REDUNDANCY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("HIGH"),
+                2 => std::borrow::Cow::Borrowed("NORMAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DISK_REDUNDANCY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DISK_REDUNDANCY_UNSPECIFIED)
+                }
+                "HIGH" => std::option::Option::Some(Self::HIGH),
+                "NORMAL" => std::option::Option::Some(Self::NORMAL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DiskRedundancy](DiskRedundancy)
-    pub mod disk_redundancy {
-        use super::DiskRedundancy;
-
-        /// Unspecified.
-        pub const DISK_REDUNDANCY_UNSPECIFIED: DiskRedundancy =
-            DiskRedundancy::new("DISK_REDUNDANCY_UNSPECIFIED");
-
-        /// High -  3 way mirror.
-        pub const HIGH: DiskRedundancy = DiskRedundancy::new("HIGH");
-
-        /// Normal - 2 way mirror.
-        pub const NORMAL: DiskRedundancy = DiskRedundancy::new("NORMAL");
-    }
-
-    impl std::convert::From<std::string::String> for DiskRedundancy {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DiskRedundancy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DiskRedundancy {
         fn default() -> Self {
-            disk_redundancy::DISK_REDUNDANCY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The various lifecycle states of the VM cluster.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Default unspecified value.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Indicates that the resource is in provisioning state.
+        pub const PROVISIONING: State = State::new(1);
+
+        /// Indicates that the resource is in available state.
+        pub const AVAILABLE: State = State::new(2);
+
+        /// Indicates that the resource is in updating state.
+        pub const UPDATING: State = State::new(3);
+
+        /// Indicates that the resource is in terminating state.
+        pub const TERMINATING: State = State::new(4);
+
+        /// Indicates that the resource is in terminated state.
+        pub const TERMINATED: State = State::new(5);
+
+        /// Indicates that the resource is in failed state.
+        pub const FAILED: State = State::new(6);
+
+        /// Indicates that the resource is in maintenance in progress state.
+        pub const MAINTENANCE_IN_PROGRESS: State = State::new(7);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
+                2 => std::borrow::Cow::Borrowed("AVAILABLE"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("TERMINATING"),
+                5 => std::borrow::Cow::Borrowed("TERMINATED"),
+                6 => std::borrow::Cow::Borrowed("FAILED"),
+                7 => std::borrow::Cow::Borrowed("MAINTENANCE_IN_PROGRESS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
+                "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "TERMINATING" => std::option::Option::Some(Self::TERMINATING),
+                "TERMINATED" => std::option::Option::Some(Self::TERMINATED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "MAINTENANCE_IN_PROGRESS" => {
+                    std::option::Option::Some(Self::MAINTENANCE_IN_PROGRESS)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Default unspecified value.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Indicates that the resource is in provisioning state.
-        pub const PROVISIONING: State = State::new("PROVISIONING");
-
-        /// Indicates that the resource is in available state.
-        pub const AVAILABLE: State = State::new("AVAILABLE");
-
-        /// Indicates that the resource is in updating state.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// Indicates that the resource is in terminating state.
-        pub const TERMINATING: State = State::new("TERMINATING");
-
-        /// Indicates that the resource is in terminated state.
-        pub const TERMINATED: State = State::new("TERMINATED");
-
-        /// Indicates that the resource is in failed state.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// Indicates that the resource is in maintenance in progress state.
-        pub const MAINTENANCE_IN_PROGRESS: State = State::new("MAINTENANCE_IN_PROGRESS");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7238,249 +7778,362 @@ impl wkt::message::Message for DataCollectionOptions {
 
 /// The type of wallet generation.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct GenerateType(std::borrow::Cow<'static, str>);
+pub struct GenerateType(i32);
 
 impl GenerateType {
+    /// Default unspecified value.
+    pub const GENERATE_TYPE_UNSPECIFIED: GenerateType = GenerateType::new(0);
+
+    /// Used to generate wallet for all databases in the region.
+    pub const ALL: GenerateType = GenerateType::new(1);
+
+    /// Used to generate wallet for a single database.
+    pub const SINGLE: GenerateType = GenerateType::new(2);
+
     /// Creates a new GenerateType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("GENERATE_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ALL"),
+            2 => std::borrow::Cow::Borrowed("SINGLE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "GENERATE_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::GENERATE_TYPE_UNSPECIFIED)
+            }
+            "ALL" => std::option::Option::Some(Self::ALL),
+            "SINGLE" => std::option::Option::Some(Self::SINGLE),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [GenerateType](GenerateType)
-pub mod generate_type {
-    use super::GenerateType;
-
-    /// Default unspecified value.
-    pub const GENERATE_TYPE_UNSPECIFIED: GenerateType =
-        GenerateType::new("GENERATE_TYPE_UNSPECIFIED");
-
-    /// Used to generate wallet for all databases in the region.
-    pub const ALL: GenerateType = GenerateType::new("ALL");
-
-    /// Used to generate wallet for a single database.
-    pub const SINGLE: GenerateType = GenerateType::new("SINGLE");
-}
-
-impl std::convert::From<std::string::String> for GenerateType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for GenerateType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for GenerateType {
     fn default() -> Self {
-        generate_type::GENERATE_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The various lifecycle states of the Autonomous Database.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct State(std::borrow::Cow<'static, str>);
+pub struct State(i32);
 
 impl State {
-    /// Creates a new State instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [State](State)
-pub mod state {
-    use super::State;
-
     /// Default unspecified value.
-    pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+    pub const STATE_UNSPECIFIED: State = State::new(0);
 
     /// Indicates that the Autonomous Database is in provisioning state.
-    pub const PROVISIONING: State = State::new("PROVISIONING");
+    pub const PROVISIONING: State = State::new(1);
 
     /// Indicates that the Autonomous Database is in available state.
-    pub const AVAILABLE: State = State::new("AVAILABLE");
+    pub const AVAILABLE: State = State::new(2);
 
     /// Indicates that the Autonomous Database is in stopping state.
-    pub const STOPPING: State = State::new("STOPPING");
+    pub const STOPPING: State = State::new(3);
 
     /// Indicates that the Autonomous Database is in stopped state.
-    pub const STOPPED: State = State::new("STOPPED");
+    pub const STOPPED: State = State::new(4);
 
     /// Indicates that the Autonomous Database is in starting state.
-    pub const STARTING: State = State::new("STARTING");
+    pub const STARTING: State = State::new(5);
 
     /// Indicates that the Autonomous Database is in terminating state.
-    pub const TERMINATING: State = State::new("TERMINATING");
+    pub const TERMINATING: State = State::new(6);
 
     /// Indicates that the Autonomous Database is in terminated state.
-    pub const TERMINATED: State = State::new("TERMINATED");
+    pub const TERMINATED: State = State::new(7);
 
     /// Indicates that the Autonomous Database is in unavailable state.
-    pub const UNAVAILABLE: State = State::new("UNAVAILABLE");
+    pub const UNAVAILABLE: State = State::new(8);
 
     /// Indicates that the Autonomous Database restore is in progress.
-    pub const RESTORE_IN_PROGRESS: State = State::new("RESTORE_IN_PROGRESS");
+    pub const RESTORE_IN_PROGRESS: State = State::new(9);
 
     /// Indicates that the Autonomous Database failed to restore.
-    pub const RESTORE_FAILED: State = State::new("RESTORE_FAILED");
+    pub const RESTORE_FAILED: State = State::new(10);
 
     /// Indicates that the Autonomous Database backup is in progress.
-    pub const BACKUP_IN_PROGRESS: State = State::new("BACKUP_IN_PROGRESS");
+    pub const BACKUP_IN_PROGRESS: State = State::new(11);
 
     /// Indicates that the Autonomous Database scale is in progress.
-    pub const SCALE_IN_PROGRESS: State = State::new("SCALE_IN_PROGRESS");
+    pub const SCALE_IN_PROGRESS: State = State::new(12);
 
     /// Indicates that the Autonomous Database is available but needs attention
     /// state.
-    pub const AVAILABLE_NEEDS_ATTENTION: State = State::new("AVAILABLE_NEEDS_ATTENTION");
+    pub const AVAILABLE_NEEDS_ATTENTION: State = State::new(13);
 
     /// Indicates that the Autonomous Database is in updating state.
-    pub const UPDATING: State = State::new("UPDATING");
+    pub const UPDATING: State = State::new(14);
 
     /// Indicates that the Autonomous Database's maintenance is in progress state.
-    pub const MAINTENANCE_IN_PROGRESS: State = State::new("MAINTENANCE_IN_PROGRESS");
+    pub const MAINTENANCE_IN_PROGRESS: State = State::new(15);
 
     /// Indicates that the Autonomous Database is in restarting state.
-    pub const RESTARTING: State = State::new("RESTARTING");
+    pub const RESTARTING: State = State::new(16);
 
     /// Indicates that the Autonomous Database is in recreating state.
-    pub const RECREATING: State = State::new("RECREATING");
+    pub const RECREATING: State = State::new(17);
 
     /// Indicates that the Autonomous Database's role change is in progress state.
-    pub const ROLE_CHANGE_IN_PROGRESS: State = State::new("ROLE_CHANGE_IN_PROGRESS");
+    pub const ROLE_CHANGE_IN_PROGRESS: State = State::new(18);
 
     /// Indicates that the Autonomous Database is in upgrading state.
-    pub const UPGRADING: State = State::new("UPGRADING");
+    pub const UPGRADING: State = State::new(19);
 
     /// Indicates that the Autonomous Database is in inaccessible state.
-    pub const INACCESSIBLE: State = State::new("INACCESSIBLE");
+    pub const INACCESSIBLE: State = State::new(20);
 
     /// Indicates that the Autonomous Database is in standby state.
-    pub const STANDBY: State = State::new("STANDBY");
+    pub const STANDBY: State = State::new(21);
+
+    /// Creates a new State instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PROVISIONING"),
+            2 => std::borrow::Cow::Borrowed("AVAILABLE"),
+            3 => std::borrow::Cow::Borrowed("STOPPING"),
+            4 => std::borrow::Cow::Borrowed("STOPPED"),
+            5 => std::borrow::Cow::Borrowed("STARTING"),
+            6 => std::borrow::Cow::Borrowed("TERMINATING"),
+            7 => std::borrow::Cow::Borrowed("TERMINATED"),
+            8 => std::borrow::Cow::Borrowed("UNAVAILABLE"),
+            9 => std::borrow::Cow::Borrowed("RESTORE_IN_PROGRESS"),
+            10 => std::borrow::Cow::Borrowed("RESTORE_FAILED"),
+            11 => std::borrow::Cow::Borrowed("BACKUP_IN_PROGRESS"),
+            12 => std::borrow::Cow::Borrowed("SCALE_IN_PROGRESS"),
+            13 => std::borrow::Cow::Borrowed("AVAILABLE_NEEDS_ATTENTION"),
+            14 => std::borrow::Cow::Borrowed("UPDATING"),
+            15 => std::borrow::Cow::Borrowed("MAINTENANCE_IN_PROGRESS"),
+            16 => std::borrow::Cow::Borrowed("RESTARTING"),
+            17 => std::borrow::Cow::Borrowed("RECREATING"),
+            18 => std::borrow::Cow::Borrowed("ROLE_CHANGE_IN_PROGRESS"),
+            19 => std::borrow::Cow::Borrowed("UPGRADING"),
+            20 => std::borrow::Cow::Borrowed("INACCESSIBLE"),
+            21 => std::borrow::Cow::Borrowed("STANDBY"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+            "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
+            "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
+            "STOPPING" => std::option::Option::Some(Self::STOPPING),
+            "STOPPED" => std::option::Option::Some(Self::STOPPED),
+            "STARTING" => std::option::Option::Some(Self::STARTING),
+            "TERMINATING" => std::option::Option::Some(Self::TERMINATING),
+            "TERMINATED" => std::option::Option::Some(Self::TERMINATED),
+            "UNAVAILABLE" => std::option::Option::Some(Self::UNAVAILABLE),
+            "RESTORE_IN_PROGRESS" => std::option::Option::Some(Self::RESTORE_IN_PROGRESS),
+            "RESTORE_FAILED" => std::option::Option::Some(Self::RESTORE_FAILED),
+            "BACKUP_IN_PROGRESS" => std::option::Option::Some(Self::BACKUP_IN_PROGRESS),
+            "SCALE_IN_PROGRESS" => std::option::Option::Some(Self::SCALE_IN_PROGRESS),
+            "AVAILABLE_NEEDS_ATTENTION" => {
+                std::option::Option::Some(Self::AVAILABLE_NEEDS_ATTENTION)
+            }
+            "UPDATING" => std::option::Option::Some(Self::UPDATING),
+            "MAINTENANCE_IN_PROGRESS" => std::option::Option::Some(Self::MAINTENANCE_IN_PROGRESS),
+            "RESTARTING" => std::option::Option::Some(Self::RESTARTING),
+            "RECREATING" => std::option::Option::Some(Self::RECREATING),
+            "ROLE_CHANGE_IN_PROGRESS" => std::option::Option::Some(Self::ROLE_CHANGE_IN_PROGRESS),
+            "UPGRADING" => std::option::Option::Some(Self::UPGRADING),
+            "INACCESSIBLE" => std::option::Option::Some(Self::INACCESSIBLE),
+            "STANDBY" => std::option::Option::Some(Self::STANDBY),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for State {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for State {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for State {
     fn default() -> Self {
-        state::STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The state of the Operations Insights for this Autonomous Database.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OperationsInsightsState(std::borrow::Cow<'static, str>);
+pub struct OperationsInsightsState(i32);
 
 impl OperationsInsightsState {
+    /// Default unspecified value.
+    pub const OPERATIONS_INSIGHTS_STATE_UNSPECIFIED: OperationsInsightsState =
+        OperationsInsightsState::new(0);
+
+    /// Enabling status for operation insights.
+    pub const ENABLING: OperationsInsightsState = OperationsInsightsState::new(1);
+
+    /// Enabled status for operation insights.
+    pub const ENABLED: OperationsInsightsState = OperationsInsightsState::new(2);
+
+    /// Disabling status for operation insights.
+    pub const DISABLING: OperationsInsightsState = OperationsInsightsState::new(3);
+
+    /// Not Enabled status for operation insights.
+    pub const NOT_ENABLED: OperationsInsightsState = OperationsInsightsState::new(4);
+
+    /// Failed enabling status for operation insights.
+    pub const FAILED_ENABLING: OperationsInsightsState = OperationsInsightsState::new(5);
+
+    /// Failed disabling status for operation insights.
+    pub const FAILED_DISABLING: OperationsInsightsState = OperationsInsightsState::new(6);
+
     /// Creates a new OperationsInsightsState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("OPERATIONS_INSIGHTS_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ENABLING"),
+            2 => std::borrow::Cow::Borrowed("ENABLED"),
+            3 => std::borrow::Cow::Borrowed("DISABLING"),
+            4 => std::borrow::Cow::Borrowed("NOT_ENABLED"),
+            5 => std::borrow::Cow::Borrowed("FAILED_ENABLING"),
+            6 => std::borrow::Cow::Borrowed("FAILED_DISABLING"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "OPERATIONS_INSIGHTS_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::OPERATIONS_INSIGHTS_STATE_UNSPECIFIED)
+            }
+            "ENABLING" => std::option::Option::Some(Self::ENABLING),
+            "ENABLED" => std::option::Option::Some(Self::ENABLED),
+            "DISABLING" => std::option::Option::Some(Self::DISABLING),
+            "NOT_ENABLED" => std::option::Option::Some(Self::NOT_ENABLED),
+            "FAILED_ENABLING" => std::option::Option::Some(Self::FAILED_ENABLING),
+            "FAILED_DISABLING" => std::option::Option::Some(Self::FAILED_DISABLING),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [OperationsInsightsState](OperationsInsightsState)
-pub mod operations_insights_state {
-    use super::OperationsInsightsState;
-
-    /// Default unspecified value.
-    pub const OPERATIONS_INSIGHTS_STATE_UNSPECIFIED: OperationsInsightsState =
-        OperationsInsightsState::new("OPERATIONS_INSIGHTS_STATE_UNSPECIFIED");
-
-    /// Enabling status for operation insights.
-    pub const ENABLING: OperationsInsightsState = OperationsInsightsState::new("ENABLING");
-
-    /// Enabled status for operation insights.
-    pub const ENABLED: OperationsInsightsState = OperationsInsightsState::new("ENABLED");
-
-    /// Disabling status for operation insights.
-    pub const DISABLING: OperationsInsightsState = OperationsInsightsState::new("DISABLING");
-
-    /// Not Enabled status for operation insights.
-    pub const NOT_ENABLED: OperationsInsightsState = OperationsInsightsState::new("NOT_ENABLED");
-
-    /// Failed enabling status for operation insights.
-    pub const FAILED_ENABLING: OperationsInsightsState =
-        OperationsInsightsState::new("FAILED_ENABLING");
-
-    /// Failed disabling status for operation insights.
-    pub const FAILED_DISABLING: OperationsInsightsState =
-        OperationsInsightsState::new("FAILED_DISABLING");
-}
-
-impl std::convert::From<std::string::String> for OperationsInsightsState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for OperationsInsightsState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for OperationsInsightsState {
     fn default() -> Self {
-        operations_insights_state::OPERATIONS_INSIGHTS_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The various states available for the Autonomous Database workload type.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DBWorkload(std::borrow::Cow<'static, str>);
+pub struct DBWorkload(i32);
 
 impl DBWorkload {
-    /// Creates a new DBWorkload instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [DBWorkload](DBWorkload)
-pub mod db_workload {
-    use super::DBWorkload;
-
     /// Default unspecified value.
-    pub const DB_WORKLOAD_UNSPECIFIED: DBWorkload = DBWorkload::new("DB_WORKLOAD_UNSPECIFIED");
+    pub const DB_WORKLOAD_UNSPECIFIED: DBWorkload = DBWorkload::new(0);
 
     /// Autonomous Transaction Processing database.
-    pub const OLTP: DBWorkload = DBWorkload::new("OLTP");
+    pub const OLTP: DBWorkload = DBWorkload::new(1);
 
     /// Autonomous Data Warehouse database.
-    pub const DW: DBWorkload = DBWorkload::new("DW");
+    pub const DW: DBWorkload = DBWorkload::new(2);
 
     /// Autonomous JSON Database.
-    pub const AJD: DBWorkload = DBWorkload::new("AJD");
+    pub const AJD: DBWorkload = DBWorkload::new(3);
 
     /// Autonomous Database with the Oracle APEX Application Development workload
     /// type.
-    pub const APEX: DBWorkload = DBWorkload::new("APEX");
+    pub const APEX: DBWorkload = DBWorkload::new(4);
+
+    /// Creates a new DBWorkload instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DB_WORKLOAD_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("OLTP"),
+            2 => std::borrow::Cow::Borrowed("DW"),
+            3 => std::borrow::Cow::Borrowed("AJD"),
+            4 => std::borrow::Cow::Borrowed("APEX"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DB_WORKLOAD_UNSPECIFIED" => std::option::Option::Some(Self::DB_WORKLOAD_UNSPECIFIED),
+            "OLTP" => std::option::Option::Some(Self::OLTP),
+            "DW" => std::option::Option::Some(Self::DW),
+            "AJD" => std::option::Option::Some(Self::AJD),
+            "APEX" => std::option::Option::Some(Self::APEX),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for DBWorkload {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DBWorkload {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DBWorkload {
     fn default() -> Self {
-        db_workload::DB_WORKLOAD_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/oracledatabase/v1/src/transport.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
                 reqwest::Method::GET,
                 format!("/v1/{}/cloudExadataInfrastructures", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -73,7 +73,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -95,7 +95,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
                 reqwest::Method::POST,
                 format!("/v1/{}/cloudExadataInfrastructures", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -119,7 +119,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -143,7 +143,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
                 reqwest::Method::GET,
                 format!("/v1/{}/cloudVmClusters", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -165,7 +165,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -187,7 +187,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
                 reqwest::Method::POST,
                 format!("/v1/{}/cloudVmClusters", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -208,7 +208,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -232,7 +232,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
                 reqwest::Method::GET,
                 format!("/v1/{}/entitlements", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -256,7 +256,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
                 reqwest::Method::GET,
                 format!("/v1/{}/dbServers", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -277,7 +277,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/dbNodes", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -301,7 +301,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
                 reqwest::Method::GET,
                 format!("/v1/{}/giVersions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -325,7 +325,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
                 reqwest::Method::GET,
                 format!("/v1/{}/dbSystemShapes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -349,7 +349,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
                 reqwest::Method::GET,
                 format!("/v1/{}/autonomousDatabases", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -372,7 +372,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -394,7 +394,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
                 reqwest::Method::POST,
                 format!("/v1/{}/autonomousDatabases", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -415,7 +415,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -435,7 +435,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:restore", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -455,7 +455,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
                 reqwest::Method::POST,
                 format!("/v1/{}:generateWallet", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -475,7 +475,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
                 reqwest::Method::GET,
                 format!("/v1/{}/autonomousDbVersions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -499,7 +499,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
                 reqwest::Method::GET,
                 format!("/v1/{}/autonomousDatabaseCharacterSets", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -524,7 +524,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
                 reqwest::Method::GET,
                 format!("/v1/{}/autonomousDatabaseBackups", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -546,7 +546,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -568,7 +568,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -587,7 +587,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -609,7 +609,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -628,7 +628,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -647,7 +647,7 @@ impl crate::stubs::OracleDatabase for OracleDatabase {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/model.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/model.rs
@@ -1737,119 +1737,173 @@ pub mod list_workloads_response {
 
     /// Supported workload types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ComposerWorkloadType(std::borrow::Cow<'static, str>);
+    pub struct ComposerWorkloadType(i32);
 
     impl ComposerWorkloadType {
+        /// Not able to determine the type of the workload.
+        pub const COMPOSER_WORKLOAD_TYPE_UNSPECIFIED: ComposerWorkloadType =
+            ComposerWorkloadType::new(0);
+
+        /// Celery worker.
+        pub const CELERY_WORKER: ComposerWorkloadType = ComposerWorkloadType::new(1);
+
+        /// Kubernetes worker.
+        pub const KUBERNETES_WORKER: ComposerWorkloadType = ComposerWorkloadType::new(2);
+
+        /// Workload created by Kubernetes Pod Operator.
+        pub const KUBERNETES_OPERATOR_POD: ComposerWorkloadType = ComposerWorkloadType::new(3);
+
+        /// Airflow scheduler.
+        pub const SCHEDULER: ComposerWorkloadType = ComposerWorkloadType::new(4);
+
+        /// Airflow Dag processor.
+        pub const DAG_PROCESSOR: ComposerWorkloadType = ComposerWorkloadType::new(5);
+
+        /// Airflow triggerer.
+        pub const TRIGGERER: ComposerWorkloadType = ComposerWorkloadType::new(6);
+
+        /// Airflow web server UI.
+        pub const WEB_SERVER: ComposerWorkloadType = ComposerWorkloadType::new(7);
+
+        /// Redis.
+        pub const REDIS: ComposerWorkloadType = ComposerWorkloadType::new(8);
+
         /// Creates a new ComposerWorkloadType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COMPOSER_WORKLOAD_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CELERY_WORKER"),
+                2 => std::borrow::Cow::Borrowed("KUBERNETES_WORKER"),
+                3 => std::borrow::Cow::Borrowed("KUBERNETES_OPERATOR_POD"),
+                4 => std::borrow::Cow::Borrowed("SCHEDULER"),
+                5 => std::borrow::Cow::Borrowed("DAG_PROCESSOR"),
+                6 => std::borrow::Cow::Borrowed("TRIGGERER"),
+                7 => std::borrow::Cow::Borrowed("WEB_SERVER"),
+                8 => std::borrow::Cow::Borrowed("REDIS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COMPOSER_WORKLOAD_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::COMPOSER_WORKLOAD_TYPE_UNSPECIFIED)
+                }
+                "CELERY_WORKER" => std::option::Option::Some(Self::CELERY_WORKER),
+                "KUBERNETES_WORKER" => std::option::Option::Some(Self::KUBERNETES_WORKER),
+                "KUBERNETES_OPERATOR_POD" => {
+                    std::option::Option::Some(Self::KUBERNETES_OPERATOR_POD)
+                }
+                "SCHEDULER" => std::option::Option::Some(Self::SCHEDULER),
+                "DAG_PROCESSOR" => std::option::Option::Some(Self::DAG_PROCESSOR),
+                "TRIGGERER" => std::option::Option::Some(Self::TRIGGERER),
+                "WEB_SERVER" => std::option::Option::Some(Self::WEB_SERVER),
+                "REDIS" => std::option::Option::Some(Self::REDIS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ComposerWorkloadType](ComposerWorkloadType)
-    pub mod composer_workload_type {
-        use super::ComposerWorkloadType;
-
-        /// Not able to determine the type of the workload.
-        pub const COMPOSER_WORKLOAD_TYPE_UNSPECIFIED: ComposerWorkloadType =
-            ComposerWorkloadType::new("COMPOSER_WORKLOAD_TYPE_UNSPECIFIED");
-
-        /// Celery worker.
-        pub const CELERY_WORKER: ComposerWorkloadType = ComposerWorkloadType::new("CELERY_WORKER");
-
-        /// Kubernetes worker.
-        pub const KUBERNETES_WORKER: ComposerWorkloadType =
-            ComposerWorkloadType::new("KUBERNETES_WORKER");
-
-        /// Workload created by Kubernetes Pod Operator.
-        pub const KUBERNETES_OPERATOR_POD: ComposerWorkloadType =
-            ComposerWorkloadType::new("KUBERNETES_OPERATOR_POD");
-
-        /// Airflow scheduler.
-        pub const SCHEDULER: ComposerWorkloadType = ComposerWorkloadType::new("SCHEDULER");
-
-        /// Airflow Dag processor.
-        pub const DAG_PROCESSOR: ComposerWorkloadType = ComposerWorkloadType::new("DAG_PROCESSOR");
-
-        /// Airflow triggerer.
-        pub const TRIGGERER: ComposerWorkloadType = ComposerWorkloadType::new("TRIGGERER");
-
-        /// Airflow web server UI.
-        pub const WEB_SERVER: ComposerWorkloadType = ComposerWorkloadType::new("WEB_SERVER");
-
-        /// Redis.
-        pub const REDIS: ComposerWorkloadType = ComposerWorkloadType::new("REDIS");
-    }
-
-    impl std::convert::From<std::string::String> for ComposerWorkloadType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ComposerWorkloadType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ComposerWorkloadType {
         fn default() -> Self {
-            composer_workload_type::COMPOSER_WORKLOAD_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Workload states.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ComposerWorkloadState(std::borrow::Cow<'static, str>);
+    pub struct ComposerWorkloadState(i32);
 
     impl ComposerWorkloadState {
+        /// Not able to determine the status of the workload.
+        pub const COMPOSER_WORKLOAD_STATE_UNSPECIFIED: ComposerWorkloadState =
+            ComposerWorkloadState::new(0);
+
+        /// Workload is in pending state and has not yet started.
+        pub const PENDING: ComposerWorkloadState = ComposerWorkloadState::new(1);
+
+        /// Workload is running fine.
+        pub const OK: ComposerWorkloadState = ComposerWorkloadState::new(2);
+
+        /// Workload is running but there are some non-critical problems.
+        pub const WARNING: ComposerWorkloadState = ComposerWorkloadState::new(3);
+
+        /// Workload is not running due to an error.
+        pub const ERROR: ComposerWorkloadState = ComposerWorkloadState::new(4);
+
+        /// Workload has finished execution with success.
+        pub const SUCCEEDED: ComposerWorkloadState = ComposerWorkloadState::new(5);
+
+        /// Workload has finished execution with failure.
+        pub const FAILED: ComposerWorkloadState = ComposerWorkloadState::new(6);
+
         /// Creates a new ComposerWorkloadState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COMPOSER_WORKLOAD_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("OK"),
+                3 => std::borrow::Cow::Borrowed("WARNING"),
+                4 => std::borrow::Cow::Borrowed("ERROR"),
+                5 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                6 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COMPOSER_WORKLOAD_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::COMPOSER_WORKLOAD_STATE_UNSPECIFIED)
+                }
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "OK" => std::option::Option::Some(Self::OK),
+                "WARNING" => std::option::Option::Some(Self::WARNING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ComposerWorkloadState](ComposerWorkloadState)
-    pub mod composer_workload_state {
-        use super::ComposerWorkloadState;
-
-        /// Not able to determine the status of the workload.
-        pub const COMPOSER_WORKLOAD_STATE_UNSPECIFIED: ComposerWorkloadState =
-            ComposerWorkloadState::new("COMPOSER_WORKLOAD_STATE_UNSPECIFIED");
-
-        /// Workload is in pending state and has not yet started.
-        pub const PENDING: ComposerWorkloadState = ComposerWorkloadState::new("PENDING");
-
-        /// Workload is running fine.
-        pub const OK: ComposerWorkloadState = ComposerWorkloadState::new("OK");
-
-        /// Workload is running but there are some non-critical problems.
-        pub const WARNING: ComposerWorkloadState = ComposerWorkloadState::new("WARNING");
-
-        /// Workload is not running due to an error.
-        pub const ERROR: ComposerWorkloadState = ComposerWorkloadState::new("ERROR");
-
-        /// Workload has finished execution with success.
-        pub const SUCCEEDED: ComposerWorkloadState = ComposerWorkloadState::new("SUCCEEDED");
-
-        /// Workload has finished execution with failure.
-        pub const FAILED: ComposerWorkloadState = ComposerWorkloadState::new("FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for ComposerWorkloadState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ComposerWorkloadState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ComposerWorkloadState {
         fn default() -> Self {
-            composer_workload_state::COMPOSER_WORKLOAD_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2543,90 +2597,121 @@ pub mod environment_config {
 
     /// The size of the Cloud Composer environment.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EnvironmentSize(std::borrow::Cow<'static, str>);
+    pub struct EnvironmentSize(i32);
 
     impl EnvironmentSize {
+        /// The size of the environment is unspecified.
+        pub const ENVIRONMENT_SIZE_UNSPECIFIED: EnvironmentSize = EnvironmentSize::new(0);
+
+        /// The environment size is small.
+        pub const ENVIRONMENT_SIZE_SMALL: EnvironmentSize = EnvironmentSize::new(1);
+
+        /// The environment size is medium.
+        pub const ENVIRONMENT_SIZE_MEDIUM: EnvironmentSize = EnvironmentSize::new(2);
+
+        /// The environment size is large.
+        pub const ENVIRONMENT_SIZE_LARGE: EnvironmentSize = EnvironmentSize::new(3);
+
         /// Creates a new EnvironmentSize instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ENVIRONMENT_SIZE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENVIRONMENT_SIZE_SMALL"),
+                2 => std::borrow::Cow::Borrowed("ENVIRONMENT_SIZE_MEDIUM"),
+                3 => std::borrow::Cow::Borrowed("ENVIRONMENT_SIZE_LARGE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ENVIRONMENT_SIZE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ENVIRONMENT_SIZE_UNSPECIFIED)
+                }
+                "ENVIRONMENT_SIZE_SMALL" => std::option::Option::Some(Self::ENVIRONMENT_SIZE_SMALL),
+                "ENVIRONMENT_SIZE_MEDIUM" => {
+                    std::option::Option::Some(Self::ENVIRONMENT_SIZE_MEDIUM)
+                }
+                "ENVIRONMENT_SIZE_LARGE" => std::option::Option::Some(Self::ENVIRONMENT_SIZE_LARGE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [EnvironmentSize](EnvironmentSize)
-    pub mod environment_size {
-        use super::EnvironmentSize;
-
-        /// The size of the environment is unspecified.
-        pub const ENVIRONMENT_SIZE_UNSPECIFIED: EnvironmentSize =
-            EnvironmentSize::new("ENVIRONMENT_SIZE_UNSPECIFIED");
-
-        /// The environment size is small.
-        pub const ENVIRONMENT_SIZE_SMALL: EnvironmentSize =
-            EnvironmentSize::new("ENVIRONMENT_SIZE_SMALL");
-
-        /// The environment size is medium.
-        pub const ENVIRONMENT_SIZE_MEDIUM: EnvironmentSize =
-            EnvironmentSize::new("ENVIRONMENT_SIZE_MEDIUM");
-
-        /// The environment size is large.
-        pub const ENVIRONMENT_SIZE_LARGE: EnvironmentSize =
-            EnvironmentSize::new("ENVIRONMENT_SIZE_LARGE");
-    }
-
-    impl std::convert::From<std::string::String> for EnvironmentSize {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EnvironmentSize {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EnvironmentSize {
         fn default() -> Self {
-            environment_size::ENVIRONMENT_SIZE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Resilience mode of the Cloud Composer Environment.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ResilienceMode(std::borrow::Cow<'static, str>);
+    pub struct ResilienceMode(i32);
 
     impl ResilienceMode {
+        /// Default mode doesn't change environment parameters.
+        pub const RESILIENCE_MODE_UNSPECIFIED: ResilienceMode = ResilienceMode::new(0);
+
+        /// Enabled High Resilience mode, including Cloud SQL HA.
+        pub const HIGH_RESILIENCE: ResilienceMode = ResilienceMode::new(1);
+
         /// Creates a new ResilienceMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RESILIENCE_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("HIGH_RESILIENCE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RESILIENCE_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RESILIENCE_MODE_UNSPECIFIED)
+                }
+                "HIGH_RESILIENCE" => std::option::Option::Some(Self::HIGH_RESILIENCE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ResilienceMode](ResilienceMode)
-    pub mod resilience_mode {
-        use super::ResilienceMode;
-
-        /// Default mode doesn't change environment parameters.
-        pub const RESILIENCE_MODE_UNSPECIFIED: ResilienceMode =
-            ResilienceMode::new("RESILIENCE_MODE_UNSPECIFIED");
-
-        /// Enabled High Resilience mode, including Cloud SQL HA.
-        pub const HIGH_RESILIENCE: ResilienceMode = ResilienceMode::new("HIGH_RESILIENCE");
-    }
-
-    impl std::convert::From<std::string::String> for ResilienceMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ResilienceMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ResilienceMode {
         fn default() -> Self {
-            resilience_mode::RESILIENCE_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3122,46 +3207,61 @@ pub mod software_config {
 
     /// Web server plugins mode of the Cloud Composer environment.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct WebServerPluginsMode(std::borrow::Cow<'static, str>);
+    pub struct WebServerPluginsMode(i32);
 
     impl WebServerPluginsMode {
+        /// Default mode.
+        pub const WEB_SERVER_PLUGINS_MODE_UNSPECIFIED: WebServerPluginsMode =
+            WebServerPluginsMode::new(0);
+
+        /// Web server plugins are not supported.
+        pub const PLUGINS_DISABLED: WebServerPluginsMode = WebServerPluginsMode::new(1);
+
+        /// Web server plugins are supported.
+        pub const PLUGINS_ENABLED: WebServerPluginsMode = WebServerPluginsMode::new(2);
+
         /// Creates a new WebServerPluginsMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("WEB_SERVER_PLUGINS_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PLUGINS_DISABLED"),
+                2 => std::borrow::Cow::Borrowed("PLUGINS_ENABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "WEB_SERVER_PLUGINS_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::WEB_SERVER_PLUGINS_MODE_UNSPECIFIED)
+                }
+                "PLUGINS_DISABLED" => std::option::Option::Some(Self::PLUGINS_DISABLED),
+                "PLUGINS_ENABLED" => std::option::Option::Some(Self::PLUGINS_ENABLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [WebServerPluginsMode](WebServerPluginsMode)
-    pub mod web_server_plugins_mode {
-        use super::WebServerPluginsMode;
-
-        /// Default mode.
-        pub const WEB_SERVER_PLUGINS_MODE_UNSPECIFIED: WebServerPluginsMode =
-            WebServerPluginsMode::new("WEB_SERVER_PLUGINS_MODE_UNSPECIFIED");
-
-        /// Web server plugins are not supported.
-        pub const PLUGINS_DISABLED: WebServerPluginsMode =
-            WebServerPluginsMode::new("PLUGINS_DISABLED");
-
-        /// Web server plugins are supported.
-        pub const PLUGINS_ENABLED: WebServerPluginsMode =
-            WebServerPluginsMode::new("PLUGINS_ENABLED");
-    }
-
-    impl std::convert::From<std::string::String> for WebServerPluginsMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for WebServerPluginsMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for WebServerPluginsMode {
         fn default() -> Self {
-            web_server_plugins_mode::WEB_SERVER_PLUGINS_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3777,48 +3877,65 @@ pub mod networking_config {
     /// Project and the corresponding Tenant project, from a predefined list
     /// of available connection modes.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConnectionType(std::borrow::Cow<'static, str>);
+    pub struct ConnectionType(i32);
 
     impl ConnectionType {
-        /// Creates a new ConnectionType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ConnectionType](ConnectionType)
-    pub mod connection_type {
-        use super::ConnectionType;
-
         /// No specific connection type was requested, so the environment uses
         /// the default value corresponding to the rest of its configuration.
-        pub const CONNECTION_TYPE_UNSPECIFIED: ConnectionType =
-            ConnectionType::new("CONNECTION_TYPE_UNSPECIFIED");
+        pub const CONNECTION_TYPE_UNSPECIFIED: ConnectionType = ConnectionType::new(0);
 
         /// Requests the use of VPC peerings for connecting the Customer and Tenant
         /// projects.
-        pub const VPC_PEERING: ConnectionType = ConnectionType::new("VPC_PEERING");
+        pub const VPC_PEERING: ConnectionType = ConnectionType::new(1);
 
         /// Requests the use of Private Service Connect for connecting the Customer
         /// and Tenant projects.
-        pub const PRIVATE_SERVICE_CONNECT: ConnectionType =
-            ConnectionType::new("PRIVATE_SERVICE_CONNECT");
+        pub const PRIVATE_SERVICE_CONNECT: ConnectionType = ConnectionType::new(2);
+
+        /// Creates a new ConnectionType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CONNECTION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("VPC_PEERING"),
+                2 => std::borrow::Cow::Borrowed("PRIVATE_SERVICE_CONNECT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CONNECTION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CONNECTION_TYPE_UNSPECIFIED)
+                }
+                "VPC_PEERING" => std::option::Option::Some(Self::VPC_PEERING),
+                "PRIVATE_SERVICE_CONNECT" => {
+                    std::option::Option::Some(Self::PRIVATE_SERVICE_CONNECT)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ConnectionType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ConnectionType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ConnectionType {
         fn default() -> Self {
-            connection_type::CONNECTION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4794,53 +4911,74 @@ pub mod environment {
 
     /// State of the environment.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The state of the environment is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The environment is in the process of being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The environment is currently running and healthy. It is ready for use.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(2);
 
         /// The environment is being updated. It remains usable but cannot receive
         /// additional update requests or be deleted at this time.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(3);
 
         /// The environment is undergoing deletion. It cannot be used.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(4);
 
         /// The environment has encountered an error and cannot be used.
-        pub const ERROR: State = State::new("ERROR");
+        pub const ERROR: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5001,44 +5139,60 @@ pub mod check_upgrade_response {
 
     /// Whether there were python modules conflict during image build.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConflictResult(std::borrow::Cow<'static, str>);
+    pub struct ConflictResult(i32);
 
     impl ConflictResult {
+        /// It is unknown whether build had conflicts or not.
+        pub const CONFLICT_RESULT_UNSPECIFIED: ConflictResult = ConflictResult::new(0);
+
+        /// There were python packages conflicts.
+        pub const CONFLICT: ConflictResult = ConflictResult::new(1);
+
+        /// There were no python packages conflicts.
+        pub const NO_CONFLICT: ConflictResult = ConflictResult::new(2);
+
         /// Creates a new ConflictResult instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CONFLICT_RESULT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CONFLICT"),
+                2 => std::borrow::Cow::Borrowed("NO_CONFLICT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CONFLICT_RESULT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CONFLICT_RESULT_UNSPECIFIED)
+                }
+                "CONFLICT" => std::option::Option::Some(Self::CONFLICT),
+                "NO_CONFLICT" => std::option::Option::Some(Self::NO_CONFLICT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ConflictResult](ConflictResult)
-    pub mod conflict_result {
-        use super::ConflictResult;
-
-        /// It is unknown whether build had conflicts or not.
-        pub const CONFLICT_RESULT_UNSPECIFIED: ConflictResult =
-            ConflictResult::new("CONFLICT_RESULT_UNSPECIFIED");
-
-        /// There were python packages conflicts.
-        pub const CONFLICT: ConflictResult = ConflictResult::new("CONFLICT");
-
-        /// There were no python packages conflicts.
-        pub const NO_CONFLICT: ConflictResult = ConflictResult::new("NO_CONFLICT");
-    }
-
-    impl std::convert::From<std::string::String> for ConflictResult {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ConflictResult {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ConflictResult {
         fn default() -> Self {
-            conflict_result::CONFLICT_RESULT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5133,47 +5287,65 @@ pub mod task_logs_retention_config {
 
     /// The definition of task_logs_storage_mode.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TaskLogsStorageMode(std::borrow::Cow<'static, str>);
+    pub struct TaskLogsStorageMode(i32);
 
     impl TaskLogsStorageMode {
-        /// Creates a new TaskLogsStorageMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [TaskLogsStorageMode](TaskLogsStorageMode)
-    pub mod task_logs_storage_mode {
-        use super::TaskLogsStorageMode;
-
         /// This configuration is not specified by the user.
         pub const TASK_LOGS_STORAGE_MODE_UNSPECIFIED: TaskLogsStorageMode =
-            TaskLogsStorageMode::new("TASK_LOGS_STORAGE_MODE_UNSPECIFIED");
+            TaskLogsStorageMode::new(0);
 
         /// Store task logs in Cloud Logging and in the environment's Cloud Storage
         /// bucket.
         pub const CLOUD_LOGGING_AND_CLOUD_STORAGE: TaskLogsStorageMode =
-            TaskLogsStorageMode::new("CLOUD_LOGGING_AND_CLOUD_STORAGE");
+            TaskLogsStorageMode::new(1);
 
         /// Store task logs in Cloud Logging only.
-        pub const CLOUD_LOGGING_ONLY: TaskLogsStorageMode =
-            TaskLogsStorageMode::new("CLOUD_LOGGING_ONLY");
+        pub const CLOUD_LOGGING_ONLY: TaskLogsStorageMode = TaskLogsStorageMode::new(2);
+
+        /// Creates a new TaskLogsStorageMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TASK_LOGS_STORAGE_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CLOUD_LOGGING_AND_CLOUD_STORAGE"),
+                2 => std::borrow::Cow::Borrowed("CLOUD_LOGGING_ONLY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TASK_LOGS_STORAGE_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::TASK_LOGS_STORAGE_MODE_UNSPECIFIED)
+                }
+                "CLOUD_LOGGING_AND_CLOUD_STORAGE" => {
+                    std::option::Option::Some(Self::CLOUD_LOGGING_AND_CLOUD_STORAGE)
+                }
+                "CLOUD_LOGGING_ONLY" => std::option::Option::Some(Self::CLOUD_LOGGING_ONLY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for TaskLogsStorageMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TaskLogsStorageMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TaskLogsStorageMode {
         fn default() -> Self {
-            task_logs_storage_mode::TASK_LOGS_STORAGE_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5227,46 +5399,62 @@ pub mod airflow_metadata_retention_policy_config {
 
     /// Describes retention policy.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RetentionMode(std::borrow::Cow<'static, str>);
+    pub struct RetentionMode(i32);
 
     impl RetentionMode {
+        /// Default mode doesn't change environment parameters.
+        pub const RETENTION_MODE_UNSPECIFIED: RetentionMode = RetentionMode::new(0);
+
+        /// Retention policy is enabled.
+        pub const RETENTION_MODE_ENABLED: RetentionMode = RetentionMode::new(1);
+
+        /// Retention policy is disabled.
+        pub const RETENTION_MODE_DISABLED: RetentionMode = RetentionMode::new(2);
+
         /// Creates a new RetentionMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RETENTION_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RETENTION_MODE_ENABLED"),
+                2 => std::borrow::Cow::Borrowed("RETENTION_MODE_DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RETENTION_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RETENTION_MODE_UNSPECIFIED)
+                }
+                "RETENTION_MODE_ENABLED" => std::option::Option::Some(Self::RETENTION_MODE_ENABLED),
+                "RETENTION_MODE_DISABLED" => {
+                    std::option::Option::Some(Self::RETENTION_MODE_DISABLED)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RetentionMode](RetentionMode)
-    pub mod retention_mode {
-        use super::RetentionMode;
-
-        /// Default mode doesn't change environment parameters.
-        pub const RETENTION_MODE_UNSPECIFIED: RetentionMode =
-            RetentionMode::new("RETENTION_MODE_UNSPECIFIED");
-
-        /// Retention policy is enabled.
-        pub const RETENTION_MODE_ENABLED: RetentionMode =
-            RetentionMode::new("RETENTION_MODE_ENABLED");
-
-        /// Retention policy is disabled.
-        pub const RETENTION_MODE_DISABLED: RetentionMode =
-            RetentionMode::new("RETENTION_MODE_DISABLED");
-    }
-
-    impl std::convert::From<std::string::String> for RetentionMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RetentionMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RetentionMode {
         fn default() -> Self {
-            retention_mode::RETENTION_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5574,109 +5762,154 @@ pub mod operation_metadata {
 
     /// An enum describing the overall state of an operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unused.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The operation has been created but is not yet started.
+        pub const PENDING: State = State::new(1);
+
+        /// The operation is underway.
+        pub const RUNNING: State = State::new(2);
+
+        /// The operation completed successfully.
+        pub const SUCCEEDED: State = State::new(3);
+
+        pub const SUCCESSFUL: State = State::new(3);
+
+        /// The operation is no longer running but did not succeed.
+        pub const FAILED: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "SUCCESSFUL" => std::option::Option::Some(Self::SUCCESSFUL),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unused.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The operation has been created but is not yet started.
-        pub const PENDING: State = State::new("PENDING");
-
-        /// The operation is underway.
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// The operation completed successfully.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-        pub const SUCCESSFUL: State = State::new("SUCCESSFUL");
-
-        /// The operation is no longer running but did not succeed.
-        pub const FAILED: State = State::new("FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Type of longrunning operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// Unused.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// A resource creation operation.
-        pub const CREATE: Type = Type::new("CREATE");
+        pub const CREATE: Type = Type::new(1);
 
         /// A resource deletion operation.
-        pub const DELETE: Type = Type::new("DELETE");
+        pub const DELETE: Type = Type::new(2);
 
         /// A resource update operation.
-        pub const UPDATE: Type = Type::new("UPDATE");
+        pub const UPDATE: Type = Type::new(3);
 
         /// A resource check operation.
-        pub const CHECK: Type = Type::new("CHECK");
+        pub const CHECK: Type = Type::new(4);
 
         /// Saves snapshot of the resource operation.
-        pub const SAVE_SNAPSHOT: Type = Type::new("SAVE_SNAPSHOT");
+        pub const SAVE_SNAPSHOT: Type = Type::new(5);
 
         /// Loads snapshot of the resource operation.
-        pub const LOAD_SNAPSHOT: Type = Type::new("LOAD_SNAPSHOT");
+        pub const LOAD_SNAPSHOT: Type = Type::new(6);
 
         /// Triggers failover of environment's Cloud SQL instance (only for highly
         /// resilient environments).
-        pub const DATABASE_FAILOVER: Type = Type::new("DATABASE_FAILOVER");
+        pub const DATABASE_FAILOVER: Type = Type::new(7);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATE"),
+                2 => std::borrow::Cow::Borrowed("DELETE"),
+                3 => std::borrow::Cow::Borrowed("UPDATE"),
+                4 => std::borrow::Cow::Borrowed("CHECK"),
+                5 => std::borrow::Cow::Borrowed("SAVE_SNAPSHOT"),
+                6 => std::borrow::Cow::Borrowed("LOAD_SNAPSHOT"),
+                7 => std::borrow::Cow::Borrowed("DATABASE_FAILOVER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "CREATE" => std::option::Option::Some(Self::CREATE),
+                "DELETE" => std::option::Option::Some(Self::DELETE),
+                "UPDATE" => std::option::Option::Some(Self::UPDATE),
+                "CHECK" => std::option::Option::Some(Self::CHECK),
+                "SAVE_SNAPSHOT" => std::option::Option::Some(Self::SAVE_SNAPSHOT),
+                "LOAD_SNAPSHOT" => std::option::Option::Some(Self::LOAD_SNAPSHOT),
+                "DATABASE_FAILOVER" => std::option::Option::Some(Self::DATABASE_FAILOVER),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/transport.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::Environments for Environments {
                 reqwest::Method::POST,
                 format!("/v1/{}/environments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -71,7 +71,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -93,7 +93,7 @@ impl crate::stubs::Environments for Environments {
                 reqwest::Method::GET,
                 format!("/v1/{}/environments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -114,7 +114,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -143,7 +143,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -165,7 +165,7 @@ impl crate::stubs::Environments for Environments {
                 reqwest::Method::POST,
                 format!("/v1/{}:executeAirflowCommand", req.environment),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -185,7 +185,7 @@ impl crate::stubs::Environments for Environments {
                 reqwest::Method::POST,
                 format!("/v1/{}:stopAirflowCommand", req.environment),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -205,7 +205,7 @@ impl crate::stubs::Environments for Environments {
                 reqwest::Method::POST,
                 format!("/v1/{}:pollAirflowCommand", req.environment),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -225,7 +225,7 @@ impl crate::stubs::Environments for Environments {
                 reqwest::Method::GET,
                 format!("/v1/{}/workloads", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -250,7 +250,7 @@ impl crate::stubs::Environments for Environments {
                 reqwest::Method::POST,
                 format!("/v1/{}:checkUpgrade", req.environment),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -270,7 +270,7 @@ impl crate::stubs::Environments for Environments {
                 reqwest::Method::POST,
                 format!("/v1/{}/userWorkloadsSecrets", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -289,7 +289,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -311,7 +311,7 @@ impl crate::stubs::Environments for Environments {
                 reqwest::Method::GET,
                 format!("/v1/{}/userWorkloadsSecrets", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -341,7 +341,7 @@ impl crate::stubs::Environments for Environments {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -360,7 +360,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -382,7 +382,7 @@ impl crate::stubs::Environments for Environments {
                 reqwest::Method::POST,
                 format!("/v1/{}/userWorkloadsConfigMaps", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -401,7 +401,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -423,7 +423,7 @@ impl crate::stubs::Environments for Environments {
                 reqwest::Method::GET,
                 format!("/v1/{}/userWorkloadsConfigMaps", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -453,7 +453,7 @@ impl crate::stubs::Environments for Environments {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -472,7 +472,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -494,7 +494,7 @@ impl crate::stubs::Environments for Environments {
                 reqwest::Method::POST,
                 format!("/v1/{}:saveSnapshot", req.environment),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -514,7 +514,7 @@ impl crate::stubs::Environments for Environments {
                 reqwest::Method::POST,
                 format!("/v1/{}:loadSnapshot", req.environment),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -534,7 +534,7 @@ impl crate::stubs::Environments for Environments {
                 reqwest::Method::POST,
                 format!("/v1/{}:databaseFailover", req.environment),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -554,7 +554,7 @@ impl crate::stubs::Environments for Environments {
                 reqwest::Method::GET,
                 format!("/v1/{}:fetchDatabaseProperties", req.environment),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -573,7 +573,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -595,7 +595,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -614,7 +614,7 @@ impl crate::stubs::Environments for Environments {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -673,7 +673,7 @@ impl crate::stubs::ImageVersions for ImageVersions {
                 reqwest::Method::GET,
                 format!("/v1/{}/imageVersions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -695,7 +695,7 @@ impl crate::stubs::ImageVersions for ImageVersions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -717,7 +717,7 @@ impl crate::stubs::ImageVersions for ImageVersions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -736,7 +736,7 @@ impl crate::stubs::ImageVersions for ImageVersions {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/orgpolicy/v1/src/model.rs
+++ b/src/generated/cloud/orgpolicy/v1/src/model.rs
@@ -445,43 +445,60 @@ pub mod policy {
         /// must be unset. Setting this to `ALL_VALUES_UNSPECIFIED` allows for
         /// setting `allowed_values` and `denied_values`.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct AllValues(std::borrow::Cow<'static, str>);
+        pub struct AllValues(i32);
 
         impl AllValues {
+            /// Indicates that allowed_values or denied_values must be set.
+            pub const ALL_VALUES_UNSPECIFIED: AllValues = AllValues::new(0);
+
+            /// A policy with this set allows all values.
+            pub const ALLOW: AllValues = AllValues::new(1);
+
+            /// A policy with this set denies all values.
+            pub const DENY: AllValues = AllValues::new(2);
+
             /// Creates a new AllValues instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("ALL_VALUES_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("ALLOW"),
+                    2 => std::borrow::Cow::Borrowed("DENY"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "ALL_VALUES_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::ALL_VALUES_UNSPECIFIED)
+                    }
+                    "ALLOW" => std::option::Option::Some(Self::ALLOW),
+                    "DENY" => std::option::Option::Some(Self::DENY),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [AllValues](AllValues)
-        pub mod all_values {
-            use super::AllValues;
-
-            /// Indicates that allowed_values or denied_values must be set.
-            pub const ALL_VALUES_UNSPECIFIED: AllValues = AllValues::new("ALL_VALUES_UNSPECIFIED");
-
-            /// A policy with this set allows all values.
-            pub const ALLOW: AllValues = AllValues::new("ALLOW");
-
-            /// A policy with this set denies all values.
-            pub const DENY: AllValues = AllValues::new("DENY");
-        }
-
-        impl std::convert::From<std::string::String> for AllValues {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for AllValues {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for AllValues {
             fn default() -> Self {
-                all_values::ALL_VALUES_UNSPECIFIED
+                Self::new(0)
             }
         }
     }

--- a/src/generated/cloud/orgpolicy/v2/src/model.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/model.rs
@@ -284,47 +284,63 @@ pub mod constraint {
     ///
     /// Immutable after creation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConstraintDefault(std::borrow::Cow<'static, str>);
+    pub struct ConstraintDefault(i32);
 
     impl ConstraintDefault {
-        /// Creates a new ConstraintDefault instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ConstraintDefault](ConstraintDefault)
-    pub mod constraint_default {
-        use super::ConstraintDefault;
-
         /// This is only used for distinguishing unset values and should never be
         /// used.
-        pub const CONSTRAINT_DEFAULT_UNSPECIFIED: ConstraintDefault =
-            ConstraintDefault::new("CONSTRAINT_DEFAULT_UNSPECIFIED");
+        pub const CONSTRAINT_DEFAULT_UNSPECIFIED: ConstraintDefault = ConstraintDefault::new(0);
 
         /// Indicate that all values are allowed for list constraints.
         /// Indicate that enforcement is off for boolean constraints.
-        pub const ALLOW: ConstraintDefault = ConstraintDefault::new("ALLOW");
+        pub const ALLOW: ConstraintDefault = ConstraintDefault::new(1);
 
         /// Indicate that all values are denied for list constraints.
         /// Indicate that enforcement is on for boolean constraints.
-        pub const DENY: ConstraintDefault = ConstraintDefault::new("DENY");
+        pub const DENY: ConstraintDefault = ConstraintDefault::new(2);
+
+        /// Creates a new ConstraintDefault instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CONSTRAINT_DEFAULT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALLOW"),
+                2 => std::borrow::Cow::Borrowed("DENY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CONSTRAINT_DEFAULT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CONSTRAINT_DEFAULT_UNSPECIFIED)
+                }
+                "ALLOW" => std::option::Option::Some(Self::ALLOW),
+                "DENY" => std::option::Option::Some(Self::DENY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ConstraintDefault {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ConstraintDefault {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ConstraintDefault {
         fn default() -> Self {
-            constraint_default::CONSTRAINT_DEFAULT_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -493,95 +509,135 @@ pub mod custom_constraint {
     /// `UPDATE` only custom constraints are not supported. Use `CREATE` or
     /// `CREATE, UPDATE`.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MethodType(std::borrow::Cow<'static, str>);
+    pub struct MethodType(i32);
 
     impl MethodType {
-        /// Creates a new MethodType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [MethodType](MethodType)
-    pub mod method_type {
-        use super::MethodType;
-
         /// Unspecified. Results in an error.
-        pub const METHOD_TYPE_UNSPECIFIED: MethodType = MethodType::new("METHOD_TYPE_UNSPECIFIED");
+        pub const METHOD_TYPE_UNSPECIFIED: MethodType = MethodType::new(0);
 
         /// Constraint applied when creating the resource.
-        pub const CREATE: MethodType = MethodType::new("CREATE");
+        pub const CREATE: MethodType = MethodType::new(1);
 
         /// Constraint applied when updating the resource.
-        pub const UPDATE: MethodType = MethodType::new("UPDATE");
+        pub const UPDATE: MethodType = MethodType::new(2);
 
         /// Constraint applied when deleting the resource.
         /// Not supported yet.
-        pub const DELETE: MethodType = MethodType::new("DELETE");
+        pub const DELETE: MethodType = MethodType::new(3);
 
         /// Constraint applied when removing an IAM grant.
-        pub const REMOVE_GRANT: MethodType = MethodType::new("REMOVE_GRANT");
+        pub const REMOVE_GRANT: MethodType = MethodType::new(4);
 
         /// Constraint applied when enforcing forced tagging.
-        pub const GOVERN_TAGS: MethodType = MethodType::new("GOVERN_TAGS");
+        pub const GOVERN_TAGS: MethodType = MethodType::new(5);
+
+        /// Creates a new MethodType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("METHOD_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATE"),
+                2 => std::borrow::Cow::Borrowed("UPDATE"),
+                3 => std::borrow::Cow::Borrowed("DELETE"),
+                4 => std::borrow::Cow::Borrowed("REMOVE_GRANT"),
+                5 => std::borrow::Cow::Borrowed("GOVERN_TAGS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "METHOD_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::METHOD_TYPE_UNSPECIFIED)
+                }
+                "CREATE" => std::option::Option::Some(Self::CREATE),
+                "UPDATE" => std::option::Option::Some(Self::UPDATE),
+                "DELETE" => std::option::Option::Some(Self::DELETE),
+                "REMOVE_GRANT" => std::option::Option::Some(Self::REMOVE_GRANT),
+                "GOVERN_TAGS" => std::option::Option::Some(Self::GOVERN_TAGS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for MethodType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MethodType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MethodType {
         fn default() -> Self {
-            method_type::METHOD_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Allow or deny type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ActionType(std::borrow::Cow<'static, str>);
+    pub struct ActionType(i32);
 
     impl ActionType {
+        /// Unspecified. Results in an error.
+        pub const ACTION_TYPE_UNSPECIFIED: ActionType = ActionType::new(0);
+
+        /// Allowed action type.
+        pub const ALLOW: ActionType = ActionType::new(1);
+
+        /// Deny action type.
+        pub const DENY: ActionType = ActionType::new(2);
+
         /// Creates a new ActionType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ACTION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALLOW"),
+                2 => std::borrow::Cow::Borrowed("DENY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ACTION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ACTION_TYPE_UNSPECIFIED)
+                }
+                "ALLOW" => std::option::Option::Some(Self::ALLOW),
+                "DENY" => std::option::Option::Some(Self::DENY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ActionType](ActionType)
-    pub mod action_type {
-        use super::ActionType;
-
-        /// Unspecified. Results in an error.
-        pub const ACTION_TYPE_UNSPECIFIED: ActionType = ActionType::new("ACTION_TYPE_UNSPECIFIED");
-
-        /// Allowed action type.
-        pub const ALLOW: ActionType = ActionType::new("ALLOW");
-
-        /// Deny action type.
-        pub const DENY: ActionType = ActionType::new("DENY");
-    }
-
-    impl std::convert::From<std::string::String> for ActionType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ActionType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ActionType {
         fn default() -> Self {
-            action_type::ACTION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/orgpolicy/v2/src/transport.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::OrgPolicy for OrgPolicy {
                 reqwest::Method::GET,
                 format!("/v2/{}/constraints", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -73,7 +73,7 @@ impl crate::stubs::OrgPolicy for OrgPolicy {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/policies", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -94,7 +94,7 @@ impl crate::stubs::OrgPolicy for OrgPolicy {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -116,7 +116,7 @@ impl crate::stubs::OrgPolicy for OrgPolicy {
                 reqwest::Method::GET,
                 format!("/v2/{}:getEffectivePolicy", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -138,7 +138,7 @@ impl crate::stubs::OrgPolicy for OrgPolicy {
                 reqwest::Method::POST,
                 format!("/v2/{}/policies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -164,7 +164,7 @@ impl crate::stubs::OrgPolicy for OrgPolicy {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -191,7 +191,7 @@ impl crate::stubs::OrgPolicy for OrgPolicy {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -214,7 +214,7 @@ impl crate::stubs::OrgPolicy for OrgPolicy {
                 reqwest::Method::POST,
                 format!("/v2/{}/customConstraints", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -242,7 +242,7 @@ impl crate::stubs::OrgPolicy for OrgPolicy {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -261,7 +261,7 @@ impl crate::stubs::OrgPolicy for OrgPolicy {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -283,7 +283,7 @@ impl crate::stubs::OrgPolicy for OrgPolicy {
                 reqwest::Method::GET,
                 format!("/v2/{}/customConstraints", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -304,7 +304,7 @@ impl crate::stubs::OrgPolicy for OrgPolicy {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/osconfig/v1/src/model.rs
+++ b/src/generated/cloud/osconfig/v1/src/model.rs
@@ -406,84 +406,113 @@ pub mod inventory {
 
         /// The origin of a specific inventory item.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct OriginType(std::borrow::Cow<'static, str>);
+        pub struct OriginType(i32);
 
         impl OriginType {
-            /// Creates a new OriginType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [OriginType](OriginType)
-        pub mod origin_type {
-            use super::OriginType;
-
             /// Invalid. An origin type must be specified.
-            pub const ORIGIN_TYPE_UNSPECIFIED: OriginType =
-                OriginType::new("ORIGIN_TYPE_UNSPECIFIED");
+            pub const ORIGIN_TYPE_UNSPECIFIED: OriginType = OriginType::new(0);
 
             /// This inventory item was discovered as the result of the agent
             /// reporting inventory via the reporting API.
-            pub const INVENTORY_REPORT: OriginType = OriginType::new("INVENTORY_REPORT");
+            pub const INVENTORY_REPORT: OriginType = OriginType::new(1);
+
+            /// Creates a new OriginType instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("ORIGIN_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("INVENTORY_REPORT"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "ORIGIN_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::ORIGIN_TYPE_UNSPECIFIED)
+                    }
+                    "INVENTORY_REPORT" => std::option::Option::Some(Self::INVENTORY_REPORT),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for OriginType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for OriginType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for OriginType {
             fn default() -> Self {
-                origin_type::ORIGIN_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
 
         /// The different types of inventory that are tracked on a VM.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(std::borrow::Cow<'static, str>);
+        pub struct Type(i32);
 
         impl Type {
+            /// Invalid. An type must be specified.
+            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+            /// This represents a package that is installed on the VM.
+            pub const INSTALLED_PACKAGE: Type = Type::new(1);
+
+            /// This represents an update that is available for a package.
+            pub const AVAILABLE_PACKAGE: Type = Type::new(2);
+
             /// Creates a new Type instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("INSTALLED_PACKAGE"),
+                    2 => std::borrow::Cow::Borrowed("AVAILABLE_PACKAGE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                    "INSTALLED_PACKAGE" => std::option::Option::Some(Self::INSTALLED_PACKAGE),
+                    "AVAILABLE_PACKAGE" => std::option::Option::Some(Self::AVAILABLE_PACKAGE),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Type](Type)
-        pub mod r#type {
-            use super::Type;
-
-            /// Invalid. An type must be specified.
-            pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-            /// This represents a package that is installed on the VM.
-            pub const INSTALLED_PACKAGE: Type = Type::new("INSTALLED_PACKAGE");
-
-            /// This represents an update that is available for a package.
-            pub const AVAILABLE_PACKAGE: Type = Type::new("AVAILABLE_PACKAGE");
-        }
-
-        impl std::convert::From<std::string::String> for Type {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                r#type::TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -2729,45 +2758,61 @@ pub mod os_policy {
 
             /// The desired state that the OS Config agent maintains on the VM.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct DesiredState(std::borrow::Cow<'static, str>);
+            pub struct DesiredState(i32);
 
             impl DesiredState {
-                /// Creates a new DesiredState instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [DesiredState](DesiredState)
-            pub mod desired_state {
-                use super::DesiredState;
-
                 /// Unspecified is invalid.
-                pub const DESIRED_STATE_UNSPECIFIED: DesiredState =
-                    DesiredState::new("DESIRED_STATE_UNSPECIFIED");
+                pub const DESIRED_STATE_UNSPECIFIED: DesiredState = DesiredState::new(0);
 
                 /// Ensure that the package is installed.
-                pub const INSTALLED: DesiredState = DesiredState::new("INSTALLED");
+                pub const INSTALLED: DesiredState = DesiredState::new(1);
 
                 /// The agent ensures that the package is not installed and
                 /// uninstalls it if detected.
-                pub const REMOVED: DesiredState = DesiredState::new("REMOVED");
+                pub const REMOVED: DesiredState = DesiredState::new(2);
+
+                /// Creates a new DesiredState instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("DESIRED_STATE_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("INSTALLED"),
+                        2 => std::borrow::Cow::Borrowed("REMOVED"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "DESIRED_STATE_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::DESIRED_STATE_UNSPECIFIED)
+                        }
+                        "INSTALLED" => std::option::Option::Some(Self::INSTALLED),
+                        "REMOVED" => std::option::Option::Some(Self::REMOVED),
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for DesiredState {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for DesiredState {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for DesiredState {
                 fn default() -> Self {
-                    desired_state::DESIRED_STATE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
 
@@ -3101,44 +3146,60 @@ pub mod os_policy {
 
                 /// Type of archive.
                 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                pub struct ArchiveType(std::borrow::Cow<'static, str>);
+                pub struct ArchiveType(i32);
 
                 impl ArchiveType {
+                    /// Unspecified is invalid.
+                    pub const ARCHIVE_TYPE_UNSPECIFIED: ArchiveType = ArchiveType::new(0);
+
+                    /// Deb indicates that the archive contains binary files.
+                    pub const DEB: ArchiveType = ArchiveType::new(1);
+
+                    /// Deb-src indicates that the archive contains source files.
+                    pub const DEB_SRC: ArchiveType = ArchiveType::new(2);
+
                     /// Creates a new ArchiveType instance.
-                    pub const fn new(v: &'static str) -> Self {
-                        Self(std::borrow::Cow::Borrowed(v))
+                    pub(crate) const fn new(value: i32) -> Self {
+                        Self(value)
                     }
 
                     /// Gets the enum value.
-                    pub fn value(&self) -> &str {
-                        &self.0
+                    pub fn value(&self) -> i32 {
+                        self.0
+                    }
+
+                    /// Gets the enum value as a string.
+                    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                        match self.0 {
+                            0 => std::borrow::Cow::Borrowed("ARCHIVE_TYPE_UNSPECIFIED"),
+                            1 => std::borrow::Cow::Borrowed("DEB"),
+                            2 => std::borrow::Cow::Borrowed("DEB_SRC"),
+                            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                        }
+                    }
+
+                    /// Creates an enum value from the value name.
+                    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                        match name {
+                            "ARCHIVE_TYPE_UNSPECIFIED" => {
+                                std::option::Option::Some(Self::ARCHIVE_TYPE_UNSPECIFIED)
+                            }
+                            "DEB" => std::option::Option::Some(Self::DEB),
+                            "DEB_SRC" => std::option::Option::Some(Self::DEB_SRC),
+                            _ => std::option::Option::None,
+                        }
                     }
                 }
 
-                /// Useful constants to work with [ArchiveType](ArchiveType)
-                pub mod archive_type {
-                    use super::ArchiveType;
-
-                    /// Unspecified is invalid.
-                    pub const ARCHIVE_TYPE_UNSPECIFIED: ArchiveType =
-                        ArchiveType::new("ARCHIVE_TYPE_UNSPECIFIED");
-
-                    /// Deb indicates that the archive contains binary files.
-                    pub const DEB: ArchiveType = ArchiveType::new("DEB");
-
-                    /// Deb-src indicates that the archive contains source files.
-                    pub const DEB_SRC: ArchiveType = ArchiveType::new("DEB_SRC");
-                }
-
-                impl std::convert::From<std::string::String> for ArchiveType {
-                    fn from(value: std::string::String) -> Self {
-                        Self(std::borrow::Cow::Owned(value))
+                impl std::convert::From<i32> for ArchiveType {
+                    fn from(value: i32) -> Self {
+                        Self::new(value)
                     }
                 }
 
                 impl std::default::Default for ArchiveType {
                     fn default() -> Self {
-                        archive_type::ARCHIVE_TYPE_UNSPECIFIED
+                        Self::new(0)
                     }
                 }
             }
@@ -3621,52 +3682,70 @@ pub mod os_policy {
 
                 /// The interpreter to use.
                 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                pub struct Interpreter(std::borrow::Cow<'static, str>);
+                pub struct Interpreter(i32);
 
                 impl Interpreter {
-                    /// Creates a new Interpreter instance.
-                    pub const fn new(v: &'static str) -> Self {
-                        Self(std::borrow::Cow::Borrowed(v))
-                    }
-
-                    /// Gets the enum value.
-                    pub fn value(&self) -> &str {
-                        &self.0
-                    }
-                }
-
-                /// Useful constants to work with [Interpreter](Interpreter)
-                pub mod interpreter {
-                    use super::Interpreter;
-
                     /// Invalid value, the request will return validation error.
-                    pub const INTERPRETER_UNSPECIFIED: Interpreter =
-                        Interpreter::new("INTERPRETER_UNSPECIFIED");
+                    pub const INTERPRETER_UNSPECIFIED: Interpreter = Interpreter::new(0);
 
                     /// If an interpreter is not specified, the
                     /// source is executed directly. This execution, without an
                     /// interpreter, only succeeds for executables and scripts that have <a
                     /// href="https://en.wikipedia.org/wiki/Shebang_(Unix)"
                     /// class="external"\>shebang lines</a>.
-                    pub const NONE: Interpreter = Interpreter::new("NONE");
+                    pub const NONE: Interpreter = Interpreter::new(1);
 
                     /// Indicates that the script runs with `/bin/sh` on Linux and
                     /// `cmd.exe` on Windows.
-                    pub const SHELL: Interpreter = Interpreter::new("SHELL");
+                    pub const SHELL: Interpreter = Interpreter::new(2);
 
                     /// Indicates that the script runs with PowerShell.
-                    pub const POWERSHELL: Interpreter = Interpreter::new("POWERSHELL");
+                    pub const POWERSHELL: Interpreter = Interpreter::new(3);
+
+                    /// Creates a new Interpreter instance.
+                    pub(crate) const fn new(value: i32) -> Self {
+                        Self(value)
+                    }
+
+                    /// Gets the enum value.
+                    pub fn value(&self) -> i32 {
+                        self.0
+                    }
+
+                    /// Gets the enum value as a string.
+                    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                        match self.0 {
+                            0 => std::borrow::Cow::Borrowed("INTERPRETER_UNSPECIFIED"),
+                            1 => std::borrow::Cow::Borrowed("NONE"),
+                            2 => std::borrow::Cow::Borrowed("SHELL"),
+                            3 => std::borrow::Cow::Borrowed("POWERSHELL"),
+                            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                        }
+                    }
+
+                    /// Creates an enum value from the value name.
+                    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                        match name {
+                            "INTERPRETER_UNSPECIFIED" => {
+                                std::option::Option::Some(Self::INTERPRETER_UNSPECIFIED)
+                            }
+                            "NONE" => std::option::Option::Some(Self::NONE),
+                            "SHELL" => std::option::Option::Some(Self::SHELL),
+                            "POWERSHELL" => std::option::Option::Some(Self::POWERSHELL),
+                            _ => std::option::Option::None,
+                        }
+                    }
                 }
 
-                impl std::convert::From<std::string::String> for Interpreter {
-                    fn from(value: std::string::String) -> Self {
-                        Self(std::borrow::Cow::Owned(value))
+                impl std::convert::From<i32> for Interpreter {
+                    fn from(value: i32) -> Self {
+                        Self::new(value)
                     }
                 }
 
                 impl std::default::Default for Interpreter {
                     fn default() -> Self {
-                        interpreter::INTERPRETER_UNSPECIFIED
+                        Self::new(0)
                     }
                 }
 
@@ -3835,48 +3914,66 @@ pub mod os_policy {
 
             /// Desired state of the file.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct DesiredState(std::borrow::Cow<'static, str>);
+            pub struct DesiredState(i32);
 
             impl DesiredState {
-                /// Creates a new DesiredState instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [DesiredState](DesiredState)
-            pub mod desired_state {
-                use super::DesiredState;
-
                 /// Unspecified is invalid.
-                pub const DESIRED_STATE_UNSPECIFIED: DesiredState =
-                    DesiredState::new("DESIRED_STATE_UNSPECIFIED");
+                pub const DESIRED_STATE_UNSPECIFIED: DesiredState = DesiredState::new(0);
 
                 /// Ensure file at path is present.
-                pub const PRESENT: DesiredState = DesiredState::new("PRESENT");
+                pub const PRESENT: DesiredState = DesiredState::new(1);
 
                 /// Ensure file at path is absent.
-                pub const ABSENT: DesiredState = DesiredState::new("ABSENT");
+                pub const ABSENT: DesiredState = DesiredState::new(2);
 
                 /// Ensure the contents of the file at path matches. If the file does
                 /// not exist it will be created.
-                pub const CONTENTS_MATCH: DesiredState = DesiredState::new("CONTENTS_MATCH");
+                pub const CONTENTS_MATCH: DesiredState = DesiredState::new(3);
+
+                /// Creates a new DesiredState instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("DESIRED_STATE_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("PRESENT"),
+                        2 => std::borrow::Cow::Borrowed("ABSENT"),
+                        3 => std::borrow::Cow::Borrowed("CONTENTS_MATCH"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "DESIRED_STATE_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::DESIRED_STATE_UNSPECIFIED)
+                        }
+                        "PRESENT" => std::option::Option::Some(Self::PRESENT),
+                        "ABSENT" => std::option::Option::Some(Self::ABSENT),
+                        "CONTENTS_MATCH" => std::option::Option::Some(Self::CONTENTS_MATCH),
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for DesiredState {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for DesiredState {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for DesiredState {
                 fn default() -> Self {
-                    desired_state::DESIRED_STATE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
 
@@ -3980,46 +4077,61 @@ pub mod os_policy {
 
     /// Policy mode
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(std::borrow::Cow<'static, str>);
+    pub struct Mode(i32);
 
     impl Mode {
-        /// Creates a new Mode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Mode](Mode)
-    pub mod mode {
-        use super::Mode;
-
         /// Invalid mode
-        pub const MODE_UNSPECIFIED: Mode = Mode::new("MODE_UNSPECIFIED");
+        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
 
         /// This mode checks if the configuration resources in the policy are in
         /// their desired state. No actions are performed if they are not in the
         /// desired state. This mode is used for reporting purposes.
-        pub const VALIDATION: Mode = Mode::new("VALIDATION");
+        pub const VALIDATION: Mode = Mode::new(1);
 
         /// This mode checks if the configuration resources in the policy are in
         /// their desired state, and if not, enforces the desired state.
-        pub const ENFORCEMENT: Mode = Mode::new("ENFORCEMENT");
+        pub const ENFORCEMENT: Mode = Mode::new(2);
+
+        /// Creates a new Mode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("VALIDATION"),
+                2 => std::borrow::Cow::Borrowed("ENFORCEMENT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
+                "VALIDATION" => std::option::Option::Some(Self::VALIDATION),
+                "ENFORCEMENT" => std::option::Option::Some(Self::ENFORCEMENT),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Mode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            mode::MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4589,37 +4701,21 @@ pub mod os_policy_assignment_report {
 
                 /// Supported configuration step types
                 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                pub struct Type(std::borrow::Cow<'static, str>);
+                pub struct Type(i32);
 
                 impl Type {
-                    /// Creates a new Type instance.
-                    pub const fn new(v: &'static str) -> Self {
-                        Self(std::borrow::Cow::Borrowed(v))
-                    }
-
-                    /// Gets the enum value.
-                    pub fn value(&self) -> &str {
-                        &self.0
-                    }
-                }
-
-                /// Useful constants to work with [Type](Type)
-                pub mod r#type {
-                    use super::Type;
-
                     /// Default value. This value is unused.
-                    pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+                    pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
                     /// Checks for resource conflicts such as schema errors.
-                    pub const VALIDATION: Type = Type::new("VALIDATION");
+                    pub const VALIDATION: Type = Type::new(1);
 
                     /// Checks the current status of the desired state for a resource.
-                    pub const DESIRED_STATE_CHECK: Type = Type::new("DESIRED_STATE_CHECK");
+                    pub const DESIRED_STATE_CHECK: Type = Type::new(2);
 
                     /// Enforces the desired state for a resource that is not in desired
                     /// state.
-                    pub const DESIRED_STATE_ENFORCEMENT: Type =
-                        Type::new("DESIRED_STATE_ENFORCEMENT");
+                    pub const DESIRED_STATE_ENFORCEMENT: Type = Type::new(3);
 
                     /// Re-checks the status of the desired state. This check is done
                     /// for a resource after the enforcement of all OS policies.
@@ -4628,19 +4724,58 @@ pub mod os_policy_assignment_report {
                     /// the resource. It accounts for any resources that might have drifted
                     /// from their desired state due to side effects from executing other
                     /// resources.
-                    pub const DESIRED_STATE_CHECK_POST_ENFORCEMENT: Type =
-                        Type::new("DESIRED_STATE_CHECK_POST_ENFORCEMENT");
+                    pub const DESIRED_STATE_CHECK_POST_ENFORCEMENT: Type = Type::new(4);
+
+                    /// Creates a new Type instance.
+                    pub(crate) const fn new(value: i32) -> Self {
+                        Self(value)
+                    }
+
+                    /// Gets the enum value.
+                    pub fn value(&self) -> i32 {
+                        self.0
+                    }
+
+                    /// Gets the enum value as a string.
+                    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                        match self.0 {
+                            0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                            1 => std::borrow::Cow::Borrowed("VALIDATION"),
+                            2 => std::borrow::Cow::Borrowed("DESIRED_STATE_CHECK"),
+                            3 => std::borrow::Cow::Borrowed("DESIRED_STATE_ENFORCEMENT"),
+                            4 => std::borrow::Cow::Borrowed("DESIRED_STATE_CHECK_POST_ENFORCEMENT"),
+                            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                        }
+                    }
+
+                    /// Creates an enum value from the value name.
+                    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                        match name {
+                            "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                            "VALIDATION" => std::option::Option::Some(Self::VALIDATION),
+                            "DESIRED_STATE_CHECK" => {
+                                std::option::Option::Some(Self::DESIRED_STATE_CHECK)
+                            }
+                            "DESIRED_STATE_ENFORCEMENT" => {
+                                std::option::Option::Some(Self::DESIRED_STATE_ENFORCEMENT)
+                            }
+                            "DESIRED_STATE_CHECK_POST_ENFORCEMENT" => std::option::Option::Some(
+                                Self::DESIRED_STATE_CHECK_POST_ENFORCEMENT,
+                            ),
+                            _ => std::option::Option::None,
+                        }
+                    }
                 }
 
-                impl std::convert::From<std::string::String> for Type {
-                    fn from(value: std::string::String) -> Self {
-                        Self(std::borrow::Cow::Owned(value))
+                impl std::convert::From<i32> for Type {
+                    fn from(value: i32) -> Self {
+                        Self::new(value)
                     }
                 }
 
                 impl std::default::Default for Type {
                     fn default() -> Self {
-                        r#type::TYPE_UNSPECIFIED
+                        Self::new(0)
                     }
                 }
             }
@@ -4681,46 +4816,61 @@ pub mod os_policy_assignment_report {
 
             /// Possible compliance states for a resource.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct ComplianceState(std::borrow::Cow<'static, str>);
+            pub struct ComplianceState(i32);
 
             impl ComplianceState {
-                /// Creates a new ComplianceState instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [ComplianceState](ComplianceState)
-            pub mod compliance_state {
-                use super::ComplianceState;
-
                 /// The resource is in an unknown compliance state.
                 ///
                 /// To get more details about why the policy is in this state, review
                 /// the output of the `compliance_state_reason` field.
-                pub const UNKNOWN: ComplianceState = ComplianceState::new("UNKNOWN");
+                pub const UNKNOWN: ComplianceState = ComplianceState::new(0);
 
                 /// Resource is compliant.
-                pub const COMPLIANT: ComplianceState = ComplianceState::new("COMPLIANT");
+                pub const COMPLIANT: ComplianceState = ComplianceState::new(1);
 
                 /// Resource is non-compliant.
-                pub const NON_COMPLIANT: ComplianceState = ComplianceState::new("NON_COMPLIANT");
+                pub const NON_COMPLIANT: ComplianceState = ComplianceState::new(2);
+
+                /// Creates a new ComplianceState instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                        1 => std::borrow::Cow::Borrowed("COMPLIANT"),
+                        2 => std::borrow::Cow::Borrowed("NON_COMPLIANT"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                        "COMPLIANT" => std::option::Option::Some(Self::COMPLIANT),
+                        "NON_COMPLIANT" => std::option::Option::Some(Self::NON_COMPLIANT),
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for ComplianceState {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for ComplianceState {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for ComplianceState {
                 fn default() -> Self {
-                    compliance_state::UNKNOWN
+                    Self::new(0)
                 }
             }
 
@@ -4736,52 +4886,67 @@ pub mod os_policy_assignment_report {
 
         /// Possible compliance states for an os policy.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ComplianceState(std::borrow::Cow<'static, str>);
+        pub struct ComplianceState(i32);
 
         impl ComplianceState {
-            /// Creates a new ComplianceState instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [ComplianceState](ComplianceState)
-        pub mod compliance_state {
-            use super::ComplianceState;
-
             /// The policy is in an unknown compliance state.
             ///
             /// Refer to the field `compliance_state_reason` to learn the exact reason
             /// for the policy to be in this compliance state.
-            pub const UNKNOWN: ComplianceState = ComplianceState::new("UNKNOWN");
+            pub const UNKNOWN: ComplianceState = ComplianceState::new(0);
 
             /// Policy is compliant.
             ///
             /// The policy is compliant if all the underlying resources are also
             /// compliant.
-            pub const COMPLIANT: ComplianceState = ComplianceState::new("COMPLIANT");
+            pub const COMPLIANT: ComplianceState = ComplianceState::new(1);
 
             /// Policy is non-compliant.
             ///
             /// The policy is non-compliant if one or more underlying resources are
             /// non-compliant.
-            pub const NON_COMPLIANT: ComplianceState = ComplianceState::new("NON_COMPLIANT");
+            pub const NON_COMPLIANT: ComplianceState = ComplianceState::new(2);
+
+            /// Creates a new ComplianceState instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                    1 => std::borrow::Cow::Borrowed("COMPLIANT"),
+                    2 => std::borrow::Cow::Borrowed("NON_COMPLIANT"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                    "COMPLIANT" => std::option::Option::Some(Self::COMPLIANT),
+                    "NON_COMPLIANT" => std::option::Option::Some(Self::NON_COMPLIANT),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for ComplianceState {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for ComplianceState {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for ComplianceState {
             fn default() -> Self {
-                compliance_state::UNKNOWN
+                Self::new(0)
             }
         }
     }
@@ -5241,50 +5406,70 @@ pub mod os_policy_assignment {
 
     /// OS policy assignment rollout state
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RolloutState(std::borrow::Cow<'static, str>);
+    pub struct RolloutState(i32);
 
     impl RolloutState {
+        /// Invalid value
+        pub const ROLLOUT_STATE_UNSPECIFIED: RolloutState = RolloutState::new(0);
+
+        /// The rollout is in progress.
+        pub const IN_PROGRESS: RolloutState = RolloutState::new(1);
+
+        /// The rollout is being cancelled.
+        pub const CANCELLING: RolloutState = RolloutState::new(2);
+
+        /// The rollout is cancelled.
+        pub const CANCELLED: RolloutState = RolloutState::new(3);
+
+        /// The rollout has completed successfully.
+        pub const SUCCEEDED: RolloutState = RolloutState::new(4);
+
         /// Creates a new RolloutState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ROLLOUT_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                2 => std::borrow::Cow::Borrowed("CANCELLING"),
+                3 => std::borrow::Cow::Borrowed("CANCELLED"),
+                4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ROLLOUT_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ROLLOUT_STATE_UNSPECIFIED)
+                }
+                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RolloutState](RolloutState)
-    pub mod rollout_state {
-        use super::RolloutState;
-
-        /// Invalid value
-        pub const ROLLOUT_STATE_UNSPECIFIED: RolloutState =
-            RolloutState::new("ROLLOUT_STATE_UNSPECIFIED");
-
-        /// The rollout is in progress.
-        pub const IN_PROGRESS: RolloutState = RolloutState::new("IN_PROGRESS");
-
-        /// The rollout is being cancelled.
-        pub const CANCELLING: RolloutState = RolloutState::new("CANCELLING");
-
-        /// The rollout is cancelled.
-        pub const CANCELLED: RolloutState = RolloutState::new("CANCELLED");
-
-        /// The rollout has completed successfully.
-        pub const SUCCEEDED: RolloutState = RolloutState::new("SUCCEEDED");
-    }
-
-    impl std::convert::From<std::string::String> for RolloutState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RolloutState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RolloutState {
         fn default() -> Self {
-            rollout_state::ROLLOUT_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5386,95 +5571,132 @@ pub mod os_policy_assignment_operation_metadata {
 
     /// The OS policy assignment API method.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct APIMethod(std::borrow::Cow<'static, str>);
+    pub struct APIMethod(i32);
 
     impl APIMethod {
+        /// Invalid value
+        pub const API_METHOD_UNSPECIFIED: APIMethod = APIMethod::new(0);
+
+        /// Create OS policy assignment API method
+        pub const CREATE: APIMethod = APIMethod::new(1);
+
+        /// Update OS policy assignment API method
+        pub const UPDATE: APIMethod = APIMethod::new(2);
+
+        /// Delete OS policy assignment API method
+        pub const DELETE: APIMethod = APIMethod::new(3);
+
         /// Creates a new APIMethod instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("API_METHOD_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATE"),
+                2 => std::borrow::Cow::Borrowed("UPDATE"),
+                3 => std::borrow::Cow::Borrowed("DELETE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "API_METHOD_UNSPECIFIED" => std::option::Option::Some(Self::API_METHOD_UNSPECIFIED),
+                "CREATE" => std::option::Option::Some(Self::CREATE),
+                "UPDATE" => std::option::Option::Some(Self::UPDATE),
+                "DELETE" => std::option::Option::Some(Self::DELETE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [APIMethod](APIMethod)
-    pub mod api_method {
-        use super::APIMethod;
-
-        /// Invalid value
-        pub const API_METHOD_UNSPECIFIED: APIMethod = APIMethod::new("API_METHOD_UNSPECIFIED");
-
-        /// Create OS policy assignment API method
-        pub const CREATE: APIMethod = APIMethod::new("CREATE");
-
-        /// Update OS policy assignment API method
-        pub const UPDATE: APIMethod = APIMethod::new("UPDATE");
-
-        /// Delete OS policy assignment API method
-        pub const DELETE: APIMethod = APIMethod::new("DELETE");
-    }
-
-    impl std::convert::From<std::string::String> for APIMethod {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for APIMethod {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for APIMethod {
         fn default() -> Self {
-            api_method::API_METHOD_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// State of the rollout
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RolloutState(std::borrow::Cow<'static, str>);
+    pub struct RolloutState(i32);
 
     impl RolloutState {
+        /// Invalid value
+        pub const ROLLOUT_STATE_UNSPECIFIED: RolloutState = RolloutState::new(0);
+
+        /// The rollout is in progress.
+        pub const IN_PROGRESS: RolloutState = RolloutState::new(1);
+
+        /// The rollout is being cancelled.
+        pub const CANCELLING: RolloutState = RolloutState::new(2);
+
+        /// The rollout is cancelled.
+        pub const CANCELLED: RolloutState = RolloutState::new(3);
+
+        /// The rollout has completed successfully.
+        pub const SUCCEEDED: RolloutState = RolloutState::new(4);
+
         /// Creates a new RolloutState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ROLLOUT_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                2 => std::borrow::Cow::Borrowed("CANCELLING"),
+                3 => std::borrow::Cow::Borrowed("CANCELLED"),
+                4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ROLLOUT_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ROLLOUT_STATE_UNSPECIFIED)
+                }
+                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RolloutState](RolloutState)
-    pub mod rollout_state {
-        use super::RolloutState;
-
-        /// Invalid value
-        pub const ROLLOUT_STATE_UNSPECIFIED: RolloutState =
-            RolloutState::new("ROLLOUT_STATE_UNSPECIFIED");
-
-        /// The rollout is in progress.
-        pub const IN_PROGRESS: RolloutState = RolloutState::new("IN_PROGRESS");
-
-        /// The rollout is being cancelled.
-        pub const CANCELLING: RolloutState = RolloutState::new("CANCELLING");
-
-        /// The rollout is cancelled.
-        pub const CANCELLED: RolloutState = RolloutState::new("CANCELLED");
-
-        /// The rollout has completed successfully.
-        pub const SUCCEEDED: RolloutState = RolloutState::new("SUCCEEDED");
-    }
-
-    impl std::convert::From<std::string::String> for RolloutState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RolloutState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RolloutState {
         fn default() -> Self {
-            rollout_state::ROLLOUT_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6210,44 +6432,59 @@ pub mod patch_deployment {
 
     /// Represents state of patch peployment.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Active value means that patch deployment generates Patch Jobs.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(1);
 
         /// Paused value means that patch deployment does not generate
         /// Patch jobs. Requires user action to move in and out from this state.
-        pub const PAUSED: State = State::new("PAUSED");
+        pub const PAUSED: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("PAUSED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "PAUSED" => std::option::Option::Some(Self::PAUSED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -6491,49 +6728,66 @@ pub mod recurring_schedule {
 
     /// Specifies the frequency of the recurring patch deployments.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Frequency(std::borrow::Cow<'static, str>);
+    pub struct Frequency(i32);
 
     impl Frequency {
-        /// Creates a new Frequency instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Frequency](Frequency)
-    pub mod frequency {
-        use super::Frequency;
-
         /// Invalid. A frequency must be specified.
-        pub const FREQUENCY_UNSPECIFIED: Frequency = Frequency::new("FREQUENCY_UNSPECIFIED");
+        pub const FREQUENCY_UNSPECIFIED: Frequency = Frequency::new(0);
 
         /// Indicates that the frequency of recurrence should be expressed in terms
         /// of weeks.
-        pub const WEEKLY: Frequency = Frequency::new("WEEKLY");
+        pub const WEEKLY: Frequency = Frequency::new(1);
 
         /// Indicates that the frequency of recurrence should be expressed in terms
         /// of months.
-        pub const MONTHLY: Frequency = Frequency::new("MONTHLY");
+        pub const MONTHLY: Frequency = Frequency::new(2);
 
         /// Indicates that the frequency of recurrence should be expressed in terms
         /// of days.
-        pub const DAILY: Frequency = Frequency::new("DAILY");
+        pub const DAILY: Frequency = Frequency::new(3);
+
+        /// Creates a new Frequency instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FREQUENCY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("WEEKLY"),
+                2 => std::borrow::Cow::Borrowed("MONTHLY"),
+                3 => std::borrow::Cow::Borrowed("DAILY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FREQUENCY_UNSPECIFIED" => std::option::Option::Some(Self::FREQUENCY_UNSPECIFIED),
+                "WEEKLY" => std::option::Option::Some(Self::WEEKLY),
+                "MONTHLY" => std::option::Option::Some(Self::MONTHLY),
+                "DAILY" => std::option::Option::Some(Self::DAILY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Frequency {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Frequency {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Frequency {
         fn default() -> Self {
-            frequency::FREQUENCY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -7961,58 +8215,83 @@ pub mod patch_job {
     /// Enumeration of the various states a patch job passes through as it
     /// executes.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State must be specified.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The patch job was successfully initiated.
+        pub const STARTED: State = State::new(1);
+
+        /// The patch job is looking up instances to run the patch on.
+        pub const INSTANCE_LOOKUP: State = State::new(2);
+
+        /// Instances are being patched.
+        pub const PATCHING: State = State::new(3);
+
+        /// Patch job completed successfully.
+        pub const SUCCEEDED: State = State::new(4);
+
+        /// Patch job completed but there were errors.
+        pub const COMPLETED_WITH_ERRORS: State = State::new(5);
+
+        /// The patch job was canceled.
+        pub const CANCELED: State = State::new(6);
+
+        /// The patch job timed out.
+        pub const TIMED_OUT: State = State::new(7);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STARTED"),
+                2 => std::borrow::Cow::Borrowed("INSTANCE_LOOKUP"),
+                3 => std::borrow::Cow::Borrowed("PATCHING"),
+                4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                5 => std::borrow::Cow::Borrowed("COMPLETED_WITH_ERRORS"),
+                6 => std::borrow::Cow::Borrowed("CANCELED"),
+                7 => std::borrow::Cow::Borrowed("TIMED_OUT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "STARTED" => std::option::Option::Some(Self::STARTED),
+                "INSTANCE_LOOKUP" => std::option::Option::Some(Self::INSTANCE_LOOKUP),
+                "PATCHING" => std::option::Option::Some(Self::PATCHING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "COMPLETED_WITH_ERRORS" => std::option::Option::Some(Self::COMPLETED_WITH_ERRORS),
+                "CANCELED" => std::option::Option::Some(Self::CANCELED),
+                "TIMED_OUT" => std::option::Option::Some(Self::TIMED_OUT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State must be specified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The patch job was successfully initiated.
-        pub const STARTED: State = State::new("STARTED");
-
-        /// The patch job is looking up instances to run the patch on.
-        pub const INSTANCE_LOOKUP: State = State::new("INSTANCE_LOOKUP");
-
-        /// Instances are being patched.
-        pub const PATCHING: State = State::new("PATCHING");
-
-        /// Patch job completed successfully.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-        /// Patch job completed but there were errors.
-        pub const COMPLETED_WITH_ERRORS: State = State::new("COMPLETED_WITH_ERRORS");
-
-        /// The patch job was canceled.
-        pub const CANCELED: State = State::new("CANCELED");
-
-        /// The patch job timed out.
-        pub const TIMED_OUT: State = State::new("TIMED_OUT");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8162,50 +8441,68 @@ pub mod patch_config {
 
     /// Post-patch reboot settings.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RebootConfig(std::borrow::Cow<'static, str>);
+    pub struct RebootConfig(i32);
 
     impl RebootConfig {
-        /// Creates a new RebootConfig instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RebootConfig](RebootConfig)
-    pub mod reboot_config {
-        use super::RebootConfig;
-
         /// The default behavior is DEFAULT.
-        pub const REBOOT_CONFIG_UNSPECIFIED: RebootConfig =
-            RebootConfig::new("REBOOT_CONFIG_UNSPECIFIED");
+        pub const REBOOT_CONFIG_UNSPECIFIED: RebootConfig = RebootConfig::new(0);
 
         /// The agent decides if a reboot is necessary by checking signals such as
         /// registry keys on Windows or `/var/run/reboot-required` on APT based
         /// systems. On RPM based systems, a set of core system package install times
         /// are compared with system boot time.
-        pub const DEFAULT: RebootConfig = RebootConfig::new("DEFAULT");
+        pub const DEFAULT: RebootConfig = RebootConfig::new(1);
 
         /// Always reboot the machine after the update completes.
-        pub const ALWAYS: RebootConfig = RebootConfig::new("ALWAYS");
+        pub const ALWAYS: RebootConfig = RebootConfig::new(2);
 
         /// Never reboot the machine after the update completes.
-        pub const NEVER: RebootConfig = RebootConfig::new("NEVER");
+        pub const NEVER: RebootConfig = RebootConfig::new(3);
+
+        /// Creates a new RebootConfig instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("REBOOT_CONFIG_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DEFAULT"),
+                2 => std::borrow::Cow::Borrowed("ALWAYS"),
+                3 => std::borrow::Cow::Borrowed("NEVER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "REBOOT_CONFIG_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::REBOOT_CONFIG_UNSPECIFIED)
+                }
+                "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
+                "ALWAYS" => std::option::Option::Some(Self::ALWAYS),
+                "NEVER" => std::option::Option::Some(Self::NEVER),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RebootConfig {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RebootConfig {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RebootConfig {
         fn default() -> Self {
-            reboot_config::REBOOT_CONFIG_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8236,85 +8533,131 @@ pub mod instance {
 
     /// Patch state of an instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PatchState(std::borrow::Cow<'static, str>);
+    pub struct PatchState(i32);
 
     impl PatchState {
-        /// Creates a new PatchState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PatchState](PatchState)
-    pub mod patch_state {
-        use super::PatchState;
-
         /// Unspecified.
-        pub const PATCH_STATE_UNSPECIFIED: PatchState = PatchState::new("PATCH_STATE_UNSPECIFIED");
+        pub const PATCH_STATE_UNSPECIFIED: PatchState = PatchState::new(0);
 
         /// The instance is not yet notified.
-        pub const PENDING: PatchState = PatchState::new("PENDING");
+        pub const PENDING: PatchState = PatchState::new(1);
 
         /// Instance is inactive and cannot be patched.
-        pub const INACTIVE: PatchState = PatchState::new("INACTIVE");
+        pub const INACTIVE: PatchState = PatchState::new(2);
 
         /// The instance is notified that it should be patched.
-        pub const NOTIFIED: PatchState = PatchState::new("NOTIFIED");
+        pub const NOTIFIED: PatchState = PatchState::new(3);
 
         /// The instance has started the patching process.
-        pub const STARTED: PatchState = PatchState::new("STARTED");
+        pub const STARTED: PatchState = PatchState::new(4);
 
         /// The instance is downloading patches.
-        pub const DOWNLOADING_PATCHES: PatchState = PatchState::new("DOWNLOADING_PATCHES");
+        pub const DOWNLOADING_PATCHES: PatchState = PatchState::new(5);
 
         /// The instance is applying patches.
-        pub const APPLYING_PATCHES: PatchState = PatchState::new("APPLYING_PATCHES");
+        pub const APPLYING_PATCHES: PatchState = PatchState::new(6);
 
         /// The instance is rebooting.
-        pub const REBOOTING: PatchState = PatchState::new("REBOOTING");
+        pub const REBOOTING: PatchState = PatchState::new(7);
 
         /// The instance has completed applying patches.
-        pub const SUCCEEDED: PatchState = PatchState::new("SUCCEEDED");
+        pub const SUCCEEDED: PatchState = PatchState::new(8);
 
         /// The instance has completed applying patches but a reboot is required.
-        pub const SUCCEEDED_REBOOT_REQUIRED: PatchState =
-            PatchState::new("SUCCEEDED_REBOOT_REQUIRED");
+        pub const SUCCEEDED_REBOOT_REQUIRED: PatchState = PatchState::new(9);
 
         /// The instance has failed to apply the patch.
-        pub const FAILED: PatchState = PatchState::new("FAILED");
+        pub const FAILED: PatchState = PatchState::new(10);
 
         /// The instance acked the notification and will start shortly.
-        pub const ACKED: PatchState = PatchState::new("ACKED");
+        pub const ACKED: PatchState = PatchState::new(11);
 
         /// The instance exceeded the time out while applying the patch.
-        pub const TIMED_OUT: PatchState = PatchState::new("TIMED_OUT");
+        pub const TIMED_OUT: PatchState = PatchState::new(12);
 
         /// The instance is running the pre-patch step.
-        pub const RUNNING_PRE_PATCH_STEP: PatchState = PatchState::new("RUNNING_PRE_PATCH_STEP");
+        pub const RUNNING_PRE_PATCH_STEP: PatchState = PatchState::new(13);
 
         /// The instance is running the post-patch step.
-        pub const RUNNING_POST_PATCH_STEP: PatchState = PatchState::new("RUNNING_POST_PATCH_STEP");
+        pub const RUNNING_POST_PATCH_STEP: PatchState = PatchState::new(14);
 
         /// The service could not detect the presence of the agent. Check to ensure
         /// that the agent is installed, running, and able to communicate with the
         /// service.
-        pub const NO_AGENT_DETECTED: PatchState = PatchState::new("NO_AGENT_DETECTED");
+        pub const NO_AGENT_DETECTED: PatchState = PatchState::new(15);
+
+        /// Creates a new PatchState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PATCH_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("INACTIVE"),
+                3 => std::borrow::Cow::Borrowed("NOTIFIED"),
+                4 => std::borrow::Cow::Borrowed("STARTED"),
+                5 => std::borrow::Cow::Borrowed("DOWNLOADING_PATCHES"),
+                6 => std::borrow::Cow::Borrowed("APPLYING_PATCHES"),
+                7 => std::borrow::Cow::Borrowed("REBOOTING"),
+                8 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                9 => std::borrow::Cow::Borrowed("SUCCEEDED_REBOOT_REQUIRED"),
+                10 => std::borrow::Cow::Borrowed("FAILED"),
+                11 => std::borrow::Cow::Borrowed("ACKED"),
+                12 => std::borrow::Cow::Borrowed("TIMED_OUT"),
+                13 => std::borrow::Cow::Borrowed("RUNNING_PRE_PATCH_STEP"),
+                14 => std::borrow::Cow::Borrowed("RUNNING_POST_PATCH_STEP"),
+                15 => std::borrow::Cow::Borrowed("NO_AGENT_DETECTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PATCH_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PATCH_STATE_UNSPECIFIED)
+                }
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
+                "NOTIFIED" => std::option::Option::Some(Self::NOTIFIED),
+                "STARTED" => std::option::Option::Some(Self::STARTED),
+                "DOWNLOADING_PATCHES" => std::option::Option::Some(Self::DOWNLOADING_PATCHES),
+                "APPLYING_PATCHES" => std::option::Option::Some(Self::APPLYING_PATCHES),
+                "REBOOTING" => std::option::Option::Some(Self::REBOOTING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "SUCCEEDED_REBOOT_REQUIRED" => {
+                    std::option::Option::Some(Self::SUCCEEDED_REBOOT_REQUIRED)
+                }
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "ACKED" => std::option::Option::Some(Self::ACKED),
+                "TIMED_OUT" => std::option::Option::Some(Self::TIMED_OUT),
+                "RUNNING_PRE_PATCH_STEP" => std::option::Option::Some(Self::RUNNING_PRE_PATCH_STEP),
+                "RUNNING_POST_PATCH_STEP" => {
+                    std::option::Option::Some(Self::RUNNING_POST_PATCH_STEP)
+                }
+                "NO_AGENT_DETECTED" => std::option::Option::Some(Self::NO_AGENT_DETECTED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PatchState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PatchState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PatchState {
         fn default() -> Self {
-            patch_state::PATCH_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8422,43 +8765,58 @@ pub mod apt_settings {
 
     /// Apt patch type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// By default, upgrade will be performed.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// Runs `apt-get dist-upgrade`.
+        pub const DIST: Type = Type::new(1);
+
+        /// Runs `apt-get upgrade`.
+        pub const UPGRADE: Type = Type::new(2);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DIST"),
+                2 => std::borrow::Cow::Borrowed("UPGRADE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "DIST" => std::option::Option::Some(Self::DIST),
+                "UPGRADE" => std::option::Option::Some(Self::UPGRADE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// By default, upgrade will be performed.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// Runs `apt-get dist-upgrade`.
-        pub const DIST: Type = Type::new("DIST");
-
-        /// Runs `apt-get upgrade`.
-        pub const UPGRADE: Type = Type::new("UPGRADE");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8735,82 +9093,112 @@ pub mod windows_update_settings {
     /// [1]
     /// <https://support.microsoft.com/en-us/help/824684/description-of-the-standard-terminology-that-is-used-to-describe-micro>
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Classification(std::borrow::Cow<'static, str>);
+    pub struct Classification(i32);
 
     impl Classification {
-        /// Creates a new Classification instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Classification](Classification)
-    pub mod classification {
-        use super::Classification;
-
         /// Invalid. If classifications are included, they must be specified.
-        pub const CLASSIFICATION_UNSPECIFIED: Classification =
-            Classification::new("CLASSIFICATION_UNSPECIFIED");
+        pub const CLASSIFICATION_UNSPECIFIED: Classification = Classification::new(0);
 
         /// "A widely released fix for a specific problem that addresses a critical,
         /// non-security-related bug." [1]
-        pub const CRITICAL: Classification = Classification::new("CRITICAL");
+        pub const CRITICAL: Classification = Classification::new(1);
 
         /// "A widely released fix for a product-specific, security-related
         /// vulnerability. Security vulnerabilities are rated by their severity. The
         /// severity rating is indicated in the Microsoft security bulletin as
         /// critical, important, moderate, or low." [1]
-        pub const SECURITY: Classification = Classification::new("SECURITY");
+        pub const SECURITY: Classification = Classification::new(2);
 
         /// "A widely released and frequent software update that contains additions
         /// to a product's definition database. Definition databases are often used
         /// to detect objects that have specific attributes, such as malicious code,
         /// phishing websites, or junk mail." [1]
-        pub const DEFINITION: Classification = Classification::new("DEFINITION");
+        pub const DEFINITION: Classification = Classification::new(3);
 
         /// "Software that controls the input and output of a device." [1]
-        pub const DRIVER: Classification = Classification::new("DRIVER");
+        pub const DRIVER: Classification = Classification::new(4);
 
         /// "New product functionality that is first distributed outside the context
         /// of a product release and that is typically included in the next full
         /// product release." [1]
-        pub const FEATURE_PACK: Classification = Classification::new("FEATURE_PACK");
+        pub const FEATURE_PACK: Classification = Classification::new(5);
 
         /// "A tested, cumulative set of all hotfixes, security updates, critical
         /// updates, and updates. Additionally, service packs may contain additional
         /// fixes for problems that are found internally since the release of the
         /// product. Service packs my also contain a limited number of
         /// customer-requested design changes or features." [1]
-        pub const SERVICE_PACK: Classification = Classification::new("SERVICE_PACK");
+        pub const SERVICE_PACK: Classification = Classification::new(6);
 
         /// "A utility or feature that helps complete a task or set of tasks." [1]
-        pub const TOOL: Classification = Classification::new("TOOL");
+        pub const TOOL: Classification = Classification::new(7);
 
         /// "A tested, cumulative set of hotfixes, security updates, critical
         /// updates, and updates that are packaged together for easy deployment. A
         /// rollup generally targets a specific area, such as security, or a
         /// component of a product, such as Internet Information Services (IIS)." [1]
-        pub const UPDATE_ROLLUP: Classification = Classification::new("UPDATE_ROLLUP");
+        pub const UPDATE_ROLLUP: Classification = Classification::new(8);
 
         /// "A widely released fix for a specific problem. An update addresses a
         /// noncritical, non-security-related bug." [1]
-        pub const UPDATE: Classification = Classification::new("UPDATE");
+        pub const UPDATE: Classification = Classification::new(9);
+
+        /// Creates a new Classification instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CLASSIFICATION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CRITICAL"),
+                2 => std::borrow::Cow::Borrowed("SECURITY"),
+                3 => std::borrow::Cow::Borrowed("DEFINITION"),
+                4 => std::borrow::Cow::Borrowed("DRIVER"),
+                5 => std::borrow::Cow::Borrowed("FEATURE_PACK"),
+                6 => std::borrow::Cow::Borrowed("SERVICE_PACK"),
+                7 => std::borrow::Cow::Borrowed("TOOL"),
+                8 => std::borrow::Cow::Borrowed("UPDATE_ROLLUP"),
+                9 => std::borrow::Cow::Borrowed("UPDATE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CLASSIFICATION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CLASSIFICATION_UNSPECIFIED)
+                }
+                "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
+                "SECURITY" => std::option::Option::Some(Self::SECURITY),
+                "DEFINITION" => std::option::Option::Some(Self::DEFINITION),
+                "DRIVER" => std::option::Option::Some(Self::DRIVER),
+                "FEATURE_PACK" => std::option::Option::Some(Self::FEATURE_PACK),
+                "SERVICE_PACK" => std::option::Option::Some(Self::SERVICE_PACK),
+                "TOOL" => std::option::Option::Some(Self::TOOL),
+                "UPDATE_ROLLUP" => std::option::Option::Some(Self::UPDATE_ROLLUP),
+                "UPDATE" => std::option::Option::Some(Self::UPDATE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Classification {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Classification {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Classification {
         fn default() -> Self {
-            classification::CLASSIFICATION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8989,48 +9377,64 @@ pub mod exec_step_config {
 
     /// The interpreter used to execute the a file.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Interpreter(std::borrow::Cow<'static, str>);
+    pub struct Interpreter(i32);
 
     impl Interpreter {
-        /// Creates a new Interpreter instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Interpreter](Interpreter)
-    pub mod interpreter {
-        use super::Interpreter;
-
         /// Invalid for a Windows ExecStepConfig. For a Linux ExecStepConfig, the
         /// interpreter will be parsed from the shebang line of the script if
         /// unspecified.
-        pub const INTERPRETER_UNSPECIFIED: Interpreter =
-            Interpreter::new("INTERPRETER_UNSPECIFIED");
+        pub const INTERPRETER_UNSPECIFIED: Interpreter = Interpreter::new(0);
 
         /// Indicates that the script is run with `/bin/sh` on Linux and `cmd`
         /// on Windows.
-        pub const SHELL: Interpreter = Interpreter::new("SHELL");
+        pub const SHELL: Interpreter = Interpreter::new(1);
 
         /// Indicates that the file is run with PowerShell flags
         /// `-NonInteractive`, `-NoProfile`, and `-ExecutionPolicy Bypass`.
-        pub const POWERSHELL: Interpreter = Interpreter::new("POWERSHELL");
+        pub const POWERSHELL: Interpreter = Interpreter::new(2);
+
+        /// Creates a new Interpreter instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("INTERPRETER_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SHELL"),
+                2 => std::borrow::Cow::Borrowed("POWERSHELL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "INTERPRETER_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::INTERPRETER_UNSPECIFIED)
+                }
+                "SHELL" => std::option::Option::Some(Self::SHELL),
+                "POWERSHELL" => std::option::Option::Some(Self::POWERSHELL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Interpreter {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Interpreter {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Interpreter {
         fn default() -> Self {
-            interpreter::INTERPRETER_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -9320,26 +9724,11 @@ pub mod patch_rollout {
 
     /// Type of the rollout.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(std::borrow::Cow<'static, str>);
+    pub struct Mode(i32);
 
     impl Mode {
-        /// Creates a new Mode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Mode](Mode)
-    pub mod mode {
-        use super::Mode;
-
         /// Mode must be specified.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new("MODE_UNSPECIFIED");
+        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
 
         /// Patches are applied one zone at a time. The patch job begins in the
         /// region with the lowest number of targeted VMs. Within the region,
@@ -9347,21 +9736,51 @@ pub mod patch_rollout {
         /// multiple regions (or zones within a region) have the same number of
         /// targeted VMs, a tie-breaker is achieved by sorting the regions or zones
         /// in alphabetical order.
-        pub const ZONE_BY_ZONE: Mode = Mode::new("ZONE_BY_ZONE");
+        pub const ZONE_BY_ZONE: Mode = Mode::new(1);
 
         /// Patches are applied to VMs in all zones at the same time.
-        pub const CONCURRENT_ZONES: Mode = Mode::new("CONCURRENT_ZONES");
+        pub const CONCURRENT_ZONES: Mode = Mode::new(2);
+
+        /// Creates a new Mode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ZONE_BY_ZONE"),
+                2 => std::borrow::Cow::Borrowed("CONCURRENT_ZONES"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
+                "ZONE_BY_ZONE" => std::option::Option::Some(Self::ZONE_BY_ZONE),
+                "CONCURRENT_ZONES" => std::option::Option::Some(Self::CONCURRENT_ZONES),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Mode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            mode::MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -10117,166 +10536,219 @@ pub mod cvs_sv_3 {
     /// This metric reflects the context by which vulnerability exploitation is
     /// possible.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AttackVector(std::borrow::Cow<'static, str>);
+    pub struct AttackVector(i32);
 
     impl AttackVector {
-        /// Creates a new AttackVector instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [AttackVector](AttackVector)
-    pub mod attack_vector {
-        use super::AttackVector;
-
         /// Invalid value.
-        pub const ATTACK_VECTOR_UNSPECIFIED: AttackVector =
-            AttackVector::new("ATTACK_VECTOR_UNSPECIFIED");
+        pub const ATTACK_VECTOR_UNSPECIFIED: AttackVector = AttackVector::new(0);
 
         /// The vulnerable component is bound to the network stack and the set of
         /// possible attackers extends beyond the other options listed below, up to
         /// and including the entire Internet.
-        pub const ATTACK_VECTOR_NETWORK: AttackVector = AttackVector::new("ATTACK_VECTOR_NETWORK");
+        pub const ATTACK_VECTOR_NETWORK: AttackVector = AttackVector::new(1);
 
         /// The vulnerable component is bound to the network stack, but the attack is
         /// limited at the protocol level to a logically adjacent topology.
-        pub const ATTACK_VECTOR_ADJACENT: AttackVector =
-            AttackVector::new("ATTACK_VECTOR_ADJACENT");
+        pub const ATTACK_VECTOR_ADJACENT: AttackVector = AttackVector::new(2);
 
         /// The vulnerable component is not bound to the network stack and the
         /// attacker's path is via read/write/execute capabilities.
-        pub const ATTACK_VECTOR_LOCAL: AttackVector = AttackVector::new("ATTACK_VECTOR_LOCAL");
+        pub const ATTACK_VECTOR_LOCAL: AttackVector = AttackVector::new(3);
 
         /// The attack requires the attacker to physically touch or manipulate the
         /// vulnerable component.
-        pub const ATTACK_VECTOR_PHYSICAL: AttackVector =
-            AttackVector::new("ATTACK_VECTOR_PHYSICAL");
+        pub const ATTACK_VECTOR_PHYSICAL: AttackVector = AttackVector::new(4);
+
+        /// Creates a new AttackVector instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_NETWORK"),
+                2 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_ADJACENT"),
+                3 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_LOCAL"),
+                4 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_PHYSICAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ATTACK_VECTOR_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ATTACK_VECTOR_UNSPECIFIED)
+                }
+                "ATTACK_VECTOR_NETWORK" => std::option::Option::Some(Self::ATTACK_VECTOR_NETWORK),
+                "ATTACK_VECTOR_ADJACENT" => std::option::Option::Some(Self::ATTACK_VECTOR_ADJACENT),
+                "ATTACK_VECTOR_LOCAL" => std::option::Option::Some(Self::ATTACK_VECTOR_LOCAL),
+                "ATTACK_VECTOR_PHYSICAL" => std::option::Option::Some(Self::ATTACK_VECTOR_PHYSICAL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for AttackVector {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AttackVector {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AttackVector {
         fn default() -> Self {
-            attack_vector::ATTACK_VECTOR_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// This metric describes the conditions beyond the attacker's control that
     /// must exist in order to exploit the vulnerability.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AttackComplexity(std::borrow::Cow<'static, str>);
+    pub struct AttackComplexity(i32);
 
     impl AttackComplexity {
-        /// Creates a new AttackComplexity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [AttackComplexity](AttackComplexity)
-    pub mod attack_complexity {
-        use super::AttackComplexity;
-
         /// Invalid value.
-        pub const ATTACK_COMPLEXITY_UNSPECIFIED: AttackComplexity =
-            AttackComplexity::new("ATTACK_COMPLEXITY_UNSPECIFIED");
+        pub const ATTACK_COMPLEXITY_UNSPECIFIED: AttackComplexity = AttackComplexity::new(0);
 
         /// Specialized access conditions or extenuating circumstances do not exist.
         /// An attacker can expect repeatable success when attacking the vulnerable
         /// component.
-        pub const ATTACK_COMPLEXITY_LOW: AttackComplexity =
-            AttackComplexity::new("ATTACK_COMPLEXITY_LOW");
+        pub const ATTACK_COMPLEXITY_LOW: AttackComplexity = AttackComplexity::new(1);
 
         /// A successful attack depends on conditions beyond the attacker's control.
         /// That is, a successful attack cannot be accomplished at will, but requires
         /// the attacker to invest in some measurable amount of effort in preparation
         /// or execution against the vulnerable component before a successful attack
         /// can be expected.
-        pub const ATTACK_COMPLEXITY_HIGH: AttackComplexity =
-            AttackComplexity::new("ATTACK_COMPLEXITY_HIGH");
+        pub const ATTACK_COMPLEXITY_HIGH: AttackComplexity = AttackComplexity::new(2);
+
+        /// Creates a new AttackComplexity instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_LOW"),
+                2 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_HIGH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ATTACK_COMPLEXITY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ATTACK_COMPLEXITY_UNSPECIFIED)
+                }
+                "ATTACK_COMPLEXITY_LOW" => std::option::Option::Some(Self::ATTACK_COMPLEXITY_LOW),
+                "ATTACK_COMPLEXITY_HIGH" => std::option::Option::Some(Self::ATTACK_COMPLEXITY_HIGH),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for AttackComplexity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AttackComplexity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AttackComplexity {
         fn default() -> Self {
-            attack_complexity::ATTACK_COMPLEXITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// This metric describes the level of privileges an attacker must possess
     /// before successfully exploiting the vulnerability.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PrivilegesRequired(std::borrow::Cow<'static, str>);
+    pub struct PrivilegesRequired(i32);
 
     impl PrivilegesRequired {
-        /// Creates a new PrivilegesRequired instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PrivilegesRequired](PrivilegesRequired)
-    pub mod privileges_required {
-        use super::PrivilegesRequired;
-
         /// Invalid value.
-        pub const PRIVILEGES_REQUIRED_UNSPECIFIED: PrivilegesRequired =
-            PrivilegesRequired::new("PRIVILEGES_REQUIRED_UNSPECIFIED");
+        pub const PRIVILEGES_REQUIRED_UNSPECIFIED: PrivilegesRequired = PrivilegesRequired::new(0);
 
         /// The attacker is unauthorized prior to attack, and therefore does not
         /// require any access to settings or files of the vulnerable system to
         /// carry out an attack.
-        pub const PRIVILEGES_REQUIRED_NONE: PrivilegesRequired =
-            PrivilegesRequired::new("PRIVILEGES_REQUIRED_NONE");
+        pub const PRIVILEGES_REQUIRED_NONE: PrivilegesRequired = PrivilegesRequired::new(1);
 
         /// The attacker requires privileges that provide basic user capabilities
         /// that could normally affect only settings and files owned by a user.
         /// Alternatively, an attacker with Low privileges has the ability to access
         /// only non-sensitive resources.
-        pub const PRIVILEGES_REQUIRED_LOW: PrivilegesRequired =
-            PrivilegesRequired::new("PRIVILEGES_REQUIRED_LOW");
+        pub const PRIVILEGES_REQUIRED_LOW: PrivilegesRequired = PrivilegesRequired::new(2);
 
         /// The attacker requires privileges that provide significant (e.g.,
         /// administrative) control over the vulnerable component allowing access to
         /// component-wide settings and files.
-        pub const PRIVILEGES_REQUIRED_HIGH: PrivilegesRequired =
-            PrivilegesRequired::new("PRIVILEGES_REQUIRED_HIGH");
+        pub const PRIVILEGES_REQUIRED_HIGH: PrivilegesRequired = PrivilegesRequired::new(3);
+
+        /// Creates a new PrivilegesRequired instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_NONE"),
+                2 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_LOW"),
+                3 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_HIGH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PRIVILEGES_REQUIRED_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_UNSPECIFIED)
+                }
+                "PRIVILEGES_REQUIRED_NONE" => {
+                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_NONE)
+                }
+                "PRIVILEGES_REQUIRED_LOW" => {
+                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_LOW)
+                }
+                "PRIVILEGES_REQUIRED_HIGH" => {
+                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_HIGH)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PrivilegesRequired {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PrivilegesRequired {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PrivilegesRequired {
         fn default() -> Self {
-            privileges_required::PRIVILEGES_REQUIRED_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -10284,92 +10756,123 @@ pub mod cvs_sv_3 {
     /// attacker, to participate in the successful compromise of the vulnerable
     /// component.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct UserInteraction(std::borrow::Cow<'static, str>);
+    pub struct UserInteraction(i32);
 
     impl UserInteraction {
-        /// Creates a new UserInteraction instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [UserInteraction](UserInteraction)
-    pub mod user_interaction {
-        use super::UserInteraction;
-
         /// Invalid value.
-        pub const USER_INTERACTION_UNSPECIFIED: UserInteraction =
-            UserInteraction::new("USER_INTERACTION_UNSPECIFIED");
+        pub const USER_INTERACTION_UNSPECIFIED: UserInteraction = UserInteraction::new(0);
 
         /// The vulnerable system can be exploited without interaction from any user.
-        pub const USER_INTERACTION_NONE: UserInteraction =
-            UserInteraction::new("USER_INTERACTION_NONE");
+        pub const USER_INTERACTION_NONE: UserInteraction = UserInteraction::new(1);
 
         /// Successful exploitation of this vulnerability requires a user to take
         /// some action before the vulnerability can be exploited.
-        pub const USER_INTERACTION_REQUIRED: UserInteraction =
-            UserInteraction::new("USER_INTERACTION_REQUIRED");
+        pub const USER_INTERACTION_REQUIRED: UserInteraction = UserInteraction::new(2);
+
+        /// Creates a new UserInteraction instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("USER_INTERACTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("USER_INTERACTION_NONE"),
+                2 => std::borrow::Cow::Borrowed("USER_INTERACTION_REQUIRED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "USER_INTERACTION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::USER_INTERACTION_UNSPECIFIED)
+                }
+                "USER_INTERACTION_NONE" => std::option::Option::Some(Self::USER_INTERACTION_NONE),
+                "USER_INTERACTION_REQUIRED" => {
+                    std::option::Option::Some(Self::USER_INTERACTION_REQUIRED)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for UserInteraction {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for UserInteraction {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for UserInteraction {
         fn default() -> Self {
-            user_interaction::USER_INTERACTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The Scope metric captures whether a vulnerability in one vulnerable
     /// component impacts resources in components beyond its security scope.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Scope(std::borrow::Cow<'static, str>);
+    pub struct Scope(i32);
 
     impl Scope {
-        /// Creates a new Scope instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Scope](Scope)
-    pub mod scope {
-        use super::Scope;
-
         /// Invalid value.
-        pub const SCOPE_UNSPECIFIED: Scope = Scope::new("SCOPE_UNSPECIFIED");
+        pub const SCOPE_UNSPECIFIED: Scope = Scope::new(0);
 
         /// An exploited vulnerability can only affect resources managed by the same
         /// security authority.
-        pub const SCOPE_UNCHANGED: Scope = Scope::new("SCOPE_UNCHANGED");
+        pub const SCOPE_UNCHANGED: Scope = Scope::new(1);
 
         /// An exploited vulnerability can affect resources beyond the security scope
         /// managed by the security authority of the vulnerable component.
-        pub const SCOPE_CHANGED: Scope = Scope::new("SCOPE_CHANGED");
+        pub const SCOPE_CHANGED: Scope = Scope::new(2);
+
+        /// Creates a new Scope instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SCOPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SCOPE_UNCHANGED"),
+                2 => std::borrow::Cow::Borrowed("SCOPE_CHANGED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SCOPE_UNSPECIFIED" => std::option::Option::Some(Self::SCOPE_UNSPECIFIED),
+                "SCOPE_UNCHANGED" => std::option::Option::Some(Self::SCOPE_UNCHANGED),
+                "SCOPE_CHANGED" => std::option::Option::Some(Self::SCOPE_CHANGED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Scope {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Scope {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Scope {
         fn default() -> Self {
-            scope::SCOPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -10377,90 +10880,123 @@ pub mod cvs_sv_3 {
     /// vulnerability on the component that suffers the worst outcome that is most
     /// directly and predictably associated with the attack.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Impact(std::borrow::Cow<'static, str>);
+    pub struct Impact(i32);
 
     impl Impact {
+        /// Invalid value.
+        pub const IMPACT_UNSPECIFIED: Impact = Impact::new(0);
+
+        /// High impact.
+        pub const IMPACT_HIGH: Impact = Impact::new(1);
+
+        /// Low impact.
+        pub const IMPACT_LOW: Impact = Impact::new(2);
+
+        /// No impact.
+        pub const IMPACT_NONE: Impact = Impact::new(3);
+
         /// Creates a new Impact instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("IMPACT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IMPACT_HIGH"),
+                2 => std::borrow::Cow::Borrowed("IMPACT_LOW"),
+                3 => std::borrow::Cow::Borrowed("IMPACT_NONE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "IMPACT_UNSPECIFIED" => std::option::Option::Some(Self::IMPACT_UNSPECIFIED),
+                "IMPACT_HIGH" => std::option::Option::Some(Self::IMPACT_HIGH),
+                "IMPACT_LOW" => std::option::Option::Some(Self::IMPACT_LOW),
+                "IMPACT_NONE" => std::option::Option::Some(Self::IMPACT_NONE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Impact](Impact)
-    pub mod impact {
-        use super::Impact;
-
-        /// Invalid value.
-        pub const IMPACT_UNSPECIFIED: Impact = Impact::new("IMPACT_UNSPECIFIED");
-
-        /// High impact.
-        pub const IMPACT_HIGH: Impact = Impact::new("IMPACT_HIGH");
-
-        /// Low impact.
-        pub const IMPACT_LOW: Impact = Impact::new("IMPACT_LOW");
-
-        /// No impact.
-        pub const IMPACT_NONE: Impact = Impact::new("IMPACT_NONE");
-    }
-
-    impl std::convert::From<std::string::String> for Impact {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Impact {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Impact {
         fn default() -> Self {
-            impact::IMPACT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
 
 /// The view for inventory objects.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct InventoryView(std::borrow::Cow<'static, str>);
+pub struct InventoryView(i32);
 
 impl InventoryView {
+    /// The default value.
+    /// The API defaults to the BASIC view.
+    pub const INVENTORY_VIEW_UNSPECIFIED: InventoryView = InventoryView::new(0);
+
+    /// Returns the basic inventory information that includes `os_info`.
+    pub const BASIC: InventoryView = InventoryView::new(1);
+
+    /// Returns all fields.
+    pub const FULL: InventoryView = InventoryView::new(2);
+
     /// Creates a new InventoryView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("INVENTORY_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("BASIC"),
+            2 => std::borrow::Cow::Borrowed("FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "INVENTORY_VIEW_UNSPECIFIED" => {
+                std::option::Option::Some(Self::INVENTORY_VIEW_UNSPECIFIED)
+            }
+            "BASIC" => std::option::Option::Some(Self::BASIC),
+            "FULL" => std::option::Option::Some(Self::FULL),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [InventoryView](InventoryView)
-pub mod inventory_view {
-    use super::InventoryView;
-
-    /// The default value.
-    /// The API defaults to the BASIC view.
-    pub const INVENTORY_VIEW_UNSPECIFIED: InventoryView =
-        InventoryView::new("INVENTORY_VIEW_UNSPECIFIED");
-
-    /// Returns the basic inventory information that includes `os_info`.
-    pub const BASIC: InventoryView = InventoryView::new("BASIC");
-
-    /// Returns all fields.
-    pub const FULL: InventoryView = InventoryView::new("FULL");
-}
-
-impl std::convert::From<std::string::String> for InventoryView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for InventoryView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for InventoryView {
     fn default() -> Self {
-        inventory_view::INVENTORY_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/osconfig/v1/src/transport.rs
+++ b/src/generated/cloud/osconfig/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::OsConfigService for OsConfigService {
                 reqwest::Method::POST,
                 format!("/v1/{}/patchJobs:execute", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -69,7 +69,7 @@ impl crate::stubs::OsConfigService for OsConfigService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -88,7 +88,7 @@ impl crate::stubs::OsConfigService for OsConfigService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -108,7 +108,7 @@ impl crate::stubs::OsConfigService for OsConfigService {
                 reqwest::Method::GET,
                 format!("/v1/{}/patchJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -133,7 +133,7 @@ impl crate::stubs::OsConfigService for OsConfigService {
                 reqwest::Method::GET,
                 format!("/v1/{}/instanceDetails", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -158,7 +158,7 @@ impl crate::stubs::OsConfigService for OsConfigService {
                 reqwest::Method::POST,
                 format!("/v1/{}/patchDeployments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -178,7 +178,7 @@ impl crate::stubs::OsConfigService for OsConfigService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -200,7 +200,7 @@ impl crate::stubs::OsConfigService for OsConfigService {
                 reqwest::Method::GET,
                 format!("/v1/{}/patchDeployments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -221,7 +221,7 @@ impl crate::stubs::OsConfigService for OsConfigService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -249,7 +249,7 @@ impl crate::stubs::OsConfigService for OsConfigService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -278,7 +278,7 @@ impl crate::stubs::OsConfigService for OsConfigService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:pause", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -295,7 +295,7 @@ impl crate::stubs::OsConfigService for OsConfigService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:resume", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -312,7 +312,7 @@ impl crate::stubs::OsConfigService for OsConfigService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -331,7 +331,7 @@ impl crate::stubs::OsConfigService for OsConfigService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -374,7 +374,7 @@ impl crate::stubs::OsConfigZonalService for OsConfigZonalService {
                 reqwest::Method::POST,
                 format!("/v1/{}/osPolicyAssignments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -403,7 +403,7 @@ impl crate::stubs::OsConfigZonalService for OsConfigZonalService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -432,7 +432,7 @@ impl crate::stubs::OsConfigZonalService for OsConfigZonalService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -454,7 +454,7 @@ impl crate::stubs::OsConfigZonalService for OsConfigZonalService {
                 reqwest::Method::GET,
                 format!("/v1/{}/osPolicyAssignments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -478,7 +478,7 @@ impl crate::stubs::OsConfigZonalService for OsConfigZonalService {
                 reqwest::Method::GET,
                 format!("/v1/{}:listRevisions", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -499,7 +499,7 @@ impl crate::stubs::OsConfigZonalService for OsConfigZonalService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -518,7 +518,7 @@ impl crate::stubs::OsConfigZonalService for OsConfigZonalService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -537,7 +537,7 @@ impl crate::stubs::OsConfigZonalService for OsConfigZonalService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/reports", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -559,7 +559,7 @@ impl crate::stubs::OsConfigZonalService for OsConfigZonalService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -582,7 +582,7 @@ impl crate::stubs::OsConfigZonalService for OsConfigZonalService {
                 reqwest::Method::GET,
                 format!("/v1/{}/inventories", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -605,7 +605,7 @@ impl crate::stubs::OsConfigZonalService for OsConfigZonalService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -627,7 +627,7 @@ impl crate::stubs::OsConfigZonalService for OsConfigZonalService {
                 reqwest::Method::GET,
                 format!("/v1/{}/vulnerabilityReports", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -649,7 +649,7 @@ impl crate::stubs::OsConfigZonalService for OsConfigZonalService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -668,7 +668,7 @@ impl crate::stubs::OsConfigZonalService for OsConfigZonalService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/oslogin/v1/src/transport.rs
+++ b/src/generated/cloud/oslogin/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::OsLoginService for OsLoginService {
                 reqwest::Method::POST,
                 format!("/v1/{}/sshPublicKeys", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -71,7 +71,7 @@ impl crate::stubs::OsLoginService for OsLoginService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -90,7 +90,7 @@ impl crate::stubs::OsLoginService for OsLoginService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -112,7 +112,7 @@ impl crate::stubs::OsLoginService for OsLoginService {
                 reqwest::Method::GET,
                 format!("/v1/{}/loginProfile", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -133,7 +133,7 @@ impl crate::stubs::OsLoginService for OsLoginService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -155,7 +155,7 @@ impl crate::stubs::OsLoginService for OsLoginService {
                 reqwest::Method::POST,
                 format!("/v1/{}:importSshPublicKey", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -179,7 +179,7 @@ impl crate::stubs::OsLoginService for OsLoginService {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/parallelstore/v1/src/model.rs
+++ b/src/generated/cloud/parallelstore/v1/src/model.rs
@@ -268,56 +268,79 @@ pub mod instance {
 
     /// The possible states of a Parallelstore instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The instance is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The instance is available for use.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(2);
 
         /// The instance is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(3);
 
         /// The instance is not usable.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(4);
 
         /// The instance is being upgraded.
-        pub const UPGRADING: State = State::new("UPGRADING");
+        pub const UPGRADING: State = State::new(5);
 
         /// The instance is being repaired. This should only be used by instances
         /// using the `PERSISTENT` deployment type.
-        pub const REPAIRING: State = State::new("REPAIRING");
+        pub const REPAIRING: State = State::new(6);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                5 => std::borrow::Cow::Borrowed("UPGRADING"),
+                6 => std::borrow::Cow::Borrowed("REPAIRING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "UPGRADING" => std::option::Option::Some(Self::UPGRADING),
+                "REPAIRING" => std::option::Option::Some(Self::REPAIRING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2031,185 +2054,256 @@ impl wkt::message::Message for TransferCounters {
 
 /// Type of transfer that occurred.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TransferType(std::borrow::Cow<'static, str>);
+pub struct TransferType(i32);
 
 impl TransferType {
+    /// Zero is an illegal value.
+    pub const TRANSFER_TYPE_UNSPECIFIED: TransferType = TransferType::new(0);
+
+    /// Imports to Parallelstore.
+    pub const IMPORT: TransferType = TransferType::new(1);
+
+    /// Exports from Parallelstore.
+    pub const EXPORT: TransferType = TransferType::new(2);
+
     /// Creates a new TransferType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("TRANSFER_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("IMPORT"),
+            2 => std::borrow::Cow::Borrowed("EXPORT"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "TRANSFER_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::TRANSFER_TYPE_UNSPECIFIED)
+            }
+            "IMPORT" => std::option::Option::Some(Self::IMPORT),
+            "EXPORT" => std::option::Option::Some(Self::EXPORT),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [TransferType](TransferType)
-pub mod transfer_type {
-    use super::TransferType;
-
-    /// Zero is an illegal value.
-    pub const TRANSFER_TYPE_UNSPECIFIED: TransferType =
-        TransferType::new("TRANSFER_TYPE_UNSPECIFIED");
-
-    /// Imports to Parallelstore.
-    pub const IMPORT: TransferType = TransferType::new("IMPORT");
-
-    /// Exports from Parallelstore.
-    pub const EXPORT: TransferType = TransferType::new("EXPORT");
-}
-
-impl std::convert::From<std::string::String> for TransferType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for TransferType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for TransferType {
     fn default() -> Self {
-        transfer_type::TRANSFER_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Represents the striping options for files.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct FileStripeLevel(std::borrow::Cow<'static, str>);
+pub struct FileStripeLevel(i32);
 
 impl FileStripeLevel {
+    /// If not set, FileStripeLevel will default to FILE_STRIPE_LEVEL_BALANCED
+    pub const FILE_STRIPE_LEVEL_UNSPECIFIED: FileStripeLevel = FileStripeLevel::new(0);
+
+    /// Minimum file striping
+    pub const FILE_STRIPE_LEVEL_MIN: FileStripeLevel = FileStripeLevel::new(1);
+
+    /// Medium file striping
+    pub const FILE_STRIPE_LEVEL_BALANCED: FileStripeLevel = FileStripeLevel::new(2);
+
+    /// Maximum file striping
+    pub const FILE_STRIPE_LEVEL_MAX: FileStripeLevel = FileStripeLevel::new(3);
+
     /// Creates a new FileStripeLevel instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("FILE_STRIPE_LEVEL_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("FILE_STRIPE_LEVEL_MIN"),
+            2 => std::borrow::Cow::Borrowed("FILE_STRIPE_LEVEL_BALANCED"),
+            3 => std::borrow::Cow::Borrowed("FILE_STRIPE_LEVEL_MAX"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "FILE_STRIPE_LEVEL_UNSPECIFIED" => {
+                std::option::Option::Some(Self::FILE_STRIPE_LEVEL_UNSPECIFIED)
+            }
+            "FILE_STRIPE_LEVEL_MIN" => std::option::Option::Some(Self::FILE_STRIPE_LEVEL_MIN),
+            "FILE_STRIPE_LEVEL_BALANCED" => {
+                std::option::Option::Some(Self::FILE_STRIPE_LEVEL_BALANCED)
+            }
+            "FILE_STRIPE_LEVEL_MAX" => std::option::Option::Some(Self::FILE_STRIPE_LEVEL_MAX),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [FileStripeLevel](FileStripeLevel)
-pub mod file_stripe_level {
-    use super::FileStripeLevel;
-
-    /// If not set, FileStripeLevel will default to FILE_STRIPE_LEVEL_BALANCED
-    pub const FILE_STRIPE_LEVEL_UNSPECIFIED: FileStripeLevel =
-        FileStripeLevel::new("FILE_STRIPE_LEVEL_UNSPECIFIED");
-
-    /// Minimum file striping
-    pub const FILE_STRIPE_LEVEL_MIN: FileStripeLevel =
-        FileStripeLevel::new("FILE_STRIPE_LEVEL_MIN");
-
-    /// Medium file striping
-    pub const FILE_STRIPE_LEVEL_BALANCED: FileStripeLevel =
-        FileStripeLevel::new("FILE_STRIPE_LEVEL_BALANCED");
-
-    /// Maximum file striping
-    pub const FILE_STRIPE_LEVEL_MAX: FileStripeLevel =
-        FileStripeLevel::new("FILE_STRIPE_LEVEL_MAX");
-}
-
-impl std::convert::From<std::string::String> for FileStripeLevel {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for FileStripeLevel {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for FileStripeLevel {
     fn default() -> Self {
-        file_stripe_level::FILE_STRIPE_LEVEL_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Represents the striping options for directories.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DirectoryStripeLevel(std::borrow::Cow<'static, str>);
+pub struct DirectoryStripeLevel(i32);
 
 impl DirectoryStripeLevel {
+    /// If not set, DirectoryStripeLevel will default to DIRECTORY_STRIPE_LEVEL_MAX
+    pub const DIRECTORY_STRIPE_LEVEL_UNSPECIFIED: DirectoryStripeLevel =
+        DirectoryStripeLevel::new(0);
+
+    /// Minimum directory striping
+    pub const DIRECTORY_STRIPE_LEVEL_MIN: DirectoryStripeLevel = DirectoryStripeLevel::new(1);
+
+    /// Medium directory striping
+    pub const DIRECTORY_STRIPE_LEVEL_BALANCED: DirectoryStripeLevel = DirectoryStripeLevel::new(2);
+
+    /// Maximum directory striping
+    pub const DIRECTORY_STRIPE_LEVEL_MAX: DirectoryStripeLevel = DirectoryStripeLevel::new(3);
+
     /// Creates a new DirectoryStripeLevel instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DIRECTORY_STRIPE_LEVEL_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("DIRECTORY_STRIPE_LEVEL_MIN"),
+            2 => std::borrow::Cow::Borrowed("DIRECTORY_STRIPE_LEVEL_BALANCED"),
+            3 => std::borrow::Cow::Borrowed("DIRECTORY_STRIPE_LEVEL_MAX"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DIRECTORY_STRIPE_LEVEL_UNSPECIFIED" => {
+                std::option::Option::Some(Self::DIRECTORY_STRIPE_LEVEL_UNSPECIFIED)
+            }
+            "DIRECTORY_STRIPE_LEVEL_MIN" => {
+                std::option::Option::Some(Self::DIRECTORY_STRIPE_LEVEL_MIN)
+            }
+            "DIRECTORY_STRIPE_LEVEL_BALANCED" => {
+                std::option::Option::Some(Self::DIRECTORY_STRIPE_LEVEL_BALANCED)
+            }
+            "DIRECTORY_STRIPE_LEVEL_MAX" => {
+                std::option::Option::Some(Self::DIRECTORY_STRIPE_LEVEL_MAX)
+            }
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [DirectoryStripeLevel](DirectoryStripeLevel)
-pub mod directory_stripe_level {
-    use super::DirectoryStripeLevel;
-
-    /// If not set, DirectoryStripeLevel will default to DIRECTORY_STRIPE_LEVEL_MAX
-    pub const DIRECTORY_STRIPE_LEVEL_UNSPECIFIED: DirectoryStripeLevel =
-        DirectoryStripeLevel::new("DIRECTORY_STRIPE_LEVEL_UNSPECIFIED");
-
-    /// Minimum directory striping
-    pub const DIRECTORY_STRIPE_LEVEL_MIN: DirectoryStripeLevel =
-        DirectoryStripeLevel::new("DIRECTORY_STRIPE_LEVEL_MIN");
-
-    /// Medium directory striping
-    pub const DIRECTORY_STRIPE_LEVEL_BALANCED: DirectoryStripeLevel =
-        DirectoryStripeLevel::new("DIRECTORY_STRIPE_LEVEL_BALANCED");
-
-    /// Maximum directory striping
-    pub const DIRECTORY_STRIPE_LEVEL_MAX: DirectoryStripeLevel =
-        DirectoryStripeLevel::new("DIRECTORY_STRIPE_LEVEL_MAX");
-}
-
-impl std::convert::From<std::string::String> for DirectoryStripeLevel {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DirectoryStripeLevel {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DirectoryStripeLevel {
     fn default() -> Self {
-        directory_stripe_level::DIRECTORY_STRIPE_LEVEL_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Represents the deployment type for the instance.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DeploymentType(std::borrow::Cow<'static, str>);
+pub struct DeploymentType(i32);
 
 impl DeploymentType {
+    /// Default Deployment Type
+    /// It is equivalent to SCRATCH
+    pub const DEPLOYMENT_TYPE_UNSPECIFIED: DeploymentType = DeploymentType::new(0);
+
+    /// Scratch
+    pub const SCRATCH: DeploymentType = DeploymentType::new(1);
+
+    /// Persistent
+    pub const PERSISTENT: DeploymentType = DeploymentType::new(2);
+
     /// Creates a new DeploymentType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DEPLOYMENT_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SCRATCH"),
+            2 => std::borrow::Cow::Borrowed("PERSISTENT"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DEPLOYMENT_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::DEPLOYMENT_TYPE_UNSPECIFIED)
+            }
+            "SCRATCH" => std::option::Option::Some(Self::SCRATCH),
+            "PERSISTENT" => std::option::Option::Some(Self::PERSISTENT),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [DeploymentType](DeploymentType)
-pub mod deployment_type {
-    use super::DeploymentType;
-
-    /// Default Deployment Type
-    /// It is equivalent to SCRATCH
-    pub const DEPLOYMENT_TYPE_UNSPECIFIED: DeploymentType =
-        DeploymentType::new("DEPLOYMENT_TYPE_UNSPECIFIED");
-
-    /// Scratch
-    pub const SCRATCH: DeploymentType = DeploymentType::new("SCRATCH");
-
-    /// Persistent
-    pub const PERSISTENT: DeploymentType = DeploymentType::new("PERSISTENT");
-}
-
-impl std::convert::From<std::string::String> for DeploymentType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DeploymentType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DeploymentType {
     fn default() -> Self {
-        deployment_type::DEPLOYMENT_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/parallelstore/v1/src/transport.rs
+++ b/src/generated/cloud/parallelstore/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::Parallelstore for Parallelstore {
                 reqwest::Method::GET,
                 format!("/v1/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::Parallelstore for Parallelstore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::Parallelstore for Parallelstore {
                 reqwest::Method::POST,
                 format!("/v1/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -127,7 +127,7 @@ impl crate::stubs::Parallelstore for Parallelstore {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -157,7 +157,7 @@ impl crate::stubs::Parallelstore for Parallelstore {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -180,7 +180,7 @@ impl crate::stubs::Parallelstore for Parallelstore {
                 reqwest::Method::POST,
                 format!("/v1/{}:importData", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -200,7 +200,7 @@ impl crate::stubs::Parallelstore for Parallelstore {
                 reqwest::Method::POST,
                 format!("/v1/{}:exportData", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -217,7 +217,7 @@ impl crate::stubs::Parallelstore for Parallelstore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -239,7 +239,7 @@ impl crate::stubs::Parallelstore for Parallelstore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -258,7 +258,7 @@ impl crate::stubs::Parallelstore for Parallelstore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -280,7 +280,7 @@ impl crate::stubs::Parallelstore for Parallelstore {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -299,7 +299,7 @@ impl crate::stubs::Parallelstore for Parallelstore {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -318,7 +318,7 @@ impl crate::stubs::Parallelstore for Parallelstore {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/parametermanager/v1/src/model.rs
+++ b/src/generated/cloud/parametermanager/v1/src/model.rs
@@ -1102,92 +1102,125 @@ impl wkt::message::Message for DeleteParameterVersionRequest {
 /// JSON). This option is user specified at the time of creation of the resource
 /// and is immutable.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ParameterFormat(std::borrow::Cow<'static, str>);
+pub struct ParameterFormat(i32);
 
 impl ParameterFormat {
+    /// The default / unset value.
+    /// The API will default to the UNFORMATTED format.
+    pub const PARAMETER_FORMAT_UNSPECIFIED: ParameterFormat = ParameterFormat::new(0);
+
+    /// Unformatted.
+    pub const UNFORMATTED: ParameterFormat = ParameterFormat::new(1);
+
+    /// YAML format.
+    pub const YAML: ParameterFormat = ParameterFormat::new(2);
+
+    /// JSON format.
+    pub const JSON: ParameterFormat = ParameterFormat::new(3);
+
     /// Creates a new ParameterFormat instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("PARAMETER_FORMAT_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("UNFORMATTED"),
+            2 => std::borrow::Cow::Borrowed("YAML"),
+            3 => std::borrow::Cow::Borrowed("JSON"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "PARAMETER_FORMAT_UNSPECIFIED" => {
+                std::option::Option::Some(Self::PARAMETER_FORMAT_UNSPECIFIED)
+            }
+            "UNFORMATTED" => std::option::Option::Some(Self::UNFORMATTED),
+            "YAML" => std::option::Option::Some(Self::YAML),
+            "JSON" => std::option::Option::Some(Self::JSON),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [ParameterFormat](ParameterFormat)
-pub mod parameter_format {
-    use super::ParameterFormat;
-
-    /// The default / unset value.
-    /// The API will default to the UNFORMATTED format.
-    pub const PARAMETER_FORMAT_UNSPECIFIED: ParameterFormat =
-        ParameterFormat::new("PARAMETER_FORMAT_UNSPECIFIED");
-
-    /// Unformatted.
-    pub const UNFORMATTED: ParameterFormat = ParameterFormat::new("UNFORMATTED");
-
-    /// YAML format.
-    pub const YAML: ParameterFormat = ParameterFormat::new("YAML");
-
-    /// JSON format.
-    pub const JSON: ParameterFormat = ParameterFormat::new("JSON");
-}
-
-impl std::convert::From<std::string::String> for ParameterFormat {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ParameterFormat {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ParameterFormat {
     fn default() -> Self {
-        parameter_format::PARAMETER_FORMAT_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Option for requesting only metadata, or user provided payload
 /// of a ParameterVersion resource.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct View(std::borrow::Cow<'static, str>);
+pub struct View(i32);
 
 impl View {
-    /// Creates a new View instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [View](View)
-pub mod view {
-    use super::View;
-
     /// The default / unset value.
     /// The API will default to the FULL view..
-    pub const VIEW_UNSPECIFIED: View = View::new("VIEW_UNSPECIFIED");
+    pub const VIEW_UNSPECIFIED: View = View::new(0);
 
     /// Include only the metadata for the resource.
-    pub const BASIC: View = View::new("BASIC");
+    pub const BASIC: View = View::new(1);
 
     /// Include metadata & other relevant payload data as well.
     /// This is the default view.
-    pub const FULL: View = View::new("FULL");
+    pub const FULL: View = View::new(2);
+
+    /// Creates a new View instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("BASIC"),
+            2 => std::borrow::Cow::Borrowed("FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "VIEW_UNSPECIFIED" => std::option::Option::Some(Self::VIEW_UNSPECIFIED),
+            "BASIC" => std::option::Option::Some(Self::BASIC),
+            "FULL" => std::option::Option::Some(Self::FULL),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for View {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for View {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for View {
     fn default() -> Self {
-        view::VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/parametermanager/v1/src/transport.rs
+++ b/src/generated/cloud/parametermanager/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::ParameterManager for ParameterManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/parameters", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::ParameterManager for ParameterManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::ParameterManager for ParameterManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/parameters", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -127,7 +127,7 @@ impl crate::stubs::ParameterManager for ParameterManager {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -157,7 +157,7 @@ impl crate::stubs::ParameterManager for ParameterManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -177,7 +177,7 @@ impl crate::stubs::ParameterManager for ParameterManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/versions", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -200,7 +200,7 @@ impl crate::stubs::ParameterManager for ParameterManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -220,7 +220,7 @@ impl crate::stubs::ParameterManager for ParameterManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}:render", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -242,7 +242,7 @@ impl crate::stubs::ParameterManager for ParameterManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/versions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -272,7 +272,7 @@ impl crate::stubs::ParameterManager for ParameterManager {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -302,7 +302,7 @@ impl crate::stubs::ParameterManager for ParameterManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -322,7 +322,7 @@ impl crate::stubs::ParameterManager for ParameterManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -344,7 +344,7 @@ impl crate::stubs::ParameterManager for ParameterManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/policysimulator/v1/src/model.rs
+++ b/src/generated/cloud/policysimulator/v1/src/model.rs
@@ -425,79 +425,85 @@ pub mod binding_explanation {
 
     /// Whether a role includes a specific permission.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RolePermission(std::borrow::Cow<'static, str>);
+    pub struct RolePermission(i32);
 
     impl RolePermission {
-        /// Creates a new RolePermission instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RolePermission](RolePermission)
-    pub mod role_permission {
-        use super::RolePermission;
-
         /// Default value. This value is unused.
-        pub const ROLE_PERMISSION_UNSPECIFIED: RolePermission =
-            RolePermission::new("ROLE_PERMISSION_UNSPECIFIED");
+        pub const ROLE_PERMISSION_UNSPECIFIED: RolePermission = RolePermission::new(0);
 
         /// The permission is included in the role.
-        pub const ROLE_PERMISSION_INCLUDED: RolePermission =
-            RolePermission::new("ROLE_PERMISSION_INCLUDED");
+        pub const ROLE_PERMISSION_INCLUDED: RolePermission = RolePermission::new(1);
 
         /// The permission is not included in the role.
-        pub const ROLE_PERMISSION_NOT_INCLUDED: RolePermission =
-            RolePermission::new("ROLE_PERMISSION_NOT_INCLUDED");
+        pub const ROLE_PERMISSION_NOT_INCLUDED: RolePermission = RolePermission::new(2);
 
         /// The user who created the
         /// [Replay][google.cloud.policysimulator.v1.Replay] is not
         /// allowed to access the binding.
         ///
         /// [google.cloud.policysimulator.v1.Replay]: crate::model::Replay
-        pub const ROLE_PERMISSION_UNKNOWN_INFO_DENIED: RolePermission =
-            RolePermission::new("ROLE_PERMISSION_UNKNOWN_INFO_DENIED");
+        pub const ROLE_PERMISSION_UNKNOWN_INFO_DENIED: RolePermission = RolePermission::new(3);
+
+        /// Creates a new RolePermission instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_INCLUDED"),
+                2 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_NOT_INCLUDED"),
+                3 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_UNKNOWN_INFO_DENIED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ROLE_PERMISSION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ROLE_PERMISSION_UNSPECIFIED)
+                }
+                "ROLE_PERMISSION_INCLUDED" => {
+                    std::option::Option::Some(Self::ROLE_PERMISSION_INCLUDED)
+                }
+                "ROLE_PERMISSION_NOT_INCLUDED" => {
+                    std::option::Option::Some(Self::ROLE_PERMISSION_NOT_INCLUDED)
+                }
+                "ROLE_PERMISSION_UNKNOWN_INFO_DENIED" => {
+                    std::option::Option::Some(Self::ROLE_PERMISSION_UNKNOWN_INFO_DENIED)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RolePermission {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RolePermission {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RolePermission {
         fn default() -> Self {
-            role_permission::ROLE_PERMISSION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Whether the binding includes the principal.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Membership(std::borrow::Cow<'static, str>);
+    pub struct Membership(i32);
 
     impl Membership {
-        /// Creates a new Membership instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Membership](Membership)
-    pub mod membership {
-        use super::Membership;
-
         /// Default value. This value is unused.
-        pub const MEMBERSHIP_UNSPECIFIED: Membership = Membership::new("MEMBERSHIP_UNSPECIFIED");
+        pub const MEMBERSHIP_UNSPECIFIED: Membership = Membership::new(0);
 
         /// The binding includes the principal. The principal can be included
         /// directly or indirectly. For example:
@@ -506,34 +512,72 @@ pub mod binding_explanation {
         ///   binding.
         /// * A principal is included indirectly if that principal is in a Google
         ///   group or Google Workspace domain that is listed in the binding.
-        pub const MEMBERSHIP_INCLUDED: Membership = Membership::new("MEMBERSHIP_INCLUDED");
+        pub const MEMBERSHIP_INCLUDED: Membership = Membership::new(1);
 
         /// The binding does not include the principal.
-        pub const MEMBERSHIP_NOT_INCLUDED: Membership = Membership::new("MEMBERSHIP_NOT_INCLUDED");
+        pub const MEMBERSHIP_NOT_INCLUDED: Membership = Membership::new(2);
 
         /// The user who created the
         /// [Replay][google.cloud.policysimulator.v1.Replay] is not
         /// allowed to access the binding.
         ///
         /// [google.cloud.policysimulator.v1.Replay]: crate::model::Replay
-        pub const MEMBERSHIP_UNKNOWN_INFO_DENIED: Membership =
-            Membership::new("MEMBERSHIP_UNKNOWN_INFO_DENIED");
+        pub const MEMBERSHIP_UNKNOWN_INFO_DENIED: Membership = Membership::new(3);
 
         /// The principal is an unsupported type. Only Google Accounts and service
         /// accounts are supported.
-        pub const MEMBERSHIP_UNKNOWN_UNSUPPORTED: Membership =
-            Membership::new("MEMBERSHIP_UNKNOWN_UNSUPPORTED");
+        pub const MEMBERSHIP_UNKNOWN_UNSUPPORTED: Membership = Membership::new(4);
+
+        /// Creates a new Membership instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MEMBERSHIP_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MEMBERSHIP_INCLUDED"),
+                2 => std::borrow::Cow::Borrowed("MEMBERSHIP_NOT_INCLUDED"),
+                3 => std::borrow::Cow::Borrowed("MEMBERSHIP_UNKNOWN_INFO_DENIED"),
+                4 => std::borrow::Cow::Borrowed("MEMBERSHIP_UNKNOWN_UNSUPPORTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MEMBERSHIP_UNSPECIFIED" => std::option::Option::Some(Self::MEMBERSHIP_UNSPECIFIED),
+                "MEMBERSHIP_INCLUDED" => std::option::Option::Some(Self::MEMBERSHIP_INCLUDED),
+                "MEMBERSHIP_NOT_INCLUDED" => {
+                    std::option::Option::Some(Self::MEMBERSHIP_NOT_INCLUDED)
+                }
+                "MEMBERSHIP_UNKNOWN_INFO_DENIED" => {
+                    std::option::Option::Some(Self::MEMBERSHIP_UNKNOWN_INFO_DENIED)
+                }
+                "MEMBERSHIP_UNKNOWN_UNSUPPORTED" => {
+                    std::option::Option::Some(Self::MEMBERSHIP_UNKNOWN_UNSUPPORTED)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Membership {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Membership {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Membership {
         fn default() -> Self {
-            membership::MEMBERSHIP_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -704,49 +748,68 @@ pub mod replay {
     ///
     /// [google.cloud.policysimulator.v1.Replay]: crate::model::Replay
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Default value. This value is unused.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The `Replay` has not started yet.
+        pub const PENDING: State = State::new(1);
+
+        /// The `Replay` is currently running.
+        pub const RUNNING: State = State::new(2);
+
+        /// The `Replay` has successfully completed.
+        pub const SUCCEEDED: State = State::new(3);
+
+        /// The `Replay` has finished with an error.
+        pub const FAILED: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The `Replay` has not started yet.
-        pub const PENDING: State = State::new("PENDING");
-
-        /// The `Replay` is currently running.
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// The `Replay` has successfully completed.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-        /// The `Replay` has finished with an error.
-        pub const FAILED: State = State::new("FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1268,46 +1331,59 @@ pub mod replay_config {
     ///
     /// [google.cloud.policysimulator.v1.Replay]: crate::model::Replay
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LogSource(std::borrow::Cow<'static, str>);
+    pub struct LogSource(i32);
 
     impl LogSource {
-        /// Creates a new LogSource instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [LogSource](LogSource)
-    pub mod log_source {
-        use super::LogSource;
-
         /// An unspecified log source.
         /// If the log source is unspecified, the
         /// [Replay][google.cloud.policysimulator.v1.Replay] defaults to using
         /// `RECENT_ACCESSES`.
         ///
         /// [google.cloud.policysimulator.v1.Replay]: crate::model::Replay
-        pub const LOG_SOURCE_UNSPECIFIED: LogSource = LogSource::new("LOG_SOURCE_UNSPECIFIED");
+        pub const LOG_SOURCE_UNSPECIFIED: LogSource = LogSource::new(0);
 
         /// All access logs from the last 90 days. These logs may not include logs
         /// from the most recent 7 days.
-        pub const RECENT_ACCESSES: LogSource = LogSource::new("RECENT_ACCESSES");
+        pub const RECENT_ACCESSES: LogSource = LogSource::new(1);
+
+        /// Creates a new LogSource instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LOG_SOURCE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RECENT_ACCESSES"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LOG_SOURCE_UNSPECIFIED" => std::option::Option::Some(Self::LOG_SOURCE_UNSPECIFIED),
+                "RECENT_ACCESSES" => std::option::Option::Some(Self::RECENT_ACCESSES),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for LogSource {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LogSource {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LogSource {
         fn default() -> Self {
-            log_source::LOG_SOURCE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1439,45 +1515,29 @@ pub mod access_state_diff {
     /// How the principal's access, specified in the AccessState field, changed
     /// between the current (baseline) policies and proposed (simulated) policies.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AccessChangeType(std::borrow::Cow<'static, str>);
+    pub struct AccessChangeType(i32);
 
     impl AccessChangeType {
-        /// Creates a new AccessChangeType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [AccessChangeType](AccessChangeType)
-    pub mod access_change_type {
-        use super::AccessChangeType;
-
         /// Default value. This value is unused.
-        pub const ACCESS_CHANGE_TYPE_UNSPECIFIED: AccessChangeType =
-            AccessChangeType::new("ACCESS_CHANGE_TYPE_UNSPECIFIED");
+        pub const ACCESS_CHANGE_TYPE_UNSPECIFIED: AccessChangeType = AccessChangeType::new(0);
 
         /// The principal's access did not change.
         /// This includes the case where both baseline and simulated are UNKNOWN,
         /// but the unknown information is equivalent.
-        pub const NO_CHANGE: AccessChangeType = AccessChangeType::new("NO_CHANGE");
+        pub const NO_CHANGE: AccessChangeType = AccessChangeType::new(1);
 
         /// The principal's access under both the current policies and the proposed
         /// policies is `UNKNOWN`, but the unknown information differs between them.
-        pub const UNKNOWN_CHANGE: AccessChangeType = AccessChangeType::new("UNKNOWN_CHANGE");
+        pub const UNKNOWN_CHANGE: AccessChangeType = AccessChangeType::new(2);
 
         /// The principal had access under the current policies (`GRANTED`), but will
         /// no longer have access after the proposed changes (`NOT_GRANTED`).
-        pub const ACCESS_REVOKED: AccessChangeType = AccessChangeType::new("ACCESS_REVOKED");
+        pub const ACCESS_REVOKED: AccessChangeType = AccessChangeType::new(3);
 
         /// The principal did not have access under the current policies
         /// (`NOT_GRANTED`), but will have access after the proposed changes
         /// (`GRANTED`).
-        pub const ACCESS_GAINED: AccessChangeType = AccessChangeType::new("ACCESS_GAINED");
+        pub const ACCESS_GAINED: AccessChangeType = AccessChangeType::new(4);
 
         /// This result can occur for the following reasons:
         ///
@@ -1488,8 +1548,7 @@ pub mod access_state_diff {
         ///   they
         ///   will not have access after the proposed changes (`NOT_GRANTED`).
         ///
-        pub const ACCESS_MAYBE_REVOKED: AccessChangeType =
-            AccessChangeType::new("ACCESS_MAYBE_REVOKED");
+        pub const ACCESS_MAYBE_REVOKED: AccessChangeType = AccessChangeType::new(5);
 
         /// This result can occur for the following reasons:
         ///
@@ -1500,19 +1559,58 @@ pub mod access_state_diff {
         /// * The principal's access under the current policies is `UNKNOWN`, but
         ///   they will have access after the proposed changes (`GRANTED`).
         ///
-        pub const ACCESS_MAYBE_GAINED: AccessChangeType =
-            AccessChangeType::new("ACCESS_MAYBE_GAINED");
+        pub const ACCESS_MAYBE_GAINED: AccessChangeType = AccessChangeType::new(6);
+
+        /// Creates a new AccessChangeType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ACCESS_CHANGE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NO_CHANGE"),
+                2 => std::borrow::Cow::Borrowed("UNKNOWN_CHANGE"),
+                3 => std::borrow::Cow::Borrowed("ACCESS_REVOKED"),
+                4 => std::borrow::Cow::Borrowed("ACCESS_GAINED"),
+                5 => std::borrow::Cow::Borrowed("ACCESS_MAYBE_REVOKED"),
+                6 => std::borrow::Cow::Borrowed("ACCESS_MAYBE_GAINED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ACCESS_CHANGE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ACCESS_CHANGE_TYPE_UNSPECIFIED)
+                }
+                "NO_CHANGE" => std::option::Option::Some(Self::NO_CHANGE),
+                "UNKNOWN_CHANGE" => std::option::Option::Some(Self::UNKNOWN_CHANGE),
+                "ACCESS_REVOKED" => std::option::Option::Some(Self::ACCESS_REVOKED),
+                "ACCESS_GAINED" => std::option::Option::Some(Self::ACCESS_GAINED),
+                "ACCESS_MAYBE_REVOKED" => std::option::Option::Some(Self::ACCESS_MAYBE_REVOKED),
+                "ACCESS_MAYBE_GAINED" => std::option::Option::Some(Self::ACCESS_MAYBE_GAINED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for AccessChangeType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AccessChangeType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AccessChangeType {
         fn default() -> Self {
-            access_change_type::ACCESS_CHANGE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1600,54 +1698,73 @@ impl wkt::message::Message for ExplainedAccess {
 
 /// Whether a principal has a permission for a resource.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AccessState(std::borrow::Cow<'static, str>);
+pub struct AccessState(i32);
 
 impl AccessState {
-    /// Creates a new AccessState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [AccessState](AccessState)
-pub mod access_state {
-    use super::AccessState;
-
     /// Default value. This value is unused.
-    pub const ACCESS_STATE_UNSPECIFIED: AccessState = AccessState::new("ACCESS_STATE_UNSPECIFIED");
+    pub const ACCESS_STATE_UNSPECIFIED: AccessState = AccessState::new(0);
 
     /// The principal has the permission.
-    pub const GRANTED: AccessState = AccessState::new("GRANTED");
+    pub const GRANTED: AccessState = AccessState::new(1);
 
     /// The principal does not have the permission.
-    pub const NOT_GRANTED: AccessState = AccessState::new("NOT_GRANTED");
+    pub const NOT_GRANTED: AccessState = AccessState::new(2);
 
     /// The principal has the permission only if a condition expression evaluates
     /// to `true`.
-    pub const UNKNOWN_CONDITIONAL: AccessState = AccessState::new("UNKNOWN_CONDITIONAL");
+    pub const UNKNOWN_CONDITIONAL: AccessState = AccessState::new(3);
 
     /// The user who created the
     /// [Replay][google.cloud.policysimulator.v1.Replay] does not have
     /// access to all of the policies that Policy Simulator needs to evaluate.
     ///
     /// [google.cloud.policysimulator.v1.Replay]: crate::model::Replay
-    pub const UNKNOWN_INFO_DENIED: AccessState = AccessState::new("UNKNOWN_INFO_DENIED");
+    pub const UNKNOWN_INFO_DENIED: AccessState = AccessState::new(4);
+
+    /// Creates a new AccessState instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ACCESS_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("GRANTED"),
+            2 => std::borrow::Cow::Borrowed("NOT_GRANTED"),
+            3 => std::borrow::Cow::Borrowed("UNKNOWN_CONDITIONAL"),
+            4 => std::borrow::Cow::Borrowed("UNKNOWN_INFO_DENIED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ACCESS_STATE_UNSPECIFIED" => std::option::Option::Some(Self::ACCESS_STATE_UNSPECIFIED),
+            "GRANTED" => std::option::Option::Some(Self::GRANTED),
+            "NOT_GRANTED" => std::option::Option::Some(Self::NOT_GRANTED),
+            "UNKNOWN_CONDITIONAL" => std::option::Option::Some(Self::UNKNOWN_CONDITIONAL),
+            "UNKNOWN_INFO_DENIED" => std::option::Option::Some(Self::UNKNOWN_INFO_DENIED),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for AccessState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for AccessState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for AccessState {
     fn default() -> Self {
-        access_state::ACCESS_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -1655,45 +1772,61 @@ impl std::default::Default for AccessState {
 /// or whether a binding includes a specific principal, contributes to an overall
 /// determination.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct HeuristicRelevance(std::borrow::Cow<'static, str>);
+pub struct HeuristicRelevance(i32);
 
 impl HeuristicRelevance {
-    /// Creates a new HeuristicRelevance instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [HeuristicRelevance](HeuristicRelevance)
-pub mod heuristic_relevance {
-    use super::HeuristicRelevance;
-
     /// Default value. This value is unused.
-    pub const HEURISTIC_RELEVANCE_UNSPECIFIED: HeuristicRelevance =
-        HeuristicRelevance::new("HEURISTIC_RELEVANCE_UNSPECIFIED");
+    pub const HEURISTIC_RELEVANCE_UNSPECIFIED: HeuristicRelevance = HeuristicRelevance::new(0);
 
     /// The data point has a limited effect on the result. Changing the data point
     /// is unlikely to affect the overall determination.
-    pub const NORMAL: HeuristicRelevance = HeuristicRelevance::new("NORMAL");
+    pub const NORMAL: HeuristicRelevance = HeuristicRelevance::new(1);
 
     /// The data point has a strong effect on the result. Changing the data point
     /// is likely to affect the overall determination.
-    pub const HIGH: HeuristicRelevance = HeuristicRelevance::new("HIGH");
+    pub const HIGH: HeuristicRelevance = HeuristicRelevance::new(2);
+
+    /// Creates a new HeuristicRelevance instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("HEURISTIC_RELEVANCE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("NORMAL"),
+            2 => std::borrow::Cow::Borrowed("HIGH"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "HEURISTIC_RELEVANCE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::HEURISTIC_RELEVANCE_UNSPECIFIED)
+            }
+            "NORMAL" => std::option::Option::Some(Self::NORMAL),
+            "HIGH" => std::option::Option::Some(Self::HIGH),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for HeuristicRelevance {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for HeuristicRelevance {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for HeuristicRelevance {
     fn default() -> Self {
-        heuristic_relevance::HEURISTIC_RELEVANCE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/policysimulator/v1/src/transport.rs
+++ b/src/generated/cloud/policysimulator/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::Simulator for Simulator {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -68,7 +68,7 @@ impl crate::stubs::Simulator for Simulator {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/replays", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -85,7 +85,7 @@ impl crate::stubs::Simulator for Simulator {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/results", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -106,7 +106,7 @@ impl crate::stubs::Simulator for Simulator {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -128,7 +128,7 @@ impl crate::stubs::Simulator for Simulator {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/policytroubleshooter/iam/v3/src/model.rs
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/src/model.rs
@@ -164,54 +164,73 @@ pub mod troubleshoot_iam_policy_response {
 
     /// Whether the principal has the permission on the resource.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OverallAccessState(std::borrow::Cow<'static, str>);
+    pub struct OverallAccessState(i32);
 
     impl OverallAccessState {
-        /// Creates a new OverallAccessState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [OverallAccessState](OverallAccessState)
-    pub mod overall_access_state {
-        use super::OverallAccessState;
-
         /// Not specified.
-        pub const OVERALL_ACCESS_STATE_UNSPECIFIED: OverallAccessState =
-            OverallAccessState::new("OVERALL_ACCESS_STATE_UNSPECIFIED");
+        pub const OVERALL_ACCESS_STATE_UNSPECIFIED: OverallAccessState = OverallAccessState::new(0);
 
         /// The principal has the permission.
-        pub const CAN_ACCESS: OverallAccessState = OverallAccessState::new("CAN_ACCESS");
+        pub const CAN_ACCESS: OverallAccessState = OverallAccessState::new(1);
 
         /// The principal doesn't have the permission.
-        pub const CANNOT_ACCESS: OverallAccessState = OverallAccessState::new("CANNOT_ACCESS");
+        pub const CANNOT_ACCESS: OverallAccessState = OverallAccessState::new(2);
 
         /// The principal might have the permission, but the sender can't access all
         /// of the information needed to fully evaluate the principal's access.
-        pub const UNKNOWN_INFO: OverallAccessState = OverallAccessState::new("UNKNOWN_INFO");
+        pub const UNKNOWN_INFO: OverallAccessState = OverallAccessState::new(3);
 
         /// The principal might have the permission, but Policy Troubleshooter can't
         /// fully evaluate the principal's access because the sender didn't provide
         /// the required context to evaluate the condition.
-        pub const UNKNOWN_CONDITIONAL: OverallAccessState =
-            OverallAccessState::new("UNKNOWN_CONDITIONAL");
+        pub const UNKNOWN_CONDITIONAL: OverallAccessState = OverallAccessState::new(4);
+
+        /// Creates a new OverallAccessState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("OVERALL_ACCESS_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CAN_ACCESS"),
+                2 => std::borrow::Cow::Borrowed("CANNOT_ACCESS"),
+                3 => std::borrow::Cow::Borrowed("UNKNOWN_INFO"),
+                4 => std::borrow::Cow::Borrowed("UNKNOWN_CONDITIONAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "OVERALL_ACCESS_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::OVERALL_ACCESS_STATE_UNSPECIFIED)
+                }
+                "CAN_ACCESS" => std::option::Option::Some(Self::CAN_ACCESS),
+                "CANNOT_ACCESS" => std::option::Option::Some(Self::CANNOT_ACCESS),
+                "UNKNOWN_INFO" => std::option::Option::Some(Self::UNKNOWN_INFO),
+                "UNKNOWN_CONDITIONAL" => std::option::Option::Some(Self::UNKNOWN_CONDITIONAL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for OverallAccessState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for OverallAccessState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for OverallAccessState {
         fn default() -> Self {
-            overall_access_state::OVERALL_ACCESS_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1853,235 +1872,310 @@ pub mod condition_explanation {
 
 /// Whether IAM allow policies gives the principal the permission.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AllowAccessState(std::borrow::Cow<'static, str>);
+pub struct AllowAccessState(i32);
 
 impl AllowAccessState {
-    /// Creates a new AllowAccessState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [AllowAccessState](AllowAccessState)
-pub mod allow_access_state {
-    use super::AllowAccessState;
-
     /// Not specified.
-    pub const ALLOW_ACCESS_STATE_UNSPECIFIED: AllowAccessState =
-        AllowAccessState::new("ALLOW_ACCESS_STATE_UNSPECIFIED");
+    pub const ALLOW_ACCESS_STATE_UNSPECIFIED: AllowAccessState = AllowAccessState::new(0);
 
     /// The allow policy gives the principal the permission.
-    pub const ALLOW_ACCESS_STATE_GRANTED: AllowAccessState =
-        AllowAccessState::new("ALLOW_ACCESS_STATE_GRANTED");
+    pub const ALLOW_ACCESS_STATE_GRANTED: AllowAccessState = AllowAccessState::new(1);
 
     /// The allow policy doesn't give the principal the permission.
-    pub const ALLOW_ACCESS_STATE_NOT_GRANTED: AllowAccessState =
-        AllowAccessState::new("ALLOW_ACCESS_STATE_NOT_GRANTED");
+    pub const ALLOW_ACCESS_STATE_NOT_GRANTED: AllowAccessState = AllowAccessState::new(2);
 
     /// The allow policy gives the principal the permission if a condition
     /// expression evaluate to `true`. However, the sender of the request didn't
     /// provide enough context for Policy Troubleshooter to evaluate the condition
     /// expression.
-    pub const ALLOW_ACCESS_STATE_UNKNOWN_CONDITIONAL: AllowAccessState =
-        AllowAccessState::new("ALLOW_ACCESS_STATE_UNKNOWN_CONDITIONAL");
+    pub const ALLOW_ACCESS_STATE_UNKNOWN_CONDITIONAL: AllowAccessState = AllowAccessState::new(3);
 
     /// The sender of the request doesn't have access to all of the allow policies
     /// that Policy Troubleshooter needs to evaluate the principal's access.
-    pub const ALLOW_ACCESS_STATE_UNKNOWN_INFO: AllowAccessState =
-        AllowAccessState::new("ALLOW_ACCESS_STATE_UNKNOWN_INFO");
+    pub const ALLOW_ACCESS_STATE_UNKNOWN_INFO: AllowAccessState = AllowAccessState::new(4);
+
+    /// Creates a new AllowAccessState instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ALLOW_ACCESS_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ALLOW_ACCESS_STATE_GRANTED"),
+            2 => std::borrow::Cow::Borrowed("ALLOW_ACCESS_STATE_NOT_GRANTED"),
+            3 => std::borrow::Cow::Borrowed("ALLOW_ACCESS_STATE_UNKNOWN_CONDITIONAL"),
+            4 => std::borrow::Cow::Borrowed("ALLOW_ACCESS_STATE_UNKNOWN_INFO"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ALLOW_ACCESS_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::ALLOW_ACCESS_STATE_UNSPECIFIED)
+            }
+            "ALLOW_ACCESS_STATE_GRANTED" => {
+                std::option::Option::Some(Self::ALLOW_ACCESS_STATE_GRANTED)
+            }
+            "ALLOW_ACCESS_STATE_NOT_GRANTED" => {
+                std::option::Option::Some(Self::ALLOW_ACCESS_STATE_NOT_GRANTED)
+            }
+            "ALLOW_ACCESS_STATE_UNKNOWN_CONDITIONAL" => {
+                std::option::Option::Some(Self::ALLOW_ACCESS_STATE_UNKNOWN_CONDITIONAL)
+            }
+            "ALLOW_ACCESS_STATE_UNKNOWN_INFO" => {
+                std::option::Option::Some(Self::ALLOW_ACCESS_STATE_UNKNOWN_INFO)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for AllowAccessState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for AllowAccessState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for AllowAccessState {
     fn default() -> Self {
-        allow_access_state::ALLOW_ACCESS_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Whether IAM deny policies deny the principal the permission.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DenyAccessState(std::borrow::Cow<'static, str>);
+pub struct DenyAccessState(i32);
 
 impl DenyAccessState {
-    /// Creates a new DenyAccessState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [DenyAccessState](DenyAccessState)
-pub mod deny_access_state {
-    use super::DenyAccessState;
-
     /// Not specified.
-    pub const DENY_ACCESS_STATE_UNSPECIFIED: DenyAccessState =
-        DenyAccessState::new("DENY_ACCESS_STATE_UNSPECIFIED");
+    pub const DENY_ACCESS_STATE_UNSPECIFIED: DenyAccessState = DenyAccessState::new(0);
 
     /// The deny policy denies the principal the permission.
-    pub const DENY_ACCESS_STATE_DENIED: DenyAccessState =
-        DenyAccessState::new("DENY_ACCESS_STATE_DENIED");
+    pub const DENY_ACCESS_STATE_DENIED: DenyAccessState = DenyAccessState::new(1);
 
     /// The deny policy doesn't deny the principal the permission.
-    pub const DENY_ACCESS_STATE_NOT_DENIED: DenyAccessState =
-        DenyAccessState::new("DENY_ACCESS_STATE_NOT_DENIED");
+    pub const DENY_ACCESS_STATE_NOT_DENIED: DenyAccessState = DenyAccessState::new(2);
 
     /// The deny policy denies the principal the permission if a condition
     /// expression evaluates to `true`. However, the sender of the request didn't
     /// provide enough context for Policy Troubleshooter to evaluate the condition
     /// expression.
-    pub const DENY_ACCESS_STATE_UNKNOWN_CONDITIONAL: DenyAccessState =
-        DenyAccessState::new("DENY_ACCESS_STATE_UNKNOWN_CONDITIONAL");
+    pub const DENY_ACCESS_STATE_UNKNOWN_CONDITIONAL: DenyAccessState = DenyAccessState::new(3);
 
     /// The sender of the request does not have access to all of the deny policies
     /// that Policy Troubleshooter needs to evaluate the principal's access.
-    pub const DENY_ACCESS_STATE_UNKNOWN_INFO: DenyAccessState =
-        DenyAccessState::new("DENY_ACCESS_STATE_UNKNOWN_INFO");
+    pub const DENY_ACCESS_STATE_UNKNOWN_INFO: DenyAccessState = DenyAccessState::new(4);
+
+    /// Creates a new DenyAccessState instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DENY_ACCESS_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("DENY_ACCESS_STATE_DENIED"),
+            2 => std::borrow::Cow::Borrowed("DENY_ACCESS_STATE_NOT_DENIED"),
+            3 => std::borrow::Cow::Borrowed("DENY_ACCESS_STATE_UNKNOWN_CONDITIONAL"),
+            4 => std::borrow::Cow::Borrowed("DENY_ACCESS_STATE_UNKNOWN_INFO"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DENY_ACCESS_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::DENY_ACCESS_STATE_UNSPECIFIED)
+            }
+            "DENY_ACCESS_STATE_DENIED" => std::option::Option::Some(Self::DENY_ACCESS_STATE_DENIED),
+            "DENY_ACCESS_STATE_NOT_DENIED" => {
+                std::option::Option::Some(Self::DENY_ACCESS_STATE_NOT_DENIED)
+            }
+            "DENY_ACCESS_STATE_UNKNOWN_CONDITIONAL" => {
+                std::option::Option::Some(Self::DENY_ACCESS_STATE_UNKNOWN_CONDITIONAL)
+            }
+            "DENY_ACCESS_STATE_UNKNOWN_INFO" => {
+                std::option::Option::Some(Self::DENY_ACCESS_STATE_UNKNOWN_INFO)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for DenyAccessState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DenyAccessState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DenyAccessState {
     fn default() -> Self {
-        deny_access_state::DENY_ACCESS_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Whether a role includes a specific permission.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RolePermissionInclusionState(std::borrow::Cow<'static, str>);
+pub struct RolePermissionInclusionState(i32);
 
 impl RolePermissionInclusionState {
-    /// Creates a new RolePermissionInclusionState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [RolePermissionInclusionState](RolePermissionInclusionState)
-pub mod role_permission_inclusion_state {
-    use super::RolePermissionInclusionState;
-
     /// Not specified.
     pub const ROLE_PERMISSION_INCLUSION_STATE_UNSPECIFIED: RolePermissionInclusionState =
-        RolePermissionInclusionState::new("ROLE_PERMISSION_INCLUSION_STATE_UNSPECIFIED");
+        RolePermissionInclusionState::new(0);
 
     /// The permission is included in the role.
     pub const ROLE_PERMISSION_INCLUDED: RolePermissionInclusionState =
-        RolePermissionInclusionState::new("ROLE_PERMISSION_INCLUDED");
+        RolePermissionInclusionState::new(1);
 
     /// The permission is not included in the role.
     pub const ROLE_PERMISSION_NOT_INCLUDED: RolePermissionInclusionState =
-        RolePermissionInclusionState::new("ROLE_PERMISSION_NOT_INCLUDED");
+        RolePermissionInclusionState::new(2);
 
     /// The sender of the request is not allowed to access the role definition.
     pub const ROLE_PERMISSION_UNKNOWN_INFO: RolePermissionInclusionState =
-        RolePermissionInclusionState::new("ROLE_PERMISSION_UNKNOWN_INFO");
+        RolePermissionInclusionState::new(3);
+
+    /// Creates a new RolePermissionInclusionState instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_INCLUSION_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_INCLUDED"),
+            2 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_NOT_INCLUDED"),
+            3 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_UNKNOWN_INFO"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ROLE_PERMISSION_INCLUSION_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::ROLE_PERMISSION_INCLUSION_STATE_UNSPECIFIED)
+            }
+            "ROLE_PERMISSION_INCLUDED" => std::option::Option::Some(Self::ROLE_PERMISSION_INCLUDED),
+            "ROLE_PERMISSION_NOT_INCLUDED" => {
+                std::option::Option::Some(Self::ROLE_PERMISSION_NOT_INCLUDED)
+            }
+            "ROLE_PERMISSION_UNKNOWN_INFO" => {
+                std::option::Option::Some(Self::ROLE_PERMISSION_UNKNOWN_INFO)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for RolePermissionInclusionState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for RolePermissionInclusionState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for RolePermissionInclusionState {
     fn default() -> Self {
-        role_permission_inclusion_state::ROLE_PERMISSION_INCLUSION_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Whether the permission in the request matches the permission in the policy.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PermissionPatternMatchingState(std::borrow::Cow<'static, str>);
+pub struct PermissionPatternMatchingState(i32);
 
 impl PermissionPatternMatchingState {
-    /// Creates a new PermissionPatternMatchingState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [PermissionPatternMatchingState](PermissionPatternMatchingState)
-pub mod permission_pattern_matching_state {
-    use super::PermissionPatternMatchingState;
-
     /// Not specified.
     pub const PERMISSION_PATTERN_MATCHING_STATE_UNSPECIFIED: PermissionPatternMatchingState =
-        PermissionPatternMatchingState::new("PERMISSION_PATTERN_MATCHING_STATE_UNSPECIFIED");
+        PermissionPatternMatchingState::new(0);
 
     /// The permission in the request matches the permission in the policy.
     pub const PERMISSION_PATTERN_MATCHED: PermissionPatternMatchingState =
-        PermissionPatternMatchingState::new("PERMISSION_PATTERN_MATCHED");
+        PermissionPatternMatchingState::new(1);
 
     /// The permission in the request matches the permission in the policy.
     pub const PERMISSION_PATTERN_NOT_MATCHED: PermissionPatternMatchingState =
-        PermissionPatternMatchingState::new("PERMISSION_PATTERN_NOT_MATCHED");
+        PermissionPatternMatchingState::new(2);
+
+    /// Creates a new PermissionPatternMatchingState instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("PERMISSION_PATTERN_MATCHING_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PERMISSION_PATTERN_MATCHED"),
+            2 => std::borrow::Cow::Borrowed("PERMISSION_PATTERN_NOT_MATCHED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "PERMISSION_PATTERN_MATCHING_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::PERMISSION_PATTERN_MATCHING_STATE_UNSPECIFIED)
+            }
+            "PERMISSION_PATTERN_MATCHED" => {
+                std::option::Option::Some(Self::PERMISSION_PATTERN_MATCHED)
+            }
+            "PERMISSION_PATTERN_NOT_MATCHED" => {
+                std::option::Option::Some(Self::PERMISSION_PATTERN_NOT_MATCHED)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for PermissionPatternMatchingState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for PermissionPatternMatchingState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for PermissionPatternMatchingState {
     fn default() -> Self {
-        permission_pattern_matching_state::PERMISSION_PATTERN_MATCHING_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Whether the principal in the request matches the principal in the policy.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct MembershipMatchingState(std::borrow::Cow<'static, str>);
+pub struct MembershipMatchingState(i32);
 
 impl MembershipMatchingState {
-    /// Creates a new MembershipMatchingState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [MembershipMatchingState](MembershipMatchingState)
-pub mod membership_matching_state {
-    use super::MembershipMatchingState;
-
     /// Not specified.
     pub const MEMBERSHIP_MATCHING_STATE_UNSPECIFIED: MembershipMatchingState =
-        MembershipMatchingState::new("MEMBERSHIP_MATCHING_STATE_UNSPECIFIED");
+        MembershipMatchingState::new(0);
 
     /// The principal in the request matches the principal in the policy. The
     /// principal can be included directly or indirectly:
@@ -2091,80 +2185,131 @@ pub mod membership_matching_state {
     /// * A principal is included indirectly if that principal is in a Google
     ///   group, Google Workspace account, or Cloud Identity domain that is listed
     ///   in the policy.
-    pub const MEMBERSHIP_MATCHED: MembershipMatchingState =
-        MembershipMatchingState::new("MEMBERSHIP_MATCHED");
+    pub const MEMBERSHIP_MATCHED: MembershipMatchingState = MembershipMatchingState::new(1);
 
     /// The principal in the request doesn't match the principal in the policy.
-    pub const MEMBERSHIP_NOT_MATCHED: MembershipMatchingState =
-        MembershipMatchingState::new("MEMBERSHIP_NOT_MATCHED");
+    pub const MEMBERSHIP_NOT_MATCHED: MembershipMatchingState = MembershipMatchingState::new(2);
 
     /// The principal in the policy is a group or domain, and the sender of the
     /// request doesn't have permission to view whether the principal in the
     /// request is a member of the group or domain.
-    pub const MEMBERSHIP_UNKNOWN_INFO: MembershipMatchingState =
-        MembershipMatchingState::new("MEMBERSHIP_UNKNOWN_INFO");
+    pub const MEMBERSHIP_UNKNOWN_INFO: MembershipMatchingState = MembershipMatchingState::new(3);
 
     /// The principal is an unsupported type.
     pub const MEMBERSHIP_UNKNOWN_UNSUPPORTED: MembershipMatchingState =
-        MembershipMatchingState::new("MEMBERSHIP_UNKNOWN_UNSUPPORTED");
+        MembershipMatchingState::new(4);
+
+    /// Creates a new MembershipMatchingState instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("MEMBERSHIP_MATCHING_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("MEMBERSHIP_MATCHED"),
+            2 => std::borrow::Cow::Borrowed("MEMBERSHIP_NOT_MATCHED"),
+            3 => std::borrow::Cow::Borrowed("MEMBERSHIP_UNKNOWN_INFO"),
+            4 => std::borrow::Cow::Borrowed("MEMBERSHIP_UNKNOWN_UNSUPPORTED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "MEMBERSHIP_MATCHING_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::MEMBERSHIP_MATCHING_STATE_UNSPECIFIED)
+            }
+            "MEMBERSHIP_MATCHED" => std::option::Option::Some(Self::MEMBERSHIP_MATCHED),
+            "MEMBERSHIP_NOT_MATCHED" => std::option::Option::Some(Self::MEMBERSHIP_NOT_MATCHED),
+            "MEMBERSHIP_UNKNOWN_INFO" => std::option::Option::Some(Self::MEMBERSHIP_UNKNOWN_INFO),
+            "MEMBERSHIP_UNKNOWN_UNSUPPORTED" => {
+                std::option::Option::Some(Self::MEMBERSHIP_UNKNOWN_UNSUPPORTED)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for MembershipMatchingState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for MembershipMatchingState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for MembershipMatchingState {
     fn default() -> Self {
-        membership_matching_state::MEMBERSHIP_MATCHING_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The extent to which a single data point contributes to an overall
 /// determination.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct HeuristicRelevance(std::borrow::Cow<'static, str>);
+pub struct HeuristicRelevance(i32);
 
 impl HeuristicRelevance {
-    /// Creates a new HeuristicRelevance instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [HeuristicRelevance](HeuristicRelevance)
-pub mod heuristic_relevance {
-    use super::HeuristicRelevance;
-
     /// Not specified.
-    pub const HEURISTIC_RELEVANCE_UNSPECIFIED: HeuristicRelevance =
-        HeuristicRelevance::new("HEURISTIC_RELEVANCE_UNSPECIFIED");
+    pub const HEURISTIC_RELEVANCE_UNSPECIFIED: HeuristicRelevance = HeuristicRelevance::new(0);
 
     /// The data point has a limited effect on the result. Changing the data point
     /// is unlikely to affect the overall determination.
-    pub const HEURISTIC_RELEVANCE_NORMAL: HeuristicRelevance =
-        HeuristicRelevance::new("HEURISTIC_RELEVANCE_NORMAL");
+    pub const HEURISTIC_RELEVANCE_NORMAL: HeuristicRelevance = HeuristicRelevance::new(1);
 
     /// The data point has a strong effect on the result. Changing the data point
     /// is likely to affect the overall determination.
-    pub const HEURISTIC_RELEVANCE_HIGH: HeuristicRelevance =
-        HeuristicRelevance::new("HEURISTIC_RELEVANCE_HIGH");
+    pub const HEURISTIC_RELEVANCE_HIGH: HeuristicRelevance = HeuristicRelevance::new(2);
+
+    /// Creates a new HeuristicRelevance instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("HEURISTIC_RELEVANCE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("HEURISTIC_RELEVANCE_NORMAL"),
+            2 => std::borrow::Cow::Borrowed("HEURISTIC_RELEVANCE_HIGH"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "HEURISTIC_RELEVANCE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::HEURISTIC_RELEVANCE_UNSPECIFIED)
+            }
+            "HEURISTIC_RELEVANCE_NORMAL" => {
+                std::option::Option::Some(Self::HEURISTIC_RELEVANCE_NORMAL)
+            }
+            "HEURISTIC_RELEVANCE_HIGH" => std::option::Option::Some(Self::HEURISTIC_RELEVANCE_HIGH),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for HeuristicRelevance {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for HeuristicRelevance {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for HeuristicRelevance {
     fn default() -> Self {
-        heuristic_relevance::HEURISTIC_RELEVANCE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/policytroubleshooter/iam/v3/src/transport.rs
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::PolicyTroubleshooter for PolicyTroubleshooter {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, "/v3/iam:troubleshoot".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/policytroubleshooter/v1/src/model.rs
+++ b/src/generated/cloud/policytroubleshooter/v1/src/model.rs
@@ -520,75 +520,81 @@ pub mod binding_explanation {
 
     /// Whether a role includes a specific permission.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RolePermission(std::borrow::Cow<'static, str>);
+    pub struct RolePermission(i32);
 
     impl RolePermission {
+        /// Default value. This value is unused.
+        pub const ROLE_PERMISSION_UNSPECIFIED: RolePermission = RolePermission::new(0);
+
+        /// The permission is included in the role.
+        pub const ROLE_PERMISSION_INCLUDED: RolePermission = RolePermission::new(1);
+
+        /// The permission is not included in the role.
+        pub const ROLE_PERMISSION_NOT_INCLUDED: RolePermission = RolePermission::new(2);
+
+        /// The sender of the request is not allowed to access the binding.
+        pub const ROLE_PERMISSION_UNKNOWN_INFO_DENIED: RolePermission = RolePermission::new(3);
+
         /// Creates a new RolePermission instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_INCLUDED"),
+                2 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_NOT_INCLUDED"),
+                3 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_UNKNOWN_INFO_DENIED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ROLE_PERMISSION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ROLE_PERMISSION_UNSPECIFIED)
+                }
+                "ROLE_PERMISSION_INCLUDED" => {
+                    std::option::Option::Some(Self::ROLE_PERMISSION_INCLUDED)
+                }
+                "ROLE_PERMISSION_NOT_INCLUDED" => {
+                    std::option::Option::Some(Self::ROLE_PERMISSION_NOT_INCLUDED)
+                }
+                "ROLE_PERMISSION_UNKNOWN_INFO_DENIED" => {
+                    std::option::Option::Some(Self::ROLE_PERMISSION_UNKNOWN_INFO_DENIED)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RolePermission](RolePermission)
-    pub mod role_permission {
-        use super::RolePermission;
-
-        /// Default value. This value is unused.
-        pub const ROLE_PERMISSION_UNSPECIFIED: RolePermission =
-            RolePermission::new("ROLE_PERMISSION_UNSPECIFIED");
-
-        /// The permission is included in the role.
-        pub const ROLE_PERMISSION_INCLUDED: RolePermission =
-            RolePermission::new("ROLE_PERMISSION_INCLUDED");
-
-        /// The permission is not included in the role.
-        pub const ROLE_PERMISSION_NOT_INCLUDED: RolePermission =
-            RolePermission::new("ROLE_PERMISSION_NOT_INCLUDED");
-
-        /// The sender of the request is not allowed to access the binding.
-        pub const ROLE_PERMISSION_UNKNOWN_INFO_DENIED: RolePermission =
-            RolePermission::new("ROLE_PERMISSION_UNKNOWN_INFO_DENIED");
-    }
-
-    impl std::convert::From<std::string::String> for RolePermission {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RolePermission {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RolePermission {
         fn default() -> Self {
-            role_permission::ROLE_PERMISSION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Whether the binding includes the principal.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Membership(std::borrow::Cow<'static, str>);
+    pub struct Membership(i32);
 
     impl Membership {
-        /// Creates a new Membership instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Membership](Membership)
-    pub mod membership {
-        use super::Membership;
-
         /// Default value. This value is unused.
-        pub const MEMBERSHIP_UNSPECIFIED: Membership = Membership::new("MEMBERSHIP_UNSPECIFIED");
+        pub const MEMBERSHIP_UNSPECIFIED: Membership = Membership::new(0);
 
         /// The binding includes the principal. The principal can be included
         /// directly or indirectly. For example:
@@ -597,81 +603,138 @@ pub mod binding_explanation {
         ///   binding.
         /// * A principal is included indirectly if that principal is in a Google
         ///   group or Google Workspace domain that is listed in the binding.
-        pub const MEMBERSHIP_INCLUDED: Membership = Membership::new("MEMBERSHIP_INCLUDED");
+        pub const MEMBERSHIP_INCLUDED: Membership = Membership::new(1);
 
         /// The binding does not include the principal.
-        pub const MEMBERSHIP_NOT_INCLUDED: Membership = Membership::new("MEMBERSHIP_NOT_INCLUDED");
+        pub const MEMBERSHIP_NOT_INCLUDED: Membership = Membership::new(2);
 
         /// The sender of the request is not allowed to access the binding.
-        pub const MEMBERSHIP_UNKNOWN_INFO_DENIED: Membership =
-            Membership::new("MEMBERSHIP_UNKNOWN_INFO_DENIED");
+        pub const MEMBERSHIP_UNKNOWN_INFO_DENIED: Membership = Membership::new(3);
 
         /// The principal is an unsupported type. Only Google Accounts and service
         /// accounts are supported.
-        pub const MEMBERSHIP_UNKNOWN_UNSUPPORTED: Membership =
-            Membership::new("MEMBERSHIP_UNKNOWN_UNSUPPORTED");
+        pub const MEMBERSHIP_UNKNOWN_UNSUPPORTED: Membership = Membership::new(4);
+
+        /// Creates a new Membership instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MEMBERSHIP_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MEMBERSHIP_INCLUDED"),
+                2 => std::borrow::Cow::Borrowed("MEMBERSHIP_NOT_INCLUDED"),
+                3 => std::borrow::Cow::Borrowed("MEMBERSHIP_UNKNOWN_INFO_DENIED"),
+                4 => std::borrow::Cow::Borrowed("MEMBERSHIP_UNKNOWN_UNSUPPORTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MEMBERSHIP_UNSPECIFIED" => std::option::Option::Some(Self::MEMBERSHIP_UNSPECIFIED),
+                "MEMBERSHIP_INCLUDED" => std::option::Option::Some(Self::MEMBERSHIP_INCLUDED),
+                "MEMBERSHIP_NOT_INCLUDED" => {
+                    std::option::Option::Some(Self::MEMBERSHIP_NOT_INCLUDED)
+                }
+                "MEMBERSHIP_UNKNOWN_INFO_DENIED" => {
+                    std::option::Option::Some(Self::MEMBERSHIP_UNKNOWN_INFO_DENIED)
+                }
+                "MEMBERSHIP_UNKNOWN_UNSUPPORTED" => {
+                    std::option::Option::Some(Self::MEMBERSHIP_UNKNOWN_UNSUPPORTED)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Membership {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Membership {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Membership {
         fn default() -> Self {
-            membership::MEMBERSHIP_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
 
 /// Whether a principal has a permission for a resource.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AccessState(std::borrow::Cow<'static, str>);
+pub struct AccessState(i32);
 
 impl AccessState {
-    /// Creates a new AccessState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [AccessState](AccessState)
-pub mod access_state {
-    use super::AccessState;
-
     /// Default value. This value is unused.
-    pub const ACCESS_STATE_UNSPECIFIED: AccessState = AccessState::new("ACCESS_STATE_UNSPECIFIED");
+    pub const ACCESS_STATE_UNSPECIFIED: AccessState = AccessState::new(0);
 
     /// The principal has the permission.
-    pub const GRANTED: AccessState = AccessState::new("GRANTED");
+    pub const GRANTED: AccessState = AccessState::new(1);
 
     /// The principal does not have the permission.
-    pub const NOT_GRANTED: AccessState = AccessState::new("NOT_GRANTED");
+    pub const NOT_GRANTED: AccessState = AccessState::new(2);
 
     /// The principal has the permission only if a condition expression evaluates
     /// to `true`.
-    pub const UNKNOWN_CONDITIONAL: AccessState = AccessState::new("UNKNOWN_CONDITIONAL");
+    pub const UNKNOWN_CONDITIONAL: AccessState = AccessState::new(3);
 
     /// The sender of the request does not have access to all of the policies that
     /// Policy Troubleshooter needs to evaluate.
-    pub const UNKNOWN_INFO_DENIED: AccessState = AccessState::new("UNKNOWN_INFO_DENIED");
+    pub const UNKNOWN_INFO_DENIED: AccessState = AccessState::new(4);
+
+    /// Creates a new AccessState instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ACCESS_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("GRANTED"),
+            2 => std::borrow::Cow::Borrowed("NOT_GRANTED"),
+            3 => std::borrow::Cow::Borrowed("UNKNOWN_CONDITIONAL"),
+            4 => std::borrow::Cow::Borrowed("UNKNOWN_INFO_DENIED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ACCESS_STATE_UNSPECIFIED" => std::option::Option::Some(Self::ACCESS_STATE_UNSPECIFIED),
+            "GRANTED" => std::option::Option::Some(Self::GRANTED),
+            "NOT_GRANTED" => std::option::Option::Some(Self::NOT_GRANTED),
+            "UNKNOWN_CONDITIONAL" => std::option::Option::Some(Self::UNKNOWN_CONDITIONAL),
+            "UNKNOWN_INFO_DENIED" => std::option::Option::Some(Self::UNKNOWN_INFO_DENIED),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for AccessState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for AccessState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for AccessState {
     fn default() -> Self {
-        access_state::ACCESS_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -679,45 +742,61 @@ impl std::default::Default for AccessState {
 /// or whether a binding includes a specific principal, contributes to an overall
 /// determination.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct HeuristicRelevance(std::borrow::Cow<'static, str>);
+pub struct HeuristicRelevance(i32);
 
 impl HeuristicRelevance {
-    /// Creates a new HeuristicRelevance instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [HeuristicRelevance](HeuristicRelevance)
-pub mod heuristic_relevance {
-    use super::HeuristicRelevance;
-
     /// Default value. This value is unused.
-    pub const HEURISTIC_RELEVANCE_UNSPECIFIED: HeuristicRelevance =
-        HeuristicRelevance::new("HEURISTIC_RELEVANCE_UNSPECIFIED");
+    pub const HEURISTIC_RELEVANCE_UNSPECIFIED: HeuristicRelevance = HeuristicRelevance::new(0);
 
     /// The data point has a limited effect on the result. Changing the data point
     /// is unlikely to affect the overall determination.
-    pub const NORMAL: HeuristicRelevance = HeuristicRelevance::new("NORMAL");
+    pub const NORMAL: HeuristicRelevance = HeuristicRelevance::new(1);
 
     /// The data point has a strong effect on the result. Changing the data point
     /// is likely to affect the overall determination.
-    pub const HIGH: HeuristicRelevance = HeuristicRelevance::new("HIGH");
+    pub const HIGH: HeuristicRelevance = HeuristicRelevance::new(2);
+
+    /// Creates a new HeuristicRelevance instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("HEURISTIC_RELEVANCE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("NORMAL"),
+            2 => std::borrow::Cow::Borrowed("HIGH"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "HEURISTIC_RELEVANCE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::HEURISTIC_RELEVANCE_UNSPECIFIED)
+            }
+            "NORMAL" => std::option::Option::Some(Self::NORMAL),
+            "HIGH" => std::option::Option::Some(Self::HIGH),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for HeuristicRelevance {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for HeuristicRelevance {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for HeuristicRelevance {
     fn default() -> Self {
-        heuristic_relevance::HEURISTIC_RELEVANCE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/policytroubleshooter/v1/src/transport.rs
+++ b/src/generated/cloud/policytroubleshooter/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::IamChecker for IamChecker {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, "/v1/iam:troubleshoot".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/model.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/model.rs
@@ -689,52 +689,73 @@ pub mod entitlement {
 
     /// Different states an entitlement can be in.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified state. This value is never returned by the server.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The entitlement is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// The entitlement is available for requesting access.
+        pub const AVAILABLE: State = State::new(2);
+
+        /// The entitlement is being deleted.
+        pub const DELETING: State = State::new(3);
+
+        /// The entitlement has been deleted.
+        pub const DELETED: State = State::new(4);
+
+        /// The entitlement is being updated.
+        pub const UPDATING: State = State::new(5);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("AVAILABLE"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("DELETED"),
+                5 => std::borrow::Cow::Borrowed("UPDATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "DELETED" => std::option::Option::Some(Self::DELETED),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified state. This value is never returned by the server.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The entitlement is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The entitlement is available for requesting access.
-        pub const AVAILABLE: State = State::new("AVAILABLE");
-
-        /// The entitlement is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// The entitlement has been deleted.
-        pub const DELETED: State = State::new("DELETED");
-
-        /// The entitlement is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1401,45 +1422,61 @@ pub mod search_entitlements_request {
 
     /// Different types of access a user can have on the entitlement resource.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CallerAccessType(std::borrow::Cow<'static, str>);
+    pub struct CallerAccessType(i32);
 
     impl CallerAccessType {
-        /// Creates a new CallerAccessType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CallerAccessType](CallerAccessType)
-    pub mod caller_access_type {
-        use super::CallerAccessType;
-
         /// Unspecified access type.
-        pub const CALLER_ACCESS_TYPE_UNSPECIFIED: CallerAccessType =
-            CallerAccessType::new("CALLER_ACCESS_TYPE_UNSPECIFIED");
+        pub const CALLER_ACCESS_TYPE_UNSPECIFIED: CallerAccessType = CallerAccessType::new(0);
 
         /// The user has access to create grants using this entitlement.
-        pub const GRANT_REQUESTER: CallerAccessType = CallerAccessType::new("GRANT_REQUESTER");
+        pub const GRANT_REQUESTER: CallerAccessType = CallerAccessType::new(1);
 
         /// The user has access to approve/deny grants created under this
         /// entitlement.
-        pub const GRANT_APPROVER: CallerAccessType = CallerAccessType::new("GRANT_APPROVER");
+        pub const GRANT_APPROVER: CallerAccessType = CallerAccessType::new(2);
+
+        /// Creates a new CallerAccessType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CALLER_ACCESS_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GRANT_REQUESTER"),
+                2 => std::borrow::Cow::Borrowed("GRANT_APPROVER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CALLER_ACCESS_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CALLER_ACCESS_TYPE_UNSPECIFIED)
+                }
+                "GRANT_REQUESTER" => std::option::Option::Some(Self::GRANT_REQUESTER),
+                "GRANT_APPROVER" => std::option::Option::Some(Self::GRANT_APPROVER),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CallerAccessType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CallerAccessType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CallerAccessType {
         fn default() -> Self {
-            caller_access_type::CALLER_ACCESS_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2770,73 +2807,104 @@ pub mod grant {
 
     /// Different states a grant can be in.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified state. This value is never returned by the server.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The entitlement had an approval workflow configured and this grant is
         /// waiting for the workflow to complete.
-        pub const APPROVAL_AWAITED: State = State::new("APPROVAL_AWAITED");
+        pub const APPROVAL_AWAITED: State = State::new(1);
 
         /// The approval workflow completed with a denied result. No access is
         /// granted for this grant. This is a terminal state.
-        pub const DENIED: State = State::new("DENIED");
+        pub const DENIED: State = State::new(3);
 
         /// The approval workflow completed successfully with an approved result or
         /// none was configured. Access is provided at an appropriate time.
-        pub const SCHEDULED: State = State::new("SCHEDULED");
+        pub const SCHEDULED: State = State::new(4);
 
         /// Access is being given.
-        pub const ACTIVATING: State = State::new("ACTIVATING");
+        pub const ACTIVATING: State = State::new(5);
 
         /// Access was successfully given and is currently active.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(6);
 
         /// The system could not give access due to a non-retriable error. This is a
         /// terminal state.
-        pub const ACTIVATION_FAILED: State = State::new("ACTIVATION_FAILED");
+        pub const ACTIVATION_FAILED: State = State::new(7);
 
         /// Expired after waiting for the approval workflow to complete. This is a
         /// terminal state.
-        pub const EXPIRED: State = State::new("EXPIRED");
+        pub const EXPIRED: State = State::new(8);
 
         /// Access is being revoked.
-        pub const REVOKING: State = State::new("REVOKING");
+        pub const REVOKING: State = State::new(9);
 
         /// Access was revoked by a user. This is a terminal state.
-        pub const REVOKED: State = State::new("REVOKED");
+        pub const REVOKED: State = State::new(10);
 
         /// System took back access as the requested duration was over. This is a
         /// terminal state.
-        pub const ENDED: State = State::new("ENDED");
+        pub const ENDED: State = State::new(11);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("APPROVAL_AWAITED"),
+                3 => std::borrow::Cow::Borrowed("DENIED"),
+                4 => std::borrow::Cow::Borrowed("SCHEDULED"),
+                5 => std::borrow::Cow::Borrowed("ACTIVATING"),
+                6 => std::borrow::Cow::Borrowed("ACTIVE"),
+                7 => std::borrow::Cow::Borrowed("ACTIVATION_FAILED"),
+                8 => std::borrow::Cow::Borrowed("EXPIRED"),
+                9 => std::borrow::Cow::Borrowed("REVOKING"),
+                10 => std::borrow::Cow::Borrowed("REVOKED"),
+                11 => std::borrow::Cow::Borrowed("ENDED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "APPROVAL_AWAITED" => std::option::Option::Some(Self::APPROVAL_AWAITED),
+                "DENIED" => std::option::Option::Some(Self::DENIED),
+                "SCHEDULED" => std::option::Option::Some(Self::SCHEDULED),
+                "ACTIVATING" => std::option::Option::Some(Self::ACTIVATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "ACTIVATION_FAILED" => std::option::Option::Some(Self::ACTIVATION_FAILED),
+                "EXPIRED" => std::option::Option::Some(Self::EXPIRED),
+                "REVOKING" => std::option::Option::Some(Self::REVOKING),
+                "REVOKED" => std::option::Option::Some(Self::REVOKED),
+                "ENDED" => std::option::Option::Some(Self::ENDED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3139,49 +3207,67 @@ pub mod search_grants_request {
 
     /// Different types of relationships a user can have with a grant.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CallerRelationshipType(std::borrow::Cow<'static, str>);
+    pub struct CallerRelationshipType(i32);
 
     impl CallerRelationshipType {
-        /// Creates a new CallerRelationshipType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CallerRelationshipType](CallerRelationshipType)
-    pub mod caller_relationship_type {
-        use super::CallerRelationshipType;
-
         /// Unspecified caller relationship type.
         pub const CALLER_RELATIONSHIP_TYPE_UNSPECIFIED: CallerRelationshipType =
-            CallerRelationshipType::new("CALLER_RELATIONSHIP_TYPE_UNSPECIFIED");
+            CallerRelationshipType::new(0);
 
         /// The user created this grant by calling `CreateGrant` earlier.
-        pub const HAD_CREATED: CallerRelationshipType = CallerRelationshipType::new("HAD_CREATED");
+        pub const HAD_CREATED: CallerRelationshipType = CallerRelationshipType::new(1);
 
         /// The user is an approver for the entitlement that this grant is parented
         /// under and can currently approve/deny it.
-        pub const CAN_APPROVE: CallerRelationshipType = CallerRelationshipType::new("CAN_APPROVE");
+        pub const CAN_APPROVE: CallerRelationshipType = CallerRelationshipType::new(2);
 
         /// The caller had successfully approved/denied this grant earlier.
-        pub const HAD_APPROVED: CallerRelationshipType =
-            CallerRelationshipType::new("HAD_APPROVED");
+        pub const HAD_APPROVED: CallerRelationshipType = CallerRelationshipType::new(3);
+
+        /// Creates a new CallerRelationshipType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CALLER_RELATIONSHIP_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("HAD_CREATED"),
+                2 => std::borrow::Cow::Borrowed("CAN_APPROVE"),
+                3 => std::borrow::Cow::Borrowed("HAD_APPROVED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CALLER_RELATIONSHIP_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CALLER_RELATIONSHIP_TYPE_UNSPECIFIED)
+                }
+                "HAD_CREATED" => std::option::Option::Some(Self::HAD_CREATED),
+                "CAN_APPROVE" => std::option::Option::Some(Self::CAN_APPROVE),
+                "HAD_APPROVED" => std::option::Option::Some(Self::HAD_APPROVED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CallerRelationshipType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CallerRelationshipType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CallerRelationshipType {
         fn default() -> Self {
-            caller_relationship_type::CALLER_RELATIONSHIP_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/transport.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::PrivilegedAccessManager for PrivilegedAccessManager {
                 reqwest::Method::GET,
                 format!("/v1/{}:checkOnboardingStatus", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -74,7 +74,7 @@ impl crate::stubs::PrivilegedAccessManager for PrivilegedAccessManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/entitlements", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -100,7 +100,7 @@ impl crate::stubs::PrivilegedAccessManager for PrivilegedAccessManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/entitlements:search", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -123,7 +123,7 @@ impl crate::stubs::PrivilegedAccessManager for PrivilegedAccessManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -145,7 +145,7 @@ impl crate::stubs::PrivilegedAccessManager for PrivilegedAccessManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/entitlements", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -166,7 +166,7 @@ impl crate::stubs::PrivilegedAccessManager for PrivilegedAccessManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -196,7 +196,7 @@ impl crate::stubs::PrivilegedAccessManager for PrivilegedAccessManager {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -225,7 +225,7 @@ impl crate::stubs::PrivilegedAccessManager for PrivilegedAccessManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/grants", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -251,7 +251,7 @@ impl crate::stubs::PrivilegedAccessManager for PrivilegedAccessManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/grants:search", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -274,7 +274,7 @@ impl crate::stubs::PrivilegedAccessManager for PrivilegedAccessManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -293,7 +293,7 @@ impl crate::stubs::PrivilegedAccessManager for PrivilegedAccessManager {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/grants", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -311,7 +311,7 @@ impl crate::stubs::PrivilegedAccessManager for PrivilegedAccessManager {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:approve", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -328,7 +328,7 @@ impl crate::stubs::PrivilegedAccessManager for PrivilegedAccessManager {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:deny", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -345,7 +345,7 @@ impl crate::stubs::PrivilegedAccessManager for PrivilegedAccessManager {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:revoke", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -362,7 +362,7 @@ impl crate::stubs::PrivilegedAccessManager for PrivilegedAccessManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -384,7 +384,7 @@ impl crate::stubs::PrivilegedAccessManager for PrivilegedAccessManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -403,7 +403,7 @@ impl crate::stubs::PrivilegedAccessManager for PrivilegedAccessManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -425,7 +425,7 @@ impl crate::stubs::PrivilegedAccessManager for PrivilegedAccessManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -444,7 +444,7 @@ impl crate::stubs::PrivilegedAccessManager for PrivilegedAccessManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/model.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/model.rs
@@ -295,63 +295,90 @@ pub mod collector {
     /// convention of legacy product:
     /// <https://cloud.google.com/migrate/stratozone/docs/about-stratoprobe>.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Collector state is not recognized.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Collector started to create, but hasn't been completed MC source creation
         /// and db object creation.
-        pub const STATE_INITIALIZING: State = State::new("STATE_INITIALIZING");
+        pub const STATE_INITIALIZING: State = State::new(1);
 
         /// Collector has been created, MC source creation and db object creation
         /// completed.
-        pub const STATE_READY_TO_USE: State = State::new("STATE_READY_TO_USE");
+        pub const STATE_READY_TO_USE: State = State::new(2);
 
         /// Collector client has been registered with client.
-        pub const STATE_REGISTERED: State = State::new("STATE_REGISTERED");
+        pub const STATE_REGISTERED: State = State::new(3);
 
         /// Collector client is actively scanning.
-        pub const STATE_ACTIVE: State = State::new("STATE_ACTIVE");
+        pub const STATE_ACTIVE: State = State::new(4);
 
         /// Collector is not actively scanning.
-        pub const STATE_PAUSED: State = State::new("STATE_PAUSED");
+        pub const STATE_PAUSED: State = State::new(5);
 
         /// Collector is starting background job for deletion.
-        pub const STATE_DELETING: State = State::new("STATE_DELETING");
+        pub const STATE_DELETING: State = State::new(6);
 
         /// Collector completed all tasks for deletion.
-        pub const STATE_DECOMMISSIONED: State = State::new("STATE_DECOMMISSIONED");
+        pub const STATE_DECOMMISSIONED: State = State::new(7);
 
         /// Collector is in error state.
-        pub const STATE_ERROR: State = State::new("STATE_ERROR");
+        pub const STATE_ERROR: State = State::new(8);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STATE_INITIALIZING"),
+                2 => std::borrow::Cow::Borrowed("STATE_READY_TO_USE"),
+                3 => std::borrow::Cow::Borrowed("STATE_REGISTERED"),
+                4 => std::borrow::Cow::Borrowed("STATE_ACTIVE"),
+                5 => std::borrow::Cow::Borrowed("STATE_PAUSED"),
+                6 => std::borrow::Cow::Borrowed("STATE_DELETING"),
+                7 => std::borrow::Cow::Borrowed("STATE_DECOMMISSIONED"),
+                8 => std::borrow::Cow::Borrowed("STATE_ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "STATE_INITIALIZING" => std::option::Option::Some(Self::STATE_INITIALIZING),
+                "STATE_READY_TO_USE" => std::option::Option::Some(Self::STATE_READY_TO_USE),
+                "STATE_REGISTERED" => std::option::Option::Some(Self::STATE_REGISTERED),
+                "STATE_ACTIVE" => std::option::Option::Some(Self::STATE_ACTIVE),
+                "STATE_PAUSED" => std::option::Option::Some(Self::STATE_PAUSED),
+                "STATE_DELETING" => std::option::Option::Some(Self::STATE_DELETING),
+                "STATE_DECOMMISSIONED" => std::option::Option::Some(Self::STATE_DECOMMISSIONED),
+                "STATE_ERROR" => std::option::Option::Some(Self::STATE_ERROR),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -444,43 +471,60 @@ pub mod annotation {
 
     /// Types for project level setting.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Unknown type
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// Indicates that this project has opted into StratoZone export.
+        pub const TYPE_LEGACY_EXPORT_CONSENT: Type = Type::new(1);
+
+        /// Indicates that this project is created by Qwiklab.
+        pub const TYPE_QWIKLAB: Type = Type::new(2);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TYPE_LEGACY_EXPORT_CONSENT"),
+                2 => std::borrow::Cow::Borrowed("TYPE_QWIKLAB"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "TYPE_LEGACY_EXPORT_CONSENT" => {
+                    std::option::Option::Some(Self::TYPE_LEGACY_EXPORT_CONSENT)
+                }
+                "TYPE_QWIKLAB" => std::option::Option::Some(Self::TYPE_QWIKLAB),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Unknown type
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// Indicates that this project has opted into StratoZone export.
-        pub const TYPE_LEGACY_EXPORT_CONSENT: Type = Type::new("TYPE_LEGACY_EXPORT_CONSENT");
-
-        /// Indicates that this project is created by Qwiklab.
-        pub const TYPE_QWIKLAB: Type = Type::new("TYPE_QWIKLAB");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/transport.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::RapidMigrationAssessment for RapidMigrationAssessment {
                 reqwest::Method::POST,
                 format!("/v1/{}/collectors", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -76,7 +76,7 @@ impl crate::stubs::RapidMigrationAssessment for RapidMigrationAssessment {
                 reqwest::Method::POST,
                 format!("/v1/{}/annotations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -96,7 +96,7 @@ impl crate::stubs::RapidMigrationAssessment for RapidMigrationAssessment {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -118,7 +118,7 @@ impl crate::stubs::RapidMigrationAssessment for RapidMigrationAssessment {
                 reqwest::Method::GET,
                 format!("/v1/{}/collectors", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -141,7 +141,7 @@ impl crate::stubs::RapidMigrationAssessment for RapidMigrationAssessment {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -169,7 +169,7 @@ impl crate::stubs::RapidMigrationAssessment for RapidMigrationAssessment {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -199,7 +199,7 @@ impl crate::stubs::RapidMigrationAssessment for RapidMigrationAssessment {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -219,7 +219,7 @@ impl crate::stubs::RapidMigrationAssessment for RapidMigrationAssessment {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:resume", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -236,7 +236,7 @@ impl crate::stubs::RapidMigrationAssessment for RapidMigrationAssessment {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:register", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -253,7 +253,7 @@ impl crate::stubs::RapidMigrationAssessment for RapidMigrationAssessment {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:pause", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -270,7 +270,7 @@ impl crate::stubs::RapidMigrationAssessment for RapidMigrationAssessment {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -292,7 +292,7 @@ impl crate::stubs::RapidMigrationAssessment for RapidMigrationAssessment {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -311,7 +311,7 @@ impl crate::stubs::RapidMigrationAssessment for RapidMigrationAssessment {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -333,7 +333,7 @@ impl crate::stubs::RapidMigrationAssessment for RapidMigrationAssessment {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -352,7 +352,7 @@ impl crate::stubs::RapidMigrationAssessment for RapidMigrationAssessment {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -371,7 +371,7 @@ impl crate::stubs::RapidMigrationAssessment for RapidMigrationAssessment {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/recaptchaenterprise/v1/src/model.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/model.rs
@@ -150,142 +150,183 @@ pub mod transaction_event {
 
     /// Enum that represents an event in the payment transaction lifecycle.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TransactionEventType(std::borrow::Cow<'static, str>);
+    pub struct TransactionEventType(i32);
 
     impl TransactionEventType {
-        /// Creates a new TransactionEventType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [TransactionEventType](TransactionEventType)
-    pub mod transaction_event_type {
-        use super::TransactionEventType;
-
         /// Default, unspecified event type.
         pub const TRANSACTION_EVENT_TYPE_UNSPECIFIED: TransactionEventType =
-            TransactionEventType::new("TRANSACTION_EVENT_TYPE_UNSPECIFIED");
+            TransactionEventType::new(0);
 
         /// Indicates that the transaction is approved by the merchant. The
         /// accompanying reasons can include terms such as 'INHOUSE', 'ACCERTIFY',
         /// 'CYBERSOURCE', or 'MANUAL_REVIEW'.
-        pub const MERCHANT_APPROVE: TransactionEventType =
-            TransactionEventType::new("MERCHANT_APPROVE");
+        pub const MERCHANT_APPROVE: TransactionEventType = TransactionEventType::new(1);
 
         /// Indicates that the transaction is denied and concluded due to risks
         /// detected by the merchant. The accompanying reasons can include terms such
         /// as 'INHOUSE',  'ACCERTIFY',  'CYBERSOURCE', or 'MANUAL_REVIEW'.
-        pub const MERCHANT_DENY: TransactionEventType = TransactionEventType::new("MERCHANT_DENY");
+        pub const MERCHANT_DENY: TransactionEventType = TransactionEventType::new(2);
 
         /// Indicates that the transaction is being evaluated by a human, due to
         /// suspicion or risk.
-        pub const MANUAL_REVIEW: TransactionEventType = TransactionEventType::new("MANUAL_REVIEW");
+        pub const MANUAL_REVIEW: TransactionEventType = TransactionEventType::new(3);
 
         /// Indicates that the authorization attempt with the card issuer succeeded.
-        pub const AUTHORIZATION: TransactionEventType = TransactionEventType::new("AUTHORIZATION");
+        pub const AUTHORIZATION: TransactionEventType = TransactionEventType::new(4);
 
         /// Indicates that the authorization attempt with the card issuer failed.
         /// The accompanying reasons can include Visa's '54' indicating that the card
         /// is expired, or '82' indicating that the CVV is incorrect.
-        pub const AUTHORIZATION_DECLINE: TransactionEventType =
-            TransactionEventType::new("AUTHORIZATION_DECLINE");
+        pub const AUTHORIZATION_DECLINE: TransactionEventType = TransactionEventType::new(5);
 
         /// Indicates that the transaction is completed because the funds were
         /// settled.
-        pub const PAYMENT_CAPTURE: TransactionEventType =
-            TransactionEventType::new("PAYMENT_CAPTURE");
+        pub const PAYMENT_CAPTURE: TransactionEventType = TransactionEventType::new(6);
 
         /// Indicates that the transaction could not be completed because the funds
         /// were not settled.
-        pub const PAYMENT_CAPTURE_DECLINE: TransactionEventType =
-            TransactionEventType::new("PAYMENT_CAPTURE_DECLINE");
+        pub const PAYMENT_CAPTURE_DECLINE: TransactionEventType = TransactionEventType::new(7);
 
         /// Indicates that the transaction has been canceled. Specify the reason
         /// for the cancellation. For example, 'INSUFFICIENT_INVENTORY'.
-        pub const CANCEL: TransactionEventType = TransactionEventType::new("CANCEL");
+        pub const CANCEL: TransactionEventType = TransactionEventType::new(8);
 
         /// Indicates that the merchant has received a chargeback inquiry due to
         /// fraud for the transaction, requesting additional information before a
         /// fraud chargeback is officially issued and a formal chargeback
         /// notification is sent.
-        pub const CHARGEBACK_INQUIRY: TransactionEventType =
-            TransactionEventType::new("CHARGEBACK_INQUIRY");
+        pub const CHARGEBACK_INQUIRY: TransactionEventType = TransactionEventType::new(9);
 
         /// Indicates that the merchant has received a chargeback alert due to fraud
         /// for the transaction. The process of resolving the dispute without
         /// involving the payment network is started.
-        pub const CHARGEBACK_ALERT: TransactionEventType =
-            TransactionEventType::new("CHARGEBACK_ALERT");
+        pub const CHARGEBACK_ALERT: TransactionEventType = TransactionEventType::new(10);
 
         /// Indicates that a fraud notification is issued for the transaction, sent
         /// by the payment instrument's issuing bank because the transaction appears
         /// to be fraudulent. We recommend including TC40 or SAFE data in the
         /// `reason` field for this event type. For partial chargebacks, we recommend
         /// that you include an amount in the `value` field.
-        pub const FRAUD_NOTIFICATION: TransactionEventType =
-            TransactionEventType::new("FRAUD_NOTIFICATION");
+        pub const FRAUD_NOTIFICATION: TransactionEventType = TransactionEventType::new(11);
 
         /// Indicates that the merchant is informed by the payment network that the
         /// transaction has entered the chargeback process due to fraud. Reason code
         /// examples include Discover's '6005' and '6041'. For partial chargebacks,
         /// we recommend that you include an amount in the `value` field.
-        pub const CHARGEBACK: TransactionEventType = TransactionEventType::new("CHARGEBACK");
+        pub const CHARGEBACK: TransactionEventType = TransactionEventType::new(12);
 
         /// Indicates that the transaction has entered the chargeback process due to
         /// fraud, and that the merchant has chosen to enter representment. Reason
         /// examples include Discover's '6005' and '6041'. For partial chargebacks,
         /// we recommend that you include an amount in the `value` field.
-        pub const CHARGEBACK_REPRESENTMENT: TransactionEventType =
-            TransactionEventType::new("CHARGEBACK_REPRESENTMENT");
+        pub const CHARGEBACK_REPRESENTMENT: TransactionEventType = TransactionEventType::new(13);
 
         /// Indicates that the transaction has had a fraud chargeback which was
         /// illegitimate and was reversed as a result. For partial chargebacks, we
         /// recommend that you include an amount in the `value` field.
-        pub const CHARGEBACK_REVERSE: TransactionEventType =
-            TransactionEventType::new("CHARGEBACK_REVERSE");
+        pub const CHARGEBACK_REVERSE: TransactionEventType = TransactionEventType::new(14);
 
         /// Indicates that the merchant has received a refund for a completed
         /// transaction. For partial refunds, we recommend that you include an amount
         /// in the `value` field. Reason example: 'TAX_EXEMPT' (partial refund of
         /// exempt tax)
-        pub const REFUND_REQUEST: TransactionEventType =
-            TransactionEventType::new("REFUND_REQUEST");
+        pub const REFUND_REQUEST: TransactionEventType = TransactionEventType::new(15);
 
         /// Indicates that the merchant has received a refund request for this
         /// transaction, but that they have declined it. For partial refunds, we
         /// recommend that you include an amount in the `value` field. Reason
         /// example: 'TAX_EXEMPT' (partial refund of exempt tax)
-        pub const REFUND_DECLINE: TransactionEventType =
-            TransactionEventType::new("REFUND_DECLINE");
+        pub const REFUND_DECLINE: TransactionEventType = TransactionEventType::new(16);
 
         /// Indicates that the completed transaction was refunded by the merchant.
         /// For partial refunds, we recommend that you include an amount in the
         /// `value` field. Reason example: 'TAX_EXEMPT' (partial refund of exempt
         /// tax)
-        pub const REFUND: TransactionEventType = TransactionEventType::new("REFUND");
+        pub const REFUND: TransactionEventType = TransactionEventType::new(17);
 
         /// Indicates that the completed transaction was refunded by the merchant,
         /// and that this refund was reversed. For partial refunds, we recommend that
         /// you include an amount in the `value` field.
-        pub const REFUND_REVERSE: TransactionEventType =
-            TransactionEventType::new("REFUND_REVERSE");
+        pub const REFUND_REVERSE: TransactionEventType = TransactionEventType::new(18);
+
+        /// Creates a new TransactionEventType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TRANSACTION_EVENT_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MERCHANT_APPROVE"),
+                2 => std::borrow::Cow::Borrowed("MERCHANT_DENY"),
+                3 => std::borrow::Cow::Borrowed("MANUAL_REVIEW"),
+                4 => std::borrow::Cow::Borrowed("AUTHORIZATION"),
+                5 => std::borrow::Cow::Borrowed("AUTHORIZATION_DECLINE"),
+                6 => std::borrow::Cow::Borrowed("PAYMENT_CAPTURE"),
+                7 => std::borrow::Cow::Borrowed("PAYMENT_CAPTURE_DECLINE"),
+                8 => std::borrow::Cow::Borrowed("CANCEL"),
+                9 => std::borrow::Cow::Borrowed("CHARGEBACK_INQUIRY"),
+                10 => std::borrow::Cow::Borrowed("CHARGEBACK_ALERT"),
+                11 => std::borrow::Cow::Borrowed("FRAUD_NOTIFICATION"),
+                12 => std::borrow::Cow::Borrowed("CHARGEBACK"),
+                13 => std::borrow::Cow::Borrowed("CHARGEBACK_REPRESENTMENT"),
+                14 => std::borrow::Cow::Borrowed("CHARGEBACK_REVERSE"),
+                15 => std::borrow::Cow::Borrowed("REFUND_REQUEST"),
+                16 => std::borrow::Cow::Borrowed("REFUND_DECLINE"),
+                17 => std::borrow::Cow::Borrowed("REFUND"),
+                18 => std::borrow::Cow::Borrowed("REFUND_REVERSE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TRANSACTION_EVENT_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::TRANSACTION_EVENT_TYPE_UNSPECIFIED)
+                }
+                "MERCHANT_APPROVE" => std::option::Option::Some(Self::MERCHANT_APPROVE),
+                "MERCHANT_DENY" => std::option::Option::Some(Self::MERCHANT_DENY),
+                "MANUAL_REVIEW" => std::option::Option::Some(Self::MANUAL_REVIEW),
+                "AUTHORIZATION" => std::option::Option::Some(Self::AUTHORIZATION),
+                "AUTHORIZATION_DECLINE" => std::option::Option::Some(Self::AUTHORIZATION_DECLINE),
+                "PAYMENT_CAPTURE" => std::option::Option::Some(Self::PAYMENT_CAPTURE),
+                "PAYMENT_CAPTURE_DECLINE" => {
+                    std::option::Option::Some(Self::PAYMENT_CAPTURE_DECLINE)
+                }
+                "CANCEL" => std::option::Option::Some(Self::CANCEL),
+                "CHARGEBACK_INQUIRY" => std::option::Option::Some(Self::CHARGEBACK_INQUIRY),
+                "CHARGEBACK_ALERT" => std::option::Option::Some(Self::CHARGEBACK_ALERT),
+                "FRAUD_NOTIFICATION" => std::option::Option::Some(Self::FRAUD_NOTIFICATION),
+                "CHARGEBACK" => std::option::Option::Some(Self::CHARGEBACK),
+                "CHARGEBACK_REPRESENTMENT" => {
+                    std::option::Option::Some(Self::CHARGEBACK_REPRESENTMENT)
+                }
+                "CHARGEBACK_REVERSE" => std::option::Option::Some(Self::CHARGEBACK_REVERSE),
+                "REFUND_REQUEST" => std::option::Option::Some(Self::REFUND_REQUEST),
+                "REFUND_DECLINE" => std::option::Option::Some(Self::REFUND_DECLINE),
+                "REFUND" => std::option::Option::Some(Self::REFUND),
+                "REFUND_REVERSE" => std::option::Option::Some(Self::REFUND_REVERSE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for TransactionEventType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TransactionEventType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TransactionEventType {
         fn default() -> Self {
-            transaction_event_type::TRANSACTION_EVENT_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -400,148 +441,206 @@ pub mod annotate_assessment_request {
 
     /// Enum that represents the types of annotations.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Annotation(std::borrow::Cow<'static, str>);
+    pub struct Annotation(i32);
 
     impl Annotation {
-        /// Creates a new Annotation instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Annotation](Annotation)
-    pub mod annotation {
-        use super::Annotation;
-
         /// Default unspecified type.
-        pub const ANNOTATION_UNSPECIFIED: Annotation = Annotation::new("ANNOTATION_UNSPECIFIED");
+        pub const ANNOTATION_UNSPECIFIED: Annotation = Annotation::new(0);
 
         /// Provides information that the event turned out to be legitimate.
-        pub const LEGITIMATE: Annotation = Annotation::new("LEGITIMATE");
+        pub const LEGITIMATE: Annotation = Annotation::new(1);
 
         /// Provides information that the event turned out to be fraudulent.
-        pub const FRAUDULENT: Annotation = Annotation::new("FRAUDULENT");
+        pub const FRAUDULENT: Annotation = Annotation::new(2);
 
         /// Provides information that the event was related to a login event in which
         /// the user typed the correct password. Deprecated, prefer indicating
         /// CORRECT_PASSWORD through the reasons field instead.
-        pub const PASSWORD_CORRECT: Annotation = Annotation::new("PASSWORD_CORRECT");
+        pub const PASSWORD_CORRECT: Annotation = Annotation::new(3);
 
         /// Provides information that the event was related to a login event in which
         /// the user typed the incorrect password. Deprecated, prefer indicating
         /// INCORRECT_PASSWORD through the reasons field instead.
-        pub const PASSWORD_INCORRECT: Annotation = Annotation::new("PASSWORD_INCORRECT");
+        pub const PASSWORD_INCORRECT: Annotation = Annotation::new(4);
+
+        /// Creates a new Annotation instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ANNOTATION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LEGITIMATE"),
+                2 => std::borrow::Cow::Borrowed("FRAUDULENT"),
+                3 => std::borrow::Cow::Borrowed("PASSWORD_CORRECT"),
+                4 => std::borrow::Cow::Borrowed("PASSWORD_INCORRECT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ANNOTATION_UNSPECIFIED" => std::option::Option::Some(Self::ANNOTATION_UNSPECIFIED),
+                "LEGITIMATE" => std::option::Option::Some(Self::LEGITIMATE),
+                "FRAUDULENT" => std::option::Option::Some(Self::FRAUDULENT),
+                "PASSWORD_CORRECT" => std::option::Option::Some(Self::PASSWORD_CORRECT),
+                "PASSWORD_INCORRECT" => std::option::Option::Some(Self::PASSWORD_INCORRECT),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Annotation {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Annotation {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Annotation {
         fn default() -> Self {
-            annotation::ANNOTATION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Enum that represents potential reasons for annotating an assessment.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Reason(std::borrow::Cow<'static, str>);
+    pub struct Reason(i32);
 
     impl Reason {
-        /// Creates a new Reason instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Reason](Reason)
-    pub mod reason {
-        use super::Reason;
-
         /// Default unspecified reason.
-        pub const REASON_UNSPECIFIED: Reason = Reason::new("REASON_UNSPECIFIED");
+        pub const REASON_UNSPECIFIED: Reason = Reason::new(0);
 
         /// Indicates that the transaction had a chargeback issued with no other
         /// details. When possible, specify the type by using CHARGEBACK_FRAUD or
         /// CHARGEBACK_DISPUTE instead.
-        pub const CHARGEBACK: Reason = Reason::new("CHARGEBACK");
+        pub const CHARGEBACK: Reason = Reason::new(1);
 
         /// Indicates that the transaction had a chargeback issued related to an
         /// alleged unauthorized transaction from the cardholder's perspective (for
         /// example, the card number was stolen).
-        pub const CHARGEBACK_FRAUD: Reason = Reason::new("CHARGEBACK_FRAUD");
+        pub const CHARGEBACK_FRAUD: Reason = Reason::new(8);
 
         /// Indicates that the transaction had a chargeback issued related to the
         /// cardholder having provided their card details but allegedly not being
         /// satisfied with the purchase (for example, misrepresentation, attempted
         /// cancellation).
-        pub const CHARGEBACK_DISPUTE: Reason = Reason::new("CHARGEBACK_DISPUTE");
+        pub const CHARGEBACK_DISPUTE: Reason = Reason::new(9);
 
         /// Indicates that the completed payment transaction was refunded by the
         /// seller.
-        pub const REFUND: Reason = Reason::new("REFUND");
+        pub const REFUND: Reason = Reason::new(10);
 
         /// Indicates that the completed payment transaction was determined to be
         /// fraudulent by the seller, and was cancelled and refunded as a result.
-        pub const REFUND_FRAUD: Reason = Reason::new("REFUND_FRAUD");
+        pub const REFUND_FRAUD: Reason = Reason::new(11);
 
         /// Indicates that the payment transaction was accepted, and the user was
         /// charged.
-        pub const TRANSACTION_ACCEPTED: Reason = Reason::new("TRANSACTION_ACCEPTED");
+        pub const TRANSACTION_ACCEPTED: Reason = Reason::new(12);
 
         /// Indicates that the payment transaction was declined, for example due to
         /// invalid card details.
-        pub const TRANSACTION_DECLINED: Reason = Reason::new("TRANSACTION_DECLINED");
+        pub const TRANSACTION_DECLINED: Reason = Reason::new(13);
 
         /// Indicates the transaction associated with the assessment is suspected of
         /// being fraudulent based on the payment method, billing details, shipping
         /// address or other transaction information.
-        pub const PAYMENT_HEURISTICS: Reason = Reason::new("PAYMENT_HEURISTICS");
+        pub const PAYMENT_HEURISTICS: Reason = Reason::new(2);
 
         /// Indicates that the user was served a 2FA challenge. An old assessment
         /// with `ENUM_VALUES.INITIATED_TWO_FACTOR` reason that has not been
         /// overwritten with `PASSED_TWO_FACTOR` is treated as an abandoned 2FA flow.
         /// This is equivalent to `FAILED_TWO_FACTOR`.
-        pub const INITIATED_TWO_FACTOR: Reason = Reason::new("INITIATED_TWO_FACTOR");
+        pub const INITIATED_TWO_FACTOR: Reason = Reason::new(7);
 
         /// Indicates that the user passed a 2FA challenge.
-        pub const PASSED_TWO_FACTOR: Reason = Reason::new("PASSED_TWO_FACTOR");
+        pub const PASSED_TWO_FACTOR: Reason = Reason::new(3);
 
         /// Indicates that the user failed a 2FA challenge.
-        pub const FAILED_TWO_FACTOR: Reason = Reason::new("FAILED_TWO_FACTOR");
+        pub const FAILED_TWO_FACTOR: Reason = Reason::new(4);
 
         /// Indicates the user provided the correct password.
-        pub const CORRECT_PASSWORD: Reason = Reason::new("CORRECT_PASSWORD");
+        pub const CORRECT_PASSWORD: Reason = Reason::new(5);
 
         /// Indicates the user provided an incorrect password.
-        pub const INCORRECT_PASSWORD: Reason = Reason::new("INCORRECT_PASSWORD");
+        pub const INCORRECT_PASSWORD: Reason = Reason::new(6);
 
         /// Indicates that the user sent unwanted and abusive messages to other users
         /// of the platform, such as spam, scams, phishing, or social engineering.
-        pub const SOCIAL_SPAM: Reason = Reason::new("SOCIAL_SPAM");
+        pub const SOCIAL_SPAM: Reason = Reason::new(14);
+
+        /// Creates a new Reason instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("REASON_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CHARGEBACK"),
+                2 => std::borrow::Cow::Borrowed("PAYMENT_HEURISTICS"),
+                3 => std::borrow::Cow::Borrowed("PASSED_TWO_FACTOR"),
+                4 => std::borrow::Cow::Borrowed("FAILED_TWO_FACTOR"),
+                5 => std::borrow::Cow::Borrowed("CORRECT_PASSWORD"),
+                6 => std::borrow::Cow::Borrowed("INCORRECT_PASSWORD"),
+                7 => std::borrow::Cow::Borrowed("INITIATED_TWO_FACTOR"),
+                8 => std::borrow::Cow::Borrowed("CHARGEBACK_FRAUD"),
+                9 => std::borrow::Cow::Borrowed("CHARGEBACK_DISPUTE"),
+                10 => std::borrow::Cow::Borrowed("REFUND"),
+                11 => std::borrow::Cow::Borrowed("REFUND_FRAUD"),
+                12 => std::borrow::Cow::Borrowed("TRANSACTION_ACCEPTED"),
+                13 => std::borrow::Cow::Borrowed("TRANSACTION_DECLINED"),
+                14 => std::borrow::Cow::Borrowed("SOCIAL_SPAM"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "REASON_UNSPECIFIED" => std::option::Option::Some(Self::REASON_UNSPECIFIED),
+                "CHARGEBACK" => std::option::Option::Some(Self::CHARGEBACK),
+                "CHARGEBACK_FRAUD" => std::option::Option::Some(Self::CHARGEBACK_FRAUD),
+                "CHARGEBACK_DISPUTE" => std::option::Option::Some(Self::CHARGEBACK_DISPUTE),
+                "REFUND" => std::option::Option::Some(Self::REFUND),
+                "REFUND_FRAUD" => std::option::Option::Some(Self::REFUND_FRAUD),
+                "TRANSACTION_ACCEPTED" => std::option::Option::Some(Self::TRANSACTION_ACCEPTED),
+                "TRANSACTION_DECLINED" => std::option::Option::Some(Self::TRANSACTION_DECLINED),
+                "PAYMENT_HEURISTICS" => std::option::Option::Some(Self::PAYMENT_HEURISTICS),
+                "INITIATED_TWO_FACTOR" => std::option::Option::Some(Self::INITIATED_TWO_FACTOR),
+                "PASSED_TWO_FACTOR" => std::option::Option::Some(Self::PASSED_TWO_FACTOR),
+                "FAILED_TWO_FACTOR" => std::option::Option::Some(Self::FAILED_TWO_FACTOR),
+                "CORRECT_PASSWORD" => std::option::Option::Some(Self::CORRECT_PASSWORD),
+                "INCORRECT_PASSWORD" => std::option::Option::Some(Self::INCORRECT_PASSWORD),
+                "SOCIAL_SPAM" => std::option::Option::Some(Self::SOCIAL_SPAM),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Reason {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Reason {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Reason {
         fn default() -> Self {
-            reason::REASON_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -770,76 +869,116 @@ pub mod account_verification_info {
     /// Result of the account verification as contained in the verdict token issued
     /// at the end of the verification flow.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Result(std::borrow::Cow<'static, str>);
+    pub struct Result(i32);
 
     impl Result {
-        /// Creates a new Result instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Result](Result)
-    pub mod result {
-        use super::Result;
-
         /// No information about the latest account verification.
-        pub const RESULT_UNSPECIFIED: Result = Result::new("RESULT_UNSPECIFIED");
+        pub const RESULT_UNSPECIFIED: Result = Result::new(0);
 
         /// The user was successfully verified. This means the account verification
         /// challenge was successfully completed.
-        pub const SUCCESS_USER_VERIFIED: Result = Result::new("SUCCESS_USER_VERIFIED");
+        pub const SUCCESS_USER_VERIFIED: Result = Result::new(1);
 
         /// The user failed the verification challenge.
-        pub const ERROR_USER_NOT_VERIFIED: Result = Result::new("ERROR_USER_NOT_VERIFIED");
+        pub const ERROR_USER_NOT_VERIFIED: Result = Result::new(2);
 
         /// The site is not properly onboarded to use the account verification
         /// feature.
-        pub const ERROR_SITE_ONBOARDING_INCOMPLETE: Result =
-            Result::new("ERROR_SITE_ONBOARDING_INCOMPLETE");
+        pub const ERROR_SITE_ONBOARDING_INCOMPLETE: Result = Result::new(3);
 
         /// The recipient is not allowed for account verification. This can occur
         /// during integration but should not occur in production.
-        pub const ERROR_RECIPIENT_NOT_ALLOWED: Result = Result::new("ERROR_RECIPIENT_NOT_ALLOWED");
+        pub const ERROR_RECIPIENT_NOT_ALLOWED: Result = Result::new(4);
 
         /// The recipient has already been sent too many verification codes in a
         /// short amount of time.
-        pub const ERROR_RECIPIENT_ABUSE_LIMIT_EXHAUSTED: Result =
-            Result::new("ERROR_RECIPIENT_ABUSE_LIMIT_EXHAUSTED");
+        pub const ERROR_RECIPIENT_ABUSE_LIMIT_EXHAUSTED: Result = Result::new(5);
 
         /// The verification flow could not be completed due to a critical internal
         /// error.
-        pub const ERROR_CRITICAL_INTERNAL: Result = Result::new("ERROR_CRITICAL_INTERNAL");
+        pub const ERROR_CRITICAL_INTERNAL: Result = Result::new(6);
 
         /// The client has exceeded their two factor request quota for this period of
         /// time.
-        pub const ERROR_CUSTOMER_QUOTA_EXHAUSTED: Result =
-            Result::new("ERROR_CUSTOMER_QUOTA_EXHAUSTED");
+        pub const ERROR_CUSTOMER_QUOTA_EXHAUSTED: Result = Result::new(7);
 
         /// The request cannot be processed at the time because of an incident. This
         /// bypass can be restricted to a problematic destination email domain, a
         /// customer, or could affect the entire service.
-        pub const ERROR_VERIFICATION_BYPASSED: Result = Result::new("ERROR_VERIFICATION_BYPASSED");
+        pub const ERROR_VERIFICATION_BYPASSED: Result = Result::new(8);
 
         /// The request parameters do not match with the token provided and cannot be
         /// processed.
-        pub const ERROR_VERDICT_MISMATCH: Result = Result::new("ERROR_VERDICT_MISMATCH");
+        pub const ERROR_VERDICT_MISMATCH: Result = Result::new(9);
+
+        /// Creates a new Result instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RESULT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SUCCESS_USER_VERIFIED"),
+                2 => std::borrow::Cow::Borrowed("ERROR_USER_NOT_VERIFIED"),
+                3 => std::borrow::Cow::Borrowed("ERROR_SITE_ONBOARDING_INCOMPLETE"),
+                4 => std::borrow::Cow::Borrowed("ERROR_RECIPIENT_NOT_ALLOWED"),
+                5 => std::borrow::Cow::Borrowed("ERROR_RECIPIENT_ABUSE_LIMIT_EXHAUSTED"),
+                6 => std::borrow::Cow::Borrowed("ERROR_CRITICAL_INTERNAL"),
+                7 => std::borrow::Cow::Borrowed("ERROR_CUSTOMER_QUOTA_EXHAUSTED"),
+                8 => std::borrow::Cow::Borrowed("ERROR_VERIFICATION_BYPASSED"),
+                9 => std::borrow::Cow::Borrowed("ERROR_VERDICT_MISMATCH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RESULT_UNSPECIFIED" => std::option::Option::Some(Self::RESULT_UNSPECIFIED),
+                "SUCCESS_USER_VERIFIED" => std::option::Option::Some(Self::SUCCESS_USER_VERIFIED),
+                "ERROR_USER_NOT_VERIFIED" => {
+                    std::option::Option::Some(Self::ERROR_USER_NOT_VERIFIED)
+                }
+                "ERROR_SITE_ONBOARDING_INCOMPLETE" => {
+                    std::option::Option::Some(Self::ERROR_SITE_ONBOARDING_INCOMPLETE)
+                }
+                "ERROR_RECIPIENT_NOT_ALLOWED" => {
+                    std::option::Option::Some(Self::ERROR_RECIPIENT_NOT_ALLOWED)
+                }
+                "ERROR_RECIPIENT_ABUSE_LIMIT_EXHAUSTED" => {
+                    std::option::Option::Some(Self::ERROR_RECIPIENT_ABUSE_LIMIT_EXHAUSTED)
+                }
+                "ERROR_CRITICAL_INTERNAL" => {
+                    std::option::Option::Some(Self::ERROR_CRITICAL_INTERNAL)
+                }
+                "ERROR_CUSTOMER_QUOTA_EXHAUSTED" => {
+                    std::option::Option::Some(Self::ERROR_CUSTOMER_QUOTA_EXHAUSTED)
+                }
+                "ERROR_VERIFICATION_BYPASSED" => {
+                    std::option::Option::Some(Self::ERROR_VERIFICATION_BYPASSED)
+                }
+                "ERROR_VERDICT_MISMATCH" => std::option::Option::Some(Self::ERROR_VERDICT_MISMATCH),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Result {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Result {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Result {
         fn default() -> Self {
-            result::RESULT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1338,48 +1477,64 @@ pub mod event {
 
     /// Setting that controls Fraud Prevention assessments.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FraudPrevention(std::borrow::Cow<'static, str>);
+    pub struct FraudPrevention(i32);
 
     impl FraudPrevention {
-        /// Creates a new FraudPrevention instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [FraudPrevention](FraudPrevention)
-    pub mod fraud_prevention {
-        use super::FraudPrevention;
-
         /// Default, unspecified setting. `fraud_prevention_assessment` is returned
         /// if `transaction_data` is present in `Event` and Fraud Prevention is
         /// enabled in the Google Cloud console.
-        pub const FRAUD_PREVENTION_UNSPECIFIED: FraudPrevention =
-            FraudPrevention::new("FRAUD_PREVENTION_UNSPECIFIED");
+        pub const FRAUD_PREVENTION_UNSPECIFIED: FraudPrevention = FraudPrevention::new(0);
 
         /// Enable Fraud Prevention for this assessment, if Fraud Prevention is
         /// enabled in the Google Cloud console.
-        pub const ENABLED: FraudPrevention = FraudPrevention::new("ENABLED");
+        pub const ENABLED: FraudPrevention = FraudPrevention::new(1);
 
         /// Disable Fraud Prevention for this assessment, regardless of Google Cloud
         /// console settings.
-        pub const DISABLED: FraudPrevention = FraudPrevention::new("DISABLED");
+        pub const DISABLED: FraudPrevention = FraudPrevention::new(2);
+
+        /// Creates a new FraudPrevention instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FRAUD_PREVENTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENABLED"),
+                2 => std::borrow::Cow::Borrowed("DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FRAUD_PREVENTION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::FRAUD_PREVENTION_UNSPECIFIED)
+                }
+                "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for FraudPrevention {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for FraudPrevention {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for FraudPrevention {
         fn default() -> Self {
-            fraud_prevention::FRAUD_PREVENTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2156,113 +2311,153 @@ pub mod risk_analysis {
 
     /// Reasons contributing to the risk analysis verdict.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ClassificationReason(std::borrow::Cow<'static, str>);
+    pub struct ClassificationReason(i32);
 
     impl ClassificationReason {
-        /// Creates a new ClassificationReason instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ClassificationReason](ClassificationReason)
-    pub mod classification_reason {
-        use super::ClassificationReason;
-
         /// Default unspecified type.
         pub const CLASSIFICATION_REASON_UNSPECIFIED: ClassificationReason =
-            ClassificationReason::new("CLASSIFICATION_REASON_UNSPECIFIED");
+            ClassificationReason::new(0);
 
         /// Interactions matched the behavior of an automated agent.
-        pub const AUTOMATION: ClassificationReason = ClassificationReason::new("AUTOMATION");
+        pub const AUTOMATION: ClassificationReason = ClassificationReason::new(1);
 
         /// The event originated from an illegitimate environment.
-        pub const UNEXPECTED_ENVIRONMENT: ClassificationReason =
-            ClassificationReason::new("UNEXPECTED_ENVIRONMENT");
+        pub const UNEXPECTED_ENVIRONMENT: ClassificationReason = ClassificationReason::new(2);
 
         /// Traffic volume from the event source is higher than normal.
-        pub const TOO_MUCH_TRAFFIC: ClassificationReason =
-            ClassificationReason::new("TOO_MUCH_TRAFFIC");
+        pub const TOO_MUCH_TRAFFIC: ClassificationReason = ClassificationReason::new(3);
 
         /// Interactions with the site were significantly different than expected
         /// patterns.
-        pub const UNEXPECTED_USAGE_PATTERNS: ClassificationReason =
-            ClassificationReason::new("UNEXPECTED_USAGE_PATTERNS");
+        pub const UNEXPECTED_USAGE_PATTERNS: ClassificationReason = ClassificationReason::new(4);
 
         /// Too little traffic has been received from this site thus far to generate
         /// quality risk analysis.
-        pub const LOW_CONFIDENCE_SCORE: ClassificationReason =
-            ClassificationReason::new("LOW_CONFIDENCE_SCORE");
+        pub const LOW_CONFIDENCE_SCORE: ClassificationReason = ClassificationReason::new(5);
 
         /// The request matches behavioral characteristics of a carding attack.
-        pub const SUSPECTED_CARDING: ClassificationReason =
-            ClassificationReason::new("SUSPECTED_CARDING");
+        pub const SUSPECTED_CARDING: ClassificationReason = ClassificationReason::new(6);
 
         /// The request matches behavioral characteristics of chargebacks for fraud.
-        pub const SUSPECTED_CHARGEBACK: ClassificationReason =
-            ClassificationReason::new("SUSPECTED_CHARGEBACK");
+        pub const SUSPECTED_CHARGEBACK: ClassificationReason = ClassificationReason::new(7);
+
+        /// Creates a new ClassificationReason instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CLASSIFICATION_REASON_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AUTOMATION"),
+                2 => std::borrow::Cow::Borrowed("UNEXPECTED_ENVIRONMENT"),
+                3 => std::borrow::Cow::Borrowed("TOO_MUCH_TRAFFIC"),
+                4 => std::borrow::Cow::Borrowed("UNEXPECTED_USAGE_PATTERNS"),
+                5 => std::borrow::Cow::Borrowed("LOW_CONFIDENCE_SCORE"),
+                6 => std::borrow::Cow::Borrowed("SUSPECTED_CARDING"),
+                7 => std::borrow::Cow::Borrowed("SUSPECTED_CHARGEBACK"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CLASSIFICATION_REASON_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CLASSIFICATION_REASON_UNSPECIFIED)
+                }
+                "AUTOMATION" => std::option::Option::Some(Self::AUTOMATION),
+                "UNEXPECTED_ENVIRONMENT" => std::option::Option::Some(Self::UNEXPECTED_ENVIRONMENT),
+                "TOO_MUCH_TRAFFIC" => std::option::Option::Some(Self::TOO_MUCH_TRAFFIC),
+                "UNEXPECTED_USAGE_PATTERNS" => {
+                    std::option::Option::Some(Self::UNEXPECTED_USAGE_PATTERNS)
+                }
+                "LOW_CONFIDENCE_SCORE" => std::option::Option::Some(Self::LOW_CONFIDENCE_SCORE),
+                "SUSPECTED_CARDING" => std::option::Option::Some(Self::SUSPECTED_CARDING),
+                "SUSPECTED_CHARGEBACK" => std::option::Option::Some(Self::SUSPECTED_CHARGEBACK),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ClassificationReason {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ClassificationReason {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ClassificationReason {
         fn default() -> Self {
-            classification_reason::CLASSIFICATION_REASON_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Challenge information for SCORE_AND_CHALLENGE and INVISIBLE keys
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Challenge(std::borrow::Cow<'static, str>);
+    pub struct Challenge(i32);
 
     impl Challenge {
-        /// Creates a new Challenge instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Challenge](Challenge)
-    pub mod challenge {
-        use super::Challenge;
-
         /// Default unspecified type.
-        pub const CHALLENGE_UNSPECIFIED: Challenge = Challenge::new("CHALLENGE_UNSPECIFIED");
+        pub const CHALLENGE_UNSPECIFIED: Challenge = Challenge::new(0);
 
         /// No challenge was presented for solving.
-        pub const NOCAPTCHA: Challenge = Challenge::new("NOCAPTCHA");
+        pub const NOCAPTCHA: Challenge = Challenge::new(1);
 
         /// A solution was submitted that was correct.
-        pub const PASSED: Challenge = Challenge::new("PASSED");
+        pub const PASSED: Challenge = Challenge::new(2);
 
         /// A solution was submitted that was incorrect or otherwise
         /// deemed suspicious.
-        pub const FAILED: Challenge = Challenge::new("FAILED");
+        pub const FAILED: Challenge = Challenge::new(3);
+
+        /// Creates a new Challenge instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CHALLENGE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NOCAPTCHA"),
+                2 => std::borrow::Cow::Borrowed("PASSED"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CHALLENGE_UNSPECIFIED" => std::option::Option::Some(Self::CHALLENGE_UNSPECIFIED),
+                "NOCAPTCHA" => std::option::Option::Some(Self::NOCAPTCHA),
+                "PASSED" => std::option::Option::Some(Self::PASSED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Challenge {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Challenge {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Challenge {
         fn default() -> Self {
-            challenge::CHALLENGE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2379,58 +2574,81 @@ pub mod token_properties {
 
     /// Enum that represents the types of invalid token reasons.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct InvalidReason(std::borrow::Cow<'static, str>);
+    pub struct InvalidReason(i32);
 
     impl InvalidReason {
-        /// Creates a new InvalidReason instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [InvalidReason](InvalidReason)
-    pub mod invalid_reason {
-        use super::InvalidReason;
-
         /// Default unspecified type.
-        pub const INVALID_REASON_UNSPECIFIED: InvalidReason =
-            InvalidReason::new("INVALID_REASON_UNSPECIFIED");
+        pub const INVALID_REASON_UNSPECIFIED: InvalidReason = InvalidReason::new(0);
 
         /// If the failure reason was not accounted for.
-        pub const UNKNOWN_INVALID_REASON: InvalidReason =
-            InvalidReason::new("UNKNOWN_INVALID_REASON");
+        pub const UNKNOWN_INVALID_REASON: InvalidReason = InvalidReason::new(1);
 
         /// The provided user verification token was malformed.
-        pub const MALFORMED: InvalidReason = InvalidReason::new("MALFORMED");
+        pub const MALFORMED: InvalidReason = InvalidReason::new(2);
 
         /// The user verification token had expired.
-        pub const EXPIRED: InvalidReason = InvalidReason::new("EXPIRED");
+        pub const EXPIRED: InvalidReason = InvalidReason::new(3);
 
         /// The user verification had already been seen.
-        pub const DUPE: InvalidReason = InvalidReason::new("DUPE");
+        pub const DUPE: InvalidReason = InvalidReason::new(4);
 
         /// The user verification token was not present.
-        pub const MISSING: InvalidReason = InvalidReason::new("MISSING");
+        pub const MISSING: InvalidReason = InvalidReason::new(5);
 
         /// A retriable error (such as network failure) occurred on the browser.
         /// Could easily be simulated by an attacker.
-        pub const BROWSER_ERROR: InvalidReason = InvalidReason::new("BROWSER_ERROR");
+        pub const BROWSER_ERROR: InvalidReason = InvalidReason::new(6);
+
+        /// Creates a new InvalidReason instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("INVALID_REASON_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("UNKNOWN_INVALID_REASON"),
+                2 => std::borrow::Cow::Borrowed("MALFORMED"),
+                3 => std::borrow::Cow::Borrowed("EXPIRED"),
+                4 => std::borrow::Cow::Borrowed("DUPE"),
+                5 => std::borrow::Cow::Borrowed("MISSING"),
+                6 => std::borrow::Cow::Borrowed("BROWSER_ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "INVALID_REASON_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::INVALID_REASON_UNSPECIFIED)
+                }
+                "UNKNOWN_INVALID_REASON" => std::option::Option::Some(Self::UNKNOWN_INVALID_REASON),
+                "MALFORMED" => std::option::Option::Some(Self::MALFORMED),
+                "EXPIRED" => std::option::Option::Some(Self::EXPIRED),
+                "DUPE" => std::option::Option::Some(Self::DUPE),
+                "MISSING" => std::option::Option::Some(Self::MISSING),
+                "BROWSER_ERROR" => std::option::Option::Some(Self::BROWSER_ERROR),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for InvalidReason {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for InvalidReason {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for InvalidReason {
         fn default() -> Self {
-            invalid_reason::INVALID_REASON_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2754,48 +2972,67 @@ pub mod fraud_signals {
         /// Risk labels describing the card being assessed, such as its funding
         /// mechanism.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct CardLabel(std::borrow::Cow<'static, str>);
+        pub struct CardLabel(i32);
 
         impl CardLabel {
-            /// Creates a new CardLabel instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [CardLabel](CardLabel)
-        pub mod card_label {
-            use super::CardLabel;
-
             /// No label specified.
-            pub const CARD_LABEL_UNSPECIFIED: CardLabel = CardLabel::new("CARD_LABEL_UNSPECIFIED");
+            pub const CARD_LABEL_UNSPECIFIED: CardLabel = CardLabel::new(0);
 
             /// This card has been detected as prepaid.
-            pub const PREPAID: CardLabel = CardLabel::new("PREPAID");
+            pub const PREPAID: CardLabel = CardLabel::new(1);
 
             /// This card has been detected as virtual, such as a card number generated
             /// for a single transaction or merchant.
-            pub const VIRTUAL: CardLabel = CardLabel::new("VIRTUAL");
+            pub const VIRTUAL: CardLabel = CardLabel::new(2);
 
             /// This card has been detected as being used in an unexpected geographic
             /// location.
-            pub const UNEXPECTED_LOCATION: CardLabel = CardLabel::new("UNEXPECTED_LOCATION");
+            pub const UNEXPECTED_LOCATION: CardLabel = CardLabel::new(3);
+
+            /// Creates a new CardLabel instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("CARD_LABEL_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("PREPAID"),
+                    2 => std::borrow::Cow::Borrowed("VIRTUAL"),
+                    3 => std::borrow::Cow::Borrowed("UNEXPECTED_LOCATION"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "CARD_LABEL_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::CARD_LABEL_UNSPECIFIED)
+                    }
+                    "PREPAID" => std::option::Option::Some(Self::PREPAID),
+                    "VIRTUAL" => std::option::Option::Some(Self::VIRTUAL),
+                    "UNEXPECTED_LOCATION" => std::option::Option::Some(Self::UNEXPECTED_LOCATION),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for CardLabel {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for CardLabel {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for CardLabel {
             fn default() -> Self {
-                card_label::CARD_LABEL_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -2852,42 +3089,56 @@ pub mod sms_toll_fraud_verdict {
 
     /// Reasons contributing to the SMS toll fraud verdict.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SmsTollFraudReason(std::borrow::Cow<'static, str>);
+    pub struct SmsTollFraudReason(i32);
 
     impl SmsTollFraudReason {
+        /// Default unspecified reason
+        pub const SMS_TOLL_FRAUD_REASON_UNSPECIFIED: SmsTollFraudReason =
+            SmsTollFraudReason::new(0);
+
+        /// The provided phone number was invalid
+        pub const INVALID_PHONE_NUMBER: SmsTollFraudReason = SmsTollFraudReason::new(1);
+
         /// Creates a new SmsTollFraudReason instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SMS_TOLL_FRAUD_REASON_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INVALID_PHONE_NUMBER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SMS_TOLL_FRAUD_REASON_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SMS_TOLL_FRAUD_REASON_UNSPECIFIED)
+                }
+                "INVALID_PHONE_NUMBER" => std::option::Option::Some(Self::INVALID_PHONE_NUMBER),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SmsTollFraudReason](SmsTollFraudReason)
-    pub mod sms_toll_fraud_reason {
-        use super::SmsTollFraudReason;
-
-        /// Default unspecified reason
-        pub const SMS_TOLL_FRAUD_REASON_UNSPECIFIED: SmsTollFraudReason =
-            SmsTollFraudReason::new("SMS_TOLL_FRAUD_REASON_UNSPECIFIED");
-
-        /// The provided phone number was invalid
-        pub const INVALID_PHONE_NUMBER: SmsTollFraudReason =
-            SmsTollFraudReason::new("INVALID_PHONE_NUMBER");
-    }
-
-    impl std::convert::From<std::string::String> for SmsTollFraudReason {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SmsTollFraudReason {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SmsTollFraudReason {
         fn default() -> Self {
-            sms_toll_fraud_reason::SMS_TOLL_FRAUD_REASON_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2967,57 +3218,81 @@ pub mod account_defender_assessment {
 
     /// Labels returned by account defender for this request.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AccountDefenderLabel(std::borrow::Cow<'static, str>);
+    pub struct AccountDefenderLabel(i32);
 
     impl AccountDefenderLabel {
-        /// Creates a new AccountDefenderLabel instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [AccountDefenderLabel](AccountDefenderLabel)
-    pub mod account_defender_label {
-        use super::AccountDefenderLabel;
-
         /// Default unspecified type.
         pub const ACCOUNT_DEFENDER_LABEL_UNSPECIFIED: AccountDefenderLabel =
-            AccountDefenderLabel::new("ACCOUNT_DEFENDER_LABEL_UNSPECIFIED");
+            AccountDefenderLabel::new(0);
 
         /// The request matches a known good profile for the user.
-        pub const PROFILE_MATCH: AccountDefenderLabel = AccountDefenderLabel::new("PROFILE_MATCH");
+        pub const PROFILE_MATCH: AccountDefenderLabel = AccountDefenderLabel::new(1);
 
         /// The request is potentially a suspicious login event and must be further
         /// verified either through multi-factor authentication or another system.
-        pub const SUSPICIOUS_LOGIN_ACTIVITY: AccountDefenderLabel =
-            AccountDefenderLabel::new("SUSPICIOUS_LOGIN_ACTIVITY");
+        pub const SUSPICIOUS_LOGIN_ACTIVITY: AccountDefenderLabel = AccountDefenderLabel::new(2);
 
         /// The request matched a profile that previously had suspicious account
         /// creation behavior. This can mean that this is a fake account.
-        pub const SUSPICIOUS_ACCOUNT_CREATION: AccountDefenderLabel =
-            AccountDefenderLabel::new("SUSPICIOUS_ACCOUNT_CREATION");
+        pub const SUSPICIOUS_ACCOUNT_CREATION: AccountDefenderLabel = AccountDefenderLabel::new(3);
 
         /// The account in the request has a high number of related accounts. It does
         /// not necessarily imply that the account is bad but can require further
         /// investigation.
-        pub const RELATED_ACCOUNTS_NUMBER_HIGH: AccountDefenderLabel =
-            AccountDefenderLabel::new("RELATED_ACCOUNTS_NUMBER_HIGH");
+        pub const RELATED_ACCOUNTS_NUMBER_HIGH: AccountDefenderLabel = AccountDefenderLabel::new(4);
+
+        /// Creates a new AccountDefenderLabel instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ACCOUNT_DEFENDER_LABEL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROFILE_MATCH"),
+                2 => std::borrow::Cow::Borrowed("SUSPICIOUS_LOGIN_ACTIVITY"),
+                3 => std::borrow::Cow::Borrowed("SUSPICIOUS_ACCOUNT_CREATION"),
+                4 => std::borrow::Cow::Borrowed("RELATED_ACCOUNTS_NUMBER_HIGH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ACCOUNT_DEFENDER_LABEL_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ACCOUNT_DEFENDER_LABEL_UNSPECIFIED)
+                }
+                "PROFILE_MATCH" => std::option::Option::Some(Self::PROFILE_MATCH),
+                "SUSPICIOUS_LOGIN_ACTIVITY" => {
+                    std::option::Option::Some(Self::SUSPICIOUS_LOGIN_ACTIVITY)
+                }
+                "SUSPICIOUS_ACCOUNT_CREATION" => {
+                    std::option::Option::Some(Self::SUSPICIOUS_ACCOUNT_CREATION)
+                }
+                "RELATED_ACCOUNTS_NUMBER_HIGH" => {
+                    std::option::Option::Some(Self::RELATED_ACCOUNTS_NUMBER_HIGH)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for AccountDefenderLabel {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AccountDefenderLabel {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AccountDefenderLabel {
         fn default() -> Self {
-            account_defender_label::ACCOUNT_DEFENDER_LABEL_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4135,48 +4410,63 @@ pub mod testing_options {
     /// Enum that represents the challenge option for challenge-based (CHECKBOX,
     /// INVISIBLE) testing keys.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TestingChallenge(std::borrow::Cow<'static, str>);
+    pub struct TestingChallenge(i32);
 
     impl TestingChallenge {
-        /// Creates a new TestingChallenge instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [TestingChallenge](TestingChallenge)
-    pub mod testing_challenge {
-        use super::TestingChallenge;
-
         /// Perform the normal risk analysis and return either nocaptcha or a
         /// challenge depending on risk and trust factors.
-        pub const TESTING_CHALLENGE_UNSPECIFIED: TestingChallenge =
-            TestingChallenge::new("TESTING_CHALLENGE_UNSPECIFIED");
+        pub const TESTING_CHALLENGE_UNSPECIFIED: TestingChallenge = TestingChallenge::new(0);
 
         /// Challenge requests for this key always return a nocaptcha, which
         /// does not require a solution.
-        pub const NOCAPTCHA: TestingChallenge = TestingChallenge::new("NOCAPTCHA");
+        pub const NOCAPTCHA: TestingChallenge = TestingChallenge::new(1);
 
         /// Challenge requests for this key always return an unsolvable
         /// challenge.
-        pub const UNSOLVABLE_CHALLENGE: TestingChallenge =
-            TestingChallenge::new("UNSOLVABLE_CHALLENGE");
+        pub const UNSOLVABLE_CHALLENGE: TestingChallenge = TestingChallenge::new(2);
+
+        /// Creates a new TestingChallenge instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TESTING_CHALLENGE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NOCAPTCHA"),
+                2 => std::borrow::Cow::Borrowed("UNSOLVABLE_CHALLENGE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TESTING_CHALLENGE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::TESTING_CHALLENGE_UNSPECIFIED)
+                }
+                "NOCAPTCHA" => std::option::Option::Some(Self::NOCAPTCHA),
+                "UNSOLVABLE_CHALLENGE" => std::option::Option::Some(Self::UNSOLVABLE_CHALLENGE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for TestingChallenge {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TestingChallenge {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TestingChallenge {
         fn default() -> Self {
-            testing_challenge::TESTING_CHALLENGE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4274,102 +4564,136 @@ pub mod web_key_settings {
 
     /// Enum that represents the integration types for web keys.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IntegrationType(std::borrow::Cow<'static, str>);
+    pub struct IntegrationType(i32);
 
     impl IntegrationType {
-        /// Creates a new IntegrationType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [IntegrationType](IntegrationType)
-    pub mod integration_type {
-        use super::IntegrationType;
-
         /// Default type that indicates this enum hasn't been specified. This is not
         /// a valid IntegrationType, one of the other types must be specified
         /// instead.
-        pub const INTEGRATION_TYPE_UNSPECIFIED: IntegrationType =
-            IntegrationType::new("INTEGRATION_TYPE_UNSPECIFIED");
+        pub const INTEGRATION_TYPE_UNSPECIFIED: IntegrationType = IntegrationType::new(0);
 
         /// Only used to produce scores. It doesn't display the "I'm not a robot"
         /// checkbox and never shows captcha challenges.
-        pub const SCORE: IntegrationType = IntegrationType::new("SCORE");
+        pub const SCORE: IntegrationType = IntegrationType::new(1);
 
         /// Displays the "I'm not a robot" checkbox and may show captcha challenges
         /// after it is checked.
-        pub const CHECKBOX: IntegrationType = IntegrationType::new("CHECKBOX");
+        pub const CHECKBOX: IntegrationType = IntegrationType::new(2);
 
         /// Doesn't display the "I'm not a robot" checkbox, but may show captcha
         /// challenges after risk analysis.
-        pub const INVISIBLE: IntegrationType = IntegrationType::new("INVISIBLE");
+        pub const INVISIBLE: IntegrationType = IntegrationType::new(3);
+
+        /// Creates a new IntegrationType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("INTEGRATION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SCORE"),
+                2 => std::borrow::Cow::Borrowed("CHECKBOX"),
+                3 => std::borrow::Cow::Borrowed("INVISIBLE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "INTEGRATION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::INTEGRATION_TYPE_UNSPECIFIED)
+                }
+                "SCORE" => std::option::Option::Some(Self::SCORE),
+                "CHECKBOX" => std::option::Option::Some(Self::CHECKBOX),
+                "INVISIBLE" => std::option::Option::Some(Self::INVISIBLE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for IntegrationType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for IntegrationType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for IntegrationType {
         fn default() -> Self {
-            integration_type::INTEGRATION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Enum that represents the possible challenge frequency and difficulty
     /// configurations for a web key.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ChallengeSecurityPreference(std::borrow::Cow<'static, str>);
+    pub struct ChallengeSecurityPreference(i32);
 
     impl ChallengeSecurityPreference {
+        /// Default type that indicates this enum hasn't been specified.
+        pub const CHALLENGE_SECURITY_PREFERENCE_UNSPECIFIED: ChallengeSecurityPreference =
+            ChallengeSecurityPreference::new(0);
+
+        /// Key tends to show fewer and easier challenges.
+        pub const USABILITY: ChallengeSecurityPreference = ChallengeSecurityPreference::new(1);
+
+        /// Key tends to show balanced (in amount and difficulty) challenges.
+        pub const BALANCE: ChallengeSecurityPreference = ChallengeSecurityPreference::new(2);
+
+        /// Key tends to show more and harder challenges.
+        pub const SECURITY: ChallengeSecurityPreference = ChallengeSecurityPreference::new(3);
+
         /// Creates a new ChallengeSecurityPreference instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CHALLENGE_SECURITY_PREFERENCE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("USABILITY"),
+                2 => std::borrow::Cow::Borrowed("BALANCE"),
+                3 => std::borrow::Cow::Borrowed("SECURITY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CHALLENGE_SECURITY_PREFERENCE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CHALLENGE_SECURITY_PREFERENCE_UNSPECIFIED)
+                }
+                "USABILITY" => std::option::Option::Some(Self::USABILITY),
+                "BALANCE" => std::option::Option::Some(Self::BALANCE),
+                "SECURITY" => std::option::Option::Some(Self::SECURITY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ChallengeSecurityPreference](ChallengeSecurityPreference)
-    pub mod challenge_security_preference {
-        use super::ChallengeSecurityPreference;
-
-        /// Default type that indicates this enum hasn't been specified.
-        pub const CHALLENGE_SECURITY_PREFERENCE_UNSPECIFIED: ChallengeSecurityPreference =
-            ChallengeSecurityPreference::new("CHALLENGE_SECURITY_PREFERENCE_UNSPECIFIED");
-
-        /// Key tends to show fewer and easier challenges.
-        pub const USABILITY: ChallengeSecurityPreference =
-            ChallengeSecurityPreference::new("USABILITY");
-
-        /// Key tends to show balanced (in amount and difficulty) challenges.
-        pub const BALANCE: ChallengeSecurityPreference =
-            ChallengeSecurityPreference::new("BALANCE");
-
-        /// Key tends to show more and harder challenges.
-        pub const SECURITY: ChallengeSecurityPreference =
-            ChallengeSecurityPreference::new("SECURITY");
-    }
-
-    impl std::convert::From<std::string::String> for ChallengeSecurityPreference {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ChallengeSecurityPreference {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ChallengeSecurityPreference {
         fn default() -> Self {
-            challenge_security_preference::CHALLENGE_SECURITY_PREFERENCE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6033,99 +6357,141 @@ pub mod waf_settings {
     /// Supported WAF features. For more information, see
     /// <https://cloud.google.com/recaptcha/docs/usecase#comparison_of_features>.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct WafFeature(std::borrow::Cow<'static, str>);
+    pub struct WafFeature(i32);
 
     impl WafFeature {
-        /// Creates a new WafFeature instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [WafFeature](WafFeature)
-    pub mod waf_feature {
-        use super::WafFeature;
-
         /// Undefined feature.
-        pub const WAF_FEATURE_UNSPECIFIED: WafFeature = WafFeature::new("WAF_FEATURE_UNSPECIFIED");
+        pub const WAF_FEATURE_UNSPECIFIED: WafFeature = WafFeature::new(0);
 
         /// Redirects suspicious traffic to reCAPTCHA.
-        pub const CHALLENGE_PAGE: WafFeature = WafFeature::new("CHALLENGE_PAGE");
+        pub const CHALLENGE_PAGE: WafFeature = WafFeature::new(1);
 
         /// Use reCAPTCHA session-tokens to protect the whole user session on the
         /// site's domain.
-        pub const SESSION_TOKEN: WafFeature = WafFeature::new("SESSION_TOKEN");
+        pub const SESSION_TOKEN: WafFeature = WafFeature::new(2);
 
         /// Use reCAPTCHA action-tokens to protect user actions.
-        pub const ACTION_TOKEN: WafFeature = WafFeature::new("ACTION_TOKEN");
+        pub const ACTION_TOKEN: WafFeature = WafFeature::new(3);
 
         /// Use reCAPTCHA WAF express protection to protect any content other than
         /// web pages, like APIs and IoT devices.
-        pub const EXPRESS: WafFeature = WafFeature::new("EXPRESS");
+        pub const EXPRESS: WafFeature = WafFeature::new(5);
+
+        /// Creates a new WafFeature instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("WAF_FEATURE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CHALLENGE_PAGE"),
+                2 => std::borrow::Cow::Borrowed("SESSION_TOKEN"),
+                3 => std::borrow::Cow::Borrowed("ACTION_TOKEN"),
+                5 => std::borrow::Cow::Borrowed("EXPRESS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "WAF_FEATURE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::WAF_FEATURE_UNSPECIFIED)
+                }
+                "CHALLENGE_PAGE" => std::option::Option::Some(Self::CHALLENGE_PAGE),
+                "SESSION_TOKEN" => std::option::Option::Some(Self::SESSION_TOKEN),
+                "ACTION_TOKEN" => std::option::Option::Some(Self::ACTION_TOKEN),
+                "EXPRESS" => std::option::Option::Some(Self::EXPRESS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for WafFeature {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for WafFeature {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for WafFeature {
         fn default() -> Self {
-            waf_feature::WAF_FEATURE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Web Application Firewalls supported by reCAPTCHA.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct WafService(std::borrow::Cow<'static, str>);
+    pub struct WafService(i32);
 
     impl WafService {
+        /// Undefined WAF
+        pub const WAF_SERVICE_UNSPECIFIED: WafService = WafService::new(0);
+
+        /// Cloud Armor
+        pub const CA: WafService = WafService::new(1);
+
+        /// Fastly
+        pub const FASTLY: WafService = WafService::new(3);
+
+        /// Cloudflare
+        pub const CLOUDFLARE: WafService = WafService::new(4);
+
+        /// Akamai
+        pub const AKAMAI: WafService = WafService::new(5);
+
         /// Creates a new WafService instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("WAF_SERVICE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CA"),
+                3 => std::borrow::Cow::Borrowed("FASTLY"),
+                4 => std::borrow::Cow::Borrowed("CLOUDFLARE"),
+                5 => std::borrow::Cow::Borrowed("AKAMAI"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "WAF_SERVICE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::WAF_SERVICE_UNSPECIFIED)
+                }
+                "CA" => std::option::Option::Some(Self::CA),
+                "FASTLY" => std::option::Option::Some(Self::FASTLY),
+                "CLOUDFLARE" => std::option::Option::Some(Self::CLOUDFLARE),
+                "AKAMAI" => std::option::Option::Some(Self::AKAMAI),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [WafService](WafService)
-    pub mod waf_service {
-        use super::WafService;
-
-        /// Undefined WAF
-        pub const WAF_SERVICE_UNSPECIFIED: WafService = WafService::new("WAF_SERVICE_UNSPECIFIED");
-
-        /// Cloud Armor
-        pub const CA: WafService = WafService::new("CA");
-
-        /// Fastly
-        pub const FASTLY: WafService = WafService::new("FASTLY");
-
-        /// Cloudflare
-        pub const CLOUDFLARE: WafService = WafService::new("CLOUDFLARE");
-
-        /// Akamai
-        pub const AKAMAI: WafService = WafService::new("AKAMAI");
-    }
-
-    impl std::convert::From<std::string::String> for WafService {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for WafService {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for WafService {
         fn default() -> Self {
-            waf_service::WAF_SERVICE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6233,42 +6599,56 @@ pub mod ip_override_data {
 
     /// Enum that represents the type of IP override.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OverrideType(std::borrow::Cow<'static, str>);
+    pub struct OverrideType(i32);
 
     impl OverrideType {
-        /// Creates a new OverrideType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [OverrideType](OverrideType)
-    pub mod override_type {
-        use super::OverrideType;
-
         /// Default override type that indicates this enum hasn't been specified.
-        pub const OVERRIDE_TYPE_UNSPECIFIED: OverrideType =
-            OverrideType::new("OVERRIDE_TYPE_UNSPECIFIED");
+        pub const OVERRIDE_TYPE_UNSPECIFIED: OverrideType = OverrideType::new(0);
 
         /// Allowlist the IP address; i.e. give a `risk_analysis.score` of 0.9 for
         /// all valid assessments.
-        pub const ALLOW: OverrideType = OverrideType::new("ALLOW");
+        pub const ALLOW: OverrideType = OverrideType::new(1);
+
+        /// Creates a new OverrideType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("OVERRIDE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALLOW"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "OVERRIDE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::OVERRIDE_TYPE_UNSPECIFIED)
+                }
+                "ALLOW" => std::option::Option::Some(Self::ALLOW),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for OverrideType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for OverrideType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for OverrideType {
         fn default() -> Self {
-            override_type::OVERRIDE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/recaptchaenterprise/v1/src/transport.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 reqwest::Method::POST,
                 format!("/v1/{}/assessments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -71,7 +71,7 @@ impl crate::stubs::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:annotate", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -88,7 +88,7 @@ impl crate::stubs::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/keys", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -105,7 +105,7 @@ impl crate::stubs::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/keys", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -129,7 +129,7 @@ impl crate::stubs::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 reqwest::Method::GET,
                 format!("/v1/{}:retrieveLegacySecretKey", req.key),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -148,7 +148,7 @@ impl crate::stubs::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -176,7 +176,7 @@ impl crate::stubs::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -203,7 +203,7 @@ impl crate::stubs::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -222,7 +222,7 @@ impl crate::stubs::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:migrate", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -242,7 +242,7 @@ impl crate::stubs::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 reqwest::Method::POST,
                 format!("/v1/{}:addIpOverride", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -262,7 +262,7 @@ impl crate::stubs::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 reqwest::Method::POST,
                 format!("/v1/{}:removeIpOverride", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -282,7 +282,7 @@ impl crate::stubs::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 reqwest::Method::GET,
                 format!("/v1/{}:listIpOverrides", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -303,7 +303,7 @@ impl crate::stubs::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -325,7 +325,7 @@ impl crate::stubs::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 reqwest::Method::POST,
                 format!("/v1/{}/firewallpolicies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -347,7 +347,7 @@ impl crate::stubs::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 reqwest::Method::GET,
                 format!("/v1/{}/firewallpolicies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -368,7 +368,7 @@ impl crate::stubs::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -396,7 +396,7 @@ impl crate::stubs::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -425,7 +425,7 @@ impl crate::stubs::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -447,7 +447,7 @@ impl crate::stubs::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 reqwest::Method::POST,
                 format!("/v1/{}/firewallpolicies:reorder", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -467,7 +467,7 @@ impl crate::stubs::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 reqwest::Method::GET,
                 format!("/v1/{}/relatedaccountgroups", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -491,7 +491,7 @@ impl crate::stubs::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 reqwest::Method::GET,
                 format!("/v1/{}/memberships", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -515,7 +515,7 @@ impl crate::stubs::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 reqwest::Method::POST,
                 format!("/v1/{}/relatedaccountgroupmemberships:search", req.project),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/recommender/v1/src/model.rs
+++ b/src/generated/cloud/recommender/v1/src/model.rs
@@ -243,103 +243,145 @@ pub mod insight {
 
     /// Insight category.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Category(std::borrow::Cow<'static, str>);
+    pub struct Category(i32);
 
     impl Category {
+        /// Unspecified category.
+        pub const CATEGORY_UNSPECIFIED: Category = Category::new(0);
+
+        /// The insight is related to cost.
+        pub const COST: Category = Category::new(1);
+
+        /// The insight is related to security.
+        pub const SECURITY: Category = Category::new(2);
+
+        /// The insight is related to performance.
+        pub const PERFORMANCE: Category = Category::new(3);
+
+        /// This insight is related to manageability.
+        pub const MANAGEABILITY: Category = Category::new(4);
+
+        /// The insight is related to sustainability.
+        pub const SUSTAINABILITY: Category = Category::new(5);
+
+        /// This insight is related to reliability.
+        pub const RELIABILITY: Category = Category::new(6);
+
         /// Creates a new Category instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CATEGORY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("COST"),
+                2 => std::borrow::Cow::Borrowed("SECURITY"),
+                3 => std::borrow::Cow::Borrowed("PERFORMANCE"),
+                4 => std::borrow::Cow::Borrowed("MANAGEABILITY"),
+                5 => std::borrow::Cow::Borrowed("SUSTAINABILITY"),
+                6 => std::borrow::Cow::Borrowed("RELIABILITY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CATEGORY_UNSPECIFIED" => std::option::Option::Some(Self::CATEGORY_UNSPECIFIED),
+                "COST" => std::option::Option::Some(Self::COST),
+                "SECURITY" => std::option::Option::Some(Self::SECURITY),
+                "PERFORMANCE" => std::option::Option::Some(Self::PERFORMANCE),
+                "MANAGEABILITY" => std::option::Option::Some(Self::MANAGEABILITY),
+                "SUSTAINABILITY" => std::option::Option::Some(Self::SUSTAINABILITY),
+                "RELIABILITY" => std::option::Option::Some(Self::RELIABILITY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Category](Category)
-    pub mod category {
-        use super::Category;
-
-        /// Unspecified category.
-        pub const CATEGORY_UNSPECIFIED: Category = Category::new("CATEGORY_UNSPECIFIED");
-
-        /// The insight is related to cost.
-        pub const COST: Category = Category::new("COST");
-
-        /// The insight is related to security.
-        pub const SECURITY: Category = Category::new("SECURITY");
-
-        /// The insight is related to performance.
-        pub const PERFORMANCE: Category = Category::new("PERFORMANCE");
-
-        /// This insight is related to manageability.
-        pub const MANAGEABILITY: Category = Category::new("MANAGEABILITY");
-
-        /// The insight is related to sustainability.
-        pub const SUSTAINABILITY: Category = Category::new("SUSTAINABILITY");
-
-        /// This insight is related to reliability.
-        pub const RELIABILITY: Category = Category::new("RELIABILITY");
-    }
-
-    impl std::convert::From<std::string::String> for Category {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Category {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Category {
         fn default() -> Self {
-            category::CATEGORY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Insight severity levels.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(std::borrow::Cow<'static, str>);
+    pub struct Severity(i32);
 
     impl Severity {
+        /// Insight has unspecified severity.
+        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
+
+        /// Insight has low severity.
+        pub const LOW: Severity = Severity::new(1);
+
+        /// Insight has medium severity.
+        pub const MEDIUM: Severity = Severity::new(2);
+
+        /// Insight has high severity.
+        pub const HIGH: Severity = Severity::new(3);
+
+        /// Insight has critical severity.
+        pub const CRITICAL: Severity = Severity::new(4);
+
         /// Creates a new Severity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LOW"),
+                2 => std::borrow::Cow::Borrowed("MEDIUM"),
+                3 => std::borrow::Cow::Borrowed("HIGH"),
+                4 => std::borrow::Cow::Borrowed("CRITICAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
+                "LOW" => std::option::Option::Some(Self::LOW),
+                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
+                "HIGH" => std::option::Option::Some(Self::HIGH),
+                "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Severity](Severity)
-    pub mod severity {
-        use super::Severity;
-
-        /// Insight has unspecified severity.
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new("SEVERITY_UNSPECIFIED");
-
-        /// Insight has low severity.
-        pub const LOW: Severity = Severity::new("LOW");
-
-        /// Insight has medium severity.
-        pub const MEDIUM: Severity = Severity::new("MEDIUM");
-
-        /// Insight has high severity.
-        pub const HIGH: Severity = Severity::new("HIGH");
-
-        /// Insight has critical severity.
-        pub const CRITICAL: Severity = Severity::new("CRITICAL");
-    }
-
-    impl std::convert::From<std::string::String> for Severity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            severity::SEVERITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -398,52 +440,69 @@ pub mod insight_state_info {
 
     /// Represents insight state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Insight is active. Content for ACTIVE insights can be updated by Google.
         /// ACTIVE insights can be marked DISMISSED OR ACCEPTED.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(1);
 
         /// Some action has been taken based on this insight. Insights become
         /// accepted when a recommendation derived from the insight has been marked
         /// CLAIMED, SUCCEEDED, or FAILED. ACTIVE insights can also be marked
         /// ACCEPTED explicitly. Content for ACCEPTED insights is immutable. ACCEPTED
         /// insights can only be marked ACCEPTED (which may update state metadata).
-        pub const ACCEPTED: State = State::new("ACCEPTED");
+        pub const ACCEPTED: State = State::new(2);
 
         /// Insight is dismissed. Content for DISMISSED insights can be updated by
         /// Google. DISMISSED insights can be marked as ACTIVE.
-        pub const DISMISSED: State = State::new("DISMISSED");
+        pub const DISMISSED: State = State::new(3);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("ACCEPTED"),
+                3 => std::borrow::Cow::Borrowed("DISMISSED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "ACCEPTED" => std::option::Option::Some(Self::ACCEPTED),
+                "DISMISSED" => std::option::Option::Some(Self::DISMISSED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -826,49 +885,68 @@ pub mod recommendation {
 
     /// Recommendation priority levels.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Priority(std::borrow::Cow<'static, str>);
+    pub struct Priority(i32);
 
     impl Priority {
+        /// Recommendation has unspecified priority.
+        pub const PRIORITY_UNSPECIFIED: Priority = Priority::new(0);
+
+        /// Recommendation has P4 priority (lowest priority).
+        pub const P4: Priority = Priority::new(1);
+
+        /// Recommendation has P3 priority (second lowest priority).
+        pub const P3: Priority = Priority::new(2);
+
+        /// Recommendation has P2 priority (second highest priority).
+        pub const P2: Priority = Priority::new(3);
+
+        /// Recommendation has P1 priority (highest priority).
+        pub const P1: Priority = Priority::new(4);
+
         /// Creates a new Priority instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PRIORITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("P4"),
+                2 => std::borrow::Cow::Borrowed("P3"),
+                3 => std::borrow::Cow::Borrowed("P2"),
+                4 => std::borrow::Cow::Borrowed("P1"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PRIORITY_UNSPECIFIED" => std::option::Option::Some(Self::PRIORITY_UNSPECIFIED),
+                "P4" => std::option::Option::Some(Self::P4),
+                "P3" => std::option::Option::Some(Self::P3),
+                "P2" => std::option::Option::Some(Self::P2),
+                "P1" => std::option::Option::Some(Self::P1),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Priority](Priority)
-    pub mod priority {
-        use super::Priority;
-
-        /// Recommendation has unspecified priority.
-        pub const PRIORITY_UNSPECIFIED: Priority = Priority::new("PRIORITY_UNSPECIFIED");
-
-        /// Recommendation has P4 priority (lowest priority).
-        pub const P4: Priority = Priority::new("P4");
-
-        /// Recommendation has P3 priority (second lowest priority).
-        pub const P3: Priority = Priority::new("P3");
-
-        /// Recommendation has P2 priority (second highest priority).
-        pub const P2: Priority = Priority::new("P2");
-
-        /// Recommendation has P1 priority (highest priority).
-        pub const P1: Priority = Priority::new("P1");
-    }
-
-    impl std::convert::From<std::string::String> for Priority {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Priority {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Priority {
         fn default() -> Self {
-            priority::PRIORITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1481,47 +1559,64 @@ pub mod reliability_projection {
 
     /// The risk associated with the reliability issue.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RiskType(std::borrow::Cow<'static, str>);
+    pub struct RiskType(i32);
 
     impl RiskType {
-        /// Creates a new RiskType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RiskType](RiskType)
-    pub mod risk_type {
-        use super::RiskType;
-
         /// Default unspecified risk. Don't use directly.
-        pub const RISK_TYPE_UNSPECIFIED: RiskType = RiskType::new("RISK_TYPE_UNSPECIFIED");
+        pub const RISK_TYPE_UNSPECIFIED: RiskType = RiskType::new(0);
 
         /// Potential service downtime.
-        pub const SERVICE_DISRUPTION: RiskType = RiskType::new("SERVICE_DISRUPTION");
+        pub const SERVICE_DISRUPTION: RiskType = RiskType::new(1);
 
         /// Potential data loss.
-        pub const DATA_LOSS: RiskType = RiskType::new("DATA_LOSS");
+        pub const DATA_LOSS: RiskType = RiskType::new(2);
 
         /// Potential access denial. The service is still up but some or all clients
         /// can't access it.
-        pub const ACCESS_DENY: RiskType = RiskType::new("ACCESS_DENY");
+        pub const ACCESS_DENY: RiskType = RiskType::new(3);
+
+        /// Creates a new RiskType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RISK_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SERVICE_DISRUPTION"),
+                2 => std::borrow::Cow::Borrowed("DATA_LOSS"),
+                3 => std::borrow::Cow::Borrowed("ACCESS_DENY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RISK_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::RISK_TYPE_UNSPECIFIED),
+                "SERVICE_DISRUPTION" => std::option::Option::Some(Self::SERVICE_DISRUPTION),
+                "DATA_LOSS" => std::option::Option::Some(Self::DATA_LOSS),
+                "ACCESS_DENY" => std::option::Option::Some(Self::ACCESS_DENY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RiskType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RiskType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RiskType {
         fn default() -> Self {
-            risk_type::RISK_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1702,55 +1797,78 @@ pub mod impact {
 
     /// The category of the impact.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Category(std::borrow::Cow<'static, str>);
+    pub struct Category(i32);
 
     impl Category {
+        /// Default unspecified category. Don't use directly.
+        pub const CATEGORY_UNSPECIFIED: Category = Category::new(0);
+
+        /// Indicates a potential increase or decrease in cost.
+        pub const COST: Category = Category::new(1);
+
+        /// Indicates a potential increase or decrease in security.
+        pub const SECURITY: Category = Category::new(2);
+
+        /// Indicates a potential increase or decrease in performance.
+        pub const PERFORMANCE: Category = Category::new(3);
+
+        /// Indicates a potential increase or decrease in manageability.
+        pub const MANAGEABILITY: Category = Category::new(4);
+
+        /// Indicates a potential increase or decrease in sustainability.
+        pub const SUSTAINABILITY: Category = Category::new(5);
+
+        /// Indicates a potential increase or decrease in reliability.
+        pub const RELIABILITY: Category = Category::new(6);
+
         /// Creates a new Category instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CATEGORY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("COST"),
+                2 => std::borrow::Cow::Borrowed("SECURITY"),
+                3 => std::borrow::Cow::Borrowed("PERFORMANCE"),
+                4 => std::borrow::Cow::Borrowed("MANAGEABILITY"),
+                5 => std::borrow::Cow::Borrowed("SUSTAINABILITY"),
+                6 => std::borrow::Cow::Borrowed("RELIABILITY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CATEGORY_UNSPECIFIED" => std::option::Option::Some(Self::CATEGORY_UNSPECIFIED),
+                "COST" => std::option::Option::Some(Self::COST),
+                "SECURITY" => std::option::Option::Some(Self::SECURITY),
+                "PERFORMANCE" => std::option::Option::Some(Self::PERFORMANCE),
+                "MANAGEABILITY" => std::option::Option::Some(Self::MANAGEABILITY),
+                "SUSTAINABILITY" => std::option::Option::Some(Self::SUSTAINABILITY),
+                "RELIABILITY" => std::option::Option::Some(Self::RELIABILITY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Category](Category)
-    pub mod category {
-        use super::Category;
-
-        /// Default unspecified category. Don't use directly.
-        pub const CATEGORY_UNSPECIFIED: Category = Category::new("CATEGORY_UNSPECIFIED");
-
-        /// Indicates a potential increase or decrease in cost.
-        pub const COST: Category = Category::new("COST");
-
-        /// Indicates a potential increase or decrease in security.
-        pub const SECURITY: Category = Category::new("SECURITY");
-
-        /// Indicates a potential increase or decrease in performance.
-        pub const PERFORMANCE: Category = Category::new("PERFORMANCE");
-
-        /// Indicates a potential increase or decrease in manageability.
-        pub const MANAGEABILITY: Category = Category::new("MANAGEABILITY");
-
-        /// Indicates a potential increase or decrease in sustainability.
-        pub const SUSTAINABILITY: Category = Category::new("SUSTAINABILITY");
-
-        /// Indicates a potential increase or decrease in reliability.
-        pub const RELIABILITY: Category = Category::new("RELIABILITY");
-    }
-
-    impl std::convert::From<std::string::String> for Category {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Category {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Category {
         fn default() -> Self {
-            category::CATEGORY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1824,67 +1942,88 @@ pub mod recommendation_state_info {
 
     /// Represents Recommendation State.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Default state. Don't use directly.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Recommendation is active and can be applied. Recommendations content can
         /// be updated by Google.
         ///
         /// ACTIVE recommendations can be marked as CLAIMED, SUCCEEDED, or FAILED.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(1);
 
         /// Recommendation is in claimed state. Recommendations content is
         /// immutable and cannot be updated by Google.
         ///
         /// CLAIMED recommendations can be marked as CLAIMED, SUCCEEDED, or FAILED.
-        pub const CLAIMED: State = State::new("CLAIMED");
+        pub const CLAIMED: State = State::new(6);
 
         /// Recommendation is in succeeded state. Recommendations content is
         /// immutable and cannot be updated by Google.
         ///
         /// SUCCEEDED recommendations can be marked as SUCCEEDED, or FAILED.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
+        pub const SUCCEEDED: State = State::new(3);
 
         /// Recommendation is in failed state. Recommendations content is immutable
         /// and cannot be updated by Google.
         ///
         /// FAILED recommendations can be marked as SUCCEEDED, or FAILED.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(4);
 
         /// Recommendation is in dismissed state. Recommendation content can be
         /// updated by Google.
         ///
         /// DISMISSED recommendations can be marked as ACTIVE.
-        pub const DISMISSED: State = State::new("DISMISSED");
+        pub const DISMISSED: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                5 => std::borrow::Cow::Borrowed("DISMISSED"),
+                6 => std::borrow::Cow::Borrowed("CLAIMED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "CLAIMED" => std::option::Option::Some(Self::CLAIMED),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "DISMISSED" => std::option::Option::Some(Self::DISMISSED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/recommender/v1/src/transport.rs
+++ b/src/generated/cloud/recommender/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::Recommender for Recommender {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/insights", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -71,7 +71,7 @@ impl crate::stubs::Recommender for Recommender {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -93,7 +93,7 @@ impl crate::stubs::Recommender for Recommender {
                 reqwest::Method::POST,
                 format!("/v1/{}:markAccepted", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -113,7 +113,7 @@ impl crate::stubs::Recommender for Recommender {
                 reqwest::Method::GET,
                 format!("/v1/{}/recommendations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -135,7 +135,7 @@ impl crate::stubs::Recommender for Recommender {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -157,7 +157,7 @@ impl crate::stubs::Recommender for Recommender {
                 reqwest::Method::POST,
                 format!("/v1/{}:markDismissed", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -177,7 +177,7 @@ impl crate::stubs::Recommender for Recommender {
                 reqwest::Method::POST,
                 format!("/v1/{}:markClaimed", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -197,7 +197,7 @@ impl crate::stubs::Recommender for Recommender {
                 reqwest::Method::POST,
                 format!("/v1/{}:markSucceeded", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -217,7 +217,7 @@ impl crate::stubs::Recommender for Recommender {
                 reqwest::Method::POST,
                 format!("/v1/{}:markFailed", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -234,7 +234,7 @@ impl crate::stubs::Recommender for Recommender {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -262,7 +262,7 @@ impl crate::stubs::Recommender for Recommender {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -292,7 +292,7 @@ impl crate::stubs::Recommender for Recommender {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -320,7 +320,7 @@ impl crate::stubs::Recommender for Recommender {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/redis/cluster/v1/src/model.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/model.rs
@@ -1623,49 +1623,68 @@ pub mod cluster {
 
     /// Represents the different states of a Redis cluster.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Not set.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Redis cluster is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// Redis cluster has been created and is fully usable.
+        pub const ACTIVE: State = State::new(2);
+
+        /// Redis cluster configuration is being updated.
+        pub const UPDATING: State = State::new(3);
+
+        /// Redis cluster is being deleted.
+        pub const DELETING: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Redis cluster is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// Redis cluster has been created and is fully usable.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// Redis cluster configuration is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// Redis cluster is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1827,44 +1846,61 @@ pub mod automated_backup_config {
 
     /// The automated backup mode.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AutomatedBackupMode(std::borrow::Cow<'static, str>);
+    pub struct AutomatedBackupMode(i32);
 
     impl AutomatedBackupMode {
+        /// Default value. Automated backup config is not specified.
+        pub const AUTOMATED_BACKUP_MODE_UNSPECIFIED: AutomatedBackupMode =
+            AutomatedBackupMode::new(0);
+
+        /// Automated backup config disabled.
+        pub const DISABLED: AutomatedBackupMode = AutomatedBackupMode::new(1);
+
+        /// Automated backup config enabled.
+        pub const ENABLED: AutomatedBackupMode = AutomatedBackupMode::new(2);
+
         /// Creates a new AutomatedBackupMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("AUTOMATED_BACKUP_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DISABLED"),
+                2 => std::borrow::Cow::Borrowed("ENABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "AUTOMATED_BACKUP_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::AUTOMATED_BACKUP_MODE_UNSPECIFIED)
+                }
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AutomatedBackupMode](AutomatedBackupMode)
-    pub mod automated_backup_mode {
-        use super::AutomatedBackupMode;
-
-        /// Default value. Automated backup config is not specified.
-        pub const AUTOMATED_BACKUP_MODE_UNSPECIFIED: AutomatedBackupMode =
-            AutomatedBackupMode::new("AUTOMATED_BACKUP_MODE_UNSPECIFIED");
-
-        /// Automated backup config disabled.
-        pub const DISABLED: AutomatedBackupMode = AutomatedBackupMode::new("DISABLED");
-
-        /// Automated backup config enabled.
-        pub const ENABLED: AutomatedBackupMode = AutomatedBackupMode::new("ENABLED");
-    }
-
-    impl std::convert::From<std::string::String> for AutomatedBackupMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AutomatedBackupMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AutomatedBackupMode {
         fn default() -> Self {
-            automated_backup_mode::AUTOMATED_BACKUP_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -2145,92 +2181,128 @@ pub mod backup {
 
     /// Type of the backup.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BackupType(std::borrow::Cow<'static, str>);
+    pub struct BackupType(i32);
 
     impl BackupType {
+        /// The default value, not set.
+        pub const BACKUP_TYPE_UNSPECIFIED: BackupType = BackupType::new(0);
+
+        /// On-demand backup.
+        pub const ON_DEMAND: BackupType = BackupType::new(1);
+
+        /// Automated backup.
+        pub const AUTOMATED: BackupType = BackupType::new(2);
+
         /// Creates a new BackupType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("BACKUP_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ON_DEMAND"),
+                2 => std::borrow::Cow::Borrowed("AUTOMATED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "BACKUP_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::BACKUP_TYPE_UNSPECIFIED)
+                }
+                "ON_DEMAND" => std::option::Option::Some(Self::ON_DEMAND),
+                "AUTOMATED" => std::option::Option::Some(Self::AUTOMATED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [BackupType](BackupType)
-    pub mod backup_type {
-        use super::BackupType;
-
-        /// The default value, not set.
-        pub const BACKUP_TYPE_UNSPECIFIED: BackupType = BackupType::new("BACKUP_TYPE_UNSPECIFIED");
-
-        /// On-demand backup.
-        pub const ON_DEMAND: BackupType = BackupType::new("ON_DEMAND");
-
-        /// Automated backup.
-        pub const AUTOMATED: BackupType = BackupType::new("AUTOMATED");
-    }
-
-    impl std::convert::From<std::string::String> for BackupType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for BackupType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for BackupType {
         fn default() -> Self {
-            backup_type::BACKUP_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// State of the backup.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The default value, not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The backup is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The backup is active to be used.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(2);
 
         /// The backup is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(3);
 
         /// The backup is currently suspended due to reasons like project deletion,
         /// billing account closure, etc.
-        pub const SUSPENDED: State = State::new("SUSPENDED");
+        pub const SUSPENDED: State = State::new(4);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("SUSPENDED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "SUSPENDED" => std::option::Option::Some(Self::SUSPENDED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2548,51 +2620,69 @@ pub mod cross_cluster_replication_config {
 
     /// The role of the cluster in cross cluster replication.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ClusterRole(std::borrow::Cow<'static, str>);
+    pub struct ClusterRole(i32);
 
     impl ClusterRole {
-        /// Creates a new ClusterRole instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ClusterRole](ClusterRole)
-    pub mod cluster_role {
-        use super::ClusterRole;
-
         /// Cluster role is not set.
         /// The behavior is equivalent to NONE.
-        pub const CLUSTER_ROLE_UNSPECIFIED: ClusterRole =
-            ClusterRole::new("CLUSTER_ROLE_UNSPECIFIED");
+        pub const CLUSTER_ROLE_UNSPECIFIED: ClusterRole = ClusterRole::new(0);
 
         /// This cluster does not participate in cross cluster replication. It is an
         /// independent cluster and does not replicate to or from any other clusters.
-        pub const NONE: ClusterRole = ClusterRole::new("NONE");
+        pub const NONE: ClusterRole = ClusterRole::new(1);
 
         /// A cluster that allows both reads and writes. Any data written to this
         /// cluster is also replicated to the attached secondary clusters.
-        pub const PRIMARY: ClusterRole = ClusterRole::new("PRIMARY");
+        pub const PRIMARY: ClusterRole = ClusterRole::new(2);
 
         /// A cluster that allows only reads and replicates data from a primary
         /// cluster.
-        pub const SECONDARY: ClusterRole = ClusterRole::new("SECONDARY");
+        pub const SECONDARY: ClusterRole = ClusterRole::new(3);
+
+        /// Creates a new ClusterRole instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CLUSTER_ROLE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NONE"),
+                2 => std::borrow::Cow::Borrowed("PRIMARY"),
+                3 => std::borrow::Cow::Borrowed("SECONDARY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CLUSTER_ROLE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CLUSTER_ROLE_UNSPECIFIED)
+                }
+                "NONE" => std::option::Option::Some(Self::NONE),
+                "PRIMARY" => std::option::Option::Some(Self::PRIMARY),
+                "SECONDARY" => std::option::Option::Some(Self::SECONDARY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ClusterRole {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ClusterRole {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ClusterRole {
         fn default() -> Self {
-            cluster_role::CLUSTER_ROLE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3639,50 +3729,70 @@ pub mod cluster_persistence_config {
 
         /// Available snapshot periods.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SnapshotPeriod(std::borrow::Cow<'static, str>);
+        pub struct SnapshotPeriod(i32);
 
         impl SnapshotPeriod {
+            /// Not set.
+            pub const SNAPSHOT_PERIOD_UNSPECIFIED: SnapshotPeriod = SnapshotPeriod::new(0);
+
+            /// One hour.
+            pub const ONE_HOUR: SnapshotPeriod = SnapshotPeriod::new(1);
+
+            /// Six hours.
+            pub const SIX_HOURS: SnapshotPeriod = SnapshotPeriod::new(2);
+
+            /// Twelve hours.
+            pub const TWELVE_HOURS: SnapshotPeriod = SnapshotPeriod::new(3);
+
+            /// Twenty four hours.
+            pub const TWENTY_FOUR_HOURS: SnapshotPeriod = SnapshotPeriod::new(4);
+
             /// Creates a new SnapshotPeriod instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("SNAPSHOT_PERIOD_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("ONE_HOUR"),
+                    2 => std::borrow::Cow::Borrowed("SIX_HOURS"),
+                    3 => std::borrow::Cow::Borrowed("TWELVE_HOURS"),
+                    4 => std::borrow::Cow::Borrowed("TWENTY_FOUR_HOURS"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "SNAPSHOT_PERIOD_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::SNAPSHOT_PERIOD_UNSPECIFIED)
+                    }
+                    "ONE_HOUR" => std::option::Option::Some(Self::ONE_HOUR),
+                    "SIX_HOURS" => std::option::Option::Some(Self::SIX_HOURS),
+                    "TWELVE_HOURS" => std::option::Option::Some(Self::TWELVE_HOURS),
+                    "TWENTY_FOUR_HOURS" => std::option::Option::Some(Self::TWENTY_FOUR_HOURS),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [SnapshotPeriod](SnapshotPeriod)
-        pub mod snapshot_period {
-            use super::SnapshotPeriod;
-
-            /// Not set.
-            pub const SNAPSHOT_PERIOD_UNSPECIFIED: SnapshotPeriod =
-                SnapshotPeriod::new("SNAPSHOT_PERIOD_UNSPECIFIED");
-
-            /// One hour.
-            pub const ONE_HOUR: SnapshotPeriod = SnapshotPeriod::new("ONE_HOUR");
-
-            /// Six hours.
-            pub const SIX_HOURS: SnapshotPeriod = SnapshotPeriod::new("SIX_HOURS");
-
-            /// Twelve hours.
-            pub const TWELVE_HOURS: SnapshotPeriod = SnapshotPeriod::new("TWELVE_HOURS");
-
-            /// Twenty four hours.
-            pub const TWENTY_FOUR_HOURS: SnapshotPeriod = SnapshotPeriod::new("TWENTY_FOUR_HOURS");
-        }
-
-        impl std::convert::From<std::string::String> for SnapshotPeriod {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for SnapshotPeriod {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for SnapshotPeriod {
             fn default() -> Self {
-                snapshot_period::SNAPSHOT_PERIOD_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -3727,97 +3837,133 @@ pub mod cluster_persistence_config {
 
         /// Available fsync modes.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct AppendFsync(std::borrow::Cow<'static, str>);
+        pub struct AppendFsync(i32);
 
         impl AppendFsync {
-            /// Creates a new AppendFsync instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [AppendFsync](AppendFsync)
-        pub mod append_fsync {
-            use super::AppendFsync;
-
             /// Not set. Default: EVERYSEC
-            pub const APPEND_FSYNC_UNSPECIFIED: AppendFsync =
-                AppendFsync::new("APPEND_FSYNC_UNSPECIFIED");
+            pub const APPEND_FSYNC_UNSPECIFIED: AppendFsync = AppendFsync::new(0);
 
             /// Never fsync. Normally Linux will flush data every 30 seconds with this
             /// configuration, but it's up to the kernel's exact tuning.
-            pub const NO: AppendFsync = AppendFsync::new("NO");
+            pub const NO: AppendFsync = AppendFsync::new(1);
 
             /// fsync every second. Fast enough, and you may lose 1 second of data if
             /// there is a disaster
-            pub const EVERYSEC: AppendFsync = AppendFsync::new("EVERYSEC");
+            pub const EVERYSEC: AppendFsync = AppendFsync::new(2);
 
             /// fsync every time new write commands are appended to the AOF. It has the
             /// best data loss protection at the cost of performance
-            pub const ALWAYS: AppendFsync = AppendFsync::new("ALWAYS");
+            pub const ALWAYS: AppendFsync = AppendFsync::new(3);
+
+            /// Creates a new AppendFsync instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("APPEND_FSYNC_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("NO"),
+                    2 => std::borrow::Cow::Borrowed("EVERYSEC"),
+                    3 => std::borrow::Cow::Borrowed("ALWAYS"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "APPEND_FSYNC_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::APPEND_FSYNC_UNSPECIFIED)
+                    }
+                    "NO" => std::option::Option::Some(Self::NO),
+                    "EVERYSEC" => std::option::Option::Some(Self::EVERYSEC),
+                    "ALWAYS" => std::option::Option::Some(Self::ALWAYS),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for AppendFsync {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for AppendFsync {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for AppendFsync {
             fn default() -> Self {
-                append_fsync::APPEND_FSYNC_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// Available persistence modes.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PersistenceMode(std::borrow::Cow<'static, str>);
+    pub struct PersistenceMode(i32);
 
     impl PersistenceMode {
+        /// Not set.
+        pub const PERSISTENCE_MODE_UNSPECIFIED: PersistenceMode = PersistenceMode::new(0);
+
+        /// Persistence is disabled, and any snapshot data is deleted.
+        pub const DISABLED: PersistenceMode = PersistenceMode::new(1);
+
+        /// RDB based persistence is enabled.
+        pub const RDB: PersistenceMode = PersistenceMode::new(2);
+
+        /// AOF based persistence is enabled.
+        pub const AOF: PersistenceMode = PersistenceMode::new(3);
+
         /// Creates a new PersistenceMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PERSISTENCE_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DISABLED"),
+                2 => std::borrow::Cow::Borrowed("RDB"),
+                3 => std::borrow::Cow::Borrowed("AOF"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PERSISTENCE_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PERSISTENCE_MODE_UNSPECIFIED)
+                }
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "RDB" => std::option::Option::Some(Self::RDB),
+                "AOF" => std::option::Option::Some(Self::AOF),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [PersistenceMode](PersistenceMode)
-    pub mod persistence_mode {
-        use super::PersistenceMode;
-
-        /// Not set.
-        pub const PERSISTENCE_MODE_UNSPECIFIED: PersistenceMode =
-            PersistenceMode::new("PERSISTENCE_MODE_UNSPECIFIED");
-
-        /// Persistence is disabled, and any snapshot data is deleted.
-        pub const DISABLED: PersistenceMode = PersistenceMode::new("DISABLED");
-
-        /// RDB based persistence is enabled.
-        pub const RDB: PersistenceMode = PersistenceMode::new("RDB");
-
-        /// AOF based persistence is enabled.
-        pub const AOF: PersistenceMode = PersistenceMode::new("AOF");
-    }
-
-    impl std::convert::From<std::string::String> for PersistenceMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PersistenceMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PersistenceMode {
         fn default() -> Self {
-            persistence_mode::PERSISTENCE_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3875,46 +4021,63 @@ pub mod zone_distribution_config {
 
     /// Defines various modes of zone distribution.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ZoneDistributionMode(std::borrow::Cow<'static, str>);
+    pub struct ZoneDistributionMode(i32);
 
     impl ZoneDistributionMode {
-        /// Creates a new ZoneDistributionMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ZoneDistributionMode](ZoneDistributionMode)
-    pub mod zone_distribution_mode {
-        use super::ZoneDistributionMode;
-
         /// Not Set. Default: MULTI_ZONE
         pub const ZONE_DISTRIBUTION_MODE_UNSPECIFIED: ZoneDistributionMode =
-            ZoneDistributionMode::new("ZONE_DISTRIBUTION_MODE_UNSPECIFIED");
+            ZoneDistributionMode::new(0);
 
         /// Distribute all resources across 3 zones picked at random, within the
         /// region.
-        pub const MULTI_ZONE: ZoneDistributionMode = ZoneDistributionMode::new("MULTI_ZONE");
+        pub const MULTI_ZONE: ZoneDistributionMode = ZoneDistributionMode::new(1);
 
         /// Distribute all resources in a single zone. The zone field must be
         /// specified, when this mode is selected.
-        pub const SINGLE_ZONE: ZoneDistributionMode = ZoneDistributionMode::new("SINGLE_ZONE");
+        pub const SINGLE_ZONE: ZoneDistributionMode = ZoneDistributionMode::new(2);
+
+        /// Creates a new ZoneDistributionMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ZONE_DISTRIBUTION_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MULTI_ZONE"),
+                2 => std::borrow::Cow::Borrowed("SINGLE_ZONE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ZONE_DISTRIBUTION_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ZONE_DISTRIBUTION_MODE_UNSPECIFIED)
+                }
+                "MULTI_ZONE" => std::option::Option::Some(Self::MULTI_ZONE),
+                "SINGLE_ZONE" => std::option::Option::Some(Self::SINGLE_ZONE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ZoneDistributionMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ZoneDistributionMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ZoneDistributionMode {
         fn default() -> Self {
-            zone_distribution_mode::ZONE_DISTRIBUTION_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3987,44 +4150,60 @@ pub mod reschedule_cluster_maintenance_request {
 
     /// Reschedule options.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RescheduleType(std::borrow::Cow<'static, str>);
+    pub struct RescheduleType(i32);
 
     impl RescheduleType {
+        /// Not set.
+        pub const RESCHEDULE_TYPE_UNSPECIFIED: RescheduleType = RescheduleType::new(0);
+
+        /// If the user wants to schedule the maintenance to happen now.
+        pub const IMMEDIATE: RescheduleType = RescheduleType::new(1);
+
+        /// If the user wants to reschedule the maintenance to a specific time.
+        pub const SPECIFIC_TIME: RescheduleType = RescheduleType::new(3);
+
         /// Creates a new RescheduleType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RESCHEDULE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IMMEDIATE"),
+                3 => std::borrow::Cow::Borrowed("SPECIFIC_TIME"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RESCHEDULE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RESCHEDULE_TYPE_UNSPECIFIED)
+                }
+                "IMMEDIATE" => std::option::Option::Some(Self::IMMEDIATE),
+                "SPECIFIC_TIME" => std::option::Option::Some(Self::SPECIFIC_TIME),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RescheduleType](RescheduleType)
-    pub mod reschedule_type {
-        use super::RescheduleType;
-
-        /// Not set.
-        pub const RESCHEDULE_TYPE_UNSPECIFIED: RescheduleType =
-            RescheduleType::new("RESCHEDULE_TYPE_UNSPECIFIED");
-
-        /// If the user wants to schedule the maintenance to happen now.
-        pub const IMMEDIATE: RescheduleType = RescheduleType::new("IMMEDIATE");
-
-        /// If the user wants to reschedule the maintenance to a specific time.
-        pub const SPECIFIC_TIME: RescheduleType = RescheduleType::new("SPECIFIC_TIME");
-    }
-
-    impl std::convert::From<std::string::String> for RescheduleType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RescheduleType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RescheduleType {
         fn default() -> Self {
-            reschedule_type::RESCHEDULE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4111,338 +4290,475 @@ pub mod encryption_info {
 
     /// Possible encryption types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// Encryption type not specified. Defaults to GOOGLE_DEFAULT_ENCRYPTION.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// The data is encrypted at rest with a key that is fully managed by Google.
         /// No key version will be populated. This is the default state.
-        pub const GOOGLE_DEFAULT_ENCRYPTION: Type = Type::new("GOOGLE_DEFAULT_ENCRYPTION");
+        pub const GOOGLE_DEFAULT_ENCRYPTION: Type = Type::new(1);
 
         /// The data is encrypted at rest with a key that is managed by the customer.
         /// KMS key versions will be populated.
-        pub const CUSTOMER_MANAGED_ENCRYPTION: Type = Type::new("CUSTOMER_MANAGED_ENCRYPTION");
+        pub const CUSTOMER_MANAGED_ENCRYPTION: Type = Type::new(2);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GOOGLE_DEFAULT_ENCRYPTION"),
+                2 => std::borrow::Cow::Borrowed("CUSTOMER_MANAGED_ENCRYPTION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "GOOGLE_DEFAULT_ENCRYPTION" => {
+                    std::option::Option::Some(Self::GOOGLE_DEFAULT_ENCRYPTION)
+                }
+                "CUSTOMER_MANAGED_ENCRYPTION" => {
+                    std::option::Option::Some(Self::CUSTOMER_MANAGED_ENCRYPTION)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The state of the KMS key perceived by the system. Refer to the public
     /// documentation for the impact of each state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct KmsKeyState(std::borrow::Cow<'static, str>);
+    pub struct KmsKeyState(i32);
 
     impl KmsKeyState {
+        /// The default value. This value is unused.
+        pub const KMS_KEY_STATE_UNSPECIFIED: KmsKeyState = KmsKeyState::new(0);
+
+        /// The KMS key is enabled and correctly configured.
+        pub const ENABLED: KmsKeyState = KmsKeyState::new(1);
+
+        /// Permission denied on the KMS key.
+        pub const PERMISSION_DENIED: KmsKeyState = KmsKeyState::new(2);
+
+        /// The KMS key is disabled.
+        pub const DISABLED: KmsKeyState = KmsKeyState::new(3);
+
+        /// The KMS key is destroyed.
+        pub const DESTROYED: KmsKeyState = KmsKeyState::new(4);
+
+        /// The KMS key is scheduled to be destroyed.
+        pub const DESTROY_SCHEDULED: KmsKeyState = KmsKeyState::new(5);
+
+        /// The EKM key is unreachable.
+        pub const EKM_KEY_UNREACHABLE_DETECTED: KmsKeyState = KmsKeyState::new(6);
+
+        /// Billing is disabled for the project.
+        pub const BILLING_DISABLED: KmsKeyState = KmsKeyState::new(7);
+
+        /// All other unknown failures.
+        pub const UNKNOWN_FAILURE: KmsKeyState = KmsKeyState::new(8);
+
         /// Creates a new KmsKeyState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("KMS_KEY_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENABLED"),
+                2 => std::borrow::Cow::Borrowed("PERMISSION_DENIED"),
+                3 => std::borrow::Cow::Borrowed("DISABLED"),
+                4 => std::borrow::Cow::Borrowed("DESTROYED"),
+                5 => std::borrow::Cow::Borrowed("DESTROY_SCHEDULED"),
+                6 => std::borrow::Cow::Borrowed("EKM_KEY_UNREACHABLE_DETECTED"),
+                7 => std::borrow::Cow::Borrowed("BILLING_DISABLED"),
+                8 => std::borrow::Cow::Borrowed("UNKNOWN_FAILURE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "KMS_KEY_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::KMS_KEY_STATE_UNSPECIFIED)
+                }
+                "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                "PERMISSION_DENIED" => std::option::Option::Some(Self::PERMISSION_DENIED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "DESTROYED" => std::option::Option::Some(Self::DESTROYED),
+                "DESTROY_SCHEDULED" => std::option::Option::Some(Self::DESTROY_SCHEDULED),
+                "EKM_KEY_UNREACHABLE_DETECTED" => {
+                    std::option::Option::Some(Self::EKM_KEY_UNREACHABLE_DETECTED)
+                }
+                "BILLING_DISABLED" => std::option::Option::Some(Self::BILLING_DISABLED),
+                "UNKNOWN_FAILURE" => std::option::Option::Some(Self::UNKNOWN_FAILURE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [KmsKeyState](KmsKeyState)
-    pub mod kms_key_state {
-        use super::KmsKeyState;
-
-        /// The default value. This value is unused.
-        pub const KMS_KEY_STATE_UNSPECIFIED: KmsKeyState =
-            KmsKeyState::new("KMS_KEY_STATE_UNSPECIFIED");
-
-        /// The KMS key is enabled and correctly configured.
-        pub const ENABLED: KmsKeyState = KmsKeyState::new("ENABLED");
-
-        /// Permission denied on the KMS key.
-        pub const PERMISSION_DENIED: KmsKeyState = KmsKeyState::new("PERMISSION_DENIED");
-
-        /// The KMS key is disabled.
-        pub const DISABLED: KmsKeyState = KmsKeyState::new("DISABLED");
-
-        /// The KMS key is destroyed.
-        pub const DESTROYED: KmsKeyState = KmsKeyState::new("DESTROYED");
-
-        /// The KMS key is scheduled to be destroyed.
-        pub const DESTROY_SCHEDULED: KmsKeyState = KmsKeyState::new("DESTROY_SCHEDULED");
-
-        /// The EKM key is unreachable.
-        pub const EKM_KEY_UNREACHABLE_DETECTED: KmsKeyState =
-            KmsKeyState::new("EKM_KEY_UNREACHABLE_DETECTED");
-
-        /// Billing is disabled for the project.
-        pub const BILLING_DISABLED: KmsKeyState = KmsKeyState::new("BILLING_DISABLED");
-
-        /// All other unknown failures.
-        pub const UNKNOWN_FAILURE: KmsKeyState = KmsKeyState::new("UNKNOWN_FAILURE");
-    }
-
-    impl std::convert::From<std::string::String> for KmsKeyState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for KmsKeyState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for KmsKeyState {
         fn default() -> Self {
-            kms_key_state::KMS_KEY_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
 
 /// Status of the PSC connection.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PscConnectionStatus(std::borrow::Cow<'static, str>);
+pub struct PscConnectionStatus(i32);
 
 impl PscConnectionStatus {
+    /// PSC connection status is not specified.
+    pub const PSC_CONNECTION_STATUS_UNSPECIFIED: PscConnectionStatus = PscConnectionStatus::new(0);
+
+    /// The connection is active
+    pub const PSC_CONNECTION_STATUS_ACTIVE: PscConnectionStatus = PscConnectionStatus::new(1);
+
+    /// Connection not found
+    pub const PSC_CONNECTION_STATUS_NOT_FOUND: PscConnectionStatus = PscConnectionStatus::new(2);
+
     /// Creates a new PscConnectionStatus instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("PSC_CONNECTION_STATUS_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PSC_CONNECTION_STATUS_ACTIVE"),
+            2 => std::borrow::Cow::Borrowed("PSC_CONNECTION_STATUS_NOT_FOUND"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "PSC_CONNECTION_STATUS_UNSPECIFIED" => {
+                std::option::Option::Some(Self::PSC_CONNECTION_STATUS_UNSPECIFIED)
+            }
+            "PSC_CONNECTION_STATUS_ACTIVE" => {
+                std::option::Option::Some(Self::PSC_CONNECTION_STATUS_ACTIVE)
+            }
+            "PSC_CONNECTION_STATUS_NOT_FOUND" => {
+                std::option::Option::Some(Self::PSC_CONNECTION_STATUS_NOT_FOUND)
+            }
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [PscConnectionStatus](PscConnectionStatus)
-pub mod psc_connection_status {
-    use super::PscConnectionStatus;
-
-    /// PSC connection status is not specified.
-    pub const PSC_CONNECTION_STATUS_UNSPECIFIED: PscConnectionStatus =
-        PscConnectionStatus::new("PSC_CONNECTION_STATUS_UNSPECIFIED");
-
-    /// The connection is active
-    pub const PSC_CONNECTION_STATUS_ACTIVE: PscConnectionStatus =
-        PscConnectionStatus::new("PSC_CONNECTION_STATUS_ACTIVE");
-
-    /// Connection not found
-    pub const PSC_CONNECTION_STATUS_NOT_FOUND: PscConnectionStatus =
-        PscConnectionStatus::new("PSC_CONNECTION_STATUS_NOT_FOUND");
-}
-
-impl std::convert::From<std::string::String> for PscConnectionStatus {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for PscConnectionStatus {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for PscConnectionStatus {
     fn default() -> Self {
-        psc_connection_status::PSC_CONNECTION_STATUS_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Available authorization mode of a Redis cluster.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AuthorizationMode(std::borrow::Cow<'static, str>);
+pub struct AuthorizationMode(i32);
 
 impl AuthorizationMode {
+    /// Not set.
+    pub const AUTH_MODE_UNSPECIFIED: AuthorizationMode = AuthorizationMode::new(0);
+
+    /// IAM basic authorization mode
+    pub const AUTH_MODE_IAM_AUTH: AuthorizationMode = AuthorizationMode::new(1);
+
+    /// Authorization disabled mode
+    pub const AUTH_MODE_DISABLED: AuthorizationMode = AuthorizationMode::new(2);
+
     /// Creates a new AuthorizationMode instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("AUTH_MODE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("AUTH_MODE_IAM_AUTH"),
+            2 => std::borrow::Cow::Borrowed("AUTH_MODE_DISABLED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "AUTH_MODE_UNSPECIFIED" => std::option::Option::Some(Self::AUTH_MODE_UNSPECIFIED),
+            "AUTH_MODE_IAM_AUTH" => std::option::Option::Some(Self::AUTH_MODE_IAM_AUTH),
+            "AUTH_MODE_DISABLED" => std::option::Option::Some(Self::AUTH_MODE_DISABLED),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [AuthorizationMode](AuthorizationMode)
-pub mod authorization_mode {
-    use super::AuthorizationMode;
-
-    /// Not set.
-    pub const AUTH_MODE_UNSPECIFIED: AuthorizationMode =
-        AuthorizationMode::new("AUTH_MODE_UNSPECIFIED");
-
-    /// IAM basic authorization mode
-    pub const AUTH_MODE_IAM_AUTH: AuthorizationMode = AuthorizationMode::new("AUTH_MODE_IAM_AUTH");
-
-    /// Authorization disabled mode
-    pub const AUTH_MODE_DISABLED: AuthorizationMode = AuthorizationMode::new("AUTH_MODE_DISABLED");
-}
-
-impl std::convert::From<std::string::String> for AuthorizationMode {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for AuthorizationMode {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for AuthorizationMode {
     fn default() -> Self {
-        authorization_mode::AUTH_MODE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// NodeType of a redis cluster node,
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct NodeType(std::borrow::Cow<'static, str>);
+pub struct NodeType(i32);
 
 impl NodeType {
+    /// Node type unspecified
+    pub const NODE_TYPE_UNSPECIFIED: NodeType = NodeType::new(0);
+
+    /// Redis shared core nano node_type.
+    pub const REDIS_SHARED_CORE_NANO: NodeType = NodeType::new(1);
+
+    /// Redis highmem medium node_type.
+    pub const REDIS_HIGHMEM_MEDIUM: NodeType = NodeType::new(2);
+
+    /// Redis highmem xlarge node_type.
+    pub const REDIS_HIGHMEM_XLARGE: NodeType = NodeType::new(3);
+
+    /// Redis standard small node_type.
+    pub const REDIS_STANDARD_SMALL: NodeType = NodeType::new(4);
+
     /// Creates a new NodeType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("NODE_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("REDIS_SHARED_CORE_NANO"),
+            2 => std::borrow::Cow::Borrowed("REDIS_HIGHMEM_MEDIUM"),
+            3 => std::borrow::Cow::Borrowed("REDIS_HIGHMEM_XLARGE"),
+            4 => std::borrow::Cow::Borrowed("REDIS_STANDARD_SMALL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "NODE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::NODE_TYPE_UNSPECIFIED),
+            "REDIS_SHARED_CORE_NANO" => std::option::Option::Some(Self::REDIS_SHARED_CORE_NANO),
+            "REDIS_HIGHMEM_MEDIUM" => std::option::Option::Some(Self::REDIS_HIGHMEM_MEDIUM),
+            "REDIS_HIGHMEM_XLARGE" => std::option::Option::Some(Self::REDIS_HIGHMEM_XLARGE),
+            "REDIS_STANDARD_SMALL" => std::option::Option::Some(Self::REDIS_STANDARD_SMALL),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [NodeType](NodeType)
-pub mod node_type {
-    use super::NodeType;
-
-    /// Node type unspecified
-    pub const NODE_TYPE_UNSPECIFIED: NodeType = NodeType::new("NODE_TYPE_UNSPECIFIED");
-
-    /// Redis shared core nano node_type.
-    pub const REDIS_SHARED_CORE_NANO: NodeType = NodeType::new("REDIS_SHARED_CORE_NANO");
-
-    /// Redis highmem medium node_type.
-    pub const REDIS_HIGHMEM_MEDIUM: NodeType = NodeType::new("REDIS_HIGHMEM_MEDIUM");
-
-    /// Redis highmem xlarge node_type.
-    pub const REDIS_HIGHMEM_XLARGE: NodeType = NodeType::new("REDIS_HIGHMEM_XLARGE");
-
-    /// Redis standard small node_type.
-    pub const REDIS_STANDARD_SMALL: NodeType = NodeType::new("REDIS_STANDARD_SMALL");
-}
-
-impl std::convert::From<std::string::String> for NodeType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for NodeType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for NodeType {
     fn default() -> Self {
-        node_type::NODE_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Available mode of in-transit encryption.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TransitEncryptionMode(std::borrow::Cow<'static, str>);
+pub struct TransitEncryptionMode(i32);
 
 impl TransitEncryptionMode {
-    /// Creates a new TransitEncryptionMode instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [TransitEncryptionMode](TransitEncryptionMode)
-pub mod transit_encryption_mode {
-    use super::TransitEncryptionMode;
-
     /// In-transit encryption not set.
     pub const TRANSIT_ENCRYPTION_MODE_UNSPECIFIED: TransitEncryptionMode =
-        TransitEncryptionMode::new("TRANSIT_ENCRYPTION_MODE_UNSPECIFIED");
+        TransitEncryptionMode::new(0);
 
     /// In-transit encryption disabled.
     pub const TRANSIT_ENCRYPTION_MODE_DISABLED: TransitEncryptionMode =
-        TransitEncryptionMode::new("TRANSIT_ENCRYPTION_MODE_DISABLED");
+        TransitEncryptionMode::new(1);
 
     /// Use server managed encryption for in-transit encryption.
     pub const TRANSIT_ENCRYPTION_MODE_SERVER_AUTHENTICATION: TransitEncryptionMode =
-        TransitEncryptionMode::new("TRANSIT_ENCRYPTION_MODE_SERVER_AUTHENTICATION");
+        TransitEncryptionMode::new(2);
+
+    /// Creates a new TransitEncryptionMode instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("TRANSIT_ENCRYPTION_MODE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("TRANSIT_ENCRYPTION_MODE_DISABLED"),
+            2 => std::borrow::Cow::Borrowed("TRANSIT_ENCRYPTION_MODE_SERVER_AUTHENTICATION"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "TRANSIT_ENCRYPTION_MODE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::TRANSIT_ENCRYPTION_MODE_UNSPECIFIED)
+            }
+            "TRANSIT_ENCRYPTION_MODE_DISABLED" => {
+                std::option::Option::Some(Self::TRANSIT_ENCRYPTION_MODE_DISABLED)
+            }
+            "TRANSIT_ENCRYPTION_MODE_SERVER_AUTHENTICATION" => {
+                std::option::Option::Some(Self::TRANSIT_ENCRYPTION_MODE_SERVER_AUTHENTICATION)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for TransitEncryptionMode {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for TransitEncryptionMode {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for TransitEncryptionMode {
     fn default() -> Self {
-        transit_encryption_mode::TRANSIT_ENCRYPTION_MODE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Type of a PSC connection, for cluster access purpose.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ConnectionType(std::borrow::Cow<'static, str>);
+pub struct ConnectionType(i32);
 
 impl ConnectionType {
+    /// Cluster endpoint Type is not set
+    pub const CONNECTION_TYPE_UNSPECIFIED: ConnectionType = ConnectionType::new(0);
+
+    /// Cluster endpoint that will be used as for cluster topology discovery.
+    pub const CONNECTION_TYPE_DISCOVERY: ConnectionType = ConnectionType::new(1);
+
+    /// Cluster endpoint that will be used as primary endpoint to access primary.
+    pub const CONNECTION_TYPE_PRIMARY: ConnectionType = ConnectionType::new(2);
+
+    /// Cluster endpoint that will be used as reader endpoint to access replicas.
+    pub const CONNECTION_TYPE_READER: ConnectionType = ConnectionType::new(3);
+
     /// Creates a new ConnectionType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("CONNECTION_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("CONNECTION_TYPE_DISCOVERY"),
+            2 => std::borrow::Cow::Borrowed("CONNECTION_TYPE_PRIMARY"),
+            3 => std::borrow::Cow::Borrowed("CONNECTION_TYPE_READER"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "CONNECTION_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::CONNECTION_TYPE_UNSPECIFIED)
+            }
+            "CONNECTION_TYPE_DISCOVERY" => {
+                std::option::Option::Some(Self::CONNECTION_TYPE_DISCOVERY)
+            }
+            "CONNECTION_TYPE_PRIMARY" => std::option::Option::Some(Self::CONNECTION_TYPE_PRIMARY),
+            "CONNECTION_TYPE_READER" => std::option::Option::Some(Self::CONNECTION_TYPE_READER),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [ConnectionType](ConnectionType)
-pub mod connection_type {
-    use super::ConnectionType;
-
-    /// Cluster endpoint Type is not set
-    pub const CONNECTION_TYPE_UNSPECIFIED: ConnectionType =
-        ConnectionType::new("CONNECTION_TYPE_UNSPECIFIED");
-
-    /// Cluster endpoint that will be used as for cluster topology discovery.
-    pub const CONNECTION_TYPE_DISCOVERY: ConnectionType =
-        ConnectionType::new("CONNECTION_TYPE_DISCOVERY");
-
-    /// Cluster endpoint that will be used as primary endpoint to access primary.
-    pub const CONNECTION_TYPE_PRIMARY: ConnectionType =
-        ConnectionType::new("CONNECTION_TYPE_PRIMARY");
-
-    /// Cluster endpoint that will be used as reader endpoint to access replicas.
-    pub const CONNECTION_TYPE_READER: ConnectionType =
-        ConnectionType::new("CONNECTION_TYPE_READER");
-}
-
-impl std::convert::From<std::string::String> for ConnectionType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ConnectionType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ConnectionType {
     fn default() -> Self {
-        connection_type::CONNECTION_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/redis/cluster/v1/src/transport.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::CloudRedisCluster for CloudRedisCluster {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/clusters", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -70,7 +70,7 @@ impl crate::stubs::CloudRedisCluster for CloudRedisCluster {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -98,7 +98,7 @@ impl crate::stubs::CloudRedisCluster for CloudRedisCluster {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -128,7 +128,7 @@ impl crate::stubs::CloudRedisCluster for CloudRedisCluster {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -151,7 +151,7 @@ impl crate::stubs::CloudRedisCluster for CloudRedisCluster {
                 reqwest::Method::POST,
                 format!("/v1/{}/clusters", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -172,7 +172,7 @@ impl crate::stubs::CloudRedisCluster for CloudRedisCluster {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -194,7 +194,7 @@ impl crate::stubs::CloudRedisCluster for CloudRedisCluster {
                 reqwest::Method::POST,
                 format!("/v1/{}:rescheduleClusterMaintenance", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -214,7 +214,7 @@ impl crate::stubs::CloudRedisCluster for CloudRedisCluster {
                 reqwest::Method::GET,
                 format!("/v1/{}/backupCollections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -235,7 +235,7 @@ impl crate::stubs::CloudRedisCluster for CloudRedisCluster {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -254,7 +254,7 @@ impl crate::stubs::CloudRedisCluster for CloudRedisCluster {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/backups", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -275,7 +275,7 @@ impl crate::stubs::CloudRedisCluster for CloudRedisCluster {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -294,7 +294,7 @@ impl crate::stubs::CloudRedisCluster for CloudRedisCluster {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -314,7 +314,7 @@ impl crate::stubs::CloudRedisCluster for CloudRedisCluster {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:export", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -331,7 +331,7 @@ impl crate::stubs::CloudRedisCluster for CloudRedisCluster {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:backup", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -348,7 +348,7 @@ impl crate::stubs::CloudRedisCluster for CloudRedisCluster {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -370,7 +370,7 @@ impl crate::stubs::CloudRedisCluster for CloudRedisCluster {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -389,7 +389,7 @@ impl crate::stubs::CloudRedisCluster for CloudRedisCluster {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -411,7 +411,7 @@ impl crate::stubs::CloudRedisCluster for CloudRedisCluster {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -430,7 +430,7 @@ impl crate::stubs::CloudRedisCluster for CloudRedisCluster {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -449,7 +449,7 @@ impl crate::stubs::CloudRedisCluster for CloudRedisCluster {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/redis/v1/src/model.rs
+++ b/src/generated/cloud/redis/v1/src/model.rs
@@ -612,283 +612,386 @@ pub mod instance {
 
     /// Represents the different states of a Redis instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Redis instance is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// Redis instance has been created and is fully usable.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(2);
 
         /// Redis instance configuration is being updated. Certain kinds of updates
         /// may cause the instance to become unusable while the update is in
         /// progress.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(3);
 
         /// Redis instance is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(4);
 
         /// Redis instance is being repaired and may be unusable.
-        pub const REPAIRING: State = State::new("REPAIRING");
+        pub const REPAIRING: State = State::new(5);
 
         /// Maintenance is being performed on this Redis instance.
-        pub const MAINTENANCE: State = State::new("MAINTENANCE");
+        pub const MAINTENANCE: State = State::new(6);
 
         /// Redis instance is importing data (availability may be affected).
-        pub const IMPORTING: State = State::new("IMPORTING");
+        pub const IMPORTING: State = State::new(8);
 
         /// Redis instance is failing over (availability may be affected).
-        pub const FAILING_OVER: State = State::new("FAILING_OVER");
+        pub const FAILING_OVER: State = State::new(9);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("REPAIRING"),
+                6 => std::borrow::Cow::Borrowed("MAINTENANCE"),
+                8 => std::borrow::Cow::Borrowed("IMPORTING"),
+                9 => std::borrow::Cow::Borrowed("FAILING_OVER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "REPAIRING" => std::option::Option::Some(Self::REPAIRING),
+                "MAINTENANCE" => std::option::Option::Some(Self::MAINTENANCE),
+                "IMPORTING" => std::option::Option::Some(Self::IMPORTING),
+                "FAILING_OVER" => std::option::Option::Some(Self::FAILING_OVER),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Available service tiers to choose from
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Tier(std::borrow::Cow<'static, str>);
+    pub struct Tier(i32);
 
     impl Tier {
+        /// Not set.
+        pub const TIER_UNSPECIFIED: Tier = Tier::new(0);
+
+        /// BASIC tier: standalone instance
+        pub const BASIC: Tier = Tier::new(1);
+
+        /// STANDARD_HA tier: highly available primary/replica instances
+        pub const STANDARD_HA: Tier = Tier::new(3);
+
         /// Creates a new Tier instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TIER_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BASIC"),
+                3 => std::borrow::Cow::Borrowed("STANDARD_HA"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TIER_UNSPECIFIED" => std::option::Option::Some(Self::TIER_UNSPECIFIED),
+                "BASIC" => std::option::Option::Some(Self::BASIC),
+                "STANDARD_HA" => std::option::Option::Some(Self::STANDARD_HA),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Tier](Tier)
-    pub mod tier {
-        use super::Tier;
-
-        /// Not set.
-        pub const TIER_UNSPECIFIED: Tier = Tier::new("TIER_UNSPECIFIED");
-
-        /// BASIC tier: standalone instance
-        pub const BASIC: Tier = Tier::new("BASIC");
-
-        /// STANDARD_HA tier: highly available primary/replica instances
-        pub const STANDARD_HA: Tier = Tier::new("STANDARD_HA");
-    }
-
-    impl std::convert::From<std::string::String> for Tier {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Tier {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Tier {
         fn default() -> Self {
-            tier::TIER_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Available connection modes.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConnectMode(std::borrow::Cow<'static, str>);
+    pub struct ConnectMode(i32);
 
     impl ConnectMode {
-        /// Creates a new ConnectMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ConnectMode](ConnectMode)
-    pub mod connect_mode {
-        use super::ConnectMode;
-
         /// Not set.
-        pub const CONNECT_MODE_UNSPECIFIED: ConnectMode =
-            ConnectMode::new("CONNECT_MODE_UNSPECIFIED");
+        pub const CONNECT_MODE_UNSPECIFIED: ConnectMode = ConnectMode::new(0);
 
         /// Connect via direct peering to the Memorystore for Redis hosted service.
-        pub const DIRECT_PEERING: ConnectMode = ConnectMode::new("DIRECT_PEERING");
+        pub const DIRECT_PEERING: ConnectMode = ConnectMode::new(1);
 
         /// Connect your Memorystore for Redis instance using Private Service
         /// Access. Private services access provides an IP address range for multiple
         /// Google Cloud services, including Memorystore.
-        pub const PRIVATE_SERVICE_ACCESS: ConnectMode = ConnectMode::new("PRIVATE_SERVICE_ACCESS");
+        pub const PRIVATE_SERVICE_ACCESS: ConnectMode = ConnectMode::new(2);
+
+        /// Creates a new ConnectMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CONNECT_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DIRECT_PEERING"),
+                2 => std::borrow::Cow::Borrowed("PRIVATE_SERVICE_ACCESS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CONNECT_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CONNECT_MODE_UNSPECIFIED)
+                }
+                "DIRECT_PEERING" => std::option::Option::Some(Self::DIRECT_PEERING),
+                "PRIVATE_SERVICE_ACCESS" => std::option::Option::Some(Self::PRIVATE_SERVICE_ACCESS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ConnectMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ConnectMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ConnectMode {
         fn default() -> Self {
-            connect_mode::CONNECT_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Available TLS modes.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TransitEncryptionMode(std::borrow::Cow<'static, str>);
+    pub struct TransitEncryptionMode(i32);
 
     impl TransitEncryptionMode {
+        /// Not set.
+        pub const TRANSIT_ENCRYPTION_MODE_UNSPECIFIED: TransitEncryptionMode =
+            TransitEncryptionMode::new(0);
+
+        /// Client to Server traffic encryption enabled with server authentication.
+        pub const SERVER_AUTHENTICATION: TransitEncryptionMode = TransitEncryptionMode::new(1);
+
+        /// TLS is disabled for the instance.
+        pub const DISABLED: TransitEncryptionMode = TransitEncryptionMode::new(2);
+
         /// Creates a new TransitEncryptionMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TRANSIT_ENCRYPTION_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SERVER_AUTHENTICATION"),
+                2 => std::borrow::Cow::Borrowed("DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TRANSIT_ENCRYPTION_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::TRANSIT_ENCRYPTION_MODE_UNSPECIFIED)
+                }
+                "SERVER_AUTHENTICATION" => std::option::Option::Some(Self::SERVER_AUTHENTICATION),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [TransitEncryptionMode](TransitEncryptionMode)
-    pub mod transit_encryption_mode {
-        use super::TransitEncryptionMode;
-
-        /// Not set.
-        pub const TRANSIT_ENCRYPTION_MODE_UNSPECIFIED: TransitEncryptionMode =
-            TransitEncryptionMode::new("TRANSIT_ENCRYPTION_MODE_UNSPECIFIED");
-
-        /// Client to Server traffic encryption enabled with server authentication.
-        pub const SERVER_AUTHENTICATION: TransitEncryptionMode =
-            TransitEncryptionMode::new("SERVER_AUTHENTICATION");
-
-        /// TLS is disabled for the instance.
-        pub const DISABLED: TransitEncryptionMode = TransitEncryptionMode::new("DISABLED");
-    }
-
-    impl std::convert::From<std::string::String> for TransitEncryptionMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TransitEncryptionMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TransitEncryptionMode {
         fn default() -> Self {
-            transit_encryption_mode::TRANSIT_ENCRYPTION_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Read replicas mode.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ReadReplicasMode(std::borrow::Cow<'static, str>);
+    pub struct ReadReplicasMode(i32);
 
     impl ReadReplicasMode {
-        /// Creates a new ReadReplicasMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ReadReplicasMode](ReadReplicasMode)
-    pub mod read_replicas_mode {
-        use super::ReadReplicasMode;
-
         /// If not set, Memorystore Redis backend will default to
         /// READ_REPLICAS_DISABLED.
-        pub const READ_REPLICAS_MODE_UNSPECIFIED: ReadReplicasMode =
-            ReadReplicasMode::new("READ_REPLICAS_MODE_UNSPECIFIED");
+        pub const READ_REPLICAS_MODE_UNSPECIFIED: ReadReplicasMode = ReadReplicasMode::new(0);
 
         /// If disabled, read endpoint will not be provided and the instance cannot
         /// scale up or down the number of replicas.
-        pub const READ_REPLICAS_DISABLED: ReadReplicasMode =
-            ReadReplicasMode::new("READ_REPLICAS_DISABLED");
+        pub const READ_REPLICAS_DISABLED: ReadReplicasMode = ReadReplicasMode::new(1);
 
         /// If enabled, read endpoint will be provided and the instance can scale
         /// up and down the number of replicas. Not valid for basic tier.
-        pub const READ_REPLICAS_ENABLED: ReadReplicasMode =
-            ReadReplicasMode::new("READ_REPLICAS_ENABLED");
+        pub const READ_REPLICAS_ENABLED: ReadReplicasMode = ReadReplicasMode::new(2);
+
+        /// Creates a new ReadReplicasMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("READ_REPLICAS_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("READ_REPLICAS_DISABLED"),
+                2 => std::borrow::Cow::Borrowed("READ_REPLICAS_ENABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "READ_REPLICAS_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::READ_REPLICAS_MODE_UNSPECIFIED)
+                }
+                "READ_REPLICAS_DISABLED" => std::option::Option::Some(Self::READ_REPLICAS_DISABLED),
+                "READ_REPLICAS_ENABLED" => std::option::Option::Some(Self::READ_REPLICAS_ENABLED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ReadReplicasMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ReadReplicasMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ReadReplicasMode {
         fn default() -> Self {
-            read_replicas_mode::READ_REPLICAS_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Possible reasons for the instance to be in a "SUSPENDED" state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SuspensionReason(std::borrow::Cow<'static, str>);
+    pub struct SuspensionReason(i32);
 
     impl SuspensionReason {
+        /// Not set.
+        pub const SUSPENSION_REASON_UNSPECIFIED: SuspensionReason = SuspensionReason::new(0);
+
+        /// Something wrong with the CMEK key provided by customer.
+        pub const CUSTOMER_MANAGED_KEY_ISSUE: SuspensionReason = SuspensionReason::new(1);
+
         /// Creates a new SuspensionReason instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SUSPENSION_REASON_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CUSTOMER_MANAGED_KEY_ISSUE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SUSPENSION_REASON_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SUSPENSION_REASON_UNSPECIFIED)
+                }
+                "CUSTOMER_MANAGED_KEY_ISSUE" => {
+                    std::option::Option::Some(Self::CUSTOMER_MANAGED_KEY_ISSUE)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SuspensionReason](SuspensionReason)
-    pub mod suspension_reason {
-        use super::SuspensionReason;
-
-        /// Not set.
-        pub const SUSPENSION_REASON_UNSPECIFIED: SuspensionReason =
-            SuspensionReason::new("SUSPENSION_REASON_UNSPECIFIED");
-
-        /// Something wrong with the CMEK key provided by customer.
-        pub const CUSTOMER_MANAGED_KEY_ISSUE: SuspensionReason =
-            SuspensionReason::new("CUSTOMER_MANAGED_KEY_ISSUE");
-    }
-
-    impl std::convert::From<std::string::String> for SuspensionReason {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SuspensionReason {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SuspensionReason {
         fn default() -> Self {
-            suspension_reason::SUSPENSION_REASON_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -985,94 +1088,130 @@ pub mod persistence_config {
 
     /// Available Persistence modes.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PersistenceMode(std::borrow::Cow<'static, str>);
+    pub struct PersistenceMode(i32);
 
     impl PersistenceMode {
-        /// Creates a new PersistenceMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PersistenceMode](PersistenceMode)
-    pub mod persistence_mode {
-        use super::PersistenceMode;
-
         /// Not set.
-        pub const PERSISTENCE_MODE_UNSPECIFIED: PersistenceMode =
-            PersistenceMode::new("PERSISTENCE_MODE_UNSPECIFIED");
+        pub const PERSISTENCE_MODE_UNSPECIFIED: PersistenceMode = PersistenceMode::new(0);
 
         /// Persistence is disabled for the instance,
         /// and any existing snapshots are deleted.
-        pub const DISABLED: PersistenceMode = PersistenceMode::new("DISABLED");
+        pub const DISABLED: PersistenceMode = PersistenceMode::new(1);
 
         /// RDB based Persistence is enabled.
-        pub const RDB: PersistenceMode = PersistenceMode::new("RDB");
+        pub const RDB: PersistenceMode = PersistenceMode::new(2);
+
+        /// Creates a new PersistenceMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PERSISTENCE_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DISABLED"),
+                2 => std::borrow::Cow::Borrowed("RDB"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PERSISTENCE_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PERSISTENCE_MODE_UNSPECIFIED)
+                }
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "RDB" => std::option::Option::Some(Self::RDB),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PersistenceMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PersistenceMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PersistenceMode {
         fn default() -> Self {
-            persistence_mode::PERSISTENCE_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Available snapshot periods for scheduling.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SnapshotPeriod(std::borrow::Cow<'static, str>);
+    pub struct SnapshotPeriod(i32);
 
     impl SnapshotPeriod {
+        /// Not set.
+        pub const SNAPSHOT_PERIOD_UNSPECIFIED: SnapshotPeriod = SnapshotPeriod::new(0);
+
+        /// Snapshot every 1 hour.
+        pub const ONE_HOUR: SnapshotPeriod = SnapshotPeriod::new(3);
+
+        /// Snapshot every 6 hours.
+        pub const SIX_HOURS: SnapshotPeriod = SnapshotPeriod::new(4);
+
+        /// Snapshot every 12 hours.
+        pub const TWELVE_HOURS: SnapshotPeriod = SnapshotPeriod::new(5);
+
+        /// Snapshot every 24 hours.
+        pub const TWENTY_FOUR_HOURS: SnapshotPeriod = SnapshotPeriod::new(6);
+
         /// Creates a new SnapshotPeriod instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SNAPSHOT_PERIOD_UNSPECIFIED"),
+                3 => std::borrow::Cow::Borrowed("ONE_HOUR"),
+                4 => std::borrow::Cow::Borrowed("SIX_HOURS"),
+                5 => std::borrow::Cow::Borrowed("TWELVE_HOURS"),
+                6 => std::borrow::Cow::Borrowed("TWENTY_FOUR_HOURS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SNAPSHOT_PERIOD_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SNAPSHOT_PERIOD_UNSPECIFIED)
+                }
+                "ONE_HOUR" => std::option::Option::Some(Self::ONE_HOUR),
+                "SIX_HOURS" => std::option::Option::Some(Self::SIX_HOURS),
+                "TWELVE_HOURS" => std::option::Option::Some(Self::TWELVE_HOURS),
+                "TWENTY_FOUR_HOURS" => std::option::Option::Some(Self::TWENTY_FOUR_HOURS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SnapshotPeriod](SnapshotPeriod)
-    pub mod snapshot_period {
-        use super::SnapshotPeriod;
-
-        /// Not set.
-        pub const SNAPSHOT_PERIOD_UNSPECIFIED: SnapshotPeriod =
-            SnapshotPeriod::new("SNAPSHOT_PERIOD_UNSPECIFIED");
-
-        /// Snapshot every 1 hour.
-        pub const ONE_HOUR: SnapshotPeriod = SnapshotPeriod::new("ONE_HOUR");
-
-        /// Snapshot every 6 hours.
-        pub const SIX_HOURS: SnapshotPeriod = SnapshotPeriod::new("SIX_HOURS");
-
-        /// Snapshot every 12 hours.
-        pub const TWELVE_HOURS: SnapshotPeriod = SnapshotPeriod::new("TWELVE_HOURS");
-
-        /// Snapshot every 24 hours.
-        pub const TWENTY_FOUR_HOURS: SnapshotPeriod = SnapshotPeriod::new("TWENTY_FOUR_HOURS");
-    }
-
-    impl std::convert::From<std::string::String> for SnapshotPeriod {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SnapshotPeriod {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SnapshotPeriod {
         fn default() -> Self {
-            snapshot_period::SNAPSHOT_PERIOD_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1148,49 +1287,66 @@ pub mod reschedule_maintenance_request {
 
     /// Reschedule options.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RescheduleType(std::borrow::Cow<'static, str>);
+    pub struct RescheduleType(i32);
 
     impl RescheduleType {
-        /// Creates a new RescheduleType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RescheduleType](RescheduleType)
-    pub mod reschedule_type {
-        use super::RescheduleType;
-
         /// Not set.
-        pub const RESCHEDULE_TYPE_UNSPECIFIED: RescheduleType =
-            RescheduleType::new("RESCHEDULE_TYPE_UNSPECIFIED");
+        pub const RESCHEDULE_TYPE_UNSPECIFIED: RescheduleType = RescheduleType::new(0);
 
         /// If the user wants to schedule the maintenance to happen now.
-        pub const IMMEDIATE: RescheduleType = RescheduleType::new("IMMEDIATE");
+        pub const IMMEDIATE: RescheduleType = RescheduleType::new(1);
 
         /// If the user wants to use the existing maintenance policy to find the
         /// next available window.
-        pub const NEXT_AVAILABLE_WINDOW: RescheduleType =
-            RescheduleType::new("NEXT_AVAILABLE_WINDOW");
+        pub const NEXT_AVAILABLE_WINDOW: RescheduleType = RescheduleType::new(2);
 
         /// If the user wants to reschedule the maintenance to a specific time.
-        pub const SPECIFIC_TIME: RescheduleType = RescheduleType::new("SPECIFIC_TIME");
+        pub const SPECIFIC_TIME: RescheduleType = RescheduleType::new(3);
+
+        /// Creates a new RescheduleType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RESCHEDULE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IMMEDIATE"),
+                2 => std::borrow::Cow::Borrowed("NEXT_AVAILABLE_WINDOW"),
+                3 => std::borrow::Cow::Borrowed("SPECIFIC_TIME"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RESCHEDULE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RESCHEDULE_TYPE_UNSPECIFIED)
+                }
+                "IMMEDIATE" => std::option::Option::Some(Self::IMMEDIATE),
+                "NEXT_AVAILABLE_WINDOW" => std::option::Option::Some(Self::NEXT_AVAILABLE_WINDOW),
+                "SPECIFIC_TIME" => std::option::Option::Some(Self::SPECIFIC_TIME),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RescheduleType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RescheduleType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RescheduleType {
         fn default() -> Self {
-            reschedule_type::RESCHEDULE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2208,49 +2364,64 @@ pub mod failover_instance_request {
 
     /// Specifies different modes of operation in relation to the data retention.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataProtectionMode(std::borrow::Cow<'static, str>);
+    pub struct DataProtectionMode(i32);
 
     impl DataProtectionMode {
-        /// Creates a new DataProtectionMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DataProtectionMode](DataProtectionMode)
-    pub mod data_protection_mode {
-        use super::DataProtectionMode;
-
         /// Defaults to LIMITED_DATA_LOSS if a data protection mode is not
         /// specified.
-        pub const DATA_PROTECTION_MODE_UNSPECIFIED: DataProtectionMode =
-            DataProtectionMode::new("DATA_PROTECTION_MODE_UNSPECIFIED");
+        pub const DATA_PROTECTION_MODE_UNSPECIFIED: DataProtectionMode = DataProtectionMode::new(0);
 
         /// Instance failover will be protected with data loss control. More
         /// specifically, the failover will only be performed if the current
         /// replication offset diff between primary and replica is under a certain
         /// threshold.
-        pub const LIMITED_DATA_LOSS: DataProtectionMode =
-            DataProtectionMode::new("LIMITED_DATA_LOSS");
+        pub const LIMITED_DATA_LOSS: DataProtectionMode = DataProtectionMode::new(1);
 
         /// Instance failover will be performed without data loss control.
-        pub const FORCE_DATA_LOSS: DataProtectionMode = DataProtectionMode::new("FORCE_DATA_LOSS");
+        pub const FORCE_DATA_LOSS: DataProtectionMode = DataProtectionMode::new(2);
+
+        /// Creates a new DataProtectionMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATA_PROTECTION_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LIMITED_DATA_LOSS"),
+                2 => std::borrow::Cow::Borrowed("FORCE_DATA_LOSS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATA_PROTECTION_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DATA_PROTECTION_MODE_UNSPECIFIED)
+                }
+                "LIMITED_DATA_LOSS" => std::option::Option::Some(Self::LIMITED_DATA_LOSS),
+                "FORCE_DATA_LOSS" => std::option::Option::Some(Self::FORCE_DATA_LOSS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DataProtectionMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DataProtectionMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DataProtectionMode {
         fn default() -> Self {
-            data_protection_mode::DATA_PROTECTION_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/redis/v1/src/transport.rs
+++ b/src/generated/cloud/redis/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::CloudRedis for CloudRedis {
                 reqwest::Method::GET,
                 format!("/v1/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -73,7 +73,7 @@ impl crate::stubs::CloudRedis for CloudRedis {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -92,7 +92,7 @@ impl crate::stubs::CloudRedis for CloudRedis {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/authString", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -114,7 +114,7 @@ impl crate::stubs::CloudRedis for CloudRedis {
                 reqwest::Method::POST,
                 format!("/v1/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -143,7 +143,7 @@ impl crate::stubs::CloudRedis for CloudRedis {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -172,7 +172,7 @@ impl crate::stubs::CloudRedis for CloudRedis {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:upgrade", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -189,7 +189,7 @@ impl crate::stubs::CloudRedis for CloudRedis {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:import", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -206,7 +206,7 @@ impl crate::stubs::CloudRedis for CloudRedis {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:export", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -223,7 +223,7 @@ impl crate::stubs::CloudRedis for CloudRedis {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:failover", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -240,7 +240,7 @@ impl crate::stubs::CloudRedis for CloudRedis {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -262,7 +262,7 @@ impl crate::stubs::CloudRedis for CloudRedis {
                 reqwest::Method::POST,
                 format!("/v1/{}:rescheduleMaintenance", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -279,7 +279,7 @@ impl crate::stubs::CloudRedis for CloudRedis {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -301,7 +301,7 @@ impl crate::stubs::CloudRedis for CloudRedis {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -320,7 +320,7 @@ impl crate::stubs::CloudRedis for CloudRedis {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -342,7 +342,7 @@ impl crate::stubs::CloudRedis for CloudRedis {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -361,7 +361,7 @@ impl crate::stubs::CloudRedis for CloudRedis {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -380,7 +380,7 @@ impl crate::stubs::CloudRedis for CloudRedis {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/resourcemanager/v3/src/model.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/model.rs
@@ -166,43 +166,58 @@ pub mod folder {
 
     /// Folder lifecycle states.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The normal and active state.
+        pub const ACTIVE: State = State::new(1);
+
+        /// The folder has been marked for deletion by the user.
+        pub const DELETE_REQUESTED: State = State::new(2);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("DELETE_REQUESTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DELETE_REQUESTED" => std::option::Option::Some(Self::DELETE_REQUESTED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The normal and active state.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The folder has been marked for deletion by the user.
-        pub const DELETE_REQUESTED: State = State::new("DELETE_REQUESTED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1017,43 +1032,58 @@ pub mod organization {
 
     /// Organization lifecycle states.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified state.  This is only useful for distinguishing unset values.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The normal and active state.
+        pub const ACTIVE: State = State::new(1);
+
+        /// The organization has been marked for deletion by the user.
+        pub const DELETE_REQUESTED: State = State::new(2);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("DELETE_REQUESTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DELETE_REQUESTED" => std::option::Option::Some(Self::DELETE_REQUESTED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified state.  This is only useful for distinguishing unset values.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The normal and active state.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The organization has been marked for deletion by the user.
-        pub const DELETE_REQUESTED: State = State::new("DELETE_REQUESTED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1445,30 +1475,15 @@ pub mod project {
 
     /// Project lifecycle states.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified state.  This is only used/useful for distinguishing
         /// unset values.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The normal and active state.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(1);
 
         /// The project has been marked for deletion by the user
         /// (by invoking
@@ -1478,18 +1493,48 @@ pub mod project {
         /// [google.cloud.resourcemanager.v3.Projects.UndeleteProject].
         ///
         /// [google.cloud.resourcemanager.v3.Projects.DeleteProject]: crate::client::Projects::delete_project
-        pub const DELETE_REQUESTED: State = State::new("DELETE_REQUESTED");
+        pub const DELETE_REQUESTED: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("DELETE_REQUESTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DELETE_REQUESTED" => std::option::Option::Some(Self::DELETE_REQUESTED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4123,26 +4168,11 @@ impl wkt::message::Message for DeleteTagValueMetadata {
 /// policy engine may have multiple purposes defined, however a TagKey may only
 /// specify a single purpose.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Purpose(std::borrow::Cow<'static, str>);
+pub struct Purpose(i32);
 
 impl Purpose {
-    /// Creates a new Purpose instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [Purpose](Purpose)
-pub mod purpose {
-    use super::Purpose;
-
     /// Unspecified purpose.
-    pub const PURPOSE_UNSPECIFIED: Purpose = Purpose::new("PURPOSE_UNSPECIFIED");
+    pub const PURPOSE_UNSPECIFIED: Purpose = Purpose::new(0);
 
     /// Purpose for Compute Engine firewalls.
     /// A corresponding `purpose_data` should be set for the network the tag is
@@ -4160,17 +4190,45 @@ pub mod purpose {
     /// `<https://www.googleapis.com/compute/staging_v1/projects/fail-closed-load-testing/global/networks/6992953698831725600>`
     ///
     /// - `fail-closed-load-testing/load-testing-network`
-    pub const GCE_FIREWALL: Purpose = Purpose::new("GCE_FIREWALL");
+    pub const GCE_FIREWALL: Purpose = Purpose::new(1);
+
+    /// Creates a new Purpose instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("PURPOSE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("GCE_FIREWALL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "PURPOSE_UNSPECIFIED" => std::option::Option::Some(Self::PURPOSE_UNSPECIFIED),
+            "GCE_FIREWALL" => std::option::Option::Some(Self::GCE_FIREWALL),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for Purpose {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Purpose {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Purpose {
     fn default() -> Self {
-        purpose::PURPOSE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/resourcemanager/v3/src/transport.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::Folders for Folders {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -68,7 +68,7 @@ impl crate::stubs::Folders for Folders {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v3/folders".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -91,7 +91,7 @@ impl crate::stubs::Folders for Folders {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v3/folders:search".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -113,7 +113,7 @@ impl crate::stubs::Folders for Folders {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, "/v3/folders".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -139,7 +139,7 @@ impl crate::stubs::Folders for Folders {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -166,7 +166,7 @@ impl crate::stubs::Folders for Folders {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:move", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -183,7 +183,7 @@ impl crate::stubs::Folders for Folders {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -202,7 +202,7 @@ impl crate::stubs::Folders for Folders {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:undelete", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -222,7 +222,7 @@ impl crate::stubs::Folders for Folders {
                 reqwest::Method::POST,
                 format!("/v3/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -242,7 +242,7 @@ impl crate::stubs::Folders for Folders {
                 reqwest::Method::POST,
                 format!("/v3/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -262,7 +262,7 @@ impl crate::stubs::Folders for Folders {
                 reqwest::Method::POST,
                 format!("/v3/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -279,7 +279,7 @@ impl crate::stubs::Folders for Folders {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -335,7 +335,7 @@ impl crate::stubs::Organizations for Organizations {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -354,7 +354,7 @@ impl crate::stubs::Organizations for Organizations {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v3/organizations:search".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -379,7 +379,7 @@ impl crate::stubs::Organizations for Organizations {
                 reqwest::Method::POST,
                 format!("/v3/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -399,7 +399,7 @@ impl crate::stubs::Organizations for Organizations {
                 reqwest::Method::POST,
                 format!("/v3/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -419,7 +419,7 @@ impl crate::stubs::Organizations for Organizations {
                 reqwest::Method::POST,
                 format!("/v3/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -436,7 +436,7 @@ impl crate::stubs::Organizations for Organizations {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -478,7 +478,7 @@ impl crate::stubs::Projects for Projects {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -497,7 +497,7 @@ impl crate::stubs::Projects for Projects {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v3/projects".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -520,7 +520,7 @@ impl crate::stubs::Projects for Projects {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v3/projects:search".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -542,7 +542,7 @@ impl crate::stubs::Projects for Projects {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, "/v3/projects".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -570,7 +570,7 @@ impl crate::stubs::Projects for Projects {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -599,7 +599,7 @@ impl crate::stubs::Projects for Projects {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:move", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -616,7 +616,7 @@ impl crate::stubs::Projects for Projects {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -635,7 +635,7 @@ impl crate::stubs::Projects for Projects {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:undelete", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -655,7 +655,7 @@ impl crate::stubs::Projects for Projects {
                 reqwest::Method::POST,
                 format!("/v3/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -675,7 +675,7 @@ impl crate::stubs::Projects for Projects {
                 reqwest::Method::POST,
                 format!("/v3/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -695,7 +695,7 @@ impl crate::stubs::Projects for Projects {
                 reqwest::Method::POST,
                 format!("/v3/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -712,7 +712,7 @@ impl crate::stubs::Projects for Projects {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -768,7 +768,7 @@ impl crate::stubs::TagBindings for TagBindings {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v3/tagBindings".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -790,7 +790,7 @@ impl crate::stubs::TagBindings for TagBindings {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, "/v3/tagBindings".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -810,7 +810,7 @@ impl crate::stubs::TagBindings for TagBindings {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -829,7 +829,7 @@ impl crate::stubs::TagBindings for TagBindings {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v3/effectiveTags".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -851,7 +851,7 @@ impl crate::stubs::TagBindings for TagBindings {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -910,7 +910,7 @@ impl crate::stubs::TagHolds for TagHolds {
                 reqwest::Method::POST,
                 format!("/v3/{}/tagHolds", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -930,7 +930,7 @@ impl crate::stubs::TagHolds for TagHolds {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -950,7 +950,7 @@ impl crate::stubs::TagHolds for TagHolds {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/tagHolds", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -972,7 +972,7 @@ impl crate::stubs::TagHolds for TagHolds {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1028,7 +1028,7 @@ impl crate::stubs::TagKeys for TagKeys {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v3/tagKeys".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1050,7 +1050,7 @@ impl crate::stubs::TagKeys for TagKeys {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1069,7 +1069,7 @@ impl crate::stubs::TagKeys for TagKeys {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v3/tagKeys/namespaced".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1089,7 +1089,7 @@ impl crate::stubs::TagKeys for TagKeys {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, "/v3/tagKeys".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1118,7 +1118,7 @@ impl crate::stubs::TagKeys for TagKeys {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1148,7 +1148,7 @@ impl crate::stubs::TagKeys for TagKeys {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1172,7 +1172,7 @@ impl crate::stubs::TagKeys for TagKeys {
                 reqwest::Method::POST,
                 format!("/v3/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1192,7 +1192,7 @@ impl crate::stubs::TagKeys for TagKeys {
                 reqwest::Method::POST,
                 format!("/v3/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1212,7 +1212,7 @@ impl crate::stubs::TagKeys for TagKeys {
                 reqwest::Method::POST,
                 format!("/v3/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1229,7 +1229,7 @@ impl crate::stubs::TagKeys for TagKeys {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1285,7 +1285,7 @@ impl crate::stubs::TagValues for TagValues {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v3/tagValues".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1307,7 +1307,7 @@ impl crate::stubs::TagValues for TagValues {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1326,7 +1326,7 @@ impl crate::stubs::TagValues for TagValues {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v3/tagValues/namespaced".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1346,7 +1346,7 @@ impl crate::stubs::TagValues for TagValues {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, "/v3/tagValues".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1375,7 +1375,7 @@ impl crate::stubs::TagValues for TagValues {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1405,7 +1405,7 @@ impl crate::stubs::TagValues for TagValues {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1429,7 +1429,7 @@ impl crate::stubs::TagValues for TagValues {
                 reqwest::Method::POST,
                 format!("/v3/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1449,7 +1449,7 @@ impl crate::stubs::TagValues for TagValues {
                 reqwest::Method::POST,
                 format!("/v3/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1469,7 +1469,7 @@ impl crate::stubs::TagValues for TagValues {
                 reqwest::Method::POST,
                 format!("/v3/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1486,7 +1486,7 @@ impl crate::stubs::TagValues for TagValues {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/retail/v2/src/model.rs
+++ b/src/generated/cloud/retail/v2/src/model.rs
@@ -734,271 +734,370 @@ pub mod catalog_attribute {
 
     /// The type of an attribute.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AttributeType(std::borrow::Cow<'static, str>);
+    pub struct AttributeType(i32);
 
     impl AttributeType {
-        /// Creates a new AttributeType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [AttributeType](AttributeType)
-    pub mod attribute_type {
-        use super::AttributeType;
-
         /// The type of the attribute is unknown.
         ///
         /// Used when type cannot be derived from attribute that is not
         /// [in_use][google.cloud.retail.v2.CatalogAttribute.in_use].
         ///
         /// [google.cloud.retail.v2.CatalogAttribute.in_use]: crate::model::CatalogAttribute::in_use
-        pub const UNKNOWN: AttributeType = AttributeType::new("UNKNOWN");
+        pub const UNKNOWN: AttributeType = AttributeType::new(0);
 
         /// Textual attribute.
-        pub const TEXTUAL: AttributeType = AttributeType::new("TEXTUAL");
+        pub const TEXTUAL: AttributeType = AttributeType::new(1);
 
         /// Numerical attribute.
-        pub const NUMERICAL: AttributeType = AttributeType::new("NUMERICAL");
+        pub const NUMERICAL: AttributeType = AttributeType::new(2);
+
+        /// Creates a new AttributeType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("TEXTUAL"),
+                2 => std::borrow::Cow::Borrowed("NUMERICAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                "TEXTUAL" => std::option::Option::Some(Self::TEXTUAL),
+                "NUMERICAL" => std::option::Option::Some(Self::NUMERICAL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for AttributeType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AttributeType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AttributeType {
         fn default() -> Self {
-            attribute_type::UNKNOWN
+            Self::new(0)
         }
     }
 
     /// The status of the indexable option of a catalog attribute.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IndexableOption(std::borrow::Cow<'static, str>);
+    pub struct IndexableOption(i32);
 
     impl IndexableOption {
+        /// Value used when unset.
+        pub const INDEXABLE_OPTION_UNSPECIFIED: IndexableOption = IndexableOption::new(0);
+
+        /// Indexable option enabled for an attribute.
+        pub const INDEXABLE_ENABLED: IndexableOption = IndexableOption::new(1);
+
+        /// Indexable option disabled for an attribute.
+        pub const INDEXABLE_DISABLED: IndexableOption = IndexableOption::new(2);
+
         /// Creates a new IndexableOption instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("INDEXABLE_OPTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INDEXABLE_ENABLED"),
+                2 => std::borrow::Cow::Borrowed("INDEXABLE_DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "INDEXABLE_OPTION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::INDEXABLE_OPTION_UNSPECIFIED)
+                }
+                "INDEXABLE_ENABLED" => std::option::Option::Some(Self::INDEXABLE_ENABLED),
+                "INDEXABLE_DISABLED" => std::option::Option::Some(Self::INDEXABLE_DISABLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [IndexableOption](IndexableOption)
-    pub mod indexable_option {
-        use super::IndexableOption;
-
-        /// Value used when unset.
-        pub const INDEXABLE_OPTION_UNSPECIFIED: IndexableOption =
-            IndexableOption::new("INDEXABLE_OPTION_UNSPECIFIED");
-
-        /// Indexable option enabled for an attribute.
-        pub const INDEXABLE_ENABLED: IndexableOption = IndexableOption::new("INDEXABLE_ENABLED");
-
-        /// Indexable option disabled for an attribute.
-        pub const INDEXABLE_DISABLED: IndexableOption = IndexableOption::new("INDEXABLE_DISABLED");
-    }
-
-    impl std::convert::From<std::string::String> for IndexableOption {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for IndexableOption {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for IndexableOption {
         fn default() -> Self {
-            indexable_option::INDEXABLE_OPTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The status of the dynamic facetable option of a catalog attribute.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DynamicFacetableOption(std::borrow::Cow<'static, str>);
+    pub struct DynamicFacetableOption(i32);
 
     impl DynamicFacetableOption {
-        /// Creates a new DynamicFacetableOption instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DynamicFacetableOption](DynamicFacetableOption)
-    pub mod dynamic_facetable_option {
-        use super::DynamicFacetableOption;
-
         /// Value used when unset.
         pub const DYNAMIC_FACETABLE_OPTION_UNSPECIFIED: DynamicFacetableOption =
-            DynamicFacetableOption::new("DYNAMIC_FACETABLE_OPTION_UNSPECIFIED");
+            DynamicFacetableOption::new(0);
 
         /// Dynamic facetable option enabled for an attribute.
         pub const DYNAMIC_FACETABLE_ENABLED: DynamicFacetableOption =
-            DynamicFacetableOption::new("DYNAMIC_FACETABLE_ENABLED");
+            DynamicFacetableOption::new(1);
 
         /// Dynamic facetable option disabled for an attribute.
         pub const DYNAMIC_FACETABLE_DISABLED: DynamicFacetableOption =
-            DynamicFacetableOption::new("DYNAMIC_FACETABLE_DISABLED");
+            DynamicFacetableOption::new(2);
+
+        /// Creates a new DynamicFacetableOption instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DYNAMIC_FACETABLE_OPTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DYNAMIC_FACETABLE_ENABLED"),
+                2 => std::borrow::Cow::Borrowed("DYNAMIC_FACETABLE_DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DYNAMIC_FACETABLE_OPTION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DYNAMIC_FACETABLE_OPTION_UNSPECIFIED)
+                }
+                "DYNAMIC_FACETABLE_ENABLED" => {
+                    std::option::Option::Some(Self::DYNAMIC_FACETABLE_ENABLED)
+                }
+                "DYNAMIC_FACETABLE_DISABLED" => {
+                    std::option::Option::Some(Self::DYNAMIC_FACETABLE_DISABLED)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DynamicFacetableOption {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DynamicFacetableOption {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DynamicFacetableOption {
         fn default() -> Self {
-            dynamic_facetable_option::DYNAMIC_FACETABLE_OPTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The status of the searchable option of a catalog attribute.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SearchableOption(std::borrow::Cow<'static, str>);
+    pub struct SearchableOption(i32);
 
     impl SearchableOption {
+        /// Value used when unset.
+        pub const SEARCHABLE_OPTION_UNSPECIFIED: SearchableOption = SearchableOption::new(0);
+
+        /// Searchable option enabled for an attribute.
+        pub const SEARCHABLE_ENABLED: SearchableOption = SearchableOption::new(1);
+
+        /// Searchable option disabled for an attribute.
+        pub const SEARCHABLE_DISABLED: SearchableOption = SearchableOption::new(2);
+
         /// Creates a new SearchableOption instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SEARCHABLE_OPTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SEARCHABLE_ENABLED"),
+                2 => std::borrow::Cow::Borrowed("SEARCHABLE_DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SEARCHABLE_OPTION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SEARCHABLE_OPTION_UNSPECIFIED)
+                }
+                "SEARCHABLE_ENABLED" => std::option::Option::Some(Self::SEARCHABLE_ENABLED),
+                "SEARCHABLE_DISABLED" => std::option::Option::Some(Self::SEARCHABLE_DISABLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SearchableOption](SearchableOption)
-    pub mod searchable_option {
-        use super::SearchableOption;
-
-        /// Value used when unset.
-        pub const SEARCHABLE_OPTION_UNSPECIFIED: SearchableOption =
-            SearchableOption::new("SEARCHABLE_OPTION_UNSPECIFIED");
-
-        /// Searchable option enabled for an attribute.
-        pub const SEARCHABLE_ENABLED: SearchableOption =
-            SearchableOption::new("SEARCHABLE_ENABLED");
-
-        /// Searchable option disabled for an attribute.
-        pub const SEARCHABLE_DISABLED: SearchableOption =
-            SearchableOption::new("SEARCHABLE_DISABLED");
-    }
-
-    impl std::convert::From<std::string::String> for SearchableOption {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SearchableOption {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SearchableOption {
         fn default() -> Self {
-            searchable_option::SEARCHABLE_OPTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The status of the exact-searchable option of a catalog attribute.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ExactSearchableOption(std::borrow::Cow<'static, str>);
+    pub struct ExactSearchableOption(i32);
 
     impl ExactSearchableOption {
+        /// Value used when unset.
+        pub const EXACT_SEARCHABLE_OPTION_UNSPECIFIED: ExactSearchableOption =
+            ExactSearchableOption::new(0);
+
+        /// Exact searchable option enabled for an attribute.
+        pub const EXACT_SEARCHABLE_ENABLED: ExactSearchableOption = ExactSearchableOption::new(1);
+
+        /// Exact searchable option disabled for an attribute.
+        pub const EXACT_SEARCHABLE_DISABLED: ExactSearchableOption = ExactSearchableOption::new(2);
+
         /// Creates a new ExactSearchableOption instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EXACT_SEARCHABLE_OPTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("EXACT_SEARCHABLE_ENABLED"),
+                2 => std::borrow::Cow::Borrowed("EXACT_SEARCHABLE_DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EXACT_SEARCHABLE_OPTION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::EXACT_SEARCHABLE_OPTION_UNSPECIFIED)
+                }
+                "EXACT_SEARCHABLE_ENABLED" => {
+                    std::option::Option::Some(Self::EXACT_SEARCHABLE_ENABLED)
+                }
+                "EXACT_SEARCHABLE_DISABLED" => {
+                    std::option::Option::Some(Self::EXACT_SEARCHABLE_DISABLED)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ExactSearchableOption](ExactSearchableOption)
-    pub mod exact_searchable_option {
-        use super::ExactSearchableOption;
-
-        /// Value used when unset.
-        pub const EXACT_SEARCHABLE_OPTION_UNSPECIFIED: ExactSearchableOption =
-            ExactSearchableOption::new("EXACT_SEARCHABLE_OPTION_UNSPECIFIED");
-
-        /// Exact searchable option enabled for an attribute.
-        pub const EXACT_SEARCHABLE_ENABLED: ExactSearchableOption =
-            ExactSearchableOption::new("EXACT_SEARCHABLE_ENABLED");
-
-        /// Exact searchable option disabled for an attribute.
-        pub const EXACT_SEARCHABLE_DISABLED: ExactSearchableOption =
-            ExactSearchableOption::new("EXACT_SEARCHABLE_DISABLED");
-    }
-
-    impl std::convert::From<std::string::String> for ExactSearchableOption {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ExactSearchableOption {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ExactSearchableOption {
         fn default() -> Self {
-            exact_searchable_option::EXACT_SEARCHABLE_OPTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The status of the retrievable option of a catalog attribute.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RetrievableOption(std::borrow::Cow<'static, str>);
+    pub struct RetrievableOption(i32);
 
     impl RetrievableOption {
+        /// Value used when unset.
+        pub const RETRIEVABLE_OPTION_UNSPECIFIED: RetrievableOption = RetrievableOption::new(0);
+
+        /// Retrievable option enabled for an attribute.
+        pub const RETRIEVABLE_ENABLED: RetrievableOption = RetrievableOption::new(1);
+
+        /// Retrievable option disabled for an attribute.
+        pub const RETRIEVABLE_DISABLED: RetrievableOption = RetrievableOption::new(2);
+
         /// Creates a new RetrievableOption instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RETRIEVABLE_OPTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RETRIEVABLE_ENABLED"),
+                2 => std::borrow::Cow::Borrowed("RETRIEVABLE_DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RETRIEVABLE_OPTION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RETRIEVABLE_OPTION_UNSPECIFIED)
+                }
+                "RETRIEVABLE_ENABLED" => std::option::Option::Some(Self::RETRIEVABLE_ENABLED),
+                "RETRIEVABLE_DISABLED" => std::option::Option::Some(Self::RETRIEVABLE_DISABLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RetrievableOption](RetrievableOption)
-    pub mod retrievable_option {
-        use super::RetrievableOption;
-
-        /// Value used when unset.
-        pub const RETRIEVABLE_OPTION_UNSPECIFIED: RetrievableOption =
-            RetrievableOption::new("RETRIEVABLE_OPTION_UNSPECIFIED");
-
-        /// Retrievable option enabled for an attribute.
-        pub const RETRIEVABLE_ENABLED: RetrievableOption =
-            RetrievableOption::new("RETRIEVABLE_ENABLED");
-
-        /// Retrievable option disabled for an attribute.
-        pub const RETRIEVABLE_DISABLED: RetrievableOption =
-            RetrievableOption::new("RETRIEVABLE_DISABLED");
-    }
-
-    impl std::convert::From<std::string::String> for RetrievableOption {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RetrievableOption {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RetrievableOption {
         fn default() -> Self {
-            retrievable_option::RETRIEVABLE_OPTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6891,45 +6990,61 @@ pub mod import_products_request {
     /// Indicates how imported products are reconciled with the existing products
     /// created or imported before.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ReconciliationMode(std::borrow::Cow<'static, str>);
+    pub struct ReconciliationMode(i32);
 
     impl ReconciliationMode {
-        /// Creates a new ReconciliationMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ReconciliationMode](ReconciliationMode)
-    pub mod reconciliation_mode {
-        use super::ReconciliationMode;
-
         /// Defaults to INCREMENTAL.
-        pub const RECONCILIATION_MODE_UNSPECIFIED: ReconciliationMode =
-            ReconciliationMode::new("RECONCILIATION_MODE_UNSPECIFIED");
+        pub const RECONCILIATION_MODE_UNSPECIFIED: ReconciliationMode = ReconciliationMode::new(0);
 
         /// Inserts new products or updates existing products.
-        pub const INCREMENTAL: ReconciliationMode = ReconciliationMode::new("INCREMENTAL");
+        pub const INCREMENTAL: ReconciliationMode = ReconciliationMode::new(1);
 
         /// Calculates diff and replaces the entire product dataset. Existing
         /// products may be deleted if they are not present in the source location.
-        pub const FULL: ReconciliationMode = ReconciliationMode::new("FULL");
+        pub const FULL: ReconciliationMode = ReconciliationMode::new(2);
+
+        /// Creates a new ReconciliationMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RECONCILIATION_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INCREMENTAL"),
+                2 => std::borrow::Cow::Borrowed("FULL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RECONCILIATION_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RECONCILIATION_MODE_UNSPECIFIED)
+                }
+                "INCREMENTAL" => std::option::Option::Some(Self::INCREMENTAL),
+                "FULL" => std::option::Option::Some(Self::FULL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ReconciliationMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ReconciliationMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ReconciliationMode {
         fn default() -> Self {
-            reconciliation_mode::RECONCILIATION_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8212,91 +8327,125 @@ pub mod model {
 
     /// The serving state of the model.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ServingState(std::borrow::Cow<'static, str>);
+    pub struct ServingState(i32);
 
     impl ServingState {
-        /// Creates a new ServingState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ServingState](ServingState)
-    pub mod serving_state {
-        use super::ServingState;
-
         /// Unspecified serving state.
-        pub const SERVING_STATE_UNSPECIFIED: ServingState =
-            ServingState::new("SERVING_STATE_UNSPECIFIED");
+        pub const SERVING_STATE_UNSPECIFIED: ServingState = ServingState::new(0);
 
         /// The model is not serving.
-        pub const INACTIVE: ServingState = ServingState::new("INACTIVE");
+        pub const INACTIVE: ServingState = ServingState::new(1);
 
         /// The model is serving and can be queried.
-        pub const ACTIVE: ServingState = ServingState::new("ACTIVE");
+        pub const ACTIVE: ServingState = ServingState::new(2);
 
         /// The model is trained on tuned hyperparameters and can be
         /// queried.
-        pub const TUNED: ServingState = ServingState::new("TUNED");
+        pub const TUNED: ServingState = ServingState::new(3);
+
+        /// Creates a new ServingState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SERVING_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INACTIVE"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("TUNED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SERVING_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SERVING_STATE_UNSPECIFIED)
+                }
+                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "TUNED" => std::option::Option::Some(Self::TUNED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ServingState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ServingState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ServingState {
         fn default() -> Self {
-            serving_state::SERVING_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The training state of the model.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TrainingState(std::borrow::Cow<'static, str>);
+    pub struct TrainingState(i32);
 
     impl TrainingState {
+        /// Unspecified training state.
+        pub const TRAINING_STATE_UNSPECIFIED: TrainingState = TrainingState::new(0);
+
+        /// The model training is paused.
+        pub const PAUSED: TrainingState = TrainingState::new(1);
+
+        /// The model is training.
+        pub const TRAINING: TrainingState = TrainingState::new(2);
+
         /// Creates a new TrainingState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TRAINING_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PAUSED"),
+                2 => std::borrow::Cow::Borrowed("TRAINING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TRAINING_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::TRAINING_STATE_UNSPECIFIED)
+                }
+                "PAUSED" => std::option::Option::Some(Self::PAUSED),
+                "TRAINING" => std::option::Option::Some(Self::TRAINING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [TrainingState](TrainingState)
-    pub mod training_state {
-        use super::TrainingState;
-
-        /// Unspecified training state.
-        pub const TRAINING_STATE_UNSPECIFIED: TrainingState =
-            TrainingState::new("TRAINING_STATE_UNSPECIFIED");
-
-        /// The model training is paused.
-        pub const PAUSED: TrainingState = TrainingState::new("PAUSED");
-
-        /// The model is training.
-        pub const TRAINING: TrainingState = TrainingState::new("TRAINING");
-    }
-
-    impl std::convert::From<std::string::String> for TrainingState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TrainingState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TrainingState {
         fn default() -> Self {
-            training_state::TRAINING_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -8307,151 +8456,203 @@ pub mod model {
     /// schedule. Enabling or disabling periodic tuning does not affect any
     /// current tuning processes.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PeriodicTuningState(std::borrow::Cow<'static, str>);
+    pub struct PeriodicTuningState(i32);
 
     impl PeriodicTuningState {
-        /// Creates a new PeriodicTuningState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PeriodicTuningState](PeriodicTuningState)
-    pub mod periodic_tuning_state {
-        use super::PeriodicTuningState;
-
         /// Unspecified default value, should never be explicitly set.
         pub const PERIODIC_TUNING_STATE_UNSPECIFIED: PeriodicTuningState =
-            PeriodicTuningState::new("PERIODIC_TUNING_STATE_UNSPECIFIED");
+            PeriodicTuningState::new(0);
 
         /// The model has periodic tuning disabled. Tuning
         /// can be reenabled by calling the `EnableModelPeriodicTuning`
         /// method or by calling the `TuneModel` method.
-        pub const PERIODIC_TUNING_DISABLED: PeriodicTuningState =
-            PeriodicTuningState::new("PERIODIC_TUNING_DISABLED");
+        pub const PERIODIC_TUNING_DISABLED: PeriodicTuningState = PeriodicTuningState::new(1);
 
         /// The model cannot be tuned with periodic tuning OR the
         /// `TuneModel` method. Hide the options in customer UI and
         /// reject any requests through the backend self serve API.
-        pub const ALL_TUNING_DISABLED: PeriodicTuningState =
-            PeriodicTuningState::new("ALL_TUNING_DISABLED");
+        pub const ALL_TUNING_DISABLED: PeriodicTuningState = PeriodicTuningState::new(3);
 
         /// The model has periodic tuning enabled. Tuning
         /// can be disabled by calling the `DisableModelPeriodicTuning`
         /// method.
-        pub const PERIODIC_TUNING_ENABLED: PeriodicTuningState =
-            PeriodicTuningState::new("PERIODIC_TUNING_ENABLED");
+        pub const PERIODIC_TUNING_ENABLED: PeriodicTuningState = PeriodicTuningState::new(2);
+
+        /// Creates a new PeriodicTuningState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PERIODIC_TUNING_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PERIODIC_TUNING_DISABLED"),
+                2 => std::borrow::Cow::Borrowed("PERIODIC_TUNING_ENABLED"),
+                3 => std::borrow::Cow::Borrowed("ALL_TUNING_DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PERIODIC_TUNING_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PERIODIC_TUNING_STATE_UNSPECIFIED)
+                }
+                "PERIODIC_TUNING_DISABLED" => {
+                    std::option::Option::Some(Self::PERIODIC_TUNING_DISABLED)
+                }
+                "ALL_TUNING_DISABLED" => std::option::Option::Some(Self::ALL_TUNING_DISABLED),
+                "PERIODIC_TUNING_ENABLED" => {
+                    std::option::Option::Some(Self::PERIODIC_TUNING_ENABLED)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PeriodicTuningState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PeriodicTuningState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PeriodicTuningState {
         fn default() -> Self {
-            periodic_tuning_state::PERIODIC_TUNING_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Describes whether this model have sufficient training data
     /// to be continuously trained.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataState(std::borrow::Cow<'static, str>);
+    pub struct DataState(i32);
 
     impl DataState {
-        /// Creates a new DataState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DataState](DataState)
-    pub mod data_state {
-        use super::DataState;
-
         /// Unspecified default value, should never be explicitly set.
-        pub const DATA_STATE_UNSPECIFIED: DataState = DataState::new("DATA_STATE_UNSPECIFIED");
+        pub const DATA_STATE_UNSPECIFIED: DataState = DataState::new(0);
 
         /// The model has sufficient training data.
-        pub const DATA_OK: DataState = DataState::new("DATA_OK");
+        pub const DATA_OK: DataState = DataState::new(1);
 
         /// The model does not have sufficient training data. Error
         /// messages can be queried via Stackdriver.
-        pub const DATA_ERROR: DataState = DataState::new("DATA_ERROR");
+        pub const DATA_ERROR: DataState = DataState::new(2);
+
+        /// Creates a new DataState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATA_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DATA_OK"),
+                2 => std::borrow::Cow::Borrowed("DATA_ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATA_STATE_UNSPECIFIED" => std::option::Option::Some(Self::DATA_STATE_UNSPECIFIED),
+                "DATA_OK" => std::option::Option::Some(Self::DATA_OK),
+                "DATA_ERROR" => std::option::Option::Some(Self::DATA_ERROR),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DataState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DataState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DataState {
         fn default() -> Self {
-            data_state::DATA_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Use single or multiple context products for recommendations.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ContextProductsType(std::borrow::Cow<'static, str>);
+    pub struct ContextProductsType(i32);
 
     impl ContextProductsType {
-        /// Creates a new ContextProductsType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ContextProductsType](ContextProductsType)
-    pub mod context_products_type {
-        use super::ContextProductsType;
-
         /// Unspecified default value, should never be explicitly set.
         /// Defaults to
         /// [MULTIPLE_CONTEXT_PRODUCTS][google.cloud.retail.v2.Model.ContextProductsType.MULTIPLE_CONTEXT_PRODUCTS].
         ///
         /// [google.cloud.retail.v2.Model.ContextProductsType.MULTIPLE_CONTEXT_PRODUCTS]: crate::model::model::context_products_type::MULTIPLE_CONTEXT_PRODUCTS
         pub const CONTEXT_PRODUCTS_TYPE_UNSPECIFIED: ContextProductsType =
-            ContextProductsType::new("CONTEXT_PRODUCTS_TYPE_UNSPECIFIED");
+            ContextProductsType::new(0);
 
         /// Use only a single product as context for the recommendation. Typically
         /// used on pages like add-to-cart or product details.
-        pub const SINGLE_CONTEXT_PRODUCT: ContextProductsType =
-            ContextProductsType::new("SINGLE_CONTEXT_PRODUCT");
+        pub const SINGLE_CONTEXT_PRODUCT: ContextProductsType = ContextProductsType::new(1);
 
         /// Use one or multiple products as context for the recommendation. Typically
         /// used on shopping cart pages.
-        pub const MULTIPLE_CONTEXT_PRODUCTS: ContextProductsType =
-            ContextProductsType::new("MULTIPLE_CONTEXT_PRODUCTS");
+        pub const MULTIPLE_CONTEXT_PRODUCTS: ContextProductsType = ContextProductsType::new(2);
+
+        /// Creates a new ContextProductsType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CONTEXT_PRODUCTS_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SINGLE_CONTEXT_PRODUCT"),
+                2 => std::borrow::Cow::Borrowed("MULTIPLE_CONTEXT_PRODUCTS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CONTEXT_PRODUCTS_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CONTEXT_PRODUCTS_TYPE_UNSPECIFIED)
+                }
+                "SINGLE_CONTEXT_PRODUCT" => std::option::Option::Some(Self::SINGLE_CONTEXT_PRODUCT),
+                "MULTIPLE_CONTEXT_PRODUCTS" => {
+                    std::option::Option::Some(Self::MULTIPLE_CONTEXT_PRODUCTS)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ContextProductsType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ContextProductsType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ContextProductsType {
         fn default() -> Self {
-            context_products_type::CONTEXT_PRODUCTS_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -10197,30 +10398,15 @@ pub mod product {
 
     /// The type of this product.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// Default value. Default to
         /// [Catalog.product_level_config.ingestion_product_type][google.cloud.retail.v2.ProductLevelConfig.ingestion_product_type]
         /// if unset.
         ///
         /// [google.cloud.retail.v2.ProductLevelConfig.ingestion_product_type]: crate::model::ProductLevelConfig::ingestion_product_type
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// The primary type.
         ///
@@ -10233,7 +10419,7 @@ pub mod product {
         /// [google.cloud.retail.v2.Product]: crate::model::Product
         /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::r#type::PRIMARY
         /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::r#type::VARIANT
-        pub const PRIMARY: Type = Type::new("PRIMARY");
+        pub const PRIMARY: Type = Type::new(1);
 
         /// The variant type.
         ///
@@ -10247,7 +10433,7 @@ pub mod product {
         /// [google.cloud.retail.v2.Product]: crate::model::Product
         /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::r#type::PRIMARY
         /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::r#type::VARIANT
-        pub const VARIANT: Type = Type::new("VARIANT");
+        pub const VARIANT: Type = Type::new(2);
 
         /// The collection type. Collection products are bundled
         /// [Type.PRIMARY][google.cloud.retail.v2.Product.Type.PRIMARY]
@@ -10259,72 +10445,124 @@ pub mod product {
         /// [google.cloud.retail.v2.Product]: crate::model::Product
         /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::r#type::PRIMARY
         /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::r#type::VARIANT
-        pub const COLLECTION: Type = Type::new("COLLECTION");
+        pub const COLLECTION: Type = Type::new(3);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PRIMARY"),
+                2 => std::borrow::Cow::Borrowed("VARIANT"),
+                3 => std::borrow::Cow::Borrowed("COLLECTION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "PRIMARY" => std::option::Option::Some(Self::PRIMARY),
+                "VARIANT" => std::option::Option::Some(Self::VARIANT),
+                "COLLECTION" => std::option::Option::Some(Self::COLLECTION),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Product availability. If this field is unspecified, the product is
     /// assumed to be in stock.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Availability(std::borrow::Cow<'static, str>);
+    pub struct Availability(i32);
 
     impl Availability {
-        /// Creates a new Availability instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Availability](Availability)
-    pub mod availability {
-        use super::Availability;
-
         /// Default product availability. Default to
         /// [Availability.IN_STOCK][google.cloud.retail.v2.Product.Availability.IN_STOCK]
         /// if unset.
         ///
         /// [google.cloud.retail.v2.Product.Availability.IN_STOCK]: crate::model::product::availability::IN_STOCK
-        pub const AVAILABILITY_UNSPECIFIED: Availability =
-            Availability::new("AVAILABILITY_UNSPECIFIED");
+        pub const AVAILABILITY_UNSPECIFIED: Availability = Availability::new(0);
 
         /// Product in stock.
-        pub const IN_STOCK: Availability = Availability::new("IN_STOCK");
+        pub const IN_STOCK: Availability = Availability::new(1);
 
         /// Product out of stock.
-        pub const OUT_OF_STOCK: Availability = Availability::new("OUT_OF_STOCK");
+        pub const OUT_OF_STOCK: Availability = Availability::new(2);
 
         /// Product that is in pre-order state.
-        pub const PREORDER: Availability = Availability::new("PREORDER");
+        pub const PREORDER: Availability = Availability::new(3);
 
         /// Product that is back-ordered (i.e. temporarily out of stock).
-        pub const BACKORDER: Availability = Availability::new("BACKORDER");
+        pub const BACKORDER: Availability = Availability::new(4);
+
+        /// Creates a new Availability instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("AVAILABILITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IN_STOCK"),
+                2 => std::borrow::Cow::Borrowed("OUT_OF_STOCK"),
+                3 => std::borrow::Cow::Borrowed("PREORDER"),
+                4 => std::borrow::Cow::Borrowed("BACKORDER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "AVAILABILITY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::AVAILABILITY_UNSPECIFIED)
+                }
+                "IN_STOCK" => std::option::Option::Some(Self::IN_STOCK),
+                "OUT_OF_STOCK" => std::option::Option::Some(Self::OUT_OF_STOCK),
+                "PREORDER" => std::option::Option::Some(Self::PREORDER),
+                "BACKORDER" => std::option::Option::Some(Self::BACKORDER),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Availability {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Availability {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Availability {
         fn default() -> Self {
-            availability::AVAILABILITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -13375,43 +13613,58 @@ pub mod search_request {
 
         /// Enum to control DynamicFacet mode
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Mode(std::borrow::Cow<'static, str>);
+        pub struct Mode(i32);
 
         impl Mode {
+            /// Default value.
+            pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
+
+            /// Disable Dynamic Facet.
+            pub const DISABLED: Mode = Mode::new(1);
+
+            /// Automatic mode built by Google Retail Search.
+            pub const ENABLED: Mode = Mode::new(2);
+
             /// Creates a new Mode instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("DISABLED"),
+                    2 => std::borrow::Cow::Borrowed("ENABLED"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
+                    "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                    "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Mode](Mode)
-        pub mod mode {
-            use super::Mode;
-
-            /// Default value.
-            pub const MODE_UNSPECIFIED: Mode = Mode::new("MODE_UNSPECIFIED");
-
-            /// Disable Dynamic Facet.
-            pub const DISABLED: Mode = Mode::new("DISABLED");
-
-            /// Automatic mode built by Google Retail Search.
-            pub const ENABLED: Mode = Mode::new("ENABLED");
-        }
-
-        impl std::convert::From<std::string::String> for Mode {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Mode {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Mode {
             fn default() -> Self {
-                mode::MODE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -13605,51 +13858,68 @@ pub mod search_request {
 
         /// Enum describing under which condition query expansion should occur.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Condition(std::borrow::Cow<'static, str>);
+        pub struct Condition(i32);
 
         impl Condition {
-            /// Creates a new Condition instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [Condition](Condition)
-        pub mod condition {
-            use super::Condition;
-
             /// Unspecified query expansion condition. In this case, server behavior
             /// defaults to
             /// [Condition.DISABLED][google.cloud.retail.v2.SearchRequest.QueryExpansionSpec.Condition.DISABLED].
             ///
             /// [google.cloud.retail.v2.SearchRequest.QueryExpansionSpec.Condition.DISABLED]: crate::model::search_request::query_expansion_spec::condition::DISABLED
-            pub const CONDITION_UNSPECIFIED: Condition = Condition::new("CONDITION_UNSPECIFIED");
+            pub const CONDITION_UNSPECIFIED: Condition = Condition::new(0);
 
             /// Disabled query expansion. Only the exact search query is used, even if
             /// [SearchResponse.total_size][google.cloud.retail.v2.SearchResponse.total_size]
             /// is zero.
             ///
             /// [google.cloud.retail.v2.SearchResponse.total_size]: crate::model::SearchResponse::total_size
-            pub const DISABLED: Condition = Condition::new("DISABLED");
+            pub const DISABLED: Condition = Condition::new(1);
 
             /// Automatic query expansion built by Google Retail Search.
-            pub const AUTO: Condition = Condition::new("AUTO");
+            pub const AUTO: Condition = Condition::new(3);
+
+            /// Creates a new Condition instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("CONDITION_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("DISABLED"),
+                    3 => std::borrow::Cow::Borrowed("AUTO"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "CONDITION_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::CONDITION_UNSPECIFIED)
+                    }
+                    "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                    "AUTO" => std::option::Option::Some(Self::AUTO),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for Condition {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Condition {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Condition {
             fn default() -> Self {
-                condition::CONDITION_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -13697,47 +13967,62 @@ pub mod search_request {
 
         /// The personalization mode of each search request.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Mode(std::borrow::Cow<'static, str>);
+        pub struct Mode(i32);
 
         impl Mode {
-            /// Creates a new Mode instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [Mode](Mode)
-        pub mod mode {
-            use super::Mode;
-
             /// Default value. In this case, server behavior defaults to
             /// [Mode.AUTO][google.cloud.retail.v2.SearchRequest.PersonalizationSpec.Mode.AUTO].
             ///
             /// [google.cloud.retail.v2.SearchRequest.PersonalizationSpec.Mode.AUTO]: crate::model::search_request::personalization_spec::mode::AUTO
-            pub const MODE_UNSPECIFIED: Mode = Mode::new("MODE_UNSPECIFIED");
+            pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
 
             /// Let CRS decide whether to use personalization based on quality of user
             /// event data.
-            pub const AUTO: Mode = Mode::new("AUTO");
+            pub const AUTO: Mode = Mode::new(1);
 
             /// Disable personalization.
-            pub const DISABLED: Mode = Mode::new("DISABLED");
+            pub const DISABLED: Mode = Mode::new(2);
+
+            /// Creates a new Mode instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("AUTO"),
+                    2 => std::borrow::Cow::Borrowed("DISABLED"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
+                    "AUTO" => std::option::Option::Some(Self::AUTO),
+                    "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for Mode {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Mode {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Mode {
             fn default() -> Self {
-                mode::MODE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -13786,30 +14071,15 @@ pub mod search_request {
 
         /// Enum describing under which mode spell correction should occur.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Mode(std::borrow::Cow<'static, str>);
+        pub struct Mode(i32);
 
         impl Mode {
-            /// Creates a new Mode instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [Mode](Mode)
-        pub mod mode {
-            use super::Mode;
-
             /// Unspecified spell correction mode. In this case, server behavior
             /// defaults to
             /// [Mode.AUTO][google.cloud.retail.v2.SearchRequest.SpellCorrectionSpec.Mode.AUTO].
             ///
             /// [google.cloud.retail.v2.SearchRequest.SpellCorrectionSpec.Mode.AUTO]: crate::model::search_request::spell_correction_spec::mode::AUTO
-            pub const MODE_UNSPECIFIED: Mode = Mode::new("MODE_UNSPECIFIED");
+            pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
 
             /// Google Retail Search will try to find a spell suggestion if there
             /// is any and put in the
@@ -13817,22 +14087,52 @@ pub mod search_request {
             /// The spell suggestion will not be used as the search query.
             ///
             /// [google.cloud.retail.v2.SearchResponse.corrected_query]: crate::model::SearchResponse::corrected_query
-            pub const SUGGESTION_ONLY: Mode = Mode::new("SUGGESTION_ONLY");
+            pub const SUGGESTION_ONLY: Mode = Mode::new(1);
 
             /// Automatic spell correction built by Google Retail Search. Search will
             /// be based on the corrected query if found.
-            pub const AUTO: Mode = Mode::new("AUTO");
+            pub const AUTO: Mode = Mode::new(2);
+
+            /// Creates a new Mode instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("SUGGESTION_ONLY"),
+                    2 => std::borrow::Cow::Borrowed("AUTO"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
+                    "SUGGESTION_ONLY" => std::option::Option::Some(Self::SUGGESTION_ONLY),
+                    "AUTO" => std::option::Option::Some(Self::AUTO),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for Mode {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Mode {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Mode {
             fn default() -> Self {
-                mode::MODE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -14135,24 +14435,9 @@ pub mod search_request {
 
     /// The search mode of each search request.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SearchMode(std::borrow::Cow<'static, str>);
+    pub struct SearchMode(i32);
 
     impl SearchMode {
-        /// Creates a new SearchMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [SearchMode](SearchMode)
-    pub mod search_mode {
-        use super::SearchMode;
-
         /// Default value. In this case both product search and faceted search will
         /// be performed. Both
         /// [SearchResponse.SearchResult][google.cloud.retail.v2.SearchResponse.SearchResult]
@@ -14161,7 +14446,7 @@ pub mod search_request {
         ///
         /// [google.cloud.retail.v2.SearchResponse.Facet]: crate::model::search_response::Facet
         /// [google.cloud.retail.v2.SearchResponse.SearchResult]: crate::model::search_response::SearchResult
-        pub const SEARCH_MODE_UNSPECIFIED: SearchMode = SearchMode::new("SEARCH_MODE_UNSPECIFIED");
+        pub const SEARCH_MODE_UNSPECIFIED: SearchMode = SearchMode::new(0);
 
         /// Only product search will be performed. The faceted search will be
         /// disabled.
@@ -14180,7 +14465,7 @@ pub mod search_request {
         /// [google.cloud.retail.v2.SearchRequest.facet_specs]: crate::model::SearchRequest::facet_specs
         /// [google.cloud.retail.v2.SearchResponse.Facet]: crate::model::search_response::Facet
         /// [google.cloud.retail.v2.SearchResponse.SearchResult]: crate::model::search_response::SearchResult
-        pub const PRODUCT_SEARCH_ONLY: SearchMode = SearchMode::new("PRODUCT_SEARCH_ONLY");
+        pub const PRODUCT_SEARCH_ONLY: SearchMode = SearchMode::new(1);
 
         /// Only faceted search will be performed. The product search will be
         /// disabled.
@@ -14199,18 +14484,50 @@ pub mod search_request {
         /// [google.cloud.retail.v2.SearchRequest.facet_specs]: crate::model::SearchRequest::facet_specs
         /// [google.cloud.retail.v2.SearchResponse.Facet]: crate::model::search_response::Facet
         /// [google.cloud.retail.v2.SearchResponse.SearchResult]: crate::model::search_response::SearchResult
-        pub const FACETED_SEARCH_ONLY: SearchMode = SearchMode::new("FACETED_SEARCH_ONLY");
+        pub const FACETED_SEARCH_ONLY: SearchMode = SearchMode::new(2);
+
+        /// Creates a new SearchMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SEARCH_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PRODUCT_SEARCH_ONLY"),
+                2 => std::borrow::Cow::Borrowed("FACETED_SEARCH_ONLY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SEARCH_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SEARCH_MODE_UNSPECIFIED)
+                }
+                "PRODUCT_SEARCH_ONLY" => std::option::Option::Some(Self::PRODUCT_SEARCH_ONLY),
+                "FACETED_SEARCH_ONLY" => std::option::Option::Some(Self::FACETED_SEARCH_ONLY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for SearchMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SearchMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SearchMode {
         fn default() -> Self {
-            search_mode::SEARCH_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -15825,45 +16142,60 @@ pub mod serving_config {
 
     /// What type of diversity - data or rule based.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DiversityType(std::borrow::Cow<'static, str>);
+    pub struct DiversityType(i32);
 
     impl DiversityType {
+        /// Default value.
+        pub const DIVERSITY_TYPE_UNSPECIFIED: DiversityType = DiversityType::new(0);
+
+        /// Rule based diversity.
+        pub const RULE_BASED_DIVERSITY: DiversityType = DiversityType::new(2);
+
+        /// Data driven diversity.
+        pub const DATA_DRIVEN_DIVERSITY: DiversityType = DiversityType::new(3);
+
         /// Creates a new DiversityType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DIVERSITY_TYPE_UNSPECIFIED"),
+                2 => std::borrow::Cow::Borrowed("RULE_BASED_DIVERSITY"),
+                3 => std::borrow::Cow::Borrowed("DATA_DRIVEN_DIVERSITY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DIVERSITY_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DIVERSITY_TYPE_UNSPECIFIED)
+                }
+                "RULE_BASED_DIVERSITY" => std::option::Option::Some(Self::RULE_BASED_DIVERSITY),
+                "DATA_DRIVEN_DIVERSITY" => std::option::Option::Some(Self::DATA_DRIVEN_DIVERSITY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DiversityType](DiversityType)
-    pub mod diversity_type {
-        use super::DiversityType;
-
-        /// Default value.
-        pub const DIVERSITY_TYPE_UNSPECIFIED: DiversityType =
-            DiversityType::new("DIVERSITY_TYPE_UNSPECIFIED");
-
-        /// Rule based diversity.
-        pub const RULE_BASED_DIVERSITY: DiversityType = DiversityType::new("RULE_BASED_DIVERSITY");
-
-        /// Data driven diversity.
-        pub const DATA_DRIVEN_DIVERSITY: DiversityType =
-            DiversityType::new("DATA_DRIVEN_DIVERSITY");
-    }
-
-    impl std::convert::From<std::string::String> for DiversityType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DiversityType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DiversityType {
         fn default() -> Self {
-            diversity_type::DIVERSITY_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -17176,46 +17508,62 @@ pub mod rejoin_user_events_request {
     /// If all events needs to be rejoined, set `UserEventRejoinScope` to
     /// `USER_EVENT_REJOIN_SCOPE_UNSPECIFIED`.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct UserEventRejoinScope(std::borrow::Cow<'static, str>);
+    pub struct UserEventRejoinScope(i32);
 
     impl UserEventRejoinScope {
-        /// Creates a new UserEventRejoinScope instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [UserEventRejoinScope](UserEventRejoinScope)
-    pub mod user_event_rejoin_scope {
-        use super::UserEventRejoinScope;
-
         /// Rejoin all events with the latest product catalog, including both joined
         /// events and unjoined events.
         pub const USER_EVENT_REJOIN_SCOPE_UNSPECIFIED: UserEventRejoinScope =
-            UserEventRejoinScope::new("USER_EVENT_REJOIN_SCOPE_UNSPECIFIED");
+            UserEventRejoinScope::new(0);
 
         /// Only rejoin joined events with the latest product catalog.
-        pub const JOINED_EVENTS: UserEventRejoinScope = UserEventRejoinScope::new("JOINED_EVENTS");
+        pub const JOINED_EVENTS: UserEventRejoinScope = UserEventRejoinScope::new(1);
 
         /// Only rejoin unjoined events with the latest product catalog.
-        pub const UNJOINED_EVENTS: UserEventRejoinScope =
-            UserEventRejoinScope::new("UNJOINED_EVENTS");
+        pub const UNJOINED_EVENTS: UserEventRejoinScope = UserEventRejoinScope::new(2);
+
+        /// Creates a new UserEventRejoinScope instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("USER_EVENT_REJOIN_SCOPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("JOINED_EVENTS"),
+                2 => std::borrow::Cow::Borrowed("UNJOINED_EVENTS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "USER_EVENT_REJOIN_SCOPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::USER_EVENT_REJOIN_SCOPE_UNSPECIFIED)
+                }
+                "JOINED_EVENTS" => std::option::Option::Some(Self::JOINED_EVENTS),
+                "UNJOINED_EVENTS" => std::option::Option::Some(Self::UNJOINED_EVENTS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for UserEventRejoinScope {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for UserEventRejoinScope {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for UserEventRejoinScope {
         fn default() -> Self {
-            user_event_rejoin_scope::USER_EVENT_REJOIN_SCOPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -17270,199 +17618,277 @@ impl wkt::message::Message for RejoinUserEventsMetadata {
 
 /// At which level we offer configuration for attributes.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AttributeConfigLevel(std::borrow::Cow<'static, str>);
+pub struct AttributeConfigLevel(i32);
 
 impl AttributeConfigLevel {
-    /// Creates a new AttributeConfigLevel instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [AttributeConfigLevel](AttributeConfigLevel)
-pub mod attribute_config_level {
-    use super::AttributeConfigLevel;
-
     /// Value used when unset. In this case, server behavior defaults to
     /// [CATALOG_LEVEL_ATTRIBUTE_CONFIG][google.cloud.retail.v2.AttributeConfigLevel.CATALOG_LEVEL_ATTRIBUTE_CONFIG].
     ///
     /// [google.cloud.retail.v2.AttributeConfigLevel.CATALOG_LEVEL_ATTRIBUTE_CONFIG]: crate::model::attribute_config_level::CATALOG_LEVEL_ATTRIBUTE_CONFIG
     pub const ATTRIBUTE_CONFIG_LEVEL_UNSPECIFIED: AttributeConfigLevel =
-        AttributeConfigLevel::new("ATTRIBUTE_CONFIG_LEVEL_UNSPECIFIED");
+        AttributeConfigLevel::new(0);
 
     /// At this level, we honor the attribute configurations set in
     /// [Product.attributes][google.cloud.retail.v2.Product.attributes].
     ///
     /// [google.cloud.retail.v2.Product.attributes]: crate::model::Product::attributes
-    pub const PRODUCT_LEVEL_ATTRIBUTE_CONFIG: AttributeConfigLevel =
-        AttributeConfigLevel::new("PRODUCT_LEVEL_ATTRIBUTE_CONFIG");
+    pub const PRODUCT_LEVEL_ATTRIBUTE_CONFIG: AttributeConfigLevel = AttributeConfigLevel::new(1);
 
     /// At this level, we honor the attribute configurations set in
     /// [CatalogConfig.attribute_configs][].
-    pub const CATALOG_LEVEL_ATTRIBUTE_CONFIG: AttributeConfigLevel =
-        AttributeConfigLevel::new("CATALOG_LEVEL_ATTRIBUTE_CONFIG");
+    pub const CATALOG_LEVEL_ATTRIBUTE_CONFIG: AttributeConfigLevel = AttributeConfigLevel::new(2);
+
+    /// Creates a new AttributeConfigLevel instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ATTRIBUTE_CONFIG_LEVEL_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PRODUCT_LEVEL_ATTRIBUTE_CONFIG"),
+            2 => std::borrow::Cow::Borrowed("CATALOG_LEVEL_ATTRIBUTE_CONFIG"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ATTRIBUTE_CONFIG_LEVEL_UNSPECIFIED" => {
+                std::option::Option::Some(Self::ATTRIBUTE_CONFIG_LEVEL_UNSPECIFIED)
+            }
+            "PRODUCT_LEVEL_ATTRIBUTE_CONFIG" => {
+                std::option::Option::Some(Self::PRODUCT_LEVEL_ATTRIBUTE_CONFIG)
+            }
+            "CATALOG_LEVEL_ATTRIBUTE_CONFIG" => {
+                std::option::Option::Some(Self::CATALOG_LEVEL_ATTRIBUTE_CONFIG)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for AttributeConfigLevel {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for AttributeConfigLevel {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for AttributeConfigLevel {
     fn default() -> Self {
-        attribute_config_level::ATTRIBUTE_CONFIG_LEVEL_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The type of solution.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SolutionType(std::borrow::Cow<'static, str>);
+pub struct SolutionType(i32);
 
 impl SolutionType {
+    /// Default value.
+    pub const SOLUTION_TYPE_UNSPECIFIED: SolutionType = SolutionType::new(0);
+
+    /// Used for Recommendations AI.
+    pub const SOLUTION_TYPE_RECOMMENDATION: SolutionType = SolutionType::new(1);
+
+    /// Used for Retail Search.
+    pub const SOLUTION_TYPE_SEARCH: SolutionType = SolutionType::new(2);
+
     /// Creates a new SolutionType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SOLUTION_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SOLUTION_TYPE_RECOMMENDATION"),
+            2 => std::borrow::Cow::Borrowed("SOLUTION_TYPE_SEARCH"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SOLUTION_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::SOLUTION_TYPE_UNSPECIFIED)
+            }
+            "SOLUTION_TYPE_RECOMMENDATION" => {
+                std::option::Option::Some(Self::SOLUTION_TYPE_RECOMMENDATION)
+            }
+            "SOLUTION_TYPE_SEARCH" => std::option::Option::Some(Self::SOLUTION_TYPE_SEARCH),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [SolutionType](SolutionType)
-pub mod solution_type {
-    use super::SolutionType;
-
-    /// Default value.
-    pub const SOLUTION_TYPE_UNSPECIFIED: SolutionType =
-        SolutionType::new("SOLUTION_TYPE_UNSPECIFIED");
-
-    /// Used for Recommendations AI.
-    pub const SOLUTION_TYPE_RECOMMENDATION: SolutionType =
-        SolutionType::new("SOLUTION_TYPE_RECOMMENDATION");
-
-    /// Used for Retail Search.
-    pub const SOLUTION_TYPE_SEARCH: SolutionType = SolutionType::new("SOLUTION_TYPE_SEARCH");
-}
-
-impl std::convert::From<std::string::String> for SolutionType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SolutionType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SolutionType {
     fn default() -> Self {
-        solution_type::SOLUTION_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// If filtering for recommendations is enabled.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RecommendationsFilteringOption(std::borrow::Cow<'static, str>);
+pub struct RecommendationsFilteringOption(i32);
 
 impl RecommendationsFilteringOption {
-    /// Creates a new RecommendationsFilteringOption instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [RecommendationsFilteringOption](RecommendationsFilteringOption)
-pub mod recommendations_filtering_option {
-    use super::RecommendationsFilteringOption;
-
     /// Value used when unset.
     /// In this case, server behavior defaults to
     /// [RECOMMENDATIONS_FILTERING_DISABLED][google.cloud.retail.v2.RecommendationsFilteringOption.RECOMMENDATIONS_FILTERING_DISABLED].
     ///
     /// [google.cloud.retail.v2.RecommendationsFilteringOption.RECOMMENDATIONS_FILTERING_DISABLED]: crate::model::recommendations_filtering_option::RECOMMENDATIONS_FILTERING_DISABLED
     pub const RECOMMENDATIONS_FILTERING_OPTION_UNSPECIFIED: RecommendationsFilteringOption =
-        RecommendationsFilteringOption::new("RECOMMENDATIONS_FILTERING_OPTION_UNSPECIFIED");
+        RecommendationsFilteringOption::new(0);
 
     /// Recommendation filtering is disabled.
     pub const RECOMMENDATIONS_FILTERING_DISABLED: RecommendationsFilteringOption =
-        RecommendationsFilteringOption::new("RECOMMENDATIONS_FILTERING_DISABLED");
+        RecommendationsFilteringOption::new(1);
 
     /// Recommendation filtering is enabled.
     pub const RECOMMENDATIONS_FILTERING_ENABLED: RecommendationsFilteringOption =
-        RecommendationsFilteringOption::new("RECOMMENDATIONS_FILTERING_ENABLED");
+        RecommendationsFilteringOption::new(3);
+
+    /// Creates a new RecommendationsFilteringOption instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("RECOMMENDATIONS_FILTERING_OPTION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("RECOMMENDATIONS_FILTERING_DISABLED"),
+            3 => std::borrow::Cow::Borrowed("RECOMMENDATIONS_FILTERING_ENABLED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "RECOMMENDATIONS_FILTERING_OPTION_UNSPECIFIED" => {
+                std::option::Option::Some(Self::RECOMMENDATIONS_FILTERING_OPTION_UNSPECIFIED)
+            }
+            "RECOMMENDATIONS_FILTERING_DISABLED" => {
+                std::option::Option::Some(Self::RECOMMENDATIONS_FILTERING_DISABLED)
+            }
+            "RECOMMENDATIONS_FILTERING_ENABLED" => {
+                std::option::Option::Some(Self::RECOMMENDATIONS_FILTERING_ENABLED)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for RecommendationsFilteringOption {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for RecommendationsFilteringOption {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for RecommendationsFilteringOption {
     fn default() -> Self {
-        recommendations_filtering_option::RECOMMENDATIONS_FILTERING_OPTION_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The use case of Cloud Retail Search.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SearchSolutionUseCase(std::borrow::Cow<'static, str>);
+pub struct SearchSolutionUseCase(i32);
 
 impl SearchSolutionUseCase {
-    /// Creates a new SearchSolutionUseCase instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [SearchSolutionUseCase](SearchSolutionUseCase)
-pub mod search_solution_use_case {
-    use super::SearchSolutionUseCase;
-
     /// The value when it's unspecified. In this case, server behavior defaults to
     /// [SEARCH_SOLUTION_USE_CASE_SEARCH][google.cloud.retail.v2.SearchSolutionUseCase.SEARCH_SOLUTION_USE_CASE_SEARCH].
     ///
     /// [google.cloud.retail.v2.SearchSolutionUseCase.SEARCH_SOLUTION_USE_CASE_SEARCH]: crate::model::search_solution_use_case::SEARCH_SOLUTION_USE_CASE_SEARCH
     pub const SEARCH_SOLUTION_USE_CASE_UNSPECIFIED: SearchSolutionUseCase =
-        SearchSolutionUseCase::new("SEARCH_SOLUTION_USE_CASE_UNSPECIFIED");
+        SearchSolutionUseCase::new(0);
 
     /// Search use case. Expects the traffic has a non-empty
     /// [query][google.cloud.retail.v2.SearchRequest.query].
     ///
     /// [google.cloud.retail.v2.SearchRequest.query]: crate::model::SearchRequest::query
     pub const SEARCH_SOLUTION_USE_CASE_SEARCH: SearchSolutionUseCase =
-        SearchSolutionUseCase::new("SEARCH_SOLUTION_USE_CASE_SEARCH");
+        SearchSolutionUseCase::new(1);
 
     /// Browse use case. Expects the traffic has an empty
     /// [query][google.cloud.retail.v2.SearchRequest.query].
     ///
     /// [google.cloud.retail.v2.SearchRequest.query]: crate::model::SearchRequest::query
     pub const SEARCH_SOLUTION_USE_CASE_BROWSE: SearchSolutionUseCase =
-        SearchSolutionUseCase::new("SEARCH_SOLUTION_USE_CASE_BROWSE");
+        SearchSolutionUseCase::new(2);
+
+    /// Creates a new SearchSolutionUseCase instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SEARCH_SOLUTION_USE_CASE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SEARCH_SOLUTION_USE_CASE_SEARCH"),
+            2 => std::borrow::Cow::Borrowed("SEARCH_SOLUTION_USE_CASE_BROWSE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SEARCH_SOLUTION_USE_CASE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::SEARCH_SOLUTION_USE_CASE_UNSPECIFIED)
+            }
+            "SEARCH_SOLUTION_USE_CASE_SEARCH" => {
+                std::option::Option::Some(Self::SEARCH_SOLUTION_USE_CASE_SEARCH)
+            }
+            "SEARCH_SOLUTION_USE_CASE_BROWSE" => {
+                std::option::Option::Some(Self::SEARCH_SOLUTION_USE_CASE_BROWSE)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for SearchSolutionUseCase {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SearchSolutionUseCase {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SearchSolutionUseCase {
     fn default() -> Self {
-        search_solution_use_case::SEARCH_SOLUTION_USE_CASE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/retail/v2/src/transport.rs
+++ b/src/generated/cloud/retail/v2/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::AnalyticsService for AnalyticsService {
                 reqwest::Method::POST,
                 format!("/v2/{}:exportAnalyticsMetrics", req.catalog),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -69,7 +69,7 @@ impl crate::stubs::AnalyticsService for AnalyticsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -91,7 +91,7 @@ impl crate::stubs::AnalyticsService for AnalyticsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -147,7 +147,7 @@ impl crate::stubs::CatalogService for CatalogService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/catalogs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -177,7 +177,7 @@ impl crate::stubs::CatalogService for CatalogService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -209,7 +209,7 @@ impl crate::stubs::CatalogService for CatalogService {
                 reqwest::Method::POST,
                 format!("/v2/{}:setDefaultBranch", req.catalog),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -229,7 +229,7 @@ impl crate::stubs::CatalogService for CatalogService {
                 reqwest::Method::GET,
                 format!("/v2/{}:getDefaultBranch", req.catalog),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -248,7 +248,7 @@ impl crate::stubs::CatalogService for CatalogService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -276,7 +276,7 @@ impl crate::stubs::CatalogService for CatalogService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -305,7 +305,7 @@ impl crate::stubs::CatalogService for CatalogService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -333,7 +333,7 @@ impl crate::stubs::CatalogService for CatalogService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -365,7 +365,7 @@ impl crate::stubs::CatalogService for CatalogService {
                 reqwest::Method::POST,
                 format!("/v2/{}:addCatalogAttribute", req.attributes_config),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -385,7 +385,7 @@ impl crate::stubs::CatalogService for CatalogService {
                 reqwest::Method::POST,
                 format!("/v2/{}:removeCatalogAttribute", req.attributes_config),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -405,7 +405,7 @@ impl crate::stubs::CatalogService for CatalogService {
                 reqwest::Method::POST,
                 format!("/v2/{}:replaceCatalogAttribute", req.attributes_config),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -422,7 +422,7 @@ impl crate::stubs::CatalogService for CatalogService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -444,7 +444,7 @@ impl crate::stubs::CatalogService for CatalogService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -489,7 +489,7 @@ impl crate::stubs::CompletionService for CompletionService {
                 reqwest::Method::GET,
                 format!("/v2/{}:completeQuery", req.catalog),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -525,7 +525,7 @@ impl crate::stubs::CompletionService for CompletionService {
                 reqwest::Method::POST,
                 format!("/v2/{}/completionData:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -542,7 +542,7 @@ impl crate::stubs::CompletionService for CompletionService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -564,7 +564,7 @@ impl crate::stubs::CompletionService for CompletionService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -623,7 +623,7 @@ impl crate::stubs::ControlService for ControlService {
                 reqwest::Method::POST,
                 format!("/v2/{}/controls", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -643,7 +643,7 @@ impl crate::stubs::ControlService for ControlService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -671,7 +671,7 @@ impl crate::stubs::ControlService for ControlService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -700,7 +700,7 @@ impl crate::stubs::ControlService for ControlService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -719,7 +719,7 @@ impl crate::stubs::ControlService for ControlService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/controls", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -741,7 +741,7 @@ impl crate::stubs::ControlService for ControlService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -763,7 +763,7 @@ impl crate::stubs::ControlService for ControlService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -816,7 +816,7 @@ impl crate::stubs::GenerativeQuestionService for GenerativeQuestionService {
                         .catalog
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -852,7 +852,7 @@ impl crate::stubs::GenerativeQuestionService for GenerativeQuestionService {
                 reqwest::Method::GET,
                 format!("/v2/{}/generativeQuestionFeature", req.catalog),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -874,7 +874,7 @@ impl crate::stubs::GenerativeQuestionService for GenerativeQuestionService {
                 reqwest::Method::GET,
                 format!("/v2/{}/generativeQuestions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -902,7 +902,7 @@ impl crate::stubs::GenerativeQuestionService for GenerativeQuestionService {
                         .catalog
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -934,7 +934,7 @@ impl crate::stubs::GenerativeQuestionService for GenerativeQuestionService {
                 reqwest::Method::POST,
                 format!("/v2/{}/generativeQuestion:batchUpdate", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -951,7 +951,7 @@ impl crate::stubs::GenerativeQuestionService for GenerativeQuestionService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -973,7 +973,7 @@ impl crate::stubs::GenerativeQuestionService for GenerativeQuestionService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1015,7 +1015,7 @@ impl crate::stubs::ModelService for ModelService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}/models", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1033,7 +1033,7 @@ impl crate::stubs::ModelService for ModelService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1052,7 +1052,7 @@ impl crate::stubs::ModelService for ModelService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:pause", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1069,7 +1069,7 @@ impl crate::stubs::ModelService for ModelService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:resume", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1086,7 +1086,7 @@ impl crate::stubs::ModelService for ModelService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1105,7 +1105,7 @@ impl crate::stubs::ModelService for ModelService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/models", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1135,7 +1135,7 @@ impl crate::stubs::ModelService for ModelService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1162,7 +1162,7 @@ impl crate::stubs::ModelService for ModelService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:tune", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1179,7 +1179,7 @@ impl crate::stubs::ModelService for ModelService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1201,7 +1201,7 @@ impl crate::stubs::ModelService for ModelService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1260,7 +1260,7 @@ impl crate::stubs::PredictionService for PredictionService {
                 reqwest::Method::POST,
                 format!("/v2/{}:predict", req.placement),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1277,7 +1277,7 @@ impl crate::stubs::PredictionService for PredictionService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1299,7 +1299,7 @@ impl crate::stubs::PredictionService for PredictionService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1344,7 +1344,7 @@ impl crate::stubs::ProductService for ProductService {
                 reqwest::Method::POST,
                 format!("/v2/{}/products", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1364,7 +1364,7 @@ impl crate::stubs::ProductService for ProductService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1383,7 +1383,7 @@ impl crate::stubs::ProductService for ProductService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/products", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1424,7 +1424,7 @@ impl crate::stubs::ProductService for ProductService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1454,7 +1454,7 @@ impl crate::stubs::ProductService for ProductService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1476,7 +1476,7 @@ impl crate::stubs::ProductService for ProductService {
                 reqwest::Method::POST,
                 format!("/v2/{}/products:purge", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1496,7 +1496,7 @@ impl crate::stubs::ProductService for ProductService {
                 reqwest::Method::POST,
                 format!("/v2/{}/products:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1522,7 +1522,7 @@ impl crate::stubs::ProductService for ProductService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1542,7 +1542,7 @@ impl crate::stubs::ProductService for ProductService {
                 reqwest::Method::POST,
                 format!("/v2/{}:addFulfillmentPlaces", req.product),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1562,7 +1562,7 @@ impl crate::stubs::ProductService for ProductService {
                 reqwest::Method::POST,
                 format!("/v2/{}:removeFulfillmentPlaces", req.product),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1582,7 +1582,7 @@ impl crate::stubs::ProductService for ProductService {
                 reqwest::Method::POST,
                 format!("/v2/{}:addLocalInventories", req.product),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1602,7 +1602,7 @@ impl crate::stubs::ProductService for ProductService {
                 reqwest::Method::POST,
                 format!("/v2/{}:removeLocalInventories", req.product),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1619,7 +1619,7 @@ impl crate::stubs::ProductService for ProductService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1641,7 +1641,7 @@ impl crate::stubs::ProductService for ProductService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1700,7 +1700,7 @@ impl crate::stubs::SearchService for SearchService {
                 reqwest::Method::POST,
                 format!("/v2/{}:search", req.placement),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1717,7 +1717,7 @@ impl crate::stubs::SearchService for SearchService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1739,7 +1739,7 @@ impl crate::stubs::SearchService for SearchService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1784,7 +1784,7 @@ impl crate::stubs::ServingConfigService for ServingConfigService {
                 reqwest::Method::POST,
                 format!("/v2/{}/servingConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1804,7 +1804,7 @@ impl crate::stubs::ServingConfigService for ServingConfigService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1832,7 +1832,7 @@ impl crate::stubs::ServingConfigService for ServingConfigService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1861,7 +1861,7 @@ impl crate::stubs::ServingConfigService for ServingConfigService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1883,7 +1883,7 @@ impl crate::stubs::ServingConfigService for ServingConfigService {
                 reqwest::Method::GET,
                 format!("/v2/{}/servingConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1907,7 +1907,7 @@ impl crate::stubs::ServingConfigService for ServingConfigService {
                 reqwest::Method::POST,
                 format!("/v2/{}:addControl", req.serving_config),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1927,7 +1927,7 @@ impl crate::stubs::ServingConfigService for ServingConfigService {
                 reqwest::Method::POST,
                 format!("/v2/{}:removeControl", req.serving_config),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1944,7 +1944,7 @@ impl crate::stubs::ServingConfigService for ServingConfigService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1966,7 +1966,7 @@ impl crate::stubs::ServingConfigService for ServingConfigService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2011,7 +2011,7 @@ impl crate::stubs::UserEventService for UserEventService {
                 reqwest::Method::POST,
                 format!("/v2/{}/userEvents:write", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2034,7 +2034,7 @@ impl crate::stubs::UserEventService for UserEventService {
                 reqwest::Method::GET,
                 format!("/v2/{}/userEvents:collect", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2064,7 +2064,7 @@ impl crate::stubs::UserEventService for UserEventService {
                 reqwest::Method::POST,
                 format!("/v2/{}/userEvents:purge", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2084,7 +2084,7 @@ impl crate::stubs::UserEventService for UserEventService {
                 reqwest::Method::POST,
                 format!("/v2/{}/userEvents:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2104,7 +2104,7 @@ impl crate::stubs::UserEventService for UserEventService {
                 reqwest::Method::POST,
                 format!("/v2/{}/userEvents:rejoin", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2121,7 +2121,7 @@ impl crate::stubs::UserEventService for UserEventService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2143,7 +2143,7 @@ impl crate::stubs::UserEventService for UserEventService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/run/v2/src/model.rs
+++ b/src/generated/cloud/run/v2/src/model.rs
@@ -701,320 +701,464 @@ pub mod condition {
 
     /// Represents the possible Condition states.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The default value. This value is used if the state is omitted.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Transient state: Reconciliation has not started yet.
+        pub const CONDITION_PENDING: State = State::new(1);
+
+        /// Transient state: reconciliation is still in progress.
+        pub const CONDITION_RECONCILING: State = State::new(2);
+
+        /// Terminal state: Reconciliation did not succeed.
+        pub const CONDITION_FAILED: State = State::new(3);
+
+        /// Terminal state: Reconciliation completed successfully.
+        pub const CONDITION_SUCCEEDED: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CONDITION_PENDING"),
+                2 => std::borrow::Cow::Borrowed("CONDITION_RECONCILING"),
+                3 => std::borrow::Cow::Borrowed("CONDITION_FAILED"),
+                4 => std::borrow::Cow::Borrowed("CONDITION_SUCCEEDED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CONDITION_PENDING" => std::option::Option::Some(Self::CONDITION_PENDING),
+                "CONDITION_RECONCILING" => std::option::Option::Some(Self::CONDITION_RECONCILING),
+                "CONDITION_FAILED" => std::option::Option::Some(Self::CONDITION_FAILED),
+                "CONDITION_SUCCEEDED" => std::option::Option::Some(Self::CONDITION_SUCCEEDED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Transient state: Reconciliation has not started yet.
-        pub const CONDITION_PENDING: State = State::new("CONDITION_PENDING");
-
-        /// Transient state: reconciliation is still in progress.
-        pub const CONDITION_RECONCILING: State = State::new("CONDITION_RECONCILING");
-
-        /// Terminal state: Reconciliation did not succeed.
-        pub const CONDITION_FAILED: State = State::new("CONDITION_FAILED");
-
-        /// Terminal state: Reconciliation completed successfully.
-        pub const CONDITION_SUCCEEDED: State = State::new("CONDITION_SUCCEEDED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Represents the severity of the condition failures.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(std::borrow::Cow<'static, str>);
+    pub struct Severity(i32);
 
     impl Severity {
+        /// Unspecified severity
+        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
+
+        /// Error severity.
+        pub const ERROR: Severity = Severity::new(1);
+
+        /// Warning severity.
+        pub const WARNING: Severity = Severity::new(2);
+
+        /// Info severity.
+        pub const INFO: Severity = Severity::new(3);
+
         /// Creates a new Severity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ERROR"),
+                2 => std::borrow::Cow::Borrowed("WARNING"),
+                3 => std::borrow::Cow::Borrowed("INFO"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "WARNING" => std::option::Option::Some(Self::WARNING),
+                "INFO" => std::option::Option::Some(Self::INFO),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Severity](Severity)
-    pub mod severity {
-        use super::Severity;
-
-        /// Unspecified severity
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new("SEVERITY_UNSPECIFIED");
-
-        /// Error severity.
-        pub const ERROR: Severity = Severity::new("ERROR");
-
-        /// Warning severity.
-        pub const WARNING: Severity = Severity::new("WARNING");
-
-        /// Info severity.
-        pub const INFO: Severity = Severity::new("INFO");
-    }
-
-    impl std::convert::From<std::string::String> for Severity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            severity::SEVERITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Reasons common to all types of conditions.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CommonReason(std::borrow::Cow<'static, str>);
+    pub struct CommonReason(i32);
 
     impl CommonReason {
+        /// Default value.
+        pub const COMMON_REASON_UNDEFINED: CommonReason = CommonReason::new(0);
+
+        /// Reason unknown. Further details will be in message.
+        pub const UNKNOWN: CommonReason = CommonReason::new(1);
+
+        /// Revision creation process failed.
+        pub const REVISION_FAILED: CommonReason = CommonReason::new(3);
+
+        /// Timed out waiting for completion.
+        pub const PROGRESS_DEADLINE_EXCEEDED: CommonReason = CommonReason::new(4);
+
+        /// The container image path is incorrect.
+        pub const CONTAINER_MISSING: CommonReason = CommonReason::new(6);
+
+        /// Insufficient permissions on the container image.
+        pub const CONTAINER_PERMISSION_DENIED: CommonReason = CommonReason::new(7);
+
+        /// Container image is not authorized by policy.
+        pub const CONTAINER_IMAGE_UNAUTHORIZED: CommonReason = CommonReason::new(8);
+
+        /// Container image policy authorization check failed.
+        pub const CONTAINER_IMAGE_AUTHORIZATION_CHECK_FAILED: CommonReason = CommonReason::new(9);
+
+        /// Insufficient permissions on encryption key.
+        pub const ENCRYPTION_KEY_PERMISSION_DENIED: CommonReason = CommonReason::new(10);
+
+        /// Permission check on encryption key failed.
+        pub const ENCRYPTION_KEY_CHECK_FAILED: CommonReason = CommonReason::new(11);
+
+        /// At least one Access check on secrets failed.
+        pub const SECRETS_ACCESS_CHECK_FAILED: CommonReason = CommonReason::new(12);
+
+        /// Waiting for operation to complete.
+        pub const WAITING_FOR_OPERATION: CommonReason = CommonReason::new(13);
+
+        /// System will retry immediately.
+        pub const IMMEDIATE_RETRY: CommonReason = CommonReason::new(14);
+
+        /// System will retry later; current attempt failed.
+        pub const POSTPONED_RETRY: CommonReason = CommonReason::new(15);
+
+        /// An internal error occurred. Further information may be in the message.
+        pub const INTERNAL: CommonReason = CommonReason::new(16);
+
         /// Creates a new CommonReason instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COMMON_REASON_UNDEFINED"),
+                1 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                3 => std::borrow::Cow::Borrowed("REVISION_FAILED"),
+                4 => std::borrow::Cow::Borrowed("PROGRESS_DEADLINE_EXCEEDED"),
+                6 => std::borrow::Cow::Borrowed("CONTAINER_MISSING"),
+                7 => std::borrow::Cow::Borrowed("CONTAINER_PERMISSION_DENIED"),
+                8 => std::borrow::Cow::Borrowed("CONTAINER_IMAGE_UNAUTHORIZED"),
+                9 => std::borrow::Cow::Borrowed("CONTAINER_IMAGE_AUTHORIZATION_CHECK_FAILED"),
+                10 => std::borrow::Cow::Borrowed("ENCRYPTION_KEY_PERMISSION_DENIED"),
+                11 => std::borrow::Cow::Borrowed("ENCRYPTION_KEY_CHECK_FAILED"),
+                12 => std::borrow::Cow::Borrowed("SECRETS_ACCESS_CHECK_FAILED"),
+                13 => std::borrow::Cow::Borrowed("WAITING_FOR_OPERATION"),
+                14 => std::borrow::Cow::Borrowed("IMMEDIATE_RETRY"),
+                15 => std::borrow::Cow::Borrowed("POSTPONED_RETRY"),
+                16 => std::borrow::Cow::Borrowed("INTERNAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COMMON_REASON_UNDEFINED" => {
+                    std::option::Option::Some(Self::COMMON_REASON_UNDEFINED)
+                }
+                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                "REVISION_FAILED" => std::option::Option::Some(Self::REVISION_FAILED),
+                "PROGRESS_DEADLINE_EXCEEDED" => {
+                    std::option::Option::Some(Self::PROGRESS_DEADLINE_EXCEEDED)
+                }
+                "CONTAINER_MISSING" => std::option::Option::Some(Self::CONTAINER_MISSING),
+                "CONTAINER_PERMISSION_DENIED" => {
+                    std::option::Option::Some(Self::CONTAINER_PERMISSION_DENIED)
+                }
+                "CONTAINER_IMAGE_UNAUTHORIZED" => {
+                    std::option::Option::Some(Self::CONTAINER_IMAGE_UNAUTHORIZED)
+                }
+                "CONTAINER_IMAGE_AUTHORIZATION_CHECK_FAILED" => {
+                    std::option::Option::Some(Self::CONTAINER_IMAGE_AUTHORIZATION_CHECK_FAILED)
+                }
+                "ENCRYPTION_KEY_PERMISSION_DENIED" => {
+                    std::option::Option::Some(Self::ENCRYPTION_KEY_PERMISSION_DENIED)
+                }
+                "ENCRYPTION_KEY_CHECK_FAILED" => {
+                    std::option::Option::Some(Self::ENCRYPTION_KEY_CHECK_FAILED)
+                }
+                "SECRETS_ACCESS_CHECK_FAILED" => {
+                    std::option::Option::Some(Self::SECRETS_ACCESS_CHECK_FAILED)
+                }
+                "WAITING_FOR_OPERATION" => std::option::Option::Some(Self::WAITING_FOR_OPERATION),
+                "IMMEDIATE_RETRY" => std::option::Option::Some(Self::IMMEDIATE_RETRY),
+                "POSTPONED_RETRY" => std::option::Option::Some(Self::POSTPONED_RETRY),
+                "INTERNAL" => std::option::Option::Some(Self::INTERNAL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [CommonReason](CommonReason)
-    pub mod common_reason {
-        use super::CommonReason;
-
-        /// Default value.
-        pub const COMMON_REASON_UNDEFINED: CommonReason =
-            CommonReason::new("COMMON_REASON_UNDEFINED");
-
-        /// Reason unknown. Further details will be in message.
-        pub const UNKNOWN: CommonReason = CommonReason::new("UNKNOWN");
-
-        /// Revision creation process failed.
-        pub const REVISION_FAILED: CommonReason = CommonReason::new("REVISION_FAILED");
-
-        /// Timed out waiting for completion.
-        pub const PROGRESS_DEADLINE_EXCEEDED: CommonReason =
-            CommonReason::new("PROGRESS_DEADLINE_EXCEEDED");
-
-        /// The container image path is incorrect.
-        pub const CONTAINER_MISSING: CommonReason = CommonReason::new("CONTAINER_MISSING");
-
-        /// Insufficient permissions on the container image.
-        pub const CONTAINER_PERMISSION_DENIED: CommonReason =
-            CommonReason::new("CONTAINER_PERMISSION_DENIED");
-
-        /// Container image is not authorized by policy.
-        pub const CONTAINER_IMAGE_UNAUTHORIZED: CommonReason =
-            CommonReason::new("CONTAINER_IMAGE_UNAUTHORIZED");
-
-        /// Container image policy authorization check failed.
-        pub const CONTAINER_IMAGE_AUTHORIZATION_CHECK_FAILED: CommonReason =
-            CommonReason::new("CONTAINER_IMAGE_AUTHORIZATION_CHECK_FAILED");
-
-        /// Insufficient permissions on encryption key.
-        pub const ENCRYPTION_KEY_PERMISSION_DENIED: CommonReason =
-            CommonReason::new("ENCRYPTION_KEY_PERMISSION_DENIED");
-
-        /// Permission check on encryption key failed.
-        pub const ENCRYPTION_KEY_CHECK_FAILED: CommonReason =
-            CommonReason::new("ENCRYPTION_KEY_CHECK_FAILED");
-
-        /// At least one Access check on secrets failed.
-        pub const SECRETS_ACCESS_CHECK_FAILED: CommonReason =
-            CommonReason::new("SECRETS_ACCESS_CHECK_FAILED");
-
-        /// Waiting for operation to complete.
-        pub const WAITING_FOR_OPERATION: CommonReason = CommonReason::new("WAITING_FOR_OPERATION");
-
-        /// System will retry immediately.
-        pub const IMMEDIATE_RETRY: CommonReason = CommonReason::new("IMMEDIATE_RETRY");
-
-        /// System will retry later; current attempt failed.
-        pub const POSTPONED_RETRY: CommonReason = CommonReason::new("POSTPONED_RETRY");
-
-        /// An internal error occurred. Further information may be in the message.
-        pub const INTERNAL: CommonReason = CommonReason::new("INTERNAL");
-    }
-
-    impl std::convert::From<std::string::String> for CommonReason {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CommonReason {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CommonReason {
         fn default() -> Self {
-            common_reason::COMMON_REASON_UNDEFINED
+            Self::new(0)
         }
     }
 
     /// Reasons specific to Revision resource.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RevisionReason(std::borrow::Cow<'static, str>);
+    pub struct RevisionReason(i32);
 
     impl RevisionReason {
-        /// Creates a new RevisionReason instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RevisionReason](RevisionReason)
-    pub mod revision_reason {
-        use super::RevisionReason;
-
         /// Default value.
-        pub const REVISION_REASON_UNDEFINED: RevisionReason =
-            RevisionReason::new("REVISION_REASON_UNDEFINED");
+        pub const REVISION_REASON_UNDEFINED: RevisionReason = RevisionReason::new(0);
 
         /// Revision in Pending state.
-        pub const PENDING: RevisionReason = RevisionReason::new("PENDING");
+        pub const PENDING: RevisionReason = RevisionReason::new(1);
 
         /// Revision is in Reserve state.
-        pub const RESERVE: RevisionReason = RevisionReason::new("RESERVE");
+        pub const RESERVE: RevisionReason = RevisionReason::new(2);
 
         /// Revision is Retired.
-        pub const RETIRED: RevisionReason = RevisionReason::new("RETIRED");
+        pub const RETIRED: RevisionReason = RevisionReason::new(3);
 
         /// Revision is being retired.
-        pub const RETIRING: RevisionReason = RevisionReason::new("RETIRING");
+        pub const RETIRING: RevisionReason = RevisionReason::new(4);
 
         /// Revision is being recreated.
-        pub const RECREATING: RevisionReason = RevisionReason::new("RECREATING");
+        pub const RECREATING: RevisionReason = RevisionReason::new(5);
 
         /// There was a health check error.
-        pub const HEALTH_CHECK_CONTAINER_ERROR: RevisionReason =
-            RevisionReason::new("HEALTH_CHECK_CONTAINER_ERROR");
+        pub const HEALTH_CHECK_CONTAINER_ERROR: RevisionReason = RevisionReason::new(6);
 
         /// Health check failed due to user error from customized path of the
         /// container. System will retry.
-        pub const CUSTOMIZED_PATH_RESPONSE_PENDING: RevisionReason =
-            RevisionReason::new("CUSTOMIZED_PATH_RESPONSE_PENDING");
+        pub const CUSTOMIZED_PATH_RESPONSE_PENDING: RevisionReason = RevisionReason::new(7);
 
         /// A revision with min_instance_count > 0 was created and is reserved, but
         /// it was not configured to serve traffic, so it's not live. This can also
         /// happen momentarily during traffic migration.
-        pub const MIN_INSTANCES_NOT_PROVISIONED: RevisionReason =
-            RevisionReason::new("MIN_INSTANCES_NOT_PROVISIONED");
+        pub const MIN_INSTANCES_NOT_PROVISIONED: RevisionReason = RevisionReason::new(8);
 
         /// The maximum allowed number of active revisions has been reached.
-        pub const ACTIVE_REVISION_LIMIT_REACHED: RevisionReason =
-            RevisionReason::new("ACTIVE_REVISION_LIMIT_REACHED");
+        pub const ACTIVE_REVISION_LIMIT_REACHED: RevisionReason = RevisionReason::new(9);
 
         /// There was no deployment defined.
         /// This value is no longer used, but Services created in older versions of
         /// the API might contain this value.
-        pub const NO_DEPLOYMENT: RevisionReason = RevisionReason::new("NO_DEPLOYMENT");
+        pub const NO_DEPLOYMENT: RevisionReason = RevisionReason::new(10);
 
         /// A revision's container has no port specified since the revision is of a
         /// manually scaled service with 0 instance count
-        pub const HEALTH_CHECK_SKIPPED: RevisionReason =
-            RevisionReason::new("HEALTH_CHECK_SKIPPED");
+        pub const HEALTH_CHECK_SKIPPED: RevisionReason = RevisionReason::new(11);
 
         /// A revision with min_instance_count > 0 was created and is waiting for
         /// enough instances to begin a traffic migration.
-        pub const MIN_INSTANCES_WARMING: RevisionReason =
-            RevisionReason::new("MIN_INSTANCES_WARMING");
+        pub const MIN_INSTANCES_WARMING: RevisionReason = RevisionReason::new(12);
+
+        /// Creates a new RevisionReason instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("REVISION_REASON_UNDEFINED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("RESERVE"),
+                3 => std::borrow::Cow::Borrowed("RETIRED"),
+                4 => std::borrow::Cow::Borrowed("RETIRING"),
+                5 => std::borrow::Cow::Borrowed("RECREATING"),
+                6 => std::borrow::Cow::Borrowed("HEALTH_CHECK_CONTAINER_ERROR"),
+                7 => std::borrow::Cow::Borrowed("CUSTOMIZED_PATH_RESPONSE_PENDING"),
+                8 => std::borrow::Cow::Borrowed("MIN_INSTANCES_NOT_PROVISIONED"),
+                9 => std::borrow::Cow::Borrowed("ACTIVE_REVISION_LIMIT_REACHED"),
+                10 => std::borrow::Cow::Borrowed("NO_DEPLOYMENT"),
+                11 => std::borrow::Cow::Borrowed("HEALTH_CHECK_SKIPPED"),
+                12 => std::borrow::Cow::Borrowed("MIN_INSTANCES_WARMING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "REVISION_REASON_UNDEFINED" => {
+                    std::option::Option::Some(Self::REVISION_REASON_UNDEFINED)
+                }
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "RESERVE" => std::option::Option::Some(Self::RESERVE),
+                "RETIRED" => std::option::Option::Some(Self::RETIRED),
+                "RETIRING" => std::option::Option::Some(Self::RETIRING),
+                "RECREATING" => std::option::Option::Some(Self::RECREATING),
+                "HEALTH_CHECK_CONTAINER_ERROR" => {
+                    std::option::Option::Some(Self::HEALTH_CHECK_CONTAINER_ERROR)
+                }
+                "CUSTOMIZED_PATH_RESPONSE_PENDING" => {
+                    std::option::Option::Some(Self::CUSTOMIZED_PATH_RESPONSE_PENDING)
+                }
+                "MIN_INSTANCES_NOT_PROVISIONED" => {
+                    std::option::Option::Some(Self::MIN_INSTANCES_NOT_PROVISIONED)
+                }
+                "ACTIVE_REVISION_LIMIT_REACHED" => {
+                    std::option::Option::Some(Self::ACTIVE_REVISION_LIMIT_REACHED)
+                }
+                "NO_DEPLOYMENT" => std::option::Option::Some(Self::NO_DEPLOYMENT),
+                "HEALTH_CHECK_SKIPPED" => std::option::Option::Some(Self::HEALTH_CHECK_SKIPPED),
+                "MIN_INSTANCES_WARMING" => std::option::Option::Some(Self::MIN_INSTANCES_WARMING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RevisionReason {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RevisionReason {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RevisionReason {
         fn default() -> Self {
-            revision_reason::REVISION_REASON_UNDEFINED
+            Self::new(0)
         }
     }
 
     /// Reasons specific to Execution resource.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ExecutionReason(std::borrow::Cow<'static, str>);
+    pub struct ExecutionReason(i32);
 
     impl ExecutionReason {
-        /// Creates a new ExecutionReason instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ExecutionReason](ExecutionReason)
-    pub mod execution_reason {
-        use super::ExecutionReason;
-
         /// Default value.
-        pub const EXECUTION_REASON_UNDEFINED: ExecutionReason =
-            ExecutionReason::new("EXECUTION_REASON_UNDEFINED");
+        pub const EXECUTION_REASON_UNDEFINED: ExecutionReason = ExecutionReason::new(0);
 
         /// Internal system error getting execution status. System will retry.
-        pub const JOB_STATUS_SERVICE_POLLING_ERROR: ExecutionReason =
-            ExecutionReason::new("JOB_STATUS_SERVICE_POLLING_ERROR");
+        pub const JOB_STATUS_SERVICE_POLLING_ERROR: ExecutionReason = ExecutionReason::new(1);
 
         /// A task reached its retry limit and the last attempt failed due to the
         /// user container exiting with a non-zero exit code.
-        pub const NON_ZERO_EXIT_CODE: ExecutionReason = ExecutionReason::new("NON_ZERO_EXIT_CODE");
+        pub const NON_ZERO_EXIT_CODE: ExecutionReason = ExecutionReason::new(2);
 
         /// The execution was cancelled by users.
-        pub const CANCELLED: ExecutionReason = ExecutionReason::new("CANCELLED");
+        pub const CANCELLED: ExecutionReason = ExecutionReason::new(3);
 
         /// The execution is in the process of being cancelled.
-        pub const CANCELLING: ExecutionReason = ExecutionReason::new("CANCELLING");
+        pub const CANCELLING: ExecutionReason = ExecutionReason::new(4);
 
         /// The execution was deleted.
-        pub const DELETED: ExecutionReason = ExecutionReason::new("DELETED");
+        pub const DELETED: ExecutionReason = ExecutionReason::new(5);
+
+        /// Creates a new ExecutionReason instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EXECUTION_REASON_UNDEFINED"),
+                1 => std::borrow::Cow::Borrowed("JOB_STATUS_SERVICE_POLLING_ERROR"),
+                2 => std::borrow::Cow::Borrowed("NON_ZERO_EXIT_CODE"),
+                3 => std::borrow::Cow::Borrowed("CANCELLED"),
+                4 => std::borrow::Cow::Borrowed("CANCELLING"),
+                5 => std::borrow::Cow::Borrowed("DELETED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EXECUTION_REASON_UNDEFINED" => {
+                    std::option::Option::Some(Self::EXECUTION_REASON_UNDEFINED)
+                }
+                "JOB_STATUS_SERVICE_POLLING_ERROR" => {
+                    std::option::Option::Some(Self::JOB_STATUS_SERVICE_POLLING_ERROR)
+                }
+                "NON_ZERO_EXIT_CODE" => std::option::Option::Some(Self::NON_ZERO_EXIT_CODE),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
+                "DELETED" => std::option::Option::Some(Self::DELETED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ExecutionReason {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ExecutionReason {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ExecutionReason {
         fn default() -> Self {
-            execution_reason::EXECUTION_REASON_UNDEFINED
+            Self::new(0)
         }
     }
 
@@ -2834,55 +2978,75 @@ pub mod execution_reference {
 
     /// Possible execution completion status.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CompletionStatus(std::borrow::Cow<'static, str>);
+    pub struct CompletionStatus(i32);
 
     impl CompletionStatus {
+        /// The default value. This value is used if the state is omitted.
+        pub const COMPLETION_STATUS_UNSPECIFIED: CompletionStatus = CompletionStatus::new(0);
+
+        /// Job execution has succeeded.
+        pub const EXECUTION_SUCCEEDED: CompletionStatus = CompletionStatus::new(1);
+
+        /// Job execution has failed.
+        pub const EXECUTION_FAILED: CompletionStatus = CompletionStatus::new(2);
+
+        /// Job execution is running normally.
+        pub const EXECUTION_RUNNING: CompletionStatus = CompletionStatus::new(3);
+
+        /// Waiting for backing resources to be provisioned.
+        pub const EXECUTION_PENDING: CompletionStatus = CompletionStatus::new(4);
+
+        /// Job execution has been cancelled by the user.
+        pub const EXECUTION_CANCELLED: CompletionStatus = CompletionStatus::new(5);
+
         /// Creates a new CompletionStatus instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COMPLETION_STATUS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("EXECUTION_SUCCEEDED"),
+                2 => std::borrow::Cow::Borrowed("EXECUTION_FAILED"),
+                3 => std::borrow::Cow::Borrowed("EXECUTION_RUNNING"),
+                4 => std::borrow::Cow::Borrowed("EXECUTION_PENDING"),
+                5 => std::borrow::Cow::Borrowed("EXECUTION_CANCELLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COMPLETION_STATUS_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::COMPLETION_STATUS_UNSPECIFIED)
+                }
+                "EXECUTION_SUCCEEDED" => std::option::Option::Some(Self::EXECUTION_SUCCEEDED),
+                "EXECUTION_FAILED" => std::option::Option::Some(Self::EXECUTION_FAILED),
+                "EXECUTION_RUNNING" => std::option::Option::Some(Self::EXECUTION_RUNNING),
+                "EXECUTION_PENDING" => std::option::Option::Some(Self::EXECUTION_PENDING),
+                "EXECUTION_CANCELLED" => std::option::Option::Some(Self::EXECUTION_CANCELLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [CompletionStatus](CompletionStatus)
-    pub mod completion_status {
-        use super::CompletionStatus;
-
-        /// The default value. This value is used if the state is omitted.
-        pub const COMPLETION_STATUS_UNSPECIFIED: CompletionStatus =
-            CompletionStatus::new("COMPLETION_STATUS_UNSPECIFIED");
-
-        /// Job execution has succeeded.
-        pub const EXECUTION_SUCCEEDED: CompletionStatus =
-            CompletionStatus::new("EXECUTION_SUCCEEDED");
-
-        /// Job execution has failed.
-        pub const EXECUTION_FAILED: CompletionStatus = CompletionStatus::new("EXECUTION_FAILED");
-
-        /// Job execution is running normally.
-        pub const EXECUTION_RUNNING: CompletionStatus = CompletionStatus::new("EXECUTION_RUNNING");
-
-        /// Waiting for backing resources to be provisioned.
-        pub const EXECUTION_PENDING: CompletionStatus = CompletionStatus::new("EXECUTION_PENDING");
-
-        /// Job execution has been cancelled by the user.
-        pub const EXECUTION_CANCELLED: CompletionStatus =
-            CompletionStatus::new("EXECUTION_CANCELLED");
-    }
-
-    impl std::convert::From<std::string::String> for CompletionStatus {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CompletionStatus {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CompletionStatus {
         fn default() -> Self {
-            completion_status::COMPLETION_STATUS_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3881,41 +4045,54 @@ pub mod empty_dir_volume_source {
 
     /// The different types of medium supported for EmptyDir.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Medium(std::borrow::Cow<'static, str>);
+    pub struct Medium(i32);
 
     impl Medium {
+        /// When not specified, falls back to the default implementation which
+        /// is currently in memory (this may change over time).
+        pub const MEDIUM_UNSPECIFIED: Medium = Medium::new(0);
+
+        /// Explicitly set the EmptyDir to be in memory. Uses tmpfs.
+        pub const MEMORY: Medium = Medium::new(1);
+
         /// Creates a new Medium instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MEDIUM_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MEMORY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MEDIUM_UNSPECIFIED" => std::option::Option::Some(Self::MEDIUM_UNSPECIFIED),
+                "MEMORY" => std::option::Option::Some(Self::MEMORY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Medium](Medium)
-    pub mod medium {
-        use super::Medium;
-
-        /// When not specified, falls back to the default implementation which
-        /// is currently in memory (this may change over time).
-        pub const MEDIUM_UNSPECIFIED: Medium = Medium::new("MEDIUM_UNSPECIFIED");
-
-        /// Explicitly set the EmptyDir to be in memory. Uses tmpfs.
-        pub const MEMORY: Medium = Medium::new("MEMORY");
-    }
-
-    impl std::convert::From<std::string::String> for Medium {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Medium {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Medium {
         fn default() -> Self {
-            medium::MEDIUM_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7286,43 +7463,58 @@ pub mod vpc_access {
 
     /// Egress options for VPC access.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VpcEgress(std::borrow::Cow<'static, str>);
+    pub struct VpcEgress(i32);
 
     impl VpcEgress {
+        /// Unspecified
+        pub const VPC_EGRESS_UNSPECIFIED: VpcEgress = VpcEgress::new(0);
+
+        /// All outbound traffic is routed through the VPC connector.
+        pub const ALL_TRAFFIC: VpcEgress = VpcEgress::new(1);
+
+        /// Only private IP ranges are routed through the VPC connector.
+        pub const PRIVATE_RANGES_ONLY: VpcEgress = VpcEgress::new(2);
+
         /// Creates a new VpcEgress instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VPC_EGRESS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALL_TRAFFIC"),
+                2 => std::borrow::Cow::Borrowed("PRIVATE_RANGES_ONLY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VPC_EGRESS_UNSPECIFIED" => std::option::Option::Some(Self::VPC_EGRESS_UNSPECIFIED),
+                "ALL_TRAFFIC" => std::option::Option::Some(Self::ALL_TRAFFIC),
+                "PRIVATE_RANGES_ONLY" => std::option::Option::Some(Self::PRIVATE_RANGES_ONLY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [VpcEgress](VpcEgress)
-    pub mod vpc_egress {
-        use super::VpcEgress;
-
-        /// Unspecified
-        pub const VPC_EGRESS_UNSPECIFIED: VpcEgress = VpcEgress::new("VPC_EGRESS_UNSPECIFIED");
-
-        /// All outbound traffic is routed through the VPC connector.
-        pub const ALL_TRAFFIC: VpcEgress = VpcEgress::new("ALL_TRAFFIC");
-
-        /// Only private IP ranges are routed through the VPC connector.
-        pub const PRIVATE_RANGES_ONLY: VpcEgress = VpcEgress::new("PRIVATE_RANGES_ONLY");
-    }
-
-    impl std::convert::From<std::string::String> for VpcEgress {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for VpcEgress {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for VpcEgress {
         fn default() -> Self {
-            vpc_egress::VPC_EGRESS_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7583,44 +7775,60 @@ pub mod service_scaling {
     /// The scaling mode for the service. If not provided, it defaults to
     /// AUTOMATIC.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ScalingMode(std::borrow::Cow<'static, str>);
+    pub struct ScalingMode(i32);
 
     impl ScalingMode {
+        /// Unspecified.
+        pub const SCALING_MODE_UNSPECIFIED: ScalingMode = ScalingMode::new(0);
+
+        /// Scale based on traffic between min and max instances.
+        pub const AUTOMATIC: ScalingMode = ScalingMode::new(1);
+
+        /// Scale to exactly min instances and ignore max instances.
+        pub const MANUAL: ScalingMode = ScalingMode::new(2);
+
         /// Creates a new ScalingMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SCALING_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AUTOMATIC"),
+                2 => std::borrow::Cow::Borrowed("MANUAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SCALING_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SCALING_MODE_UNSPECIFIED)
+                }
+                "AUTOMATIC" => std::option::Option::Some(Self::AUTOMATIC),
+                "MANUAL" => std::option::Option::Some(Self::MANUAL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ScalingMode](ScalingMode)
-    pub mod scaling_mode {
-        use super::ScalingMode;
-
-        /// Unspecified.
-        pub const SCALING_MODE_UNSPECIFIED: ScalingMode =
-            ScalingMode::new("SCALING_MODE_UNSPECIFIED");
-
-        /// Scale based on traffic between min and max instances.
-        pub const AUTOMATIC: ScalingMode = ScalingMode::new("AUTOMATIC");
-
-        /// Scale to exactly min instances and ignore max instances.
-        pub const MANUAL: ScalingMode = ScalingMode::new("MANUAL");
-    }
-
-    impl std::convert::From<std::string::String> for ScalingMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ScalingMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ScalingMode {
         fn default() -> Self {
-            scaling_mode::SCALING_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7783,186 +7991,263 @@ impl wkt::message::Message for BuildConfig {
 
 /// The type of instance allocation.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TrafficTargetAllocationType(std::borrow::Cow<'static, str>);
+pub struct TrafficTargetAllocationType(i32);
 
 impl TrafficTargetAllocationType {
-    /// Creates a new TrafficTargetAllocationType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [TrafficTargetAllocationType](TrafficTargetAllocationType)
-pub mod traffic_target_allocation_type {
-    use super::TrafficTargetAllocationType;
-
     /// Unspecified instance allocation type.
     pub const TRAFFIC_TARGET_ALLOCATION_TYPE_UNSPECIFIED: TrafficTargetAllocationType =
-        TrafficTargetAllocationType::new("TRAFFIC_TARGET_ALLOCATION_TYPE_UNSPECIFIED");
+        TrafficTargetAllocationType::new(0);
 
     /// Allocates instances to the Service's latest ready Revision.
     pub const TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST: TrafficTargetAllocationType =
-        TrafficTargetAllocationType::new("TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST");
+        TrafficTargetAllocationType::new(1);
 
     /// Allocates instances to a Revision by name.
     pub const TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION: TrafficTargetAllocationType =
-        TrafficTargetAllocationType::new("TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION");
+        TrafficTargetAllocationType::new(2);
+
+    /// Creates a new TrafficTargetAllocationType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("TRAFFIC_TARGET_ALLOCATION_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"),
+            2 => std::borrow::Cow::Borrowed("TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "TRAFFIC_TARGET_ALLOCATION_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::TRAFFIC_TARGET_ALLOCATION_TYPE_UNSPECIFIED)
+            }
+            "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST" => {
+                std::option::Option::Some(Self::TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST)
+            }
+            "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION" => {
+                std::option::Option::Some(Self::TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for TrafficTargetAllocationType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for TrafficTargetAllocationType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for TrafficTargetAllocationType {
     fn default() -> Self {
-        traffic_target_allocation_type::TRAFFIC_TARGET_ALLOCATION_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Allowed ingress traffic for the Container.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct IngressTraffic(std::borrow::Cow<'static, str>);
+pub struct IngressTraffic(i32);
 
 impl IngressTraffic {
+    /// Unspecified
+    pub const INGRESS_TRAFFIC_UNSPECIFIED: IngressTraffic = IngressTraffic::new(0);
+
+    /// All inbound traffic is allowed.
+    pub const INGRESS_TRAFFIC_ALL: IngressTraffic = IngressTraffic::new(1);
+
+    /// Only internal traffic is allowed.
+    pub const INGRESS_TRAFFIC_INTERNAL_ONLY: IngressTraffic = IngressTraffic::new(2);
+
+    /// Both internal and Google Cloud Load Balancer traffic is allowed.
+    pub const INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER: IngressTraffic = IngressTraffic::new(3);
+
+    /// No ingress traffic is allowed.
+    pub const INGRESS_TRAFFIC_NONE: IngressTraffic = IngressTraffic::new(4);
+
     /// Creates a new IngressTraffic instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("INGRESS_TRAFFIC_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("INGRESS_TRAFFIC_ALL"),
+            2 => std::borrow::Cow::Borrowed("INGRESS_TRAFFIC_INTERNAL_ONLY"),
+            3 => std::borrow::Cow::Borrowed("INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"),
+            4 => std::borrow::Cow::Borrowed("INGRESS_TRAFFIC_NONE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "INGRESS_TRAFFIC_UNSPECIFIED" => {
+                std::option::Option::Some(Self::INGRESS_TRAFFIC_UNSPECIFIED)
+            }
+            "INGRESS_TRAFFIC_ALL" => std::option::Option::Some(Self::INGRESS_TRAFFIC_ALL),
+            "INGRESS_TRAFFIC_INTERNAL_ONLY" => {
+                std::option::Option::Some(Self::INGRESS_TRAFFIC_INTERNAL_ONLY)
+            }
+            "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER" => {
+                std::option::Option::Some(Self::INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER)
+            }
+            "INGRESS_TRAFFIC_NONE" => std::option::Option::Some(Self::INGRESS_TRAFFIC_NONE),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [IngressTraffic](IngressTraffic)
-pub mod ingress_traffic {
-    use super::IngressTraffic;
-
-    /// Unspecified
-    pub const INGRESS_TRAFFIC_UNSPECIFIED: IngressTraffic =
-        IngressTraffic::new("INGRESS_TRAFFIC_UNSPECIFIED");
-
-    /// All inbound traffic is allowed.
-    pub const INGRESS_TRAFFIC_ALL: IngressTraffic = IngressTraffic::new("INGRESS_TRAFFIC_ALL");
-
-    /// Only internal traffic is allowed.
-    pub const INGRESS_TRAFFIC_INTERNAL_ONLY: IngressTraffic =
-        IngressTraffic::new("INGRESS_TRAFFIC_INTERNAL_ONLY");
-
-    /// Both internal and Google Cloud Load Balancer traffic is allowed.
-    pub const INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER: IngressTraffic =
-        IngressTraffic::new("INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER");
-
-    /// No ingress traffic is allowed.
-    pub const INGRESS_TRAFFIC_NONE: IngressTraffic = IngressTraffic::new("INGRESS_TRAFFIC_NONE");
-}
-
-impl std::convert::From<std::string::String> for IngressTraffic {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for IngressTraffic {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for IngressTraffic {
     fn default() -> Self {
-        ingress_traffic::INGRESS_TRAFFIC_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Alternatives for execution environments.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ExecutionEnvironment(std::borrow::Cow<'static, str>);
+pub struct ExecutionEnvironment(i32);
 
 impl ExecutionEnvironment {
+    /// Unspecified
+    pub const EXECUTION_ENVIRONMENT_UNSPECIFIED: ExecutionEnvironment =
+        ExecutionEnvironment::new(0);
+
+    /// Uses the First Generation environment.
+    pub const EXECUTION_ENVIRONMENT_GEN1: ExecutionEnvironment = ExecutionEnvironment::new(1);
+
+    /// Uses Second Generation environment.
+    pub const EXECUTION_ENVIRONMENT_GEN2: ExecutionEnvironment = ExecutionEnvironment::new(2);
+
     /// Creates a new ExecutionEnvironment instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("EXECUTION_ENVIRONMENT_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("EXECUTION_ENVIRONMENT_GEN1"),
+            2 => std::borrow::Cow::Borrowed("EXECUTION_ENVIRONMENT_GEN2"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "EXECUTION_ENVIRONMENT_UNSPECIFIED" => {
+                std::option::Option::Some(Self::EXECUTION_ENVIRONMENT_UNSPECIFIED)
+            }
+            "EXECUTION_ENVIRONMENT_GEN1" => {
+                std::option::Option::Some(Self::EXECUTION_ENVIRONMENT_GEN1)
+            }
+            "EXECUTION_ENVIRONMENT_GEN2" => {
+                std::option::Option::Some(Self::EXECUTION_ENVIRONMENT_GEN2)
+            }
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [ExecutionEnvironment](ExecutionEnvironment)
-pub mod execution_environment {
-    use super::ExecutionEnvironment;
-
-    /// Unspecified
-    pub const EXECUTION_ENVIRONMENT_UNSPECIFIED: ExecutionEnvironment =
-        ExecutionEnvironment::new("EXECUTION_ENVIRONMENT_UNSPECIFIED");
-
-    /// Uses the First Generation environment.
-    pub const EXECUTION_ENVIRONMENT_GEN1: ExecutionEnvironment =
-        ExecutionEnvironment::new("EXECUTION_ENVIRONMENT_GEN1");
-
-    /// Uses Second Generation environment.
-    pub const EXECUTION_ENVIRONMENT_GEN2: ExecutionEnvironment =
-        ExecutionEnvironment::new("EXECUTION_ENVIRONMENT_GEN2");
-}
-
-impl std::convert::From<std::string::String> for ExecutionEnvironment {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ExecutionEnvironment {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ExecutionEnvironment {
     fn default() -> Self {
-        execution_environment::EXECUTION_ENVIRONMENT_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Specifies behavior if an encryption key used by a resource is revoked.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EncryptionKeyRevocationAction(std::borrow::Cow<'static, str>);
+pub struct EncryptionKeyRevocationAction(i32);
 
 impl EncryptionKeyRevocationAction {
+    /// Unspecified
+    pub const ENCRYPTION_KEY_REVOCATION_ACTION_UNSPECIFIED: EncryptionKeyRevocationAction =
+        EncryptionKeyRevocationAction::new(0);
+
+    /// Prevents the creation of new instances.
+    pub const PREVENT_NEW: EncryptionKeyRevocationAction = EncryptionKeyRevocationAction::new(1);
+
+    /// Shuts down existing instances, and prevents creation of new ones.
+    pub const SHUTDOWN: EncryptionKeyRevocationAction = EncryptionKeyRevocationAction::new(2);
+
     /// Creates a new EncryptionKeyRevocationAction instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ENCRYPTION_KEY_REVOCATION_ACTION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PREVENT_NEW"),
+            2 => std::borrow::Cow::Borrowed("SHUTDOWN"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ENCRYPTION_KEY_REVOCATION_ACTION_UNSPECIFIED" => {
+                std::option::Option::Some(Self::ENCRYPTION_KEY_REVOCATION_ACTION_UNSPECIFIED)
+            }
+            "PREVENT_NEW" => std::option::Option::Some(Self::PREVENT_NEW),
+            "SHUTDOWN" => std::option::Option::Some(Self::SHUTDOWN),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [EncryptionKeyRevocationAction](EncryptionKeyRevocationAction)
-pub mod encryption_key_revocation_action {
-    use super::EncryptionKeyRevocationAction;
-
-    /// Unspecified
-    pub const ENCRYPTION_KEY_REVOCATION_ACTION_UNSPECIFIED: EncryptionKeyRevocationAction =
-        EncryptionKeyRevocationAction::new("ENCRYPTION_KEY_REVOCATION_ACTION_UNSPECIFIED");
-
-    /// Prevents the creation of new instances.
-    pub const PREVENT_NEW: EncryptionKeyRevocationAction =
-        EncryptionKeyRevocationAction::new("PREVENT_NEW");
-
-    /// Shuts down existing instances, and prevents creation of new ones.
-    pub const SHUTDOWN: EncryptionKeyRevocationAction =
-        EncryptionKeyRevocationAction::new("SHUTDOWN");
-}
-
-impl std::convert::From<std::string::String> for EncryptionKeyRevocationAction {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for EncryptionKeyRevocationAction {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for EncryptionKeyRevocationAction {
     fn default() -> Self {
-        encryption_key_revocation_action::ENCRYPTION_KEY_REVOCATION_ACTION_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/run/v2/src/transport.rs
+++ b/src/generated/cloud/run/v2/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::Builds for Builds {
                 reqwest::Method::POST,
                 format!("/v2/{}/builds:submit", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -69,7 +69,7 @@ impl crate::stubs::Builds for Builds {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -91,7 +91,7 @@ impl crate::stubs::Builds for Builds {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -110,7 +110,7 @@ impl crate::stubs::Builds for Builds {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -129,7 +129,7 @@ impl crate::stubs::Builds for Builds {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -169,7 +169,7 @@ impl crate::stubs::Executions for Executions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -191,7 +191,7 @@ impl crate::stubs::Executions for Executions {
                 reqwest::Method::GET,
                 format!("/v2/{}/executions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -213,7 +213,7 @@ impl crate::stubs::Executions for Executions {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -234,7 +234,7 @@ impl crate::stubs::Executions for Executions {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -251,7 +251,7 @@ impl crate::stubs::Executions for Executions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -273,7 +273,7 @@ impl crate::stubs::Executions for Executions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -292,7 +292,7 @@ impl crate::stubs::Executions for Executions {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -311,7 +311,7 @@ impl crate::stubs::Executions for Executions {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -363,7 +363,7 @@ impl crate::stubs::Jobs for Jobs {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}/jobs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -382,7 +382,7 @@ impl crate::stubs::Jobs for Jobs {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -401,7 +401,7 @@ impl crate::stubs::Jobs for Jobs {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/jobs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -432,7 +432,7 @@ impl crate::stubs::Jobs for Jobs {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -451,7 +451,7 @@ impl crate::stubs::Jobs for Jobs {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -472,7 +472,7 @@ impl crate::stubs::Jobs for Jobs {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:run", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -492,7 +492,7 @@ impl crate::stubs::Jobs for Jobs {
                 reqwest::Method::GET,
                 format!("/v2/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -524,7 +524,7 @@ impl crate::stubs::Jobs for Jobs {
                 reqwest::Method::POST,
                 format!("/v2/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -544,7 +544,7 @@ impl crate::stubs::Jobs for Jobs {
                 reqwest::Method::POST,
                 format!("/v2/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -561,7 +561,7 @@ impl crate::stubs::Jobs for Jobs {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -583,7 +583,7 @@ impl crate::stubs::Jobs for Jobs {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -602,7 +602,7 @@ impl crate::stubs::Jobs for Jobs {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -621,7 +621,7 @@ impl crate::stubs::Jobs for Jobs {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -675,7 +675,7 @@ impl crate::stubs::Revisions for Revisions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -697,7 +697,7 @@ impl crate::stubs::Revisions for Revisions {
                 reqwest::Method::GET,
                 format!("/v2/{}/revisions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -719,7 +719,7 @@ impl crate::stubs::Revisions for Revisions {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -740,7 +740,7 @@ impl crate::stubs::Revisions for Revisions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -762,7 +762,7 @@ impl crate::stubs::Revisions for Revisions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -781,7 +781,7 @@ impl crate::stubs::Revisions for Revisions {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -800,7 +800,7 @@ impl crate::stubs::Revisions for Revisions {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -857,7 +857,7 @@ impl crate::stubs::Services for Services {
                 reqwest::Method::POST,
                 format!("/v2/{}/services", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -878,7 +878,7 @@ impl crate::stubs::Services for Services {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -897,7 +897,7 @@ impl crate::stubs::Services for Services {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/services", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -928,7 +928,7 @@ impl crate::stubs::Services for Services {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -959,7 +959,7 @@ impl crate::stubs::Services for Services {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -983,7 +983,7 @@ impl crate::stubs::Services for Services {
                 reqwest::Method::GET,
                 format!("/v2/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1015,7 +1015,7 @@ impl crate::stubs::Services for Services {
                 reqwest::Method::POST,
                 format!("/v2/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1035,7 +1035,7 @@ impl crate::stubs::Services for Services {
                 reqwest::Method::POST,
                 format!("/v2/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1052,7 +1052,7 @@ impl crate::stubs::Services for Services {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1074,7 +1074,7 @@ impl crate::stubs::Services for Services {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1093,7 +1093,7 @@ impl crate::stubs::Services for Services {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1112,7 +1112,7 @@ impl crate::stubs::Services for Services {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1164,7 +1164,7 @@ impl crate::stubs::Tasks for Tasks {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1183,7 +1183,7 @@ impl crate::stubs::Tasks for Tasks {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/tasks", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1205,7 +1205,7 @@ impl crate::stubs::Tasks for Tasks {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1227,7 +1227,7 @@ impl crate::stubs::Tasks for Tasks {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1246,7 +1246,7 @@ impl crate::stubs::Tasks for Tasks {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1265,7 +1265,7 @@ impl crate::stubs::Tasks for Tasks {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/scheduler/v1/src/model.rs
+++ b/src/generated/cloud/scheduler/v1/src/model.rs
@@ -787,40 +787,25 @@ pub mod job {
 
     /// State of the job.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The job is executing normally.
-        pub const ENABLED: State = State::new("ENABLED");
+        pub const ENABLED: State = State::new(1);
 
         /// The job is paused by the user. It will not execute. A user can
         /// intentionally pause the job using
         /// [PauseJobRequest][google.cloud.scheduler.v1.PauseJobRequest].
         ///
         /// [google.cloud.scheduler.v1.PauseJobRequest]: crate::model::PauseJobRequest
-        pub const PAUSED: State = State::new("PAUSED");
+        pub const PAUSED: State = State::new(2);
 
         /// The job is disabled by the system due to error. The user
         /// cannot directly set a job to be disabled.
-        pub const DISABLED: State = State::new("DISABLED");
+        pub const DISABLED: State = State::new(3);
 
         /// The job state resulting from a failed
         /// [CloudScheduler.UpdateJob][google.cloud.scheduler.v1.CloudScheduler.UpdateJob]
@@ -829,18 +814,52 @@ pub mod job {
         /// until a successful response is received.
         ///
         /// [google.cloud.scheduler.v1.CloudScheduler.UpdateJob]: crate::client::CloudScheduler::update_job
-        pub const UPDATE_FAILED: State = State::new("UPDATE_FAILED");
+        pub const UPDATE_FAILED: State = State::new(4);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENABLED"),
+                2 => std::borrow::Cow::Borrowed("PAUSED"),
+                3 => std::borrow::Cow::Borrowed("DISABLED"),
+                4 => std::borrow::Cow::Borrowed("UPDATE_FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                "PAUSED" => std::option::Option::Some(Self::PAUSED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "UPDATE_FAILED" => std::option::Option::Some(Self::UPDATE_FAILED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1708,57 +1727,82 @@ impl wkt::message::Message for OidcToken {
 
 /// The HTTP method used to execute the job.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct HttpMethod(std::borrow::Cow<'static, str>);
+pub struct HttpMethod(i32);
 
 impl HttpMethod {
+    /// HTTP method unspecified. Defaults to POST.
+    pub const HTTP_METHOD_UNSPECIFIED: HttpMethod = HttpMethod::new(0);
+
+    /// HTTP POST
+    pub const POST: HttpMethod = HttpMethod::new(1);
+
+    /// HTTP GET
+    pub const GET: HttpMethod = HttpMethod::new(2);
+
+    /// HTTP HEAD
+    pub const HEAD: HttpMethod = HttpMethod::new(3);
+
+    /// HTTP PUT
+    pub const PUT: HttpMethod = HttpMethod::new(4);
+
+    /// HTTP DELETE
+    pub const DELETE: HttpMethod = HttpMethod::new(5);
+
+    /// HTTP PATCH
+    pub const PATCH: HttpMethod = HttpMethod::new(6);
+
+    /// HTTP OPTIONS
+    pub const OPTIONS: HttpMethod = HttpMethod::new(7);
+
     /// Creates a new HttpMethod instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("HTTP_METHOD_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("POST"),
+            2 => std::borrow::Cow::Borrowed("GET"),
+            3 => std::borrow::Cow::Borrowed("HEAD"),
+            4 => std::borrow::Cow::Borrowed("PUT"),
+            5 => std::borrow::Cow::Borrowed("DELETE"),
+            6 => std::borrow::Cow::Borrowed("PATCH"),
+            7 => std::borrow::Cow::Borrowed("OPTIONS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "HTTP_METHOD_UNSPECIFIED" => std::option::Option::Some(Self::HTTP_METHOD_UNSPECIFIED),
+            "POST" => std::option::Option::Some(Self::POST),
+            "GET" => std::option::Option::Some(Self::GET),
+            "HEAD" => std::option::Option::Some(Self::HEAD),
+            "PUT" => std::option::Option::Some(Self::PUT),
+            "DELETE" => std::option::Option::Some(Self::DELETE),
+            "PATCH" => std::option::Option::Some(Self::PATCH),
+            "OPTIONS" => std::option::Option::Some(Self::OPTIONS),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [HttpMethod](HttpMethod)
-pub mod http_method {
-    use super::HttpMethod;
-
-    /// HTTP method unspecified. Defaults to POST.
-    pub const HTTP_METHOD_UNSPECIFIED: HttpMethod = HttpMethod::new("HTTP_METHOD_UNSPECIFIED");
-
-    /// HTTP POST
-    pub const POST: HttpMethod = HttpMethod::new("POST");
-
-    /// HTTP GET
-    pub const GET: HttpMethod = HttpMethod::new("GET");
-
-    /// HTTP HEAD
-    pub const HEAD: HttpMethod = HttpMethod::new("HEAD");
-
-    /// HTTP PUT
-    pub const PUT: HttpMethod = HttpMethod::new("PUT");
-
-    /// HTTP DELETE
-    pub const DELETE: HttpMethod = HttpMethod::new("DELETE");
-
-    /// HTTP PATCH
-    pub const PATCH: HttpMethod = HttpMethod::new("PATCH");
-
-    /// HTTP OPTIONS
-    pub const OPTIONS: HttpMethod = HttpMethod::new("OPTIONS");
-}
-
-impl std::convert::From<std::string::String> for HttpMethod {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for HttpMethod {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for HttpMethod {
     fn default() -> Self {
-        http_method::HTTP_METHOD_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/scheduler/v1/src/transport.rs
+++ b/src/generated/cloud/scheduler/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::CloudScheduler for CloudScheduler {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/jobs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -70,7 +70,7 @@ impl crate::stubs::CloudScheduler for CloudScheduler {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -89,7 +89,7 @@ impl crate::stubs::CloudScheduler for CloudScheduler {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/jobs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -115,7 +115,7 @@ impl crate::stubs::CloudScheduler for CloudScheduler {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -142,7 +142,7 @@ impl crate::stubs::CloudScheduler for CloudScheduler {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -161,7 +161,7 @@ impl crate::stubs::CloudScheduler for CloudScheduler {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:pause", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -178,7 +178,7 @@ impl crate::stubs::CloudScheduler for CloudScheduler {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:resume", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -195,7 +195,7 @@ impl crate::stubs::CloudScheduler for CloudScheduler {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:run", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -212,7 +212,7 @@ impl crate::stubs::CloudScheduler for CloudScheduler {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -234,7 +234,7 @@ impl crate::stubs::CloudScheduler for CloudScheduler {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/secretmanager/v1/src/model.rs
+++ b/src/generated/cloud/secretmanager/v1/src/model.rs
@@ -584,32 +584,17 @@ pub mod secret_version {
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Not specified. This value is unused and invalid.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] may be
         /// accessed.
         ///
         /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-        pub const ENABLED: State = State::new("ENABLED");
+        pub const ENABLED: State = State::new(1);
 
         /// The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] may not
         /// be accessed, but the secret data is still available and can be placed
@@ -619,25 +604,57 @@ pub mod secret_version {
         ///
         /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
         /// [google.cloud.secretmanager.v1.SecretVersion.State.ENABLED]: crate::model::secret_version::state::ENABLED
-        pub const DISABLED: State = State::new("DISABLED");
+        pub const DISABLED: State = State::new(2);
 
         /// The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] is
         /// destroyed and the secret data is no longer stored. A version may not
         /// leave this state once entered.
         ///
         /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-        pub const DESTROYED: State = State::new("DESTROYED");
+        pub const DESTROYED: State = State::new(3);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENABLED"),
+                2 => std::borrow::Cow::Borrowed("DISABLED"),
+                3 => std::borrow::Cow::Borrowed("DESTROYED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "DESTROYED" => std::option::Option::Some(Self::DESTROYED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/secretmanager/v1/src/transport.rs
+++ b/src/generated/cloud/secretmanager/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/secrets", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -71,7 +71,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/secrets", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -92,7 +92,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                 reqwest::Method::POST,
                 format!("/v1/{}:addVersion", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -109,7 +109,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -137,7 +137,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -164,7 +164,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -184,7 +184,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/versions", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -206,7 +206,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -225,7 +225,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}:access", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -244,7 +244,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:disable", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -261,7 +261,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:enable", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -278,7 +278,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:destroy", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -298,7 +298,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -318,7 +318,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -350,7 +350,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -367,7 +367,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -389,7 +389,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/securesourcemanager/v1/src/model.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/model.rs
@@ -329,95 +329,133 @@ pub mod instance {
 
     /// Secure Source Manager instance state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Not set. This should only be the case for incoming requests.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Instance is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// Instance is ready.
+        pub const ACTIVE: State = State::new(2);
+
+        /// Instance is being deleted.
+        pub const DELETING: State = State::new(3);
+
+        /// Instance is paused.
+        pub const PAUSED: State = State::new(4);
+
+        /// Instance is unknown, we are not sure if it's functioning.
+        pub const UNKNOWN: State = State::new(6);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("PAUSED"),
+                6 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "PAUSED" => std::option::Option::Some(Self::PAUSED),
+                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Not set. This should only be the case for incoming requests.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Instance is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// Instance is ready.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// Instance is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// Instance is paused.
-        pub const PAUSED: State = State::new("PAUSED");
-
-        /// Instance is unknown, we are not sure if it's functioning.
-        pub const UNKNOWN: State = State::new("UNKNOWN");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Provides information about the current instance state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StateNote(std::borrow::Cow<'static, str>);
+    pub struct StateNote(i32);
 
     impl StateNote {
-        /// Creates a new StateNote instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [StateNote](StateNote)
-    pub mod state_note {
-        use super::StateNote;
-
         /// STATE_NOTE_UNSPECIFIED as the first value of State.
-        pub const STATE_NOTE_UNSPECIFIED: StateNote = StateNote::new("STATE_NOTE_UNSPECIFIED");
+        pub const STATE_NOTE_UNSPECIFIED: StateNote = StateNote::new(0);
 
         /// CMEK access is unavailable.
-        pub const PAUSED_CMEK_UNAVAILABLE: StateNote = StateNote::new("PAUSED_CMEK_UNAVAILABLE");
+        pub const PAUSED_CMEK_UNAVAILABLE: StateNote = StateNote::new(1);
 
         /// INSTANCE_RESUMING indicates that the instance was previously paused
         /// and is under the process of being brought back.
-        pub const INSTANCE_RESUMING: StateNote = StateNote::new("INSTANCE_RESUMING");
+        pub const INSTANCE_RESUMING: StateNote = StateNote::new(2);
+
+        /// Creates a new StateNote instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_NOTE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PAUSED_CMEK_UNAVAILABLE"),
+                2 => std::borrow::Cow::Borrowed("INSTANCE_RESUMING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_NOTE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_NOTE_UNSPECIFIED),
+                "PAUSED_CMEK_UNAVAILABLE" => {
+                    std::option::Option::Some(Self::PAUSED_CMEK_UNAVAILABLE)
+                }
+                "INSTANCE_RESUMING" => std::option::Option::Some(Self::INSTANCE_RESUMING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for StateNote {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for StateNote {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for StateNote {
         fn default() -> Self {
-            state_note::STATE_NOTE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/securesourcemanager/v1/src/transport.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -118,7 +118,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -141,7 +141,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/repositories", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -164,7 +164,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -186,7 +186,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/repositories", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -206,7 +206,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -229,7 +229,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -261,7 +261,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -281,7 +281,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -301,7 +301,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/branchRules", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -324,7 +324,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/branchRules", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -345,7 +345,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -373,7 +373,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -403,7 +403,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -423,7 +423,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -445,7 +445,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -467,7 +467,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -487,7 +487,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -519,7 +519,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -536,7 +536,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -558,7 +558,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -577,7 +577,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -596,7 +596,7 @@ impl crate::stubs::SecureSourceManager for SecureSourceManager {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/security/privateca/v1/src/model.rs
+++ b/src/generated/cloud/security/privateca/v1/src/model.rs
@@ -571,47 +571,62 @@ pub mod certificate_authority {
     ///
     /// [google.cloud.security.privateca.v1.CertificateAuthority]: crate::model::CertificateAuthority
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// Not specified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// Self-signed CA.
-        pub const SELF_SIGNED: Type = Type::new("SELF_SIGNED");
+        pub const SELF_SIGNED: Type = Type::new(1);
 
         /// Subordinate CA. Could be issued by a Private CA
         /// [CertificateAuthority][google.cloud.security.privateca.v1.CertificateAuthority]
         /// or an unmanaged CA.
         ///
         /// [google.cloud.security.privateca.v1.CertificateAuthority]: crate::model::CertificateAuthority
-        pub const SUBORDINATE: Type = Type::new("SUBORDINATE");
+        pub const SUBORDINATE: Type = Type::new(2);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SELF_SIGNED"),
+                2 => std::borrow::Cow::Borrowed("SUBORDINATE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "SELF_SIGNED" => std::option::Option::Some(Self::SELF_SIGNED),
+                "SUBORDINATE" => std::option::Option::Some(Self::SUBORDINATE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -621,26 +636,11 @@ pub mod certificate_authority {
     ///
     /// [google.cloud.security.privateca.v1.CertificateAuthority]: crate::model::CertificateAuthority
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Not specified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Certificates can be issued from this CA. CRLs will be generated for this
         /// CA. The CA will be part of the
@@ -649,7 +649,7 @@ pub mod certificate_authority {
         /// [CaPool][google.cloud.security.privateca.v1.CaPool].
         ///
         /// [google.cloud.security.privateca.v1.CaPool]: crate::model::CaPool
-        pub const ENABLED: State = State::new("ENABLED");
+        pub const ENABLED: State = State::new(1);
 
         /// Certificates cannot be issued from this CA. CRLs will still be generated.
         /// The CA will be part of the
@@ -658,7 +658,7 @@ pub mod certificate_authority {
         /// [CaPool][google.cloud.security.privateca.v1.CaPool].
         ///
         /// [google.cloud.security.privateca.v1.CaPool]: crate::model::CaPool
-        pub const DISABLED: State = State::new("DISABLED");
+        pub const DISABLED: State = State::new(2);
 
         /// Certificates can be issued from this CA. CRLs will be generated for this
         /// CA. The CA will be part of the
@@ -667,7 +667,7 @@ pub mod certificate_authority {
         /// [CaPool][google.cloud.security.privateca.v1.CaPool].
         ///
         /// [google.cloud.security.privateca.v1.CaPool]: crate::model::CaPool
-        pub const STAGED: State = State::new("STAGED");
+        pub const STAGED: State = State::new(3);
 
         /// Certificates cannot be issued from this CA. CRLs will not be generated.
         /// The CA will not be part of the
@@ -676,7 +676,7 @@ pub mod certificate_authority {
         /// [CaPool][google.cloud.security.privateca.v1.CaPool].
         ///
         /// [google.cloud.security.privateca.v1.CaPool]: crate::model::CaPool
-        pub const AWAITING_USER_ACTIVATION: State = State::new("AWAITING_USER_ACTIVATION");
+        pub const AWAITING_USER_ACTIVATION: State = State::new(4);
 
         /// Certificates cannot be issued from this CA. CRLs will not be generated.
         /// The CA may still be recovered by calling
@@ -691,18 +691,56 @@ pub mod certificate_authority {
         /// [google.cloud.security.privateca.v1.CaPool]: crate::model::CaPool
         /// [google.cloud.security.privateca.v1.CertificateAuthority.expire_time]: crate::model::CertificateAuthority::expire_time
         /// [google.cloud.security.privateca.v1.CertificateAuthorityService.UndeleteCertificateAuthority]: crate::client::CertificateAuthorityService::undelete_certificate_authority
-        pub const DELETED: State = State::new("DELETED");
+        pub const DELETED: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENABLED"),
+                2 => std::borrow::Cow::Borrowed("DISABLED"),
+                3 => std::borrow::Cow::Borrowed("STAGED"),
+                4 => std::borrow::Cow::Borrowed("AWAITING_USER_ACTIVATION"),
+                5 => std::borrow::Cow::Borrowed("DELETED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "STAGED" => std::option::Option::Some(Self::STAGED),
+                "AWAITING_USER_ACTIVATION" => {
+                    std::option::Option::Some(Self::AWAITING_USER_ACTIVATION)
+                }
+                "DELETED" => std::option::Option::Some(Self::DELETED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -716,68 +754,90 @@ pub mod certificate_authority {
     /// recommendations, see
     /// <https://cloud.google.com/kms/docs/algorithms#algorithm_recommendations>.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SignHashAlgorithm(std::borrow::Cow<'static, str>);
+    pub struct SignHashAlgorithm(i32);
 
     impl SignHashAlgorithm {
+        /// Not specified.
+        pub const SIGN_HASH_ALGORITHM_UNSPECIFIED: SignHashAlgorithm = SignHashAlgorithm::new(0);
+
+        /// maps to CryptoKeyVersionAlgorithm.RSA_SIGN_PSS_2048_SHA256
+        pub const RSA_PSS_2048_SHA256: SignHashAlgorithm = SignHashAlgorithm::new(1);
+
+        /// maps to CryptoKeyVersionAlgorithm. RSA_SIGN_PSS_3072_SHA256
+        pub const RSA_PSS_3072_SHA256: SignHashAlgorithm = SignHashAlgorithm::new(2);
+
+        /// maps to CryptoKeyVersionAlgorithm.RSA_SIGN_PSS_4096_SHA256
+        pub const RSA_PSS_4096_SHA256: SignHashAlgorithm = SignHashAlgorithm::new(3);
+
+        /// maps to CryptoKeyVersionAlgorithm.RSA_SIGN_PKCS1_2048_SHA256
+        pub const RSA_PKCS1_2048_SHA256: SignHashAlgorithm = SignHashAlgorithm::new(6);
+
+        /// maps to CryptoKeyVersionAlgorithm.RSA_SIGN_PKCS1_3072_SHA256
+        pub const RSA_PKCS1_3072_SHA256: SignHashAlgorithm = SignHashAlgorithm::new(7);
+
+        /// maps to CryptoKeyVersionAlgorithm.RSA_SIGN_PKCS1_4096_SHA256
+        pub const RSA_PKCS1_4096_SHA256: SignHashAlgorithm = SignHashAlgorithm::new(8);
+
+        /// maps to CryptoKeyVersionAlgorithm.EC_SIGN_P256_SHA256
+        pub const EC_P256_SHA256: SignHashAlgorithm = SignHashAlgorithm::new(4);
+
+        /// maps to CryptoKeyVersionAlgorithm.EC_SIGN_P384_SHA384
+        pub const EC_P384_SHA384: SignHashAlgorithm = SignHashAlgorithm::new(5);
+
         /// Creates a new SignHashAlgorithm instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SIGN_HASH_ALGORITHM_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RSA_PSS_2048_SHA256"),
+                2 => std::borrow::Cow::Borrowed("RSA_PSS_3072_SHA256"),
+                3 => std::borrow::Cow::Borrowed("RSA_PSS_4096_SHA256"),
+                4 => std::borrow::Cow::Borrowed("EC_P256_SHA256"),
+                5 => std::borrow::Cow::Borrowed("EC_P384_SHA384"),
+                6 => std::borrow::Cow::Borrowed("RSA_PKCS1_2048_SHA256"),
+                7 => std::borrow::Cow::Borrowed("RSA_PKCS1_3072_SHA256"),
+                8 => std::borrow::Cow::Borrowed("RSA_PKCS1_4096_SHA256"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SIGN_HASH_ALGORITHM_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SIGN_HASH_ALGORITHM_UNSPECIFIED)
+                }
+                "RSA_PSS_2048_SHA256" => std::option::Option::Some(Self::RSA_PSS_2048_SHA256),
+                "RSA_PSS_3072_SHA256" => std::option::Option::Some(Self::RSA_PSS_3072_SHA256),
+                "RSA_PSS_4096_SHA256" => std::option::Option::Some(Self::RSA_PSS_4096_SHA256),
+                "RSA_PKCS1_2048_SHA256" => std::option::Option::Some(Self::RSA_PKCS1_2048_SHA256),
+                "RSA_PKCS1_3072_SHA256" => std::option::Option::Some(Self::RSA_PKCS1_3072_SHA256),
+                "RSA_PKCS1_4096_SHA256" => std::option::Option::Some(Self::RSA_PKCS1_4096_SHA256),
+                "EC_P256_SHA256" => std::option::Option::Some(Self::EC_P256_SHA256),
+                "EC_P384_SHA384" => std::option::Option::Some(Self::EC_P384_SHA384),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SignHashAlgorithm](SignHashAlgorithm)
-    pub mod sign_hash_algorithm {
-        use super::SignHashAlgorithm;
-
-        /// Not specified.
-        pub const SIGN_HASH_ALGORITHM_UNSPECIFIED: SignHashAlgorithm =
-            SignHashAlgorithm::new("SIGN_HASH_ALGORITHM_UNSPECIFIED");
-
-        /// maps to CryptoKeyVersionAlgorithm.RSA_SIGN_PSS_2048_SHA256
-        pub const RSA_PSS_2048_SHA256: SignHashAlgorithm =
-            SignHashAlgorithm::new("RSA_PSS_2048_SHA256");
-
-        /// maps to CryptoKeyVersionAlgorithm. RSA_SIGN_PSS_3072_SHA256
-        pub const RSA_PSS_3072_SHA256: SignHashAlgorithm =
-            SignHashAlgorithm::new("RSA_PSS_3072_SHA256");
-
-        /// maps to CryptoKeyVersionAlgorithm.RSA_SIGN_PSS_4096_SHA256
-        pub const RSA_PSS_4096_SHA256: SignHashAlgorithm =
-            SignHashAlgorithm::new("RSA_PSS_4096_SHA256");
-
-        /// maps to CryptoKeyVersionAlgorithm.RSA_SIGN_PKCS1_2048_SHA256
-        pub const RSA_PKCS1_2048_SHA256: SignHashAlgorithm =
-            SignHashAlgorithm::new("RSA_PKCS1_2048_SHA256");
-
-        /// maps to CryptoKeyVersionAlgorithm.RSA_SIGN_PKCS1_3072_SHA256
-        pub const RSA_PKCS1_3072_SHA256: SignHashAlgorithm =
-            SignHashAlgorithm::new("RSA_PKCS1_3072_SHA256");
-
-        /// maps to CryptoKeyVersionAlgorithm.RSA_SIGN_PKCS1_4096_SHA256
-        pub const RSA_PKCS1_4096_SHA256: SignHashAlgorithm =
-            SignHashAlgorithm::new("RSA_PKCS1_4096_SHA256");
-
-        /// maps to CryptoKeyVersionAlgorithm.EC_SIGN_P256_SHA256
-        pub const EC_P256_SHA256: SignHashAlgorithm = SignHashAlgorithm::new("EC_P256_SHA256");
-
-        /// maps to CryptoKeyVersionAlgorithm.EC_SIGN_P384_SHA384
-        pub const EC_P384_SHA384: SignHashAlgorithm = SignHashAlgorithm::new("EC_P384_SHA384");
-    }
-
-    impl std::convert::From<std::string::String> for SignHashAlgorithm {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SignHashAlgorithm {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SignHashAlgorithm {
         fn default() -> Self {
-            sign_hash_algorithm::SIGN_HASH_ALGORITHM_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1000,52 +1060,68 @@ pub mod ca_pool {
 
         /// Supported encoding formats for publishing.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct EncodingFormat(std::borrow::Cow<'static, str>);
+        pub struct EncodingFormat(i32);
 
         impl EncodingFormat {
-            /// Creates a new EncodingFormat instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [EncodingFormat](EncodingFormat)
-        pub mod encoding_format {
-            use super::EncodingFormat;
-
             /// Not specified. By default, PEM format will be used.
-            pub const ENCODING_FORMAT_UNSPECIFIED: EncodingFormat =
-                EncodingFormat::new("ENCODING_FORMAT_UNSPECIFIED");
+            pub const ENCODING_FORMAT_UNSPECIFIED: EncodingFormat = EncodingFormat::new(0);
 
             /// The
             /// [CertificateAuthority][google.cloud.security.privateca.v1.CertificateAuthority]'s
             /// CA certificate and CRLs will be published in PEM format.
             ///
             /// [google.cloud.security.privateca.v1.CertificateAuthority]: crate::model::CertificateAuthority
-            pub const PEM: EncodingFormat = EncodingFormat::new("PEM");
+            pub const PEM: EncodingFormat = EncodingFormat::new(1);
 
             /// The
             /// [CertificateAuthority][google.cloud.security.privateca.v1.CertificateAuthority]'s
             /// CA certificate and CRLs will be published in DER format.
             ///
             /// [google.cloud.security.privateca.v1.CertificateAuthority]: crate::model::CertificateAuthority
-            pub const DER: EncodingFormat = EncodingFormat::new("DER");
+            pub const DER: EncodingFormat = EncodingFormat::new(2);
+
+            /// Creates a new EncodingFormat instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("ENCODING_FORMAT_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("PEM"),
+                    2 => std::borrow::Cow::Borrowed("DER"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "ENCODING_FORMAT_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::ENCODING_FORMAT_UNSPECIFIED)
+                    }
+                    "PEM" => std::option::Option::Some(Self::PEM),
+                    "DER" => std::option::Option::Some(Self::DER),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for EncodingFormat {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for EncodingFormat {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for EncodingFormat {
             fn default() -> Self {
-                encoding_format::ENCODING_FORMAT_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -1463,53 +1539,69 @@ pub mod ca_pool {
                 /// [google.cloud.security.privateca.v1.CaPool]: crate::model::CaPool
                 /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
                 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                pub struct EcSignatureAlgorithm(std::borrow::Cow<'static, str>);
+                pub struct EcSignatureAlgorithm(i32);
 
                 impl EcSignatureAlgorithm {
-                    /// Creates a new EcSignatureAlgorithm instance.
-                    pub const fn new(v: &'static str) -> Self {
-                        Self(std::borrow::Cow::Borrowed(v))
-                    }
-
-                    /// Gets the enum value.
-                    pub fn value(&self) -> &str {
-                        &self.0
-                    }
-                }
-
-                /// Useful constants to work with [EcSignatureAlgorithm](EcSignatureAlgorithm)
-                pub mod ec_signature_algorithm {
-                    use super::EcSignatureAlgorithm;
-
                     /// Not specified. Signifies that any signature algorithm may be used.
                     pub const EC_SIGNATURE_ALGORITHM_UNSPECIFIED: EcSignatureAlgorithm =
-                        EcSignatureAlgorithm::new("EC_SIGNATURE_ALGORITHM_UNSPECIFIED");
+                        EcSignatureAlgorithm::new(0);
 
                     /// Refers to the Elliptic Curve Digital Signature Algorithm over the
                     /// NIST P-256 curve.
-                    pub const ECDSA_P256: EcSignatureAlgorithm =
-                        EcSignatureAlgorithm::new("ECDSA_P256");
+                    pub const ECDSA_P256: EcSignatureAlgorithm = EcSignatureAlgorithm::new(1);
 
                     /// Refers to the Elliptic Curve Digital Signature Algorithm over the
                     /// NIST P-384 curve.
-                    pub const ECDSA_P384: EcSignatureAlgorithm =
-                        EcSignatureAlgorithm::new("ECDSA_P384");
+                    pub const ECDSA_P384: EcSignatureAlgorithm = EcSignatureAlgorithm::new(2);
 
                     /// Refers to the Edwards-curve Digital Signature Algorithm over curve
                     /// 25519, as described in RFC 8410.
-                    pub const EDDSA_25519: EcSignatureAlgorithm =
-                        EcSignatureAlgorithm::new("EDDSA_25519");
+                    pub const EDDSA_25519: EcSignatureAlgorithm = EcSignatureAlgorithm::new(3);
+
+                    /// Creates a new EcSignatureAlgorithm instance.
+                    pub(crate) const fn new(value: i32) -> Self {
+                        Self(value)
+                    }
+
+                    /// Gets the enum value.
+                    pub fn value(&self) -> i32 {
+                        self.0
+                    }
+
+                    /// Gets the enum value as a string.
+                    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                        match self.0 {
+                            0 => std::borrow::Cow::Borrowed("EC_SIGNATURE_ALGORITHM_UNSPECIFIED"),
+                            1 => std::borrow::Cow::Borrowed("ECDSA_P256"),
+                            2 => std::borrow::Cow::Borrowed("ECDSA_P384"),
+                            3 => std::borrow::Cow::Borrowed("EDDSA_25519"),
+                            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                        }
+                    }
+
+                    /// Creates an enum value from the value name.
+                    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                        match name {
+                            "EC_SIGNATURE_ALGORITHM_UNSPECIFIED" => {
+                                std::option::Option::Some(Self::EC_SIGNATURE_ALGORITHM_UNSPECIFIED)
+                            }
+                            "ECDSA_P256" => std::option::Option::Some(Self::ECDSA_P256),
+                            "ECDSA_P384" => std::option::Option::Some(Self::ECDSA_P384),
+                            "EDDSA_25519" => std::option::Option::Some(Self::EDDSA_25519),
+                            _ => std::option::Option::None,
+                        }
+                    }
                 }
 
-                impl std::convert::From<std::string::String> for EcSignatureAlgorithm {
-                    fn from(value: std::string::String) -> Self {
-                        Self(std::borrow::Cow::Owned(value))
+                impl std::convert::From<i32> for EcSignatureAlgorithm {
+                    fn from(value: i32) -> Self {
+                        Self::new(value)
                     }
                 }
 
                 impl std::default::Default for EcSignatureAlgorithm {
                     fn default() -> Self {
-                        ec_signature_algorithm::EC_SIGNATURE_ALGORITHM_UNSPECIFIED
+                        Self::new(0)
                     }
                 }
             }
@@ -1599,43 +1691,58 @@ pub mod ca_pool {
     ///
     /// [google.cloud.security.privateca.v1.CaPool]: crate::model::CaPool
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Tier(std::borrow::Cow<'static, str>);
+    pub struct Tier(i32);
 
     impl Tier {
+        /// Not specified.
+        pub const TIER_UNSPECIFIED: Tier = Tier::new(0);
+
+        /// Enterprise tier.
+        pub const ENTERPRISE: Tier = Tier::new(1);
+
+        /// DevOps tier.
+        pub const DEVOPS: Tier = Tier::new(2);
+
         /// Creates a new Tier instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TIER_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENTERPRISE"),
+                2 => std::borrow::Cow::Borrowed("DEVOPS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TIER_UNSPECIFIED" => std::option::Option::Some(Self::TIER_UNSPECIFIED),
+                "ENTERPRISE" => std::option::Option::Some(Self::ENTERPRISE),
+                "DEVOPS" => std::option::Option::Some(Self::DEVOPS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Tier](Tier)
-    pub mod tier {
-        use super::Tier;
-
-        /// Not specified.
-        pub const TIER_UNSPECIFIED: Tier = Tier::new("TIER_UNSPECIFIED");
-
-        /// Enterprise tier.
-        pub const ENTERPRISE: Tier = Tier::new("ENTERPRISE");
-
-        /// DevOps tier.
-        pub const DEVOPS: Tier = Tier::new("DEVOPS");
-    }
-
-    impl std::convert::From<std::string::String> for Tier {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Tier {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Tier {
         fn default() -> Self {
-            tier::TIER_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1887,51 +1994,66 @@ pub mod certificate_revocation_list {
     ///
     /// [google.cloud.security.privateca.v1.CertificateRevocationList]: crate::model::CertificateRevocationList
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Not specified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The
         /// [CertificateRevocationList][google.cloud.security.privateca.v1.CertificateRevocationList]
         /// is up to date.
         ///
         /// [google.cloud.security.privateca.v1.CertificateRevocationList]: crate::model::CertificateRevocationList
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(1);
 
         /// The
         /// [CertificateRevocationList][google.cloud.security.privateca.v1.CertificateRevocationList]
         /// is no longer current.
         ///
         /// [google.cloud.security.privateca.v1.CertificateRevocationList]: crate::model::CertificateRevocationList
-        pub const SUPERSEDED: State = State::new("SUPERSEDED");
+        pub const SUPERSEDED: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("SUPERSEDED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "SUPERSEDED" => std::option::Option::Some(Self::SUPERSEDED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3082,26 +3204,11 @@ pub mod public_key {
     /// Types of public keys formats that are supported. Currently, only `PEM`
     /// format is supported.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct KeyFormat(std::borrow::Cow<'static, str>);
+    pub struct KeyFormat(i32);
 
     impl KeyFormat {
-        /// Creates a new KeyFormat instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [KeyFormat](KeyFormat)
-    pub mod key_format {
-        use super::KeyFormat;
-
         /// Default unspecified value.
-        pub const KEY_FORMAT_UNSPECIFIED: KeyFormat = KeyFormat::new("KEY_FORMAT_UNSPECIFIED");
+        pub const KEY_FORMAT_UNSPECIFIED: KeyFormat = KeyFormat::new(0);
 
         /// The key is PEM-encoded as defined in [RFC
         /// 7468](https://tools.ietf.org/html/rfc7468). It can be any of the
@@ -3116,18 +3223,46 @@ pub mod public_key {
         /// generated by the service, it will always be an RFC 5280
         /// [SubjectPublicKeyInfo](https://tools.ietf.org/html/rfc5280#section-4.1)
         /// structure containing an algorithm identifier and a key.
-        pub const PEM: KeyFormat = KeyFormat::new("PEM");
+        pub const PEM: KeyFormat = KeyFormat::new(1);
+
+        /// Creates a new KeyFormat instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("KEY_FORMAT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PEM"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "KEY_FORMAT_UNSPECIFIED" => std::option::Option::Some(Self::KEY_FORMAT_UNSPECIFIED),
+                "PEM" => std::option::Option::Some(Self::PEM),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for KeyFormat {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for KeyFormat {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for KeyFormat {
         fn default() -> Self {
-            key_format::KEY_FORMAT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4366,27 +4501,12 @@ pub mod certificate_extension_constraints {
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
     /// [google.cloud.security.privateca.v1.SubjectAltNames]: crate::model::SubjectAltNames
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct KnownCertificateExtension(std::borrow::Cow<'static, str>);
+    pub struct KnownCertificateExtension(i32);
 
     impl KnownCertificateExtension {
-        /// Creates a new KnownCertificateExtension instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [KnownCertificateExtension](KnownCertificateExtension)
-    pub mod known_certificate_extension {
-        use super::KnownCertificateExtension;
-
         /// Not specified.
         pub const KNOWN_CERTIFICATE_EXTENSION_UNSPECIFIED: KnownCertificateExtension =
-            KnownCertificateExtension::new("KNOWN_CERTIFICATE_EXTENSION_UNSPECIFIED");
+            KnownCertificateExtension::new(0);
 
         /// Refers to a certificate's Key Usage extension, as described in [RFC 5280
         /// section 4.2.1.3](https://tools.ietf.org/html/rfc5280#section-4.2.1.3).
@@ -4395,8 +4515,7 @@ pub mod certificate_extension_constraints {
         /// field.
         ///
         /// [google.cloud.security.privateca.v1.KeyUsage.base_key_usage]: crate::model::KeyUsage::base_key_usage
-        pub const BASE_KEY_USAGE: KnownCertificateExtension =
-            KnownCertificateExtension::new("BASE_KEY_USAGE");
+        pub const BASE_KEY_USAGE: KnownCertificateExtension = KnownCertificateExtension::new(1);
 
         /// Refers to a certificate's Extended Key Usage extension, as described in
         /// [RFC 5280
@@ -4406,8 +4525,7 @@ pub mod certificate_extension_constraints {
         /// message.
         ///
         /// [google.cloud.security.privateca.v1.KeyUsage.extended_key_usage]: crate::model::KeyUsage::extended_key_usage
-        pub const EXTENDED_KEY_USAGE: KnownCertificateExtension =
-            KnownCertificateExtension::new("EXTENDED_KEY_USAGE");
+        pub const EXTENDED_KEY_USAGE: KnownCertificateExtension = KnownCertificateExtension::new(2);
 
         /// Refers to a certificate's Basic Constraints extension, as described in
         /// [RFC 5280
@@ -4417,8 +4535,7 @@ pub mod certificate_extension_constraints {
         /// field.
         ///
         /// [google.cloud.security.privateca.v1.X509Parameters.ca_options]: crate::model::X509Parameters::ca_options
-        pub const CA_OPTIONS: KnownCertificateExtension =
-            KnownCertificateExtension::new("CA_OPTIONS");
+        pub const CA_OPTIONS: KnownCertificateExtension = KnownCertificateExtension::new(3);
 
         /// Refers to a certificate's Policy object identifiers, as described in
         /// [RFC 5280
@@ -4428,8 +4545,7 @@ pub mod certificate_extension_constraints {
         /// field.
         ///
         /// [google.cloud.security.privateca.v1.X509Parameters.policy_ids]: crate::model::X509Parameters::policy_ids
-        pub const POLICY_IDS: KnownCertificateExtension =
-            KnownCertificateExtension::new("POLICY_IDS");
+        pub const POLICY_IDS: KnownCertificateExtension = KnownCertificateExtension::new(4);
 
         /// Refers to OCSP servers in a certificate's Authority Information Access
         /// extension, as described in
@@ -4440,25 +4556,63 @@ pub mod certificate_extension_constraints {
         /// field.
         ///
         /// [google.cloud.security.privateca.v1.X509Parameters.aia_ocsp_servers]: crate::model::X509Parameters::aia_ocsp_servers
-        pub const AIA_OCSP_SERVERS: KnownCertificateExtension =
-            KnownCertificateExtension::new("AIA_OCSP_SERVERS");
+        pub const AIA_OCSP_SERVERS: KnownCertificateExtension = KnownCertificateExtension::new(5);
 
         /// Refers to Name Constraints extension as described in
         /// [RFC 5280
         /// section 4.2.1.10](https://tools.ietf.org/html/rfc5280#section-4.2.1.10)
-        pub const NAME_CONSTRAINTS: KnownCertificateExtension =
-            KnownCertificateExtension::new("NAME_CONSTRAINTS");
+        pub const NAME_CONSTRAINTS: KnownCertificateExtension = KnownCertificateExtension::new(6);
+
+        /// Creates a new KnownCertificateExtension instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("KNOWN_CERTIFICATE_EXTENSION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BASE_KEY_USAGE"),
+                2 => std::borrow::Cow::Borrowed("EXTENDED_KEY_USAGE"),
+                3 => std::borrow::Cow::Borrowed("CA_OPTIONS"),
+                4 => std::borrow::Cow::Borrowed("POLICY_IDS"),
+                5 => std::borrow::Cow::Borrowed("AIA_OCSP_SERVERS"),
+                6 => std::borrow::Cow::Borrowed("NAME_CONSTRAINTS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "KNOWN_CERTIFICATE_EXTENSION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::KNOWN_CERTIFICATE_EXTENSION_UNSPECIFIED)
+                }
+                "BASE_KEY_USAGE" => std::option::Option::Some(Self::BASE_KEY_USAGE),
+                "EXTENDED_KEY_USAGE" => std::option::Option::Some(Self::EXTENDED_KEY_USAGE),
+                "CA_OPTIONS" => std::option::Option::Some(Self::CA_OPTIONS),
+                "POLICY_IDS" => std::option::Option::Some(Self::POLICY_IDS),
+                "AIA_OCSP_SERVERS" => std::option::Option::Some(Self::AIA_OCSP_SERVERS),
+                "NAME_CONSTRAINTS" => std::option::Option::Some(Self::NAME_CONSTRAINTS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for KnownCertificateExtension {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for KnownCertificateExtension {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for KnownCertificateExtension {
         fn default() -> Self {
-            known_certificate_extension::KNOWN_CERTIFICATE_EXTENSION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7177,94 +7331,123 @@ impl wkt::message::Message for OperationMetadata {
 /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
 /// [google.cloud.security.privateca.v1.RevocationReason]: crate::model::RevocationReason
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RevocationReason(std::borrow::Cow<'static, str>);
+pub struct RevocationReason(i32);
 
 impl RevocationReason {
-    /// Creates a new RevocationReason instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [RevocationReason](RevocationReason)
-pub mod revocation_reason {
-    use super::RevocationReason;
-
     /// Default unspecified value. This value does indicate that a
     /// [Certificate][google.cloud.security.privateca.v1.Certificate] has been
     /// revoked, but that a reason has not been recorded.
     ///
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
-    pub const REVOCATION_REASON_UNSPECIFIED: RevocationReason =
-        RevocationReason::new("REVOCATION_REASON_UNSPECIFIED");
+    pub const REVOCATION_REASON_UNSPECIFIED: RevocationReason = RevocationReason::new(0);
 
     /// Key material for this
     /// [Certificate][google.cloud.security.privateca.v1.Certificate] may have
     /// leaked.
     ///
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
-    pub const KEY_COMPROMISE: RevocationReason = RevocationReason::new("KEY_COMPROMISE");
+    pub const KEY_COMPROMISE: RevocationReason = RevocationReason::new(1);
 
     /// The key material for a certificate authority in the issuing path may have
     /// leaked.
-    pub const CERTIFICATE_AUTHORITY_COMPROMISE: RevocationReason =
-        RevocationReason::new("CERTIFICATE_AUTHORITY_COMPROMISE");
+    pub const CERTIFICATE_AUTHORITY_COMPROMISE: RevocationReason = RevocationReason::new(2);
 
     /// The subject or other attributes in this
     /// [Certificate][google.cloud.security.privateca.v1.Certificate] have changed.
     ///
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
-    pub const AFFILIATION_CHANGED: RevocationReason = RevocationReason::new("AFFILIATION_CHANGED");
+    pub const AFFILIATION_CHANGED: RevocationReason = RevocationReason::new(3);
 
     /// This [Certificate][google.cloud.security.privateca.v1.Certificate] has been
     /// superseded.
     ///
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
-    pub const SUPERSEDED: RevocationReason = RevocationReason::new("SUPERSEDED");
+    pub const SUPERSEDED: RevocationReason = RevocationReason::new(4);
 
     /// This [Certificate][google.cloud.security.privateca.v1.Certificate] or
     /// entities in the issuing path have ceased to operate.
     ///
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
-    pub const CESSATION_OF_OPERATION: RevocationReason =
-        RevocationReason::new("CESSATION_OF_OPERATION");
+    pub const CESSATION_OF_OPERATION: RevocationReason = RevocationReason::new(5);
 
     /// This [Certificate][google.cloud.security.privateca.v1.Certificate] should
     /// not be considered valid, it is expected that it may become valid in the
     /// future.
     ///
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
-    pub const CERTIFICATE_HOLD: RevocationReason = RevocationReason::new("CERTIFICATE_HOLD");
+    pub const CERTIFICATE_HOLD: RevocationReason = RevocationReason::new(6);
 
     /// This [Certificate][google.cloud.security.privateca.v1.Certificate] no
     /// longer has permission to assert the listed attributes.
     ///
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
-    pub const PRIVILEGE_WITHDRAWN: RevocationReason = RevocationReason::new("PRIVILEGE_WITHDRAWN");
+    pub const PRIVILEGE_WITHDRAWN: RevocationReason = RevocationReason::new(7);
 
     /// The authority which determines appropriate attributes for a
     /// [Certificate][google.cloud.security.privateca.v1.Certificate] may have been
     /// compromised.
     ///
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
-    pub const ATTRIBUTE_AUTHORITY_COMPROMISE: RevocationReason =
-        RevocationReason::new("ATTRIBUTE_AUTHORITY_COMPROMISE");
+    pub const ATTRIBUTE_AUTHORITY_COMPROMISE: RevocationReason = RevocationReason::new(8);
+
+    /// Creates a new RevocationReason instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("REVOCATION_REASON_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("KEY_COMPROMISE"),
+            2 => std::borrow::Cow::Borrowed("CERTIFICATE_AUTHORITY_COMPROMISE"),
+            3 => std::borrow::Cow::Borrowed("AFFILIATION_CHANGED"),
+            4 => std::borrow::Cow::Borrowed("SUPERSEDED"),
+            5 => std::borrow::Cow::Borrowed("CESSATION_OF_OPERATION"),
+            6 => std::borrow::Cow::Borrowed("CERTIFICATE_HOLD"),
+            7 => std::borrow::Cow::Borrowed("PRIVILEGE_WITHDRAWN"),
+            8 => std::borrow::Cow::Borrowed("ATTRIBUTE_AUTHORITY_COMPROMISE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "REVOCATION_REASON_UNSPECIFIED" => {
+                std::option::Option::Some(Self::REVOCATION_REASON_UNSPECIFIED)
+            }
+            "KEY_COMPROMISE" => std::option::Option::Some(Self::KEY_COMPROMISE),
+            "CERTIFICATE_AUTHORITY_COMPROMISE" => {
+                std::option::Option::Some(Self::CERTIFICATE_AUTHORITY_COMPROMISE)
+            }
+            "AFFILIATION_CHANGED" => std::option::Option::Some(Self::AFFILIATION_CHANGED),
+            "SUPERSEDED" => std::option::Option::Some(Self::SUPERSEDED),
+            "CESSATION_OF_OPERATION" => std::option::Option::Some(Self::CESSATION_OF_OPERATION),
+            "CERTIFICATE_HOLD" => std::option::Option::Some(Self::CERTIFICATE_HOLD),
+            "PRIVILEGE_WITHDRAWN" => std::option::Option::Some(Self::PRIVILEGE_WITHDRAWN),
+            "ATTRIBUTE_AUTHORITY_COMPROMISE" => {
+                std::option::Option::Some(Self::ATTRIBUTE_AUTHORITY_COMPROMISE)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for RevocationReason {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for RevocationReason {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for RevocationReason {
     fn default() -> Self {
-        revocation_reason::REVOCATION_REASON_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -7278,27 +7461,11 @@ impl std::default::Default for RevocationReason {
 /// [google.cloud.security.privateca.v1.Subject]: crate::model::Subject
 /// [google.cloud.security.privateca.v1.SubjectAltNames]: crate::model::SubjectAltNames
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SubjectRequestMode(std::borrow::Cow<'static, str>);
+pub struct SubjectRequestMode(i32);
 
 impl SubjectRequestMode {
-    /// Creates a new SubjectRequestMode instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [SubjectRequestMode](SubjectRequestMode)
-pub mod subject_request_mode {
-    use super::SubjectRequestMode;
-
     /// Not specified.
-    pub const SUBJECT_REQUEST_MODE_UNSPECIFIED: SubjectRequestMode =
-        SubjectRequestMode::new("SUBJECT_REQUEST_MODE_UNSPECIFIED");
+    pub const SUBJECT_REQUEST_MODE_UNSPECIFIED: SubjectRequestMode = SubjectRequestMode::new(0);
 
     /// The default mode used in most cases. Indicates that the certificate's
     /// [Subject][google.cloud.security.privateca.v1.Subject] and/or
@@ -7308,7 +7475,7 @@ pub mod subject_request_mode {
     ///
     /// [google.cloud.security.privateca.v1.Subject]: crate::model::Subject
     /// [google.cloud.security.privateca.v1.SubjectAltNames]: crate::model::SubjectAltNames
-    pub const DEFAULT: SubjectRequestMode = SubjectRequestMode::new("DEFAULT");
+    pub const DEFAULT: SubjectRequestMode = SubjectRequestMode::new(1);
 
     /// A mode reserved for special cases. Indicates that the certificate should
     /// have one SPIFFE
@@ -7322,17 +7489,49 @@ pub mod subject_request_mode {
     ///
     /// [google.cloud.security.privateca.v1.Subject]: crate::model::Subject
     /// [google.cloud.security.privateca.v1.SubjectAltNames]: crate::model::SubjectAltNames
-    pub const REFLECTED_SPIFFE: SubjectRequestMode = SubjectRequestMode::new("REFLECTED_SPIFFE");
+    pub const REFLECTED_SPIFFE: SubjectRequestMode = SubjectRequestMode::new(2);
+
+    /// Creates a new SubjectRequestMode instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SUBJECT_REQUEST_MODE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("DEFAULT"),
+            2 => std::borrow::Cow::Borrowed("REFLECTED_SPIFFE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SUBJECT_REQUEST_MODE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::SUBJECT_REQUEST_MODE_UNSPECIFIED)
+            }
+            "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
+            "REFLECTED_SPIFFE" => std::option::Option::Some(Self::REFLECTED_SPIFFE),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for SubjectRequestMode {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SubjectRequestMode {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SubjectRequestMode {
     fn default() -> Self {
-        subject_request_mode::SUBJECT_REQUEST_MODE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/security/privateca/v1/src/transport.rs
+++ b/src/generated/cloud/security/privateca/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
                 reqwest::Method::POST,
                 format!("/v1/{}/certificates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -78,7 +78,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -100,7 +100,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
                 reqwest::Method::GET,
                 format!("/v1/{}/certificates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -123,7 +123,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:revoke", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -149,7 +149,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -179,7 +179,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:activate", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -199,7 +199,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
                 reqwest::Method::POST,
                 format!("/v1/{}/certificateAuthorities", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -220,7 +220,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:disable", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -237,7 +237,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:enable", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -254,7 +254,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}:fetch", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -273,7 +273,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -295,7 +295,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
                 reqwest::Method::GET,
                 format!("/v1/{}/certificateAuthorities", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -318,7 +318,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:undelete", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -335,7 +335,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -369,7 +369,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -399,7 +399,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/caPools", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -429,7 +429,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -459,7 +459,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -478,7 +478,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/caPools", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -501,7 +501,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -526,7 +526,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
                 reqwest::Method::POST,
                 format!("/v1/{}:fetchCaCerts", req.ca_pool),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -543,7 +543,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -565,7 +565,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
                 reqwest::Method::GET,
                 format!("/v1/{}/certificateRevocationLists", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -597,7 +597,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -630,7 +630,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
                 reqwest::Method::POST,
                 format!("/v1/{}/certificateTemplates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -651,7 +651,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -671,7 +671,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -693,7 +693,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
                 reqwest::Method::GET,
                 format!("/v1/{}/certificateTemplates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -725,7 +725,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -755,7 +755,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -777,7 +777,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -799,7 +799,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -819,7 +819,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -851,7 +851,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -868,7 +868,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -890,7 +890,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -909,7 +909,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -928,7 +928,7 @@ impl crate::stubs::CertificateAuthorityService for CertificateAuthorityService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/security/publicca/v1/src/transport.rs
+++ b/src/generated/cloud/security/publicca/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::PublicCertificateAuthorityService for PublicCertificateAuthor
                 reqwest::Method::POST,
                 format!("/v1/{}/externalAccountKeys", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/securitycenter/v2/src/model.rs
+++ b/src/generated/cloud/securitycenter/v2/src/model.rs
@@ -445,43 +445,58 @@ pub mod attack_exposure {
 
     /// This enum defines the various states an AttackExposure can be in.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The state is not specified.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The attack exposure has been calculated.
+        pub const CALCULATED: State = State::new(1);
+
+        /// The attack exposure has not been calculated.
+        pub const NOT_CALCULATED: State = State::new(2);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CALCULATED"),
+                2 => std::borrow::Cow::Borrowed("NOT_CALCULATED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CALCULATED" => std::option::Option::Some(Self::CALCULATED),
+                "NOT_CALCULATED" => std::option::Option::Some(Self::NOT_CALCULATED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The state is not specified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The attack exposure has been calculated.
-        pub const CALCULATED: State = State::new("CALCULATED");
-
-        /// The attack exposure has not been calculated.
-        pub const NOT_CALCULATED: State = State::new("NOT_CALCULATED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -803,49 +818,70 @@ pub mod attack_path {
 
         /// The type of the incoming attack step node.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct NodeType(std::borrow::Cow<'static, str>);
+        pub struct NodeType(i32);
 
         impl NodeType {
+            /// Type not specified
+            pub const NODE_TYPE_UNSPECIFIED: NodeType = NodeType::new(0);
+
+            /// Incoming edge joined with AND
+            pub const NODE_TYPE_AND: NodeType = NodeType::new(1);
+
+            /// Incoming edge joined with OR
+            pub const NODE_TYPE_OR: NodeType = NodeType::new(2);
+
+            /// Incoming edge is defense
+            pub const NODE_TYPE_DEFENSE: NodeType = NodeType::new(3);
+
+            /// Incoming edge is attacker
+            pub const NODE_TYPE_ATTACKER: NodeType = NodeType::new(4);
+
             /// Creates a new NodeType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("NODE_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("NODE_TYPE_AND"),
+                    2 => std::borrow::Cow::Borrowed("NODE_TYPE_OR"),
+                    3 => std::borrow::Cow::Borrowed("NODE_TYPE_DEFENSE"),
+                    4 => std::borrow::Cow::Borrowed("NODE_TYPE_ATTACKER"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "NODE_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::NODE_TYPE_UNSPECIFIED)
+                    }
+                    "NODE_TYPE_AND" => std::option::Option::Some(Self::NODE_TYPE_AND),
+                    "NODE_TYPE_OR" => std::option::Option::Some(Self::NODE_TYPE_OR),
+                    "NODE_TYPE_DEFENSE" => std::option::Option::Some(Self::NODE_TYPE_DEFENSE),
+                    "NODE_TYPE_ATTACKER" => std::option::Option::Some(Self::NODE_TYPE_ATTACKER),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [NodeType](NodeType)
-        pub mod node_type {
-            use super::NodeType;
-
-            /// Type not specified
-            pub const NODE_TYPE_UNSPECIFIED: NodeType = NodeType::new("NODE_TYPE_UNSPECIFIED");
-
-            /// Incoming edge joined with AND
-            pub const NODE_TYPE_AND: NodeType = NodeType::new("NODE_TYPE_AND");
-
-            /// Incoming edge joined with OR
-            pub const NODE_TYPE_OR: NodeType = NodeType::new("NODE_TYPE_OR");
-
-            /// Incoming edge is defense
-            pub const NODE_TYPE_DEFENSE: NodeType = NodeType::new("NODE_TYPE_DEFENSE");
-
-            /// Incoming edge is attacker
-            pub const NODE_TYPE_ATTACKER: NodeType = NodeType::new("NODE_TYPE_ATTACKER");
-        }
-
-        impl std::convert::From<std::string::String> for NodeType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for NodeType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for NodeType {
             fn default() -> Self {
-                node_type::NODE_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -1577,43 +1613,60 @@ pub mod cloud_dlp_data_profile {
 
     /// Parents for configurations that produce data profile findings.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ParentType(std::borrow::Cow<'static, str>);
+    pub struct ParentType(i32);
 
     impl ParentType {
+        /// Unspecified parent type.
+        pub const PARENT_TYPE_UNSPECIFIED: ParentType = ParentType::new(0);
+
+        /// Organization-level configurations.
+        pub const ORGANIZATION: ParentType = ParentType::new(1);
+
+        /// Project-level configurations.
+        pub const PROJECT: ParentType = ParentType::new(2);
+
         /// Creates a new ParentType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PARENT_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ORGANIZATION"),
+                2 => std::borrow::Cow::Borrowed("PROJECT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PARENT_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PARENT_TYPE_UNSPECIFIED)
+                }
+                "ORGANIZATION" => std::option::Option::Some(Self::ORGANIZATION),
+                "PROJECT" => std::option::Option::Some(Self::PROJECT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ParentType](ParentType)
-    pub mod parent_type {
-        use super::ParentType;
-
-        /// Unspecified parent type.
-        pub const PARENT_TYPE_UNSPECIFIED: ParentType = ParentType::new("PARENT_TYPE_UNSPECIFIED");
-
-        /// Organization-level configurations.
-        pub const ORGANIZATION: ParentType = ParentType::new("ORGANIZATION");
-
-        /// Project-level configurations.
-        pub const PROJECT: ParentType = ParentType::new("PROJECT");
-    }
-
-    impl std::convert::From<std::string::String> for ParentType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ParentType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ParentType {
         fn default() -> Self {
-            parent_type::PARENT_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1816,52 +1869,73 @@ pub mod connection {
 
     /// IANA Internet Protocol Number such as TCP(6) and UDP(17).
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Protocol(std::borrow::Cow<'static, str>);
+    pub struct Protocol(i32);
 
     impl Protocol {
+        /// Unspecified protocol (not HOPOPT).
+        pub const PROTOCOL_UNSPECIFIED: Protocol = Protocol::new(0);
+
+        /// Internet Control Message Protocol.
+        pub const ICMP: Protocol = Protocol::new(1);
+
+        /// Transmission Control Protocol.
+        pub const TCP: Protocol = Protocol::new(6);
+
+        /// User Datagram Protocol.
+        pub const UDP: Protocol = Protocol::new(17);
+
+        /// Generic Routing Encapsulation.
+        pub const GRE: Protocol = Protocol::new(47);
+
+        /// Encap Security Payload.
+        pub const ESP: Protocol = Protocol::new(50);
+
         /// Creates a new Protocol instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PROTOCOL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ICMP"),
+                6 => std::borrow::Cow::Borrowed("TCP"),
+                17 => std::borrow::Cow::Borrowed("UDP"),
+                47 => std::borrow::Cow::Borrowed("GRE"),
+                50 => std::borrow::Cow::Borrowed("ESP"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PROTOCOL_UNSPECIFIED" => std::option::Option::Some(Self::PROTOCOL_UNSPECIFIED),
+                "ICMP" => std::option::Option::Some(Self::ICMP),
+                "TCP" => std::option::Option::Some(Self::TCP),
+                "UDP" => std::option::Option::Some(Self::UDP),
+                "GRE" => std::option::Option::Some(Self::GRE),
+                "ESP" => std::option::Option::Some(Self::ESP),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Protocol](Protocol)
-    pub mod protocol {
-        use super::Protocol;
-
-        /// Unspecified protocol (not HOPOPT).
-        pub const PROTOCOL_UNSPECIFIED: Protocol = Protocol::new("PROTOCOL_UNSPECIFIED");
-
-        /// Internet Control Message Protocol.
-        pub const ICMP: Protocol = Protocol::new("ICMP");
-
-        /// Transmission Control Protocol.
-        pub const TCP: Protocol = Protocol::new("TCP");
-
-        /// User Datagram Protocol.
-        pub const UDP: Protocol = Protocol::new("UDP");
-
-        /// Generic Routing Encapsulation.
-        pub const GRE: Protocol = Protocol::new("GRE");
-
-        /// Encap Security Payload.
-        pub const ESP: Protocol = Protocol::new("ESP");
-    }
-
-    impl std::convert::From<std::string::String> for Protocol {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Protocol {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Protocol {
         fn default() -> Self {
-            protocol::PROTOCOL_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2081,46 +2155,63 @@ pub mod data_access_event {
 
     /// The operation of a data access event.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Operation(std::borrow::Cow<'static, str>);
+    pub struct Operation(i32);
 
     impl Operation {
+        /// The operation is unspecified.
+        pub const OPERATION_UNSPECIFIED: Operation = Operation::new(0);
+
+        /// Represents a read operation.
+        pub const READ: Operation = Operation::new(1);
+
+        /// Represents a move operation.
+        pub const MOVE: Operation = Operation::new(2);
+
+        /// Represents a copy operation.
+        pub const COPY: Operation = Operation::new(3);
+
         /// Creates a new Operation instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("OPERATION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("READ"),
+                2 => std::borrow::Cow::Borrowed("MOVE"),
+                3 => std::borrow::Cow::Borrowed("COPY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "OPERATION_UNSPECIFIED" => std::option::Option::Some(Self::OPERATION_UNSPECIFIED),
+                "READ" => std::option::Option::Some(Self::READ),
+                "MOVE" => std::option::Option::Some(Self::MOVE),
+                "COPY" => std::option::Option::Some(Self::COPY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Operation](Operation)
-    pub mod operation {
-        use super::Operation;
-
-        /// The operation is unspecified.
-        pub const OPERATION_UNSPECIFIED: Operation = Operation::new("OPERATION_UNSPECIFIED");
-
-        /// Represents a read operation.
-        pub const READ: Operation = Operation::new("READ");
-
-        /// Represents a move operation.
-        pub const MOVE: Operation = Operation::new("MOVE");
-
-        /// Represents a copy operation.
-        pub const COPY: Operation = Operation::new("COPY");
-    }
-
-    impl std::convert::From<std::string::String> for Operation {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Operation {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Operation {
         fn default() -> Self {
-            operation::OPERATION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2212,46 +2303,63 @@ pub mod data_flow_event {
 
     /// The operation of a data flow event.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Operation(std::borrow::Cow<'static, str>);
+    pub struct Operation(i32);
 
     impl Operation {
+        /// The operation is unspecified.
+        pub const OPERATION_UNSPECIFIED: Operation = Operation::new(0);
+
+        /// Represents a read operation.
+        pub const READ: Operation = Operation::new(1);
+
+        /// Represents a move operation.
+        pub const MOVE: Operation = Operation::new(2);
+
+        /// Represents a copy operation.
+        pub const COPY: Operation = Operation::new(3);
+
         /// Creates a new Operation instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("OPERATION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("READ"),
+                2 => std::borrow::Cow::Borrowed("MOVE"),
+                3 => std::borrow::Cow::Borrowed("COPY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "OPERATION_UNSPECIFIED" => std::option::Option::Some(Self::OPERATION_UNSPECIFIED),
+                "READ" => std::option::Option::Some(Self::READ),
+                "MOVE" => std::option::Option::Some(Self::MOVE),
+                "COPY" => std::option::Option::Some(Self::COPY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Operation](Operation)
-    pub mod operation {
-        use super::Operation;
-
-        /// The operation is unspecified.
-        pub const OPERATION_UNSPECIFIED: Operation = Operation::new("OPERATION_UNSPECIFIED");
-
-        /// Represents a read operation.
-        pub const READ: Operation = Operation::new("READ");
-
-        /// Represents a move operation.
-        pub const MOVE: Operation = Operation::new("MOVE");
-
-        /// Represents a copy operation.
-        pub const COPY: Operation = Operation::new("COPY");
-    }
-
-    impl std::convert::From<std::string::String> for Operation {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Operation {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Operation {
         fn default() -> Self {
-            operation::OPERATION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2348,41 +2456,55 @@ pub mod data_retention_deletion_event {
 
     /// Type of the DRD event.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EventType(std::borrow::Cow<'static, str>);
+    pub struct EventType(i32);
 
     impl EventType {
+        /// Unspecified event type.
+        pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new(0);
+
+        /// The maximum retention time has been exceeded.
+        pub const EVENT_TYPE_MAX_TTL_EXCEEDED: EventType = EventType::new(1);
+
         /// Creates a new EventType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EVENT_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("EVENT_TYPE_MAX_TTL_EXCEEDED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EVENT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::EVENT_TYPE_UNSPECIFIED),
+                "EVENT_TYPE_MAX_TTL_EXCEEDED" => {
+                    std::option::Option::Some(Self::EVENT_TYPE_MAX_TTL_EXCEEDED)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [EventType](EventType)
-    pub mod event_type {
-        use super::EventType;
-
-        /// Unspecified event type.
-        pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new("EVENT_TYPE_UNSPECIFIED");
-
-        /// The maximum retention time has been exceeded.
-        pub const EVENT_TYPE_MAX_TTL_EXCEEDED: EventType =
-            EventType::new("EVENT_TYPE_MAX_TTL_EXCEEDED");
-    }
-
-    impl std::convert::From<std::string::String> for EventType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EventType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EventType {
         fn default() -> Self {
-            event_type::EVENT_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4061,70 +4183,70 @@ pub mod finding {
 
     /// The state of the finding.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The finding requires attention and has not been addressed yet.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(1);
 
         /// The finding has been fixed, triaged as a non-issue or otherwise addressed
         /// and is no longer active.
-        pub const INACTIVE: State = State::new("INACTIVE");
+        pub const INACTIVE: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("INACTIVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The severity of the finding.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(std::borrow::Cow<'static, str>);
+    pub struct Severity(i32);
 
     impl Severity {
-        /// Creates a new Severity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Severity](Severity)
-    pub mod severity {
-        use super::Severity;
-
         /// This value is used for findings when a source doesn't write a severity
         /// value.
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new("SEVERITY_UNSPECIFIED");
+        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
 
         /// Vulnerability:
         /// A critical vulnerability is easily discoverable by an external actor,
@@ -4137,7 +4259,7 @@ pub mod finding {
         /// Threat:
         /// Indicates a threat that is able to access, modify, or delete data or
         /// execute unauthorized code within existing resources.
-        pub const CRITICAL: Severity = Severity::new("CRITICAL");
+        pub const CRITICAL: Severity = Severity::new(1);
 
         /// Vulnerability:
         /// A high risk vulnerability can be easily discovered and exploited in
@@ -4152,7 +4274,7 @@ pub mod finding {
         /// Indicates a threat that is able to create new computational resources in
         /// an environment but not able to access data or execute code in existing
         /// resources.
-        pub const HIGH: Severity = Severity::new("HIGH");
+        pub const HIGH: Severity = Severity::new(2);
 
         /// Vulnerability:
         /// A medium risk vulnerability could be used by an actor to gain access to
@@ -4166,7 +4288,7 @@ pub mod finding {
         /// Threat:
         /// Indicates a threat that is able to cause operational impact but may not
         /// access data or execute unauthorized code.
-        pub const MEDIUM: Severity = Severity::new("MEDIUM");
+        pub const MEDIUM: Severity = Severity::new(3);
 
         /// Vulnerability:
         /// A low risk vulnerability hampers a security organization's ability to
@@ -4177,129 +4299,208 @@ pub mod finding {
         /// Threat:
         /// Indicates a threat that has obtained minimal access to an environment but
         /// is not able to access data, execute code, or create resources.
-        pub const LOW: Severity = Severity::new("LOW");
+        pub const LOW: Severity = Severity::new(4);
+
+        /// Creates a new Severity instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CRITICAL"),
+                2 => std::borrow::Cow::Borrowed("HIGH"),
+                3 => std::borrow::Cow::Borrowed("MEDIUM"),
+                4 => std::borrow::Cow::Borrowed("LOW"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
+                "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
+                "HIGH" => std::option::Option::Some(Self::HIGH),
+                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
+                "LOW" => std::option::Option::Some(Self::LOW),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Severity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            severity::SEVERITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Mute state a finding can be in.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mute(std::borrow::Cow<'static, str>);
+    pub struct Mute(i32);
 
     impl Mute {
+        /// Unspecified.
+        pub const MUTE_UNSPECIFIED: Mute = Mute::new(0);
+
+        /// Finding has been muted.
+        pub const MUTED: Mute = Mute::new(1);
+
+        /// Finding has been unmuted.
+        pub const UNMUTED: Mute = Mute::new(2);
+
+        /// Finding has never been muted/unmuted.
+        pub const UNDEFINED: Mute = Mute::new(3);
+
         /// Creates a new Mute instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MUTE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MUTED"),
+                2 => std::borrow::Cow::Borrowed("UNMUTED"),
+                3 => std::borrow::Cow::Borrowed("UNDEFINED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MUTE_UNSPECIFIED" => std::option::Option::Some(Self::MUTE_UNSPECIFIED),
+                "MUTED" => std::option::Option::Some(Self::MUTED),
+                "UNMUTED" => std::option::Option::Some(Self::UNMUTED),
+                "UNDEFINED" => std::option::Option::Some(Self::UNDEFINED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Mute](Mute)
-    pub mod mute {
-        use super::Mute;
-
-        /// Unspecified.
-        pub const MUTE_UNSPECIFIED: Mute = Mute::new("MUTE_UNSPECIFIED");
-
-        /// Finding has been muted.
-        pub const MUTED: Mute = Mute::new("MUTED");
-
-        /// Finding has been unmuted.
-        pub const UNMUTED: Mute = Mute::new("UNMUTED");
-
-        /// Finding has never been muted/unmuted.
-        pub const UNDEFINED: Mute = Mute::new("UNDEFINED");
-    }
-
-    impl std::convert::From<std::string::String> for Mute {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Mute {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Mute {
         fn default() -> Self {
-            mute::MUTE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Represents what kind of Finding it is.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FindingClass(std::borrow::Cow<'static, str>);
+    pub struct FindingClass(i32);
 
     impl FindingClass {
-        /// Creates a new FindingClass instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [FindingClass](FindingClass)
-    pub mod finding_class {
-        use super::FindingClass;
-
         /// Unspecified finding class.
-        pub const FINDING_CLASS_UNSPECIFIED: FindingClass =
-            FindingClass::new("FINDING_CLASS_UNSPECIFIED");
+        pub const FINDING_CLASS_UNSPECIFIED: FindingClass = FindingClass::new(0);
 
         /// Describes unwanted or malicious activity.
-        pub const THREAT: FindingClass = FindingClass::new("THREAT");
+        pub const THREAT: FindingClass = FindingClass::new(1);
 
         /// Describes a potential weakness in software that increases risk to
         /// Confidentiality & Integrity & Availability.
-        pub const VULNERABILITY: FindingClass = FindingClass::new("VULNERABILITY");
+        pub const VULNERABILITY: FindingClass = FindingClass::new(2);
 
         /// Describes a potential weakness in cloud resource/asset configuration that
         /// increases risk.
-        pub const MISCONFIGURATION: FindingClass = FindingClass::new("MISCONFIGURATION");
+        pub const MISCONFIGURATION: FindingClass = FindingClass::new(3);
 
         /// Describes a security observation that is for informational purposes.
-        pub const OBSERVATION: FindingClass = FindingClass::new("OBSERVATION");
+        pub const OBSERVATION: FindingClass = FindingClass::new(4);
 
         /// Describes an error that prevents some SCC functionality.
-        pub const SCC_ERROR: FindingClass = FindingClass::new("SCC_ERROR");
+        pub const SCC_ERROR: FindingClass = FindingClass::new(5);
 
         /// Describes a potential security risk due to a change in the security
         /// posture.
-        pub const POSTURE_VIOLATION: FindingClass = FindingClass::new("POSTURE_VIOLATION");
+        pub const POSTURE_VIOLATION: FindingClass = FindingClass::new(6);
 
         /// Describes a combination of security issues that represent a more severe
         /// security problem when taken together.
-        pub const TOXIC_COMBINATION: FindingClass = FindingClass::new("TOXIC_COMBINATION");
+        pub const TOXIC_COMBINATION: FindingClass = FindingClass::new(7);
 
         /// Describes a potential security risk to data assets that contain sensitive
         /// data.
-        pub const SENSITIVE_DATA_RISK: FindingClass = FindingClass::new("SENSITIVE_DATA_RISK");
+        pub const SENSITIVE_DATA_RISK: FindingClass = FindingClass::new(8);
+
+        /// Creates a new FindingClass instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FINDING_CLASS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("THREAT"),
+                2 => std::borrow::Cow::Borrowed("VULNERABILITY"),
+                3 => std::borrow::Cow::Borrowed("MISCONFIGURATION"),
+                4 => std::borrow::Cow::Borrowed("OBSERVATION"),
+                5 => std::borrow::Cow::Borrowed("SCC_ERROR"),
+                6 => std::borrow::Cow::Borrowed("POSTURE_VIOLATION"),
+                7 => std::borrow::Cow::Borrowed("TOXIC_COMBINATION"),
+                8 => std::borrow::Cow::Borrowed("SENSITIVE_DATA_RISK"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FINDING_CLASS_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::FINDING_CLASS_UNSPECIFIED)
+                }
+                "THREAT" => std::option::Option::Some(Self::THREAT),
+                "VULNERABILITY" => std::option::Option::Some(Self::VULNERABILITY),
+                "MISCONFIGURATION" => std::option::Option::Some(Self::MISCONFIGURATION),
+                "OBSERVATION" => std::option::Option::Some(Self::OBSERVATION),
+                "SCC_ERROR" => std::option::Option::Some(Self::SCC_ERROR),
+                "POSTURE_VIOLATION" => std::option::Option::Some(Self::POSTURE_VIOLATION),
+                "TOXIC_COMBINATION" => std::option::Option::Some(Self::TOXIC_COMBINATION),
+                "SENSITIVE_DATA_RISK" => std::option::Option::Some(Self::SENSITIVE_DATA_RISK),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for FindingClass {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for FindingClass {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for FindingClass {
         fn default() -> Self {
-            finding_class::FINDING_CLASS_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4397,41 +4598,55 @@ pub mod group_membership {
 
     /// Possible types of groups.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct GroupType(std::borrow::Cow<'static, str>);
+    pub struct GroupType(i32);
 
     impl GroupType {
+        /// Default value.
+        pub const GROUP_TYPE_UNSPECIFIED: GroupType = GroupType::new(0);
+
+        /// Group represents a toxic combination.
+        pub const GROUP_TYPE_TOXIC_COMBINATION: GroupType = GroupType::new(1);
+
         /// Creates a new GroupType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("GROUP_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GROUP_TYPE_TOXIC_COMBINATION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "GROUP_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::GROUP_TYPE_UNSPECIFIED),
+                "GROUP_TYPE_TOXIC_COMBINATION" => {
+                    std::option::Option::Some(Self::GROUP_TYPE_TOXIC_COMBINATION)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [GroupType](GroupType)
-    pub mod group_type {
-        use super::GroupType;
-
-        /// Default value.
-        pub const GROUP_TYPE_UNSPECIFIED: GroupType = GroupType::new("GROUP_TYPE_UNSPECIFIED");
-
-        /// Group represents a toxic combination.
-        pub const GROUP_TYPE_TOXIC_COMBINATION: GroupType =
-            GroupType::new("GROUP_TYPE_TOXIC_COMBINATION");
-    }
-
-    impl std::convert::From<std::string::String> for GroupType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for GroupType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for GroupType {
         fn default() -> Self {
-            group_type::GROUP_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4497,43 +4712,58 @@ pub mod iam_binding {
 
     /// The type of action performed on a Binding in a policy.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(std::borrow::Cow<'static, str>);
+    pub struct Action(i32);
 
     impl Action {
+        /// Unspecified.
+        pub const ACTION_UNSPECIFIED: Action = Action::new(0);
+
+        /// Addition of a Binding.
+        pub const ADD: Action = Action::new(1);
+
+        /// Removal of a Binding.
+        pub const REMOVE: Action = Action::new(2);
+
         /// Creates a new Action instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ACTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ADD"),
+                2 => std::borrow::Cow::Borrowed("REMOVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ACTION_UNSPECIFIED" => std::option::Option::Some(Self::ACTION_UNSPECIFIED),
+                "ADD" => std::option::Option::Some(Self::ADD),
+                "REMOVE" => std::option::Option::Some(Self::REMOVE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Action](Action)
-    pub mod action {
-        use super::Action;
-
-        /// Unspecified.
-        pub const ACTION_UNSPECIFIED: Action = Action::new("ACTION_UNSPECIFIED");
-
-        /// Addition of a Binding.
-        pub const ADD: Action = Action::new("ADD");
-
-        /// Removal of a Binding.
-        pub const REMOVE: Action = Action::new("REMOVE");
-    }
-
-    impl std::convert::From<std::string::String> for Action {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            action::ACTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4893,46 +5123,62 @@ pub mod indicator {
 
         /// Possible resource types to be associated with a signature.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SignatureType(std::borrow::Cow<'static, str>);
+        pub struct SignatureType(i32);
 
         impl SignatureType {
+            /// The default signature type.
+            pub const SIGNATURE_TYPE_UNSPECIFIED: SignatureType = SignatureType::new(0);
+
+            /// Used for signatures concerning processes.
+            pub const SIGNATURE_TYPE_PROCESS: SignatureType = SignatureType::new(1);
+
+            /// Used for signatures concerning disks.
+            pub const SIGNATURE_TYPE_FILE: SignatureType = SignatureType::new(2);
+
             /// Creates a new SignatureType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("SIGNATURE_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("SIGNATURE_TYPE_PROCESS"),
+                    2 => std::borrow::Cow::Borrowed("SIGNATURE_TYPE_FILE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "SIGNATURE_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::SIGNATURE_TYPE_UNSPECIFIED)
+                    }
+                    "SIGNATURE_TYPE_PROCESS" => {
+                        std::option::Option::Some(Self::SIGNATURE_TYPE_PROCESS)
+                    }
+                    "SIGNATURE_TYPE_FILE" => std::option::Option::Some(Self::SIGNATURE_TYPE_FILE),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [SignatureType](SignatureType)
-        pub mod signature_type {
-            use super::SignatureType;
-
-            /// The default signature type.
-            pub const SIGNATURE_TYPE_UNSPECIFIED: SignatureType =
-                SignatureType::new("SIGNATURE_TYPE_UNSPECIFIED");
-
-            /// Used for signatures concerning processes.
-            pub const SIGNATURE_TYPE_PROCESS: SignatureType =
-                SignatureType::new("SIGNATURE_TYPE_PROCESS");
-
-            /// Used for signatures concerning disks.
-            pub const SIGNATURE_TYPE_FILE: SignatureType =
-                SignatureType::new("SIGNATURE_TYPE_FILE");
-        }
-
-        impl std::convert::From<std::string::String> for SignatureType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for SignatureType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for SignatureType {
             fn default() -> Self {
-                signature_type::SIGNATURE_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -5409,43 +5655,58 @@ pub mod kubernetes {
 
         /// Types of Kubernetes roles.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Kind(std::borrow::Cow<'static, str>);
+        pub struct Kind(i32);
 
         impl Kind {
+            /// Role type is not specified.
+            pub const KIND_UNSPECIFIED: Kind = Kind::new(0);
+
+            /// Kubernetes Role.
+            pub const ROLE: Kind = Kind::new(1);
+
+            /// Kubernetes ClusterRole.
+            pub const CLUSTER_ROLE: Kind = Kind::new(2);
+
             /// Creates a new Kind instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("KIND_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("ROLE"),
+                    2 => std::borrow::Cow::Borrowed("CLUSTER_ROLE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "KIND_UNSPECIFIED" => std::option::Option::Some(Self::KIND_UNSPECIFIED),
+                    "ROLE" => std::option::Option::Some(Self::ROLE),
+                    "CLUSTER_ROLE" => std::option::Option::Some(Self::CLUSTER_ROLE),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Kind](Kind)
-        pub mod kind {
-            use super::Kind;
-
-            /// Role type is not specified.
-            pub const KIND_UNSPECIFIED: Kind = Kind::new("KIND_UNSPECIFIED");
-
-            /// Kubernetes Role.
-            pub const ROLE: Kind = Kind::new("ROLE");
-
-            /// Kubernetes ClusterRole.
-            pub const CLUSTER_ROLE: Kind = Kind::new("CLUSTER_ROLE");
-        }
-
-        impl std::convert::From<std::string::String> for Kind {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Kind {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Kind {
             fn default() -> Self {
-                kind::KIND_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -5578,46 +5839,65 @@ pub mod kubernetes {
 
         /// Auth types that can be used for the subject's kind field.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct AuthType(std::borrow::Cow<'static, str>);
+        pub struct AuthType(i32);
 
         impl AuthType {
+            /// Authentication is not specified.
+            pub const AUTH_TYPE_UNSPECIFIED: AuthType = AuthType::new(0);
+
+            /// User with valid certificate.
+            pub const USER: AuthType = AuthType::new(1);
+
+            /// Users managed by Kubernetes API with credentials stored as secrets.
+            pub const SERVICEACCOUNT: AuthType = AuthType::new(2);
+
+            /// Collection of users.
+            pub const GROUP: AuthType = AuthType::new(3);
+
             /// Creates a new AuthType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("AUTH_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("USER"),
+                    2 => std::borrow::Cow::Borrowed("SERVICEACCOUNT"),
+                    3 => std::borrow::Cow::Borrowed("GROUP"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "AUTH_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::AUTH_TYPE_UNSPECIFIED)
+                    }
+                    "USER" => std::option::Option::Some(Self::USER),
+                    "SERVICEACCOUNT" => std::option::Option::Some(Self::SERVICEACCOUNT),
+                    "GROUP" => std::option::Option::Some(Self::GROUP),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [AuthType](AuthType)
-        pub mod auth_type {
-            use super::AuthType;
-
-            /// Authentication is not specified.
-            pub const AUTH_TYPE_UNSPECIFIED: AuthType = AuthType::new("AUTH_TYPE_UNSPECIFIED");
-
-            /// User with valid certificate.
-            pub const USER: AuthType = AuthType::new("USER");
-
-            /// Users managed by Kubernetes API with credentials stored as secrets.
-            pub const SERVICEACCOUNT: AuthType = AuthType::new("SERVICEACCOUNT");
-
-            /// Collection of users.
-            pub const GROUP: AuthType = AuthType::new("GROUP");
-        }
-
-        impl std::convert::From<std::string::String> for AuthType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for AuthType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for AuthType {
             fn default() -> Self {
-                auth_type::AUTH_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -6117,342 +6397,560 @@ pub mod mitre_attack {
     /// MITRE ATT&CK tactics that can be referenced by SCC findings.
     /// See: <https://attack.mitre.org/tactics/enterprise/>
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Tactic(std::borrow::Cow<'static, str>);
+    pub struct Tactic(i32);
 
     impl Tactic {
+        /// Unspecified value.
+        pub const TACTIC_UNSPECIFIED: Tactic = Tactic::new(0);
+
+        /// TA0043
+        pub const RECONNAISSANCE: Tactic = Tactic::new(1);
+
+        /// TA0042
+        pub const RESOURCE_DEVELOPMENT: Tactic = Tactic::new(2);
+
+        /// TA0001
+        pub const INITIAL_ACCESS: Tactic = Tactic::new(5);
+
+        /// TA0002
+        pub const EXECUTION: Tactic = Tactic::new(3);
+
+        /// TA0003
+        pub const PERSISTENCE: Tactic = Tactic::new(6);
+
+        /// TA0004
+        pub const PRIVILEGE_ESCALATION: Tactic = Tactic::new(8);
+
+        /// TA0005
+        pub const DEFENSE_EVASION: Tactic = Tactic::new(7);
+
+        /// TA0006
+        pub const CREDENTIAL_ACCESS: Tactic = Tactic::new(9);
+
+        /// TA0007
+        pub const DISCOVERY: Tactic = Tactic::new(10);
+
+        /// TA0008
+        pub const LATERAL_MOVEMENT: Tactic = Tactic::new(11);
+
+        /// TA0009
+        pub const COLLECTION: Tactic = Tactic::new(12);
+
+        /// TA0011
+        pub const COMMAND_AND_CONTROL: Tactic = Tactic::new(4);
+
+        /// TA0010
+        pub const EXFILTRATION: Tactic = Tactic::new(13);
+
+        /// TA0040
+        pub const IMPACT: Tactic = Tactic::new(14);
+
         /// Creates a new Tactic instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TACTIC_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RECONNAISSANCE"),
+                2 => std::borrow::Cow::Borrowed("RESOURCE_DEVELOPMENT"),
+                3 => std::borrow::Cow::Borrowed("EXECUTION"),
+                4 => std::borrow::Cow::Borrowed("COMMAND_AND_CONTROL"),
+                5 => std::borrow::Cow::Borrowed("INITIAL_ACCESS"),
+                6 => std::borrow::Cow::Borrowed("PERSISTENCE"),
+                7 => std::borrow::Cow::Borrowed("DEFENSE_EVASION"),
+                8 => std::borrow::Cow::Borrowed("PRIVILEGE_ESCALATION"),
+                9 => std::borrow::Cow::Borrowed("CREDENTIAL_ACCESS"),
+                10 => std::borrow::Cow::Borrowed("DISCOVERY"),
+                11 => std::borrow::Cow::Borrowed("LATERAL_MOVEMENT"),
+                12 => std::borrow::Cow::Borrowed("COLLECTION"),
+                13 => std::borrow::Cow::Borrowed("EXFILTRATION"),
+                14 => std::borrow::Cow::Borrowed("IMPACT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TACTIC_UNSPECIFIED" => std::option::Option::Some(Self::TACTIC_UNSPECIFIED),
+                "RECONNAISSANCE" => std::option::Option::Some(Self::RECONNAISSANCE),
+                "RESOURCE_DEVELOPMENT" => std::option::Option::Some(Self::RESOURCE_DEVELOPMENT),
+                "INITIAL_ACCESS" => std::option::Option::Some(Self::INITIAL_ACCESS),
+                "EXECUTION" => std::option::Option::Some(Self::EXECUTION),
+                "PERSISTENCE" => std::option::Option::Some(Self::PERSISTENCE),
+                "PRIVILEGE_ESCALATION" => std::option::Option::Some(Self::PRIVILEGE_ESCALATION),
+                "DEFENSE_EVASION" => std::option::Option::Some(Self::DEFENSE_EVASION),
+                "CREDENTIAL_ACCESS" => std::option::Option::Some(Self::CREDENTIAL_ACCESS),
+                "DISCOVERY" => std::option::Option::Some(Self::DISCOVERY),
+                "LATERAL_MOVEMENT" => std::option::Option::Some(Self::LATERAL_MOVEMENT),
+                "COLLECTION" => std::option::Option::Some(Self::COLLECTION),
+                "COMMAND_AND_CONTROL" => std::option::Option::Some(Self::COMMAND_AND_CONTROL),
+                "EXFILTRATION" => std::option::Option::Some(Self::EXFILTRATION),
+                "IMPACT" => std::option::Option::Some(Self::IMPACT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Tactic](Tactic)
-    pub mod tactic {
-        use super::Tactic;
-
-        /// Unspecified value.
-        pub const TACTIC_UNSPECIFIED: Tactic = Tactic::new("TACTIC_UNSPECIFIED");
-
-        /// TA0043
-        pub const RECONNAISSANCE: Tactic = Tactic::new("RECONNAISSANCE");
-
-        /// TA0042
-        pub const RESOURCE_DEVELOPMENT: Tactic = Tactic::new("RESOURCE_DEVELOPMENT");
-
-        /// TA0001
-        pub const INITIAL_ACCESS: Tactic = Tactic::new("INITIAL_ACCESS");
-
-        /// TA0002
-        pub const EXECUTION: Tactic = Tactic::new("EXECUTION");
-
-        /// TA0003
-        pub const PERSISTENCE: Tactic = Tactic::new("PERSISTENCE");
-
-        /// TA0004
-        pub const PRIVILEGE_ESCALATION: Tactic = Tactic::new("PRIVILEGE_ESCALATION");
-
-        /// TA0005
-        pub const DEFENSE_EVASION: Tactic = Tactic::new("DEFENSE_EVASION");
-
-        /// TA0006
-        pub const CREDENTIAL_ACCESS: Tactic = Tactic::new("CREDENTIAL_ACCESS");
-
-        /// TA0007
-        pub const DISCOVERY: Tactic = Tactic::new("DISCOVERY");
-
-        /// TA0008
-        pub const LATERAL_MOVEMENT: Tactic = Tactic::new("LATERAL_MOVEMENT");
-
-        /// TA0009
-        pub const COLLECTION: Tactic = Tactic::new("COLLECTION");
-
-        /// TA0011
-        pub const COMMAND_AND_CONTROL: Tactic = Tactic::new("COMMAND_AND_CONTROL");
-
-        /// TA0010
-        pub const EXFILTRATION: Tactic = Tactic::new("EXFILTRATION");
-
-        /// TA0040
-        pub const IMPACT: Tactic = Tactic::new("IMPACT");
-    }
-
-    impl std::convert::From<std::string::String> for Tactic {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Tactic {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Tactic {
         fn default() -> Self {
-            tactic::TACTIC_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// MITRE ATT&CK techniques that can be referenced by SCC findings.
     /// See: <https://attack.mitre.org/techniques/enterprise/>
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Technique(std::borrow::Cow<'static, str>);
+    pub struct Technique(i32);
 
     impl Technique {
+        /// Unspecified value.
+        pub const TECHNIQUE_UNSPECIFIED: Technique = Technique::new(0);
+
+        /// T1036
+        pub const MASQUERADING: Technique = Technique::new(49);
+
+        /// T1036.005
+        pub const MATCH_LEGITIMATE_NAME_OR_LOCATION: Technique = Technique::new(50);
+
+        /// T1037
+        pub const BOOT_OR_LOGON_INITIALIZATION_SCRIPTS: Technique = Technique::new(37);
+
+        /// T1037.005
+        pub const STARTUP_ITEMS: Technique = Technique::new(38);
+
+        /// T1046
+        pub const NETWORK_SERVICE_DISCOVERY: Technique = Technique::new(32);
+
+        /// T1057
+        pub const PROCESS_DISCOVERY: Technique = Technique::new(56);
+
+        /// T1059
+        pub const COMMAND_AND_SCRIPTING_INTERPRETER: Technique = Technique::new(6);
+
+        /// T1059.004
+        pub const UNIX_SHELL: Technique = Technique::new(7);
+
+        /// T1059.006
+        pub const PYTHON: Technique = Technique::new(59);
+
+        /// T1068
+        pub const EXPLOITATION_FOR_PRIVILEGE_ESCALATION: Technique = Technique::new(63);
+
+        /// T1069
+        pub const PERMISSION_GROUPS_DISCOVERY: Technique = Technique::new(18);
+
+        /// T1069.003
+        pub const CLOUD_GROUPS: Technique = Technique::new(19);
+
+        /// T1070.004
+        pub const INDICATOR_REMOVAL_FILE_DELETION: Technique = Technique::new(64);
+
+        /// T1071
+        pub const APPLICATION_LAYER_PROTOCOL: Technique = Technique::new(45);
+
+        /// T1071.004
+        pub const DNS: Technique = Technique::new(46);
+
+        /// T1072
+        pub const SOFTWARE_DEPLOYMENT_TOOLS: Technique = Technique::new(47);
+
+        /// T1078
+        pub const VALID_ACCOUNTS: Technique = Technique::new(14);
+
+        /// T1078.001
+        pub const DEFAULT_ACCOUNTS: Technique = Technique::new(35);
+
+        /// T1078.003
+        pub const LOCAL_ACCOUNTS: Technique = Technique::new(15);
+
+        /// T1078.004
+        pub const CLOUD_ACCOUNTS: Technique = Technique::new(16);
+
+        /// T1090
+        pub const PROXY: Technique = Technique::new(9);
+
+        /// T1090.002
+        pub const EXTERNAL_PROXY: Technique = Technique::new(10);
+
+        /// T1090.003
+        pub const MULTI_HOP_PROXY: Technique = Technique::new(11);
+
+        /// T1098
+        pub const ACCOUNT_MANIPULATION: Technique = Technique::new(22);
+
+        /// T1098.001
+        pub const ADDITIONAL_CLOUD_CREDENTIALS: Technique = Technique::new(40);
+
+        /// T1098.004
+        pub const SSH_AUTHORIZED_KEYS: Technique = Technique::new(23);
+
+        /// T1098.006
+        pub const ADDITIONAL_CONTAINER_CLUSTER_ROLES: Technique = Technique::new(58);
+
+        /// T1105
+        pub const INGRESS_TOOL_TRANSFER: Technique = Technique::new(3);
+
+        /// T1106
+        pub const NATIVE_API: Technique = Technique::new(4);
+
+        /// T1110
+        pub const BRUTE_FORCE: Technique = Technique::new(44);
+
+        /// T1129
+        pub const SHARED_MODULES: Technique = Technique::new(5);
+
+        /// T1134
+        pub const ACCESS_TOKEN_MANIPULATION: Technique = Technique::new(33);
+
+        /// T1134.001
+        pub const TOKEN_IMPERSONATION_OR_THEFT: Technique = Technique::new(39);
+
+        /// T1190
+        pub const EXPLOIT_PUBLIC_FACING_APPLICATION: Technique = Technique::new(27);
+
+        /// T1484
+        pub const DOMAIN_POLICY_MODIFICATION: Technique = Technique::new(30);
+
+        /// T1485
+        pub const DATA_DESTRUCTION: Technique = Technique::new(29);
+
+        /// T1489
+        pub const SERVICE_STOP: Technique = Technique::new(52);
+
+        /// T1490
+        pub const INHIBIT_SYSTEM_RECOVERY: Technique = Technique::new(36);
+
+        /// T1496
+        pub const RESOURCE_HIJACKING: Technique = Technique::new(8);
+
+        /// T1498
+        pub const NETWORK_DENIAL_OF_SERVICE: Technique = Technique::new(17);
+
+        /// T1526
+        pub const CLOUD_SERVICE_DISCOVERY: Technique = Technique::new(48);
+
+        /// T1528
+        pub const STEAL_APPLICATION_ACCESS_TOKEN: Technique = Technique::new(42);
+
+        /// T1531
+        pub const ACCOUNT_ACCESS_REMOVAL: Technique = Technique::new(51);
+
+        /// T1539
+        pub const STEAL_WEB_SESSION_COOKIE: Technique = Technique::new(25);
+
+        /// T1543
+        pub const CREATE_OR_MODIFY_SYSTEM_PROCESS: Technique = Technique::new(24);
+
+        /// T1546
+        pub const EVENT_TRIGGERED_EXECUTION: Technique = Technique::new(65);
+
+        /// T1548
+        pub const ABUSE_ELEVATION_CONTROL_MECHANISM: Technique = Technique::new(34);
+
+        /// T1552
+        pub const UNSECURED_CREDENTIALS: Technique = Technique::new(13);
+
+        /// T1556
+        pub const MODIFY_AUTHENTICATION_PROCESS: Technique = Technique::new(28);
+
+        /// T1562
+        pub const IMPAIR_DEFENSES: Technique = Technique::new(31);
+
+        /// T1562.001
+        pub const DISABLE_OR_MODIFY_TOOLS: Technique = Technique::new(55);
+
+        /// T1567
+        pub const EXFILTRATION_OVER_WEB_SERVICE: Technique = Technique::new(20);
+
+        /// T1567.002
+        pub const EXFILTRATION_TO_CLOUD_STORAGE: Technique = Technique::new(21);
+
+        /// T1568
+        pub const DYNAMIC_RESOLUTION: Technique = Technique::new(12);
+
+        /// T1570
+        pub const LATERAL_TOOL_TRANSFER: Technique = Technique::new(41);
+
+        /// T1578
+        pub const MODIFY_CLOUD_COMPUTE_INFRASTRUCTURE: Technique = Technique::new(26);
+
+        /// T1578.001
+        pub const CREATE_SNAPSHOT: Technique = Technique::new(54);
+
+        /// T1580
+        pub const CLOUD_INFRASTRUCTURE_DISCOVERY: Technique = Technique::new(53);
+
+        /// T1588
+        pub const OBTAIN_CAPABILITIES: Technique = Technique::new(43);
+
+        /// T1595
+        pub const ACTIVE_SCANNING: Technique = Technique::new(1);
+
+        /// T1595.001
+        pub const SCANNING_IP_BLOCKS: Technique = Technique::new(2);
+
+        /// T1609
+        pub const CONTAINER_ADMINISTRATION_COMMAND: Technique = Technique::new(60);
+
+        /// T1610
+        pub const DEPLOY_CONTAINER: Technique = Technique::new(66);
+
+        /// T1611
+        pub const ESCAPE_TO_HOST: Technique = Technique::new(61);
+
+        /// T1613
+        pub const CONTAINER_AND_RESOURCE_DISCOVERY: Technique = Technique::new(57);
+
+        /// T1649
+        pub const STEAL_OR_FORGE_AUTHENTICATION_CERTIFICATES: Technique = Technique::new(62);
+
         /// Creates a new Technique instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TECHNIQUE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE_SCANNING"),
+                2 => std::borrow::Cow::Borrowed("SCANNING_IP_BLOCKS"),
+                3 => std::borrow::Cow::Borrowed("INGRESS_TOOL_TRANSFER"),
+                4 => std::borrow::Cow::Borrowed("NATIVE_API"),
+                5 => std::borrow::Cow::Borrowed("SHARED_MODULES"),
+                6 => std::borrow::Cow::Borrowed("COMMAND_AND_SCRIPTING_INTERPRETER"),
+                7 => std::borrow::Cow::Borrowed("UNIX_SHELL"),
+                8 => std::borrow::Cow::Borrowed("RESOURCE_HIJACKING"),
+                9 => std::borrow::Cow::Borrowed("PROXY"),
+                10 => std::borrow::Cow::Borrowed("EXTERNAL_PROXY"),
+                11 => std::borrow::Cow::Borrowed("MULTI_HOP_PROXY"),
+                12 => std::borrow::Cow::Borrowed("DYNAMIC_RESOLUTION"),
+                13 => std::borrow::Cow::Borrowed("UNSECURED_CREDENTIALS"),
+                14 => std::borrow::Cow::Borrowed("VALID_ACCOUNTS"),
+                15 => std::borrow::Cow::Borrowed("LOCAL_ACCOUNTS"),
+                16 => std::borrow::Cow::Borrowed("CLOUD_ACCOUNTS"),
+                17 => std::borrow::Cow::Borrowed("NETWORK_DENIAL_OF_SERVICE"),
+                18 => std::borrow::Cow::Borrowed("PERMISSION_GROUPS_DISCOVERY"),
+                19 => std::borrow::Cow::Borrowed("CLOUD_GROUPS"),
+                20 => std::borrow::Cow::Borrowed("EXFILTRATION_OVER_WEB_SERVICE"),
+                21 => std::borrow::Cow::Borrowed("EXFILTRATION_TO_CLOUD_STORAGE"),
+                22 => std::borrow::Cow::Borrowed("ACCOUNT_MANIPULATION"),
+                23 => std::borrow::Cow::Borrowed("SSH_AUTHORIZED_KEYS"),
+                24 => std::borrow::Cow::Borrowed("CREATE_OR_MODIFY_SYSTEM_PROCESS"),
+                25 => std::borrow::Cow::Borrowed("STEAL_WEB_SESSION_COOKIE"),
+                26 => std::borrow::Cow::Borrowed("MODIFY_CLOUD_COMPUTE_INFRASTRUCTURE"),
+                27 => std::borrow::Cow::Borrowed("EXPLOIT_PUBLIC_FACING_APPLICATION"),
+                28 => std::borrow::Cow::Borrowed("MODIFY_AUTHENTICATION_PROCESS"),
+                29 => std::borrow::Cow::Borrowed("DATA_DESTRUCTION"),
+                30 => std::borrow::Cow::Borrowed("DOMAIN_POLICY_MODIFICATION"),
+                31 => std::borrow::Cow::Borrowed("IMPAIR_DEFENSES"),
+                32 => std::borrow::Cow::Borrowed("NETWORK_SERVICE_DISCOVERY"),
+                33 => std::borrow::Cow::Borrowed("ACCESS_TOKEN_MANIPULATION"),
+                34 => std::borrow::Cow::Borrowed("ABUSE_ELEVATION_CONTROL_MECHANISM"),
+                35 => std::borrow::Cow::Borrowed("DEFAULT_ACCOUNTS"),
+                36 => std::borrow::Cow::Borrowed("INHIBIT_SYSTEM_RECOVERY"),
+                37 => std::borrow::Cow::Borrowed("BOOT_OR_LOGON_INITIALIZATION_SCRIPTS"),
+                38 => std::borrow::Cow::Borrowed("STARTUP_ITEMS"),
+                39 => std::borrow::Cow::Borrowed("TOKEN_IMPERSONATION_OR_THEFT"),
+                40 => std::borrow::Cow::Borrowed("ADDITIONAL_CLOUD_CREDENTIALS"),
+                41 => std::borrow::Cow::Borrowed("LATERAL_TOOL_TRANSFER"),
+                42 => std::borrow::Cow::Borrowed("STEAL_APPLICATION_ACCESS_TOKEN"),
+                43 => std::borrow::Cow::Borrowed("OBTAIN_CAPABILITIES"),
+                44 => std::borrow::Cow::Borrowed("BRUTE_FORCE"),
+                45 => std::borrow::Cow::Borrowed("APPLICATION_LAYER_PROTOCOL"),
+                46 => std::borrow::Cow::Borrowed("DNS"),
+                47 => std::borrow::Cow::Borrowed("SOFTWARE_DEPLOYMENT_TOOLS"),
+                48 => std::borrow::Cow::Borrowed("CLOUD_SERVICE_DISCOVERY"),
+                49 => std::borrow::Cow::Borrowed("MASQUERADING"),
+                50 => std::borrow::Cow::Borrowed("MATCH_LEGITIMATE_NAME_OR_LOCATION"),
+                51 => std::borrow::Cow::Borrowed("ACCOUNT_ACCESS_REMOVAL"),
+                52 => std::borrow::Cow::Borrowed("SERVICE_STOP"),
+                53 => std::borrow::Cow::Borrowed("CLOUD_INFRASTRUCTURE_DISCOVERY"),
+                54 => std::borrow::Cow::Borrowed("CREATE_SNAPSHOT"),
+                55 => std::borrow::Cow::Borrowed("DISABLE_OR_MODIFY_TOOLS"),
+                56 => std::borrow::Cow::Borrowed("PROCESS_DISCOVERY"),
+                57 => std::borrow::Cow::Borrowed("CONTAINER_AND_RESOURCE_DISCOVERY"),
+                58 => std::borrow::Cow::Borrowed("ADDITIONAL_CONTAINER_CLUSTER_ROLES"),
+                59 => std::borrow::Cow::Borrowed("PYTHON"),
+                60 => std::borrow::Cow::Borrowed("CONTAINER_ADMINISTRATION_COMMAND"),
+                61 => std::borrow::Cow::Borrowed("ESCAPE_TO_HOST"),
+                62 => std::borrow::Cow::Borrowed("STEAL_OR_FORGE_AUTHENTICATION_CERTIFICATES"),
+                63 => std::borrow::Cow::Borrowed("EXPLOITATION_FOR_PRIVILEGE_ESCALATION"),
+                64 => std::borrow::Cow::Borrowed("INDICATOR_REMOVAL_FILE_DELETION"),
+                65 => std::borrow::Cow::Borrowed("EVENT_TRIGGERED_EXECUTION"),
+                66 => std::borrow::Cow::Borrowed("DEPLOY_CONTAINER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TECHNIQUE_UNSPECIFIED" => std::option::Option::Some(Self::TECHNIQUE_UNSPECIFIED),
+                "MASQUERADING" => std::option::Option::Some(Self::MASQUERADING),
+                "MATCH_LEGITIMATE_NAME_OR_LOCATION" => {
+                    std::option::Option::Some(Self::MATCH_LEGITIMATE_NAME_OR_LOCATION)
+                }
+                "BOOT_OR_LOGON_INITIALIZATION_SCRIPTS" => {
+                    std::option::Option::Some(Self::BOOT_OR_LOGON_INITIALIZATION_SCRIPTS)
+                }
+                "STARTUP_ITEMS" => std::option::Option::Some(Self::STARTUP_ITEMS),
+                "NETWORK_SERVICE_DISCOVERY" => {
+                    std::option::Option::Some(Self::NETWORK_SERVICE_DISCOVERY)
+                }
+                "PROCESS_DISCOVERY" => std::option::Option::Some(Self::PROCESS_DISCOVERY),
+                "COMMAND_AND_SCRIPTING_INTERPRETER" => {
+                    std::option::Option::Some(Self::COMMAND_AND_SCRIPTING_INTERPRETER)
+                }
+                "UNIX_SHELL" => std::option::Option::Some(Self::UNIX_SHELL),
+                "PYTHON" => std::option::Option::Some(Self::PYTHON),
+                "EXPLOITATION_FOR_PRIVILEGE_ESCALATION" => {
+                    std::option::Option::Some(Self::EXPLOITATION_FOR_PRIVILEGE_ESCALATION)
+                }
+                "PERMISSION_GROUPS_DISCOVERY" => {
+                    std::option::Option::Some(Self::PERMISSION_GROUPS_DISCOVERY)
+                }
+                "CLOUD_GROUPS" => std::option::Option::Some(Self::CLOUD_GROUPS),
+                "INDICATOR_REMOVAL_FILE_DELETION" => {
+                    std::option::Option::Some(Self::INDICATOR_REMOVAL_FILE_DELETION)
+                }
+                "APPLICATION_LAYER_PROTOCOL" => {
+                    std::option::Option::Some(Self::APPLICATION_LAYER_PROTOCOL)
+                }
+                "DNS" => std::option::Option::Some(Self::DNS),
+                "SOFTWARE_DEPLOYMENT_TOOLS" => {
+                    std::option::Option::Some(Self::SOFTWARE_DEPLOYMENT_TOOLS)
+                }
+                "VALID_ACCOUNTS" => std::option::Option::Some(Self::VALID_ACCOUNTS),
+                "DEFAULT_ACCOUNTS" => std::option::Option::Some(Self::DEFAULT_ACCOUNTS),
+                "LOCAL_ACCOUNTS" => std::option::Option::Some(Self::LOCAL_ACCOUNTS),
+                "CLOUD_ACCOUNTS" => std::option::Option::Some(Self::CLOUD_ACCOUNTS),
+                "PROXY" => std::option::Option::Some(Self::PROXY),
+                "EXTERNAL_PROXY" => std::option::Option::Some(Self::EXTERNAL_PROXY),
+                "MULTI_HOP_PROXY" => std::option::Option::Some(Self::MULTI_HOP_PROXY),
+                "ACCOUNT_MANIPULATION" => std::option::Option::Some(Self::ACCOUNT_MANIPULATION),
+                "ADDITIONAL_CLOUD_CREDENTIALS" => {
+                    std::option::Option::Some(Self::ADDITIONAL_CLOUD_CREDENTIALS)
+                }
+                "SSH_AUTHORIZED_KEYS" => std::option::Option::Some(Self::SSH_AUTHORIZED_KEYS),
+                "ADDITIONAL_CONTAINER_CLUSTER_ROLES" => {
+                    std::option::Option::Some(Self::ADDITIONAL_CONTAINER_CLUSTER_ROLES)
+                }
+                "INGRESS_TOOL_TRANSFER" => std::option::Option::Some(Self::INGRESS_TOOL_TRANSFER),
+                "NATIVE_API" => std::option::Option::Some(Self::NATIVE_API),
+                "BRUTE_FORCE" => std::option::Option::Some(Self::BRUTE_FORCE),
+                "SHARED_MODULES" => std::option::Option::Some(Self::SHARED_MODULES),
+                "ACCESS_TOKEN_MANIPULATION" => {
+                    std::option::Option::Some(Self::ACCESS_TOKEN_MANIPULATION)
+                }
+                "TOKEN_IMPERSONATION_OR_THEFT" => {
+                    std::option::Option::Some(Self::TOKEN_IMPERSONATION_OR_THEFT)
+                }
+                "EXPLOIT_PUBLIC_FACING_APPLICATION" => {
+                    std::option::Option::Some(Self::EXPLOIT_PUBLIC_FACING_APPLICATION)
+                }
+                "DOMAIN_POLICY_MODIFICATION" => {
+                    std::option::Option::Some(Self::DOMAIN_POLICY_MODIFICATION)
+                }
+                "DATA_DESTRUCTION" => std::option::Option::Some(Self::DATA_DESTRUCTION),
+                "SERVICE_STOP" => std::option::Option::Some(Self::SERVICE_STOP),
+                "INHIBIT_SYSTEM_RECOVERY" => {
+                    std::option::Option::Some(Self::INHIBIT_SYSTEM_RECOVERY)
+                }
+                "RESOURCE_HIJACKING" => std::option::Option::Some(Self::RESOURCE_HIJACKING),
+                "NETWORK_DENIAL_OF_SERVICE" => {
+                    std::option::Option::Some(Self::NETWORK_DENIAL_OF_SERVICE)
+                }
+                "CLOUD_SERVICE_DISCOVERY" => {
+                    std::option::Option::Some(Self::CLOUD_SERVICE_DISCOVERY)
+                }
+                "STEAL_APPLICATION_ACCESS_TOKEN" => {
+                    std::option::Option::Some(Self::STEAL_APPLICATION_ACCESS_TOKEN)
+                }
+                "ACCOUNT_ACCESS_REMOVAL" => std::option::Option::Some(Self::ACCOUNT_ACCESS_REMOVAL),
+                "STEAL_WEB_SESSION_COOKIE" => {
+                    std::option::Option::Some(Self::STEAL_WEB_SESSION_COOKIE)
+                }
+                "CREATE_OR_MODIFY_SYSTEM_PROCESS" => {
+                    std::option::Option::Some(Self::CREATE_OR_MODIFY_SYSTEM_PROCESS)
+                }
+                "EVENT_TRIGGERED_EXECUTION" => {
+                    std::option::Option::Some(Self::EVENT_TRIGGERED_EXECUTION)
+                }
+                "ABUSE_ELEVATION_CONTROL_MECHANISM" => {
+                    std::option::Option::Some(Self::ABUSE_ELEVATION_CONTROL_MECHANISM)
+                }
+                "UNSECURED_CREDENTIALS" => std::option::Option::Some(Self::UNSECURED_CREDENTIALS),
+                "MODIFY_AUTHENTICATION_PROCESS" => {
+                    std::option::Option::Some(Self::MODIFY_AUTHENTICATION_PROCESS)
+                }
+                "IMPAIR_DEFENSES" => std::option::Option::Some(Self::IMPAIR_DEFENSES),
+                "DISABLE_OR_MODIFY_TOOLS" => {
+                    std::option::Option::Some(Self::DISABLE_OR_MODIFY_TOOLS)
+                }
+                "EXFILTRATION_OVER_WEB_SERVICE" => {
+                    std::option::Option::Some(Self::EXFILTRATION_OVER_WEB_SERVICE)
+                }
+                "EXFILTRATION_TO_CLOUD_STORAGE" => {
+                    std::option::Option::Some(Self::EXFILTRATION_TO_CLOUD_STORAGE)
+                }
+                "DYNAMIC_RESOLUTION" => std::option::Option::Some(Self::DYNAMIC_RESOLUTION),
+                "LATERAL_TOOL_TRANSFER" => std::option::Option::Some(Self::LATERAL_TOOL_TRANSFER),
+                "MODIFY_CLOUD_COMPUTE_INFRASTRUCTURE" => {
+                    std::option::Option::Some(Self::MODIFY_CLOUD_COMPUTE_INFRASTRUCTURE)
+                }
+                "CREATE_SNAPSHOT" => std::option::Option::Some(Self::CREATE_SNAPSHOT),
+                "CLOUD_INFRASTRUCTURE_DISCOVERY" => {
+                    std::option::Option::Some(Self::CLOUD_INFRASTRUCTURE_DISCOVERY)
+                }
+                "OBTAIN_CAPABILITIES" => std::option::Option::Some(Self::OBTAIN_CAPABILITIES),
+                "ACTIVE_SCANNING" => std::option::Option::Some(Self::ACTIVE_SCANNING),
+                "SCANNING_IP_BLOCKS" => std::option::Option::Some(Self::SCANNING_IP_BLOCKS),
+                "CONTAINER_ADMINISTRATION_COMMAND" => {
+                    std::option::Option::Some(Self::CONTAINER_ADMINISTRATION_COMMAND)
+                }
+                "DEPLOY_CONTAINER" => std::option::Option::Some(Self::DEPLOY_CONTAINER),
+                "ESCAPE_TO_HOST" => std::option::Option::Some(Self::ESCAPE_TO_HOST),
+                "CONTAINER_AND_RESOURCE_DISCOVERY" => {
+                    std::option::Option::Some(Self::CONTAINER_AND_RESOURCE_DISCOVERY)
+                }
+                "STEAL_OR_FORGE_AUTHENTICATION_CERTIFICATES" => {
+                    std::option::Option::Some(Self::STEAL_OR_FORGE_AUTHENTICATION_CERTIFICATES)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Technique](Technique)
-    pub mod technique {
-        use super::Technique;
-
-        /// Unspecified value.
-        pub const TECHNIQUE_UNSPECIFIED: Technique = Technique::new("TECHNIQUE_UNSPECIFIED");
-
-        /// T1036
-        pub const MASQUERADING: Technique = Technique::new("MASQUERADING");
-
-        /// T1036.005
-        pub const MATCH_LEGITIMATE_NAME_OR_LOCATION: Technique =
-            Technique::new("MATCH_LEGITIMATE_NAME_OR_LOCATION");
-
-        /// T1037
-        pub const BOOT_OR_LOGON_INITIALIZATION_SCRIPTS: Technique =
-            Technique::new("BOOT_OR_LOGON_INITIALIZATION_SCRIPTS");
-
-        /// T1037.005
-        pub const STARTUP_ITEMS: Technique = Technique::new("STARTUP_ITEMS");
-
-        /// T1046
-        pub const NETWORK_SERVICE_DISCOVERY: Technique =
-            Technique::new("NETWORK_SERVICE_DISCOVERY");
-
-        /// T1057
-        pub const PROCESS_DISCOVERY: Technique = Technique::new("PROCESS_DISCOVERY");
-
-        /// T1059
-        pub const COMMAND_AND_SCRIPTING_INTERPRETER: Technique =
-            Technique::new("COMMAND_AND_SCRIPTING_INTERPRETER");
-
-        /// T1059.004
-        pub const UNIX_SHELL: Technique = Technique::new("UNIX_SHELL");
-
-        /// T1059.006
-        pub const PYTHON: Technique = Technique::new("PYTHON");
-
-        /// T1068
-        pub const EXPLOITATION_FOR_PRIVILEGE_ESCALATION: Technique =
-            Technique::new("EXPLOITATION_FOR_PRIVILEGE_ESCALATION");
-
-        /// T1069
-        pub const PERMISSION_GROUPS_DISCOVERY: Technique =
-            Technique::new("PERMISSION_GROUPS_DISCOVERY");
-
-        /// T1069.003
-        pub const CLOUD_GROUPS: Technique = Technique::new("CLOUD_GROUPS");
-
-        /// T1070.004
-        pub const INDICATOR_REMOVAL_FILE_DELETION: Technique =
-            Technique::new("INDICATOR_REMOVAL_FILE_DELETION");
-
-        /// T1071
-        pub const APPLICATION_LAYER_PROTOCOL: Technique =
-            Technique::new("APPLICATION_LAYER_PROTOCOL");
-
-        /// T1071.004
-        pub const DNS: Technique = Technique::new("DNS");
-
-        /// T1072
-        pub const SOFTWARE_DEPLOYMENT_TOOLS: Technique =
-            Technique::new("SOFTWARE_DEPLOYMENT_TOOLS");
-
-        /// T1078
-        pub const VALID_ACCOUNTS: Technique = Technique::new("VALID_ACCOUNTS");
-
-        /// T1078.001
-        pub const DEFAULT_ACCOUNTS: Technique = Technique::new("DEFAULT_ACCOUNTS");
-
-        /// T1078.003
-        pub const LOCAL_ACCOUNTS: Technique = Technique::new("LOCAL_ACCOUNTS");
-
-        /// T1078.004
-        pub const CLOUD_ACCOUNTS: Technique = Technique::new("CLOUD_ACCOUNTS");
-
-        /// T1090
-        pub const PROXY: Technique = Technique::new("PROXY");
-
-        /// T1090.002
-        pub const EXTERNAL_PROXY: Technique = Technique::new("EXTERNAL_PROXY");
-
-        /// T1090.003
-        pub const MULTI_HOP_PROXY: Technique = Technique::new("MULTI_HOP_PROXY");
-
-        /// T1098
-        pub const ACCOUNT_MANIPULATION: Technique = Technique::new("ACCOUNT_MANIPULATION");
-
-        /// T1098.001
-        pub const ADDITIONAL_CLOUD_CREDENTIALS: Technique =
-            Technique::new("ADDITIONAL_CLOUD_CREDENTIALS");
-
-        /// T1098.004
-        pub const SSH_AUTHORIZED_KEYS: Technique = Technique::new("SSH_AUTHORIZED_KEYS");
-
-        /// T1098.006
-        pub const ADDITIONAL_CONTAINER_CLUSTER_ROLES: Technique =
-            Technique::new("ADDITIONAL_CONTAINER_CLUSTER_ROLES");
-
-        /// T1105
-        pub const INGRESS_TOOL_TRANSFER: Technique = Technique::new("INGRESS_TOOL_TRANSFER");
-
-        /// T1106
-        pub const NATIVE_API: Technique = Technique::new("NATIVE_API");
-
-        /// T1110
-        pub const BRUTE_FORCE: Technique = Technique::new("BRUTE_FORCE");
-
-        /// T1129
-        pub const SHARED_MODULES: Technique = Technique::new("SHARED_MODULES");
-
-        /// T1134
-        pub const ACCESS_TOKEN_MANIPULATION: Technique =
-            Technique::new("ACCESS_TOKEN_MANIPULATION");
-
-        /// T1134.001
-        pub const TOKEN_IMPERSONATION_OR_THEFT: Technique =
-            Technique::new("TOKEN_IMPERSONATION_OR_THEFT");
-
-        /// T1190
-        pub const EXPLOIT_PUBLIC_FACING_APPLICATION: Technique =
-            Technique::new("EXPLOIT_PUBLIC_FACING_APPLICATION");
-
-        /// T1484
-        pub const DOMAIN_POLICY_MODIFICATION: Technique =
-            Technique::new("DOMAIN_POLICY_MODIFICATION");
-
-        /// T1485
-        pub const DATA_DESTRUCTION: Technique = Technique::new("DATA_DESTRUCTION");
-
-        /// T1489
-        pub const SERVICE_STOP: Technique = Technique::new("SERVICE_STOP");
-
-        /// T1490
-        pub const INHIBIT_SYSTEM_RECOVERY: Technique = Technique::new("INHIBIT_SYSTEM_RECOVERY");
-
-        /// T1496
-        pub const RESOURCE_HIJACKING: Technique = Technique::new("RESOURCE_HIJACKING");
-
-        /// T1498
-        pub const NETWORK_DENIAL_OF_SERVICE: Technique =
-            Technique::new("NETWORK_DENIAL_OF_SERVICE");
-
-        /// T1526
-        pub const CLOUD_SERVICE_DISCOVERY: Technique = Technique::new("CLOUD_SERVICE_DISCOVERY");
-
-        /// T1528
-        pub const STEAL_APPLICATION_ACCESS_TOKEN: Technique =
-            Technique::new("STEAL_APPLICATION_ACCESS_TOKEN");
-
-        /// T1531
-        pub const ACCOUNT_ACCESS_REMOVAL: Technique = Technique::new("ACCOUNT_ACCESS_REMOVAL");
-
-        /// T1539
-        pub const STEAL_WEB_SESSION_COOKIE: Technique = Technique::new("STEAL_WEB_SESSION_COOKIE");
-
-        /// T1543
-        pub const CREATE_OR_MODIFY_SYSTEM_PROCESS: Technique =
-            Technique::new("CREATE_OR_MODIFY_SYSTEM_PROCESS");
-
-        /// T1546
-        pub const EVENT_TRIGGERED_EXECUTION: Technique =
-            Technique::new("EVENT_TRIGGERED_EXECUTION");
-
-        /// T1548
-        pub const ABUSE_ELEVATION_CONTROL_MECHANISM: Technique =
-            Technique::new("ABUSE_ELEVATION_CONTROL_MECHANISM");
-
-        /// T1552
-        pub const UNSECURED_CREDENTIALS: Technique = Technique::new("UNSECURED_CREDENTIALS");
-
-        /// T1556
-        pub const MODIFY_AUTHENTICATION_PROCESS: Technique =
-            Technique::new("MODIFY_AUTHENTICATION_PROCESS");
-
-        /// T1562
-        pub const IMPAIR_DEFENSES: Technique = Technique::new("IMPAIR_DEFENSES");
-
-        /// T1562.001
-        pub const DISABLE_OR_MODIFY_TOOLS: Technique = Technique::new("DISABLE_OR_MODIFY_TOOLS");
-
-        /// T1567
-        pub const EXFILTRATION_OVER_WEB_SERVICE: Technique =
-            Technique::new("EXFILTRATION_OVER_WEB_SERVICE");
-
-        /// T1567.002
-        pub const EXFILTRATION_TO_CLOUD_STORAGE: Technique =
-            Technique::new("EXFILTRATION_TO_CLOUD_STORAGE");
-
-        /// T1568
-        pub const DYNAMIC_RESOLUTION: Technique = Technique::new("DYNAMIC_RESOLUTION");
-
-        /// T1570
-        pub const LATERAL_TOOL_TRANSFER: Technique = Technique::new("LATERAL_TOOL_TRANSFER");
-
-        /// T1578
-        pub const MODIFY_CLOUD_COMPUTE_INFRASTRUCTURE: Technique =
-            Technique::new("MODIFY_CLOUD_COMPUTE_INFRASTRUCTURE");
-
-        /// T1578.001
-        pub const CREATE_SNAPSHOT: Technique = Technique::new("CREATE_SNAPSHOT");
-
-        /// T1580
-        pub const CLOUD_INFRASTRUCTURE_DISCOVERY: Technique =
-            Technique::new("CLOUD_INFRASTRUCTURE_DISCOVERY");
-
-        /// T1588
-        pub const OBTAIN_CAPABILITIES: Technique = Technique::new("OBTAIN_CAPABILITIES");
-
-        /// T1595
-        pub const ACTIVE_SCANNING: Technique = Technique::new("ACTIVE_SCANNING");
-
-        /// T1595.001
-        pub const SCANNING_IP_BLOCKS: Technique = Technique::new("SCANNING_IP_BLOCKS");
-
-        /// T1609
-        pub const CONTAINER_ADMINISTRATION_COMMAND: Technique =
-            Technique::new("CONTAINER_ADMINISTRATION_COMMAND");
-
-        /// T1610
-        pub const DEPLOY_CONTAINER: Technique = Technique::new("DEPLOY_CONTAINER");
-
-        /// T1611
-        pub const ESCAPE_TO_HOST: Technique = Technique::new("ESCAPE_TO_HOST");
-
-        /// T1613
-        pub const CONTAINER_AND_RESOURCE_DISCOVERY: Technique =
-            Technique::new("CONTAINER_AND_RESOURCE_DISCOVERY");
-
-        /// T1649
-        pub const STEAL_OR_FORGE_AUTHENTICATION_CERTIFICATES: Technique =
-            Technique::new("STEAL_OR_FORGE_AUTHENTICATION_CERTIFICATES");
-    }
-
-    impl std::convert::From<std::string::String> for Technique {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Technique {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Technique {
         fn default() -> Self {
-            technique::TECHNIQUE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6617,32 +7115,16 @@ pub mod mute_config {
 
     /// The type of MuteConfig.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MuteConfigType(std::borrow::Cow<'static, str>);
+    pub struct MuteConfigType(i32);
 
     impl MuteConfigType {
-        /// Creates a new MuteConfigType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [MuteConfigType](MuteConfigType)
-    pub mod mute_config_type {
-        use super::MuteConfigType;
-
         /// Unused.
-        pub const MUTE_CONFIG_TYPE_UNSPECIFIED: MuteConfigType =
-            MuteConfigType::new("MUTE_CONFIG_TYPE_UNSPECIFIED");
+        pub const MUTE_CONFIG_TYPE_UNSPECIFIED: MuteConfigType = MuteConfigType::new(0);
 
         /// A static mute config, which sets the static mute state of future matching
         /// findings to muted. Once the static mute state has been set, finding or
         /// config modifications will not affect the state.
-        pub const STATIC: MuteConfigType = MuteConfigType::new("STATIC");
+        pub const STATIC: MuteConfigType = MuteConfigType::new(1);
 
         /// A dynamic mute config, which is applied to existing and future matching
         /// findings, setting their dynamic mute state to "muted". If the config is
@@ -6650,18 +7132,50 @@ pub mod mute_config {
         /// finding doesn't match the config, the config will be removed from the
         /// finding, and the finding's dynamic mute state may become "unmuted"
         /// (unless other configs still match).
-        pub const DYNAMIC: MuteConfigType = MuteConfigType::new("DYNAMIC");
+        pub const DYNAMIC: MuteConfigType = MuteConfigType::new(2);
+
+        /// Creates a new MuteConfigType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MUTE_CONFIG_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STATIC"),
+                2 => std::borrow::Cow::Borrowed("DYNAMIC"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MUTE_CONFIG_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MUTE_CONFIG_TYPE_UNSPECIFIED)
+                }
+                "STATIC" => std::option::Option::Some(Self::STATIC),
+                "DYNAMIC" => std::option::Option::Some(Self::DYNAMIC),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for MuteConfigType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MuteConfigType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MuteConfigType {
         fn default() -> Self {
-            mute_config_type::MUTE_CONFIG_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8110,71 +8624,98 @@ pub mod resource_path {
 
     /// The type of resource the node represents.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ResourcePathNodeType(std::borrow::Cow<'static, str>);
+    pub struct ResourcePathNodeType(i32);
 
     impl ResourcePathNodeType {
+        /// Node type is unspecified.
+        pub const RESOURCE_PATH_NODE_TYPE_UNSPECIFIED: ResourcePathNodeType =
+            ResourcePathNodeType::new(0);
+
+        /// The node represents a Google Cloud organization.
+        pub const GCP_ORGANIZATION: ResourcePathNodeType = ResourcePathNodeType::new(1);
+
+        /// The node represents a Google Cloud folder.
+        pub const GCP_FOLDER: ResourcePathNodeType = ResourcePathNodeType::new(2);
+
+        /// The node represents a Google Cloud project.
+        pub const GCP_PROJECT: ResourcePathNodeType = ResourcePathNodeType::new(3);
+
+        /// The node represents an AWS organization.
+        pub const AWS_ORGANIZATION: ResourcePathNodeType = ResourcePathNodeType::new(4);
+
+        /// The node represents an AWS organizational unit.
+        pub const AWS_ORGANIZATIONAL_UNIT: ResourcePathNodeType = ResourcePathNodeType::new(5);
+
+        /// The node represents an AWS account.
+        pub const AWS_ACCOUNT: ResourcePathNodeType = ResourcePathNodeType::new(6);
+
+        /// The node represents an Azure management group.
+        pub const AZURE_MANAGEMENT_GROUP: ResourcePathNodeType = ResourcePathNodeType::new(7);
+
+        /// The node represents an Azure subscription.
+        pub const AZURE_SUBSCRIPTION: ResourcePathNodeType = ResourcePathNodeType::new(8);
+
+        /// The node represents an Azure resource group.
+        pub const AZURE_RESOURCE_GROUP: ResourcePathNodeType = ResourcePathNodeType::new(9);
+
         /// Creates a new ResourcePathNodeType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RESOURCE_PATH_NODE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GCP_ORGANIZATION"),
+                2 => std::borrow::Cow::Borrowed("GCP_FOLDER"),
+                3 => std::borrow::Cow::Borrowed("GCP_PROJECT"),
+                4 => std::borrow::Cow::Borrowed("AWS_ORGANIZATION"),
+                5 => std::borrow::Cow::Borrowed("AWS_ORGANIZATIONAL_UNIT"),
+                6 => std::borrow::Cow::Borrowed("AWS_ACCOUNT"),
+                7 => std::borrow::Cow::Borrowed("AZURE_MANAGEMENT_GROUP"),
+                8 => std::borrow::Cow::Borrowed("AZURE_SUBSCRIPTION"),
+                9 => std::borrow::Cow::Borrowed("AZURE_RESOURCE_GROUP"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RESOURCE_PATH_NODE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RESOURCE_PATH_NODE_TYPE_UNSPECIFIED)
+                }
+                "GCP_ORGANIZATION" => std::option::Option::Some(Self::GCP_ORGANIZATION),
+                "GCP_FOLDER" => std::option::Option::Some(Self::GCP_FOLDER),
+                "GCP_PROJECT" => std::option::Option::Some(Self::GCP_PROJECT),
+                "AWS_ORGANIZATION" => std::option::Option::Some(Self::AWS_ORGANIZATION),
+                "AWS_ORGANIZATIONAL_UNIT" => {
+                    std::option::Option::Some(Self::AWS_ORGANIZATIONAL_UNIT)
+                }
+                "AWS_ACCOUNT" => std::option::Option::Some(Self::AWS_ACCOUNT),
+                "AZURE_MANAGEMENT_GROUP" => std::option::Option::Some(Self::AZURE_MANAGEMENT_GROUP),
+                "AZURE_SUBSCRIPTION" => std::option::Option::Some(Self::AZURE_SUBSCRIPTION),
+                "AZURE_RESOURCE_GROUP" => std::option::Option::Some(Self::AZURE_RESOURCE_GROUP),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ResourcePathNodeType](ResourcePathNodeType)
-    pub mod resource_path_node_type {
-        use super::ResourcePathNodeType;
-
-        /// Node type is unspecified.
-        pub const RESOURCE_PATH_NODE_TYPE_UNSPECIFIED: ResourcePathNodeType =
-            ResourcePathNodeType::new("RESOURCE_PATH_NODE_TYPE_UNSPECIFIED");
-
-        /// The node represents a Google Cloud organization.
-        pub const GCP_ORGANIZATION: ResourcePathNodeType =
-            ResourcePathNodeType::new("GCP_ORGANIZATION");
-
-        /// The node represents a Google Cloud folder.
-        pub const GCP_FOLDER: ResourcePathNodeType = ResourcePathNodeType::new("GCP_FOLDER");
-
-        /// The node represents a Google Cloud project.
-        pub const GCP_PROJECT: ResourcePathNodeType = ResourcePathNodeType::new("GCP_PROJECT");
-
-        /// The node represents an AWS organization.
-        pub const AWS_ORGANIZATION: ResourcePathNodeType =
-            ResourcePathNodeType::new("AWS_ORGANIZATION");
-
-        /// The node represents an AWS organizational unit.
-        pub const AWS_ORGANIZATIONAL_UNIT: ResourcePathNodeType =
-            ResourcePathNodeType::new("AWS_ORGANIZATIONAL_UNIT");
-
-        /// The node represents an AWS account.
-        pub const AWS_ACCOUNT: ResourcePathNodeType = ResourcePathNodeType::new("AWS_ACCOUNT");
-
-        /// The node represents an Azure management group.
-        pub const AZURE_MANAGEMENT_GROUP: ResourcePathNodeType =
-            ResourcePathNodeType::new("AZURE_MANAGEMENT_GROUP");
-
-        /// The node represents an Azure subscription.
-        pub const AZURE_SUBSCRIPTION: ResourcePathNodeType =
-            ResourcePathNodeType::new("AZURE_SUBSCRIPTION");
-
-        /// The node represents an Azure resource group.
-        pub const AZURE_RESOURCE_GROUP: ResourcePathNodeType =
-            ResourcePathNodeType::new("AZURE_RESOURCE_GROUP");
-    }
-
-    impl std::convert::From<std::string::String> for ResourcePathNodeType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ResourcePathNodeType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ResourcePathNodeType {
         fn default() -> Self {
-            resource_path_node_type::RESOURCE_PATH_NODE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8864,43 +9405,58 @@ pub mod bulk_mute_findings_request {
 
     /// The mute state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MuteState(std::borrow::Cow<'static, str>);
+    pub struct MuteState(i32);
 
     impl MuteState {
+        /// Unused.
+        pub const MUTE_STATE_UNSPECIFIED: MuteState = MuteState::new(0);
+
+        /// Matching findings will be muted (default).
+        pub const MUTED: MuteState = MuteState::new(1);
+
+        /// Matching findings will have their mute state cleared.
+        pub const UNDEFINED: MuteState = MuteState::new(2);
+
         /// Creates a new MuteState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MUTE_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MUTED"),
+                2 => std::borrow::Cow::Borrowed("UNDEFINED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MUTE_STATE_UNSPECIFIED" => std::option::Option::Some(Self::MUTE_STATE_UNSPECIFIED),
+                "MUTED" => std::option::Option::Some(Self::MUTED),
+                "UNDEFINED" => std::option::Option::Some(Self::UNDEFINED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [MuteState](MuteState)
-    pub mod mute_state {
-        use super::MuteState;
-
-        /// Unused.
-        pub const MUTE_STATE_UNSPECIFIED: MuteState = MuteState::new("MUTE_STATE_UNSPECIFIED");
-
-        /// Matching findings will be muted (default).
-        pub const MUTED: MuteState = MuteState::new("MUTED");
-
-        /// Matching findings will have their mute state cleared.
-        pub const UNDEFINED: MuteState = MuteState::new("UNDEFINED");
-    }
-
-    impl std::convert::From<std::string::String> for MuteState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MuteState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MuteState {
         fn default() -> Self {
-            mute_state::MUTE_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -12155,48 +12711,65 @@ pub mod valued_resource {
 
     /// How valuable the resource is.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ResourceValue(std::borrow::Cow<'static, str>);
+    pub struct ResourceValue(i32);
 
     impl ResourceValue {
+        /// The resource value isn't specified.
+        pub const RESOURCE_VALUE_UNSPECIFIED: ResourceValue = ResourceValue::new(0);
+
+        /// This is a low-value resource.
+        pub const RESOURCE_VALUE_LOW: ResourceValue = ResourceValue::new(1);
+
+        /// This is a medium-value resource.
+        pub const RESOURCE_VALUE_MEDIUM: ResourceValue = ResourceValue::new(2);
+
+        /// This is a high-value resource.
+        pub const RESOURCE_VALUE_HIGH: ResourceValue = ResourceValue::new(3);
+
         /// Creates a new ResourceValue instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RESOURCE_VALUE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RESOURCE_VALUE_LOW"),
+                2 => std::borrow::Cow::Borrowed("RESOURCE_VALUE_MEDIUM"),
+                3 => std::borrow::Cow::Borrowed("RESOURCE_VALUE_HIGH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RESOURCE_VALUE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RESOURCE_VALUE_UNSPECIFIED)
+                }
+                "RESOURCE_VALUE_LOW" => std::option::Option::Some(Self::RESOURCE_VALUE_LOW),
+                "RESOURCE_VALUE_MEDIUM" => std::option::Option::Some(Self::RESOURCE_VALUE_MEDIUM),
+                "RESOURCE_VALUE_HIGH" => std::option::Option::Some(Self::RESOURCE_VALUE_HIGH),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ResourceValue](ResourceValue)
-    pub mod resource_value {
-        use super::ResourceValue;
-
-        /// The resource value isn't specified.
-        pub const RESOURCE_VALUE_UNSPECIFIED: ResourceValue =
-            ResourceValue::new("RESOURCE_VALUE_UNSPECIFIED");
-
-        /// This is a low-value resource.
-        pub const RESOURCE_VALUE_LOW: ResourceValue = ResourceValue::new("RESOURCE_VALUE_LOW");
-
-        /// This is a medium-value resource.
-        pub const RESOURCE_VALUE_MEDIUM: ResourceValue =
-            ResourceValue::new("RESOURCE_VALUE_MEDIUM");
-
-        /// This is a high-value resource.
-        pub const RESOURCE_VALUE_HIGH: ResourceValue = ResourceValue::new("RESOURCE_VALUE_HIGH");
-    }
-
-    impl std::convert::From<std::string::String> for ResourceValue {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ResourceValue {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ResourceValue {
         fn default() -> Self {
-            resource_value::RESOURCE_VALUE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -12458,107 +13031,151 @@ pub mod cve {
     /// The possible values of impact of the vulnerability if it was to be
     /// exploited.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RiskRating(std::borrow::Cow<'static, str>);
+    pub struct RiskRating(i32);
 
     impl RiskRating {
-        /// Creates a new RiskRating instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RiskRating](RiskRating)
-    pub mod risk_rating {
-        use super::RiskRating;
-
         /// Invalid or empty value.
-        pub const RISK_RATING_UNSPECIFIED: RiskRating = RiskRating::new("RISK_RATING_UNSPECIFIED");
+        pub const RISK_RATING_UNSPECIFIED: RiskRating = RiskRating::new(0);
 
         /// Exploitation would have little to no security impact.
-        pub const LOW: RiskRating = RiskRating::new("LOW");
+        pub const LOW: RiskRating = RiskRating::new(1);
 
         /// Exploitation would enable attackers to perform activities, or could allow
         /// attackers to have a direct impact, but would require additional steps.
-        pub const MEDIUM: RiskRating = RiskRating::new("MEDIUM");
+        pub const MEDIUM: RiskRating = RiskRating::new(2);
 
         /// Exploitation would enable attackers to have a notable direct impact
         /// without needing to overcome any major mitigating factors.
-        pub const HIGH: RiskRating = RiskRating::new("HIGH");
+        pub const HIGH: RiskRating = RiskRating::new(3);
 
         /// Exploitation would fundamentally undermine the security of affected
         /// systems, enable actors to perform significant attacks with minimal
         /// effort, with little to no mitigating factors to overcome.
-        pub const CRITICAL: RiskRating = RiskRating::new("CRITICAL");
+        pub const CRITICAL: RiskRating = RiskRating::new(4);
+
+        /// Creates a new RiskRating instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RISK_RATING_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LOW"),
+                2 => std::borrow::Cow::Borrowed("MEDIUM"),
+                3 => std::borrow::Cow::Borrowed("HIGH"),
+                4 => std::borrow::Cow::Borrowed("CRITICAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RISK_RATING_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RISK_RATING_UNSPECIFIED)
+                }
+                "LOW" => std::option::Option::Some(Self::LOW),
+                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
+                "HIGH" => std::option::Option::Some(Self::HIGH),
+                "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RiskRating {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RiskRating {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RiskRating {
         fn default() -> Self {
-            risk_rating::RISK_RATING_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The possible values of exploitation activity of the vulnerability in the
     /// wild.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ExploitationActivity(std::borrow::Cow<'static, str>);
+    pub struct ExploitationActivity(i32);
 
     impl ExploitationActivity {
-        /// Creates a new ExploitationActivity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ExploitationActivity](ExploitationActivity)
-    pub mod exploitation_activity {
-        use super::ExploitationActivity;
-
         /// Invalid or empty value.
         pub const EXPLOITATION_ACTIVITY_UNSPECIFIED: ExploitationActivity =
-            ExploitationActivity::new("EXPLOITATION_ACTIVITY_UNSPECIFIED");
+            ExploitationActivity::new(0);
 
         /// Exploitation has been reported or confirmed to widely occur.
-        pub const WIDE: ExploitationActivity = ExploitationActivity::new("WIDE");
+        pub const WIDE: ExploitationActivity = ExploitationActivity::new(1);
 
         /// Limited reported or confirmed exploitation activities.
-        pub const CONFIRMED: ExploitationActivity = ExploitationActivity::new("CONFIRMED");
+        pub const CONFIRMED: ExploitationActivity = ExploitationActivity::new(2);
 
         /// Exploit is publicly available.
-        pub const AVAILABLE: ExploitationActivity = ExploitationActivity::new("AVAILABLE");
+        pub const AVAILABLE: ExploitationActivity = ExploitationActivity::new(3);
 
         /// No known exploitation activity, but has a high potential for
         /// exploitation.
-        pub const ANTICIPATED: ExploitationActivity = ExploitationActivity::new("ANTICIPATED");
+        pub const ANTICIPATED: ExploitationActivity = ExploitationActivity::new(4);
 
         /// No known exploitation activity.
-        pub const NO_KNOWN: ExploitationActivity = ExploitationActivity::new("NO_KNOWN");
+        pub const NO_KNOWN: ExploitationActivity = ExploitationActivity::new(5);
+
+        /// Creates a new ExploitationActivity instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EXPLOITATION_ACTIVITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("WIDE"),
+                2 => std::borrow::Cow::Borrowed("CONFIRMED"),
+                3 => std::borrow::Cow::Borrowed("AVAILABLE"),
+                4 => std::borrow::Cow::Borrowed("ANTICIPATED"),
+                5 => std::borrow::Cow::Borrowed("NO_KNOWN"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EXPLOITATION_ACTIVITY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::EXPLOITATION_ACTIVITY_UNSPECIFIED)
+                }
+                "WIDE" => std::option::Option::Some(Self::WIDE),
+                "CONFIRMED" => std::option::Option::Some(Self::CONFIRMED),
+                "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
+                "ANTICIPATED" => std::option::Option::Some(Self::ANTICIPATED),
+                "NO_KNOWN" => std::option::Option::Some(Self::NO_KNOWN),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ExploitationActivity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ExploitationActivity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ExploitationActivity {
         fn default() -> Self {
-            exploitation_activity::EXPLOITATION_ACTIVITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -12747,166 +13364,219 @@ pub mod cvssv_3 {
     /// This metric reflects the context by which vulnerability exploitation is
     /// possible.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AttackVector(std::borrow::Cow<'static, str>);
+    pub struct AttackVector(i32);
 
     impl AttackVector {
-        /// Creates a new AttackVector instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [AttackVector](AttackVector)
-    pub mod attack_vector {
-        use super::AttackVector;
-
         /// Invalid value.
-        pub const ATTACK_VECTOR_UNSPECIFIED: AttackVector =
-            AttackVector::new("ATTACK_VECTOR_UNSPECIFIED");
+        pub const ATTACK_VECTOR_UNSPECIFIED: AttackVector = AttackVector::new(0);
 
         /// The vulnerable component is bound to the network stack and the set of
         /// possible attackers extends beyond the other options listed below, up to
         /// and including the entire Internet.
-        pub const ATTACK_VECTOR_NETWORK: AttackVector = AttackVector::new("ATTACK_VECTOR_NETWORK");
+        pub const ATTACK_VECTOR_NETWORK: AttackVector = AttackVector::new(1);
 
         /// The vulnerable component is bound to the network stack, but the attack is
         /// limited at the protocol level to a logically adjacent topology.
-        pub const ATTACK_VECTOR_ADJACENT: AttackVector =
-            AttackVector::new("ATTACK_VECTOR_ADJACENT");
+        pub const ATTACK_VECTOR_ADJACENT: AttackVector = AttackVector::new(2);
 
         /// The vulnerable component is not bound to the network stack and the
         /// attacker's path is via read/write/execute capabilities.
-        pub const ATTACK_VECTOR_LOCAL: AttackVector = AttackVector::new("ATTACK_VECTOR_LOCAL");
+        pub const ATTACK_VECTOR_LOCAL: AttackVector = AttackVector::new(3);
 
         /// The attack requires the attacker to physically touch or manipulate the
         /// vulnerable component.
-        pub const ATTACK_VECTOR_PHYSICAL: AttackVector =
-            AttackVector::new("ATTACK_VECTOR_PHYSICAL");
+        pub const ATTACK_VECTOR_PHYSICAL: AttackVector = AttackVector::new(4);
+
+        /// Creates a new AttackVector instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_NETWORK"),
+                2 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_ADJACENT"),
+                3 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_LOCAL"),
+                4 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_PHYSICAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ATTACK_VECTOR_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ATTACK_VECTOR_UNSPECIFIED)
+                }
+                "ATTACK_VECTOR_NETWORK" => std::option::Option::Some(Self::ATTACK_VECTOR_NETWORK),
+                "ATTACK_VECTOR_ADJACENT" => std::option::Option::Some(Self::ATTACK_VECTOR_ADJACENT),
+                "ATTACK_VECTOR_LOCAL" => std::option::Option::Some(Self::ATTACK_VECTOR_LOCAL),
+                "ATTACK_VECTOR_PHYSICAL" => std::option::Option::Some(Self::ATTACK_VECTOR_PHYSICAL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for AttackVector {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AttackVector {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AttackVector {
         fn default() -> Self {
-            attack_vector::ATTACK_VECTOR_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// This metric describes the conditions beyond the attacker's control that
     /// must exist in order to exploit the vulnerability.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AttackComplexity(std::borrow::Cow<'static, str>);
+    pub struct AttackComplexity(i32);
 
     impl AttackComplexity {
-        /// Creates a new AttackComplexity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [AttackComplexity](AttackComplexity)
-    pub mod attack_complexity {
-        use super::AttackComplexity;
-
         /// Invalid value.
-        pub const ATTACK_COMPLEXITY_UNSPECIFIED: AttackComplexity =
-            AttackComplexity::new("ATTACK_COMPLEXITY_UNSPECIFIED");
+        pub const ATTACK_COMPLEXITY_UNSPECIFIED: AttackComplexity = AttackComplexity::new(0);
 
         /// Specialized access conditions or extenuating circumstances do not exist.
         /// An attacker can expect repeatable success when attacking the vulnerable
         /// component.
-        pub const ATTACK_COMPLEXITY_LOW: AttackComplexity =
-            AttackComplexity::new("ATTACK_COMPLEXITY_LOW");
+        pub const ATTACK_COMPLEXITY_LOW: AttackComplexity = AttackComplexity::new(1);
 
         /// A successful attack depends on conditions beyond the attacker's control.
         /// That is, a successful attack cannot be accomplished at will, but requires
         /// the attacker to invest in some measurable amount of effort in preparation
         /// or execution against the vulnerable component before a successful attack
         /// can be expected.
-        pub const ATTACK_COMPLEXITY_HIGH: AttackComplexity =
-            AttackComplexity::new("ATTACK_COMPLEXITY_HIGH");
+        pub const ATTACK_COMPLEXITY_HIGH: AttackComplexity = AttackComplexity::new(2);
+
+        /// Creates a new AttackComplexity instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_LOW"),
+                2 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_HIGH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ATTACK_COMPLEXITY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ATTACK_COMPLEXITY_UNSPECIFIED)
+                }
+                "ATTACK_COMPLEXITY_LOW" => std::option::Option::Some(Self::ATTACK_COMPLEXITY_LOW),
+                "ATTACK_COMPLEXITY_HIGH" => std::option::Option::Some(Self::ATTACK_COMPLEXITY_HIGH),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for AttackComplexity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AttackComplexity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AttackComplexity {
         fn default() -> Self {
-            attack_complexity::ATTACK_COMPLEXITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// This metric describes the level of privileges an attacker must possess
     /// before successfully exploiting the vulnerability.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PrivilegesRequired(std::borrow::Cow<'static, str>);
+    pub struct PrivilegesRequired(i32);
 
     impl PrivilegesRequired {
-        /// Creates a new PrivilegesRequired instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PrivilegesRequired](PrivilegesRequired)
-    pub mod privileges_required {
-        use super::PrivilegesRequired;
-
         /// Invalid value.
-        pub const PRIVILEGES_REQUIRED_UNSPECIFIED: PrivilegesRequired =
-            PrivilegesRequired::new("PRIVILEGES_REQUIRED_UNSPECIFIED");
+        pub const PRIVILEGES_REQUIRED_UNSPECIFIED: PrivilegesRequired = PrivilegesRequired::new(0);
 
         /// The attacker is unauthorized prior to attack, and therefore does not
         /// require any access to settings or files of the vulnerable system to
         /// carry out an attack.
-        pub const PRIVILEGES_REQUIRED_NONE: PrivilegesRequired =
-            PrivilegesRequired::new("PRIVILEGES_REQUIRED_NONE");
+        pub const PRIVILEGES_REQUIRED_NONE: PrivilegesRequired = PrivilegesRequired::new(1);
 
         /// The attacker requires privileges that provide basic user capabilities
         /// that could normally affect only settings and files owned by a user.
         /// Alternatively, an attacker with Low privileges has the ability to access
         /// only non-sensitive resources.
-        pub const PRIVILEGES_REQUIRED_LOW: PrivilegesRequired =
-            PrivilegesRequired::new("PRIVILEGES_REQUIRED_LOW");
+        pub const PRIVILEGES_REQUIRED_LOW: PrivilegesRequired = PrivilegesRequired::new(2);
 
         /// The attacker requires privileges that provide significant (e.g.,
         /// administrative) control over the vulnerable component allowing access to
         /// component-wide settings and files.
-        pub const PRIVILEGES_REQUIRED_HIGH: PrivilegesRequired =
-            PrivilegesRequired::new("PRIVILEGES_REQUIRED_HIGH");
+        pub const PRIVILEGES_REQUIRED_HIGH: PrivilegesRequired = PrivilegesRequired::new(3);
+
+        /// Creates a new PrivilegesRequired instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_NONE"),
+                2 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_LOW"),
+                3 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_HIGH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PRIVILEGES_REQUIRED_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_UNSPECIFIED)
+                }
+                "PRIVILEGES_REQUIRED_NONE" => {
+                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_NONE)
+                }
+                "PRIVILEGES_REQUIRED_LOW" => {
+                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_LOW)
+                }
+                "PRIVILEGES_REQUIRED_HIGH" => {
+                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_HIGH)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PrivilegesRequired {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PrivilegesRequired {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PrivilegesRequired {
         fn default() -> Self {
-            privileges_required::PRIVILEGES_REQUIRED_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -12914,92 +13584,123 @@ pub mod cvssv_3 {
     /// attacker, to participate in the successful compromise of the vulnerable
     /// component.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct UserInteraction(std::borrow::Cow<'static, str>);
+    pub struct UserInteraction(i32);
 
     impl UserInteraction {
-        /// Creates a new UserInteraction instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [UserInteraction](UserInteraction)
-    pub mod user_interaction {
-        use super::UserInteraction;
-
         /// Invalid value.
-        pub const USER_INTERACTION_UNSPECIFIED: UserInteraction =
-            UserInteraction::new("USER_INTERACTION_UNSPECIFIED");
+        pub const USER_INTERACTION_UNSPECIFIED: UserInteraction = UserInteraction::new(0);
 
         /// The vulnerable system can be exploited without interaction from any user.
-        pub const USER_INTERACTION_NONE: UserInteraction =
-            UserInteraction::new("USER_INTERACTION_NONE");
+        pub const USER_INTERACTION_NONE: UserInteraction = UserInteraction::new(1);
 
         /// Successful exploitation of this vulnerability requires a user to take
         /// some action before the vulnerability can be exploited.
-        pub const USER_INTERACTION_REQUIRED: UserInteraction =
-            UserInteraction::new("USER_INTERACTION_REQUIRED");
+        pub const USER_INTERACTION_REQUIRED: UserInteraction = UserInteraction::new(2);
+
+        /// Creates a new UserInteraction instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("USER_INTERACTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("USER_INTERACTION_NONE"),
+                2 => std::borrow::Cow::Borrowed("USER_INTERACTION_REQUIRED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "USER_INTERACTION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::USER_INTERACTION_UNSPECIFIED)
+                }
+                "USER_INTERACTION_NONE" => std::option::Option::Some(Self::USER_INTERACTION_NONE),
+                "USER_INTERACTION_REQUIRED" => {
+                    std::option::Option::Some(Self::USER_INTERACTION_REQUIRED)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for UserInteraction {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for UserInteraction {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for UserInteraction {
         fn default() -> Self {
-            user_interaction::USER_INTERACTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The Scope metric captures whether a vulnerability in one vulnerable
     /// component impacts resources in components beyond its security scope.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Scope(std::borrow::Cow<'static, str>);
+    pub struct Scope(i32);
 
     impl Scope {
-        /// Creates a new Scope instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Scope](Scope)
-    pub mod scope {
-        use super::Scope;
-
         /// Invalid value.
-        pub const SCOPE_UNSPECIFIED: Scope = Scope::new("SCOPE_UNSPECIFIED");
+        pub const SCOPE_UNSPECIFIED: Scope = Scope::new(0);
 
         /// An exploited vulnerability can only affect resources managed by the same
         /// security authority.
-        pub const SCOPE_UNCHANGED: Scope = Scope::new("SCOPE_UNCHANGED");
+        pub const SCOPE_UNCHANGED: Scope = Scope::new(1);
 
         /// An exploited vulnerability can affect resources beyond the security scope
         /// managed by the security authority of the vulnerable component.
-        pub const SCOPE_CHANGED: Scope = Scope::new("SCOPE_CHANGED");
+        pub const SCOPE_CHANGED: Scope = Scope::new(2);
+
+        /// Creates a new Scope instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SCOPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SCOPE_UNCHANGED"),
+                2 => std::borrow::Cow::Borrowed("SCOPE_CHANGED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SCOPE_UNSPECIFIED" => std::option::Option::Some(Self::SCOPE_UNSPECIFIED),
+                "SCOPE_UNCHANGED" => std::option::Option::Some(Self::SCOPE_UNCHANGED),
+                "SCOPE_CHANGED" => std::option::Option::Some(Self::SCOPE_CHANGED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Scope {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Scope {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Scope {
         fn default() -> Self {
-            scope::SCOPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -13007,46 +13708,63 @@ pub mod cvssv_3 {
     /// vulnerability on the component that suffers the worst outcome that is most
     /// directly and predictably associated with the attack.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Impact(std::borrow::Cow<'static, str>);
+    pub struct Impact(i32);
 
     impl Impact {
+        /// Invalid value.
+        pub const IMPACT_UNSPECIFIED: Impact = Impact::new(0);
+
+        /// High impact.
+        pub const IMPACT_HIGH: Impact = Impact::new(1);
+
+        /// Low impact.
+        pub const IMPACT_LOW: Impact = Impact::new(2);
+
+        /// No impact.
+        pub const IMPACT_NONE: Impact = Impact::new(3);
+
         /// Creates a new Impact instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("IMPACT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IMPACT_HIGH"),
+                2 => std::borrow::Cow::Borrowed("IMPACT_LOW"),
+                3 => std::borrow::Cow::Borrowed("IMPACT_NONE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "IMPACT_UNSPECIFIED" => std::option::Option::Some(Self::IMPACT_UNSPECIFIED),
+                "IMPACT_HIGH" => std::option::Option::Some(Self::IMPACT_HIGH),
+                "IMPACT_LOW" => std::option::Option::Some(Self::IMPACT_LOW),
+                "IMPACT_NONE" => std::option::Option::Some(Self::IMPACT_NONE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Impact](Impact)
-    pub mod impact {
-        use super::Impact;
-
-        /// Invalid value.
-        pub const IMPACT_UNSPECIFIED: Impact = Impact::new("IMPACT_UNSPECIFIED");
-
-        /// High impact.
-        pub const IMPACT_HIGH: Impact = Impact::new("IMPACT_HIGH");
-
-        /// Low impact.
-        pub const IMPACT_LOW: Impact = Impact::new("IMPACT_LOW");
-
-        /// No impact.
-        pub const IMPACT_NONE: Impact = Impact::new("IMPACT_NONE");
-    }
-
-    impl std::convert::From<std::string::String> for Impact {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Impact {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Impact {
         fn default() -> Self {
-            impact::IMPACT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -13168,95 +13886,133 @@ impl wkt::message::Message for SecurityBulletin {
 
 /// The cloud provider the finding pertains to.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct CloudProvider(std::borrow::Cow<'static, str>);
+pub struct CloudProvider(i32);
 
 impl CloudProvider {
+    /// The cloud provider is unspecified.
+    pub const CLOUD_PROVIDER_UNSPECIFIED: CloudProvider = CloudProvider::new(0);
+
+    /// The cloud provider is Google Cloud Platform.
+    pub const GOOGLE_CLOUD_PLATFORM: CloudProvider = CloudProvider::new(1);
+
+    /// The cloud provider is Amazon Web Services.
+    pub const AMAZON_WEB_SERVICES: CloudProvider = CloudProvider::new(2);
+
+    /// The cloud provider is Microsoft Azure.
+    pub const MICROSOFT_AZURE: CloudProvider = CloudProvider::new(3);
+
     /// Creates a new CloudProvider instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("CLOUD_PROVIDER_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("GOOGLE_CLOUD_PLATFORM"),
+            2 => std::borrow::Cow::Borrowed("AMAZON_WEB_SERVICES"),
+            3 => std::borrow::Cow::Borrowed("MICROSOFT_AZURE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "CLOUD_PROVIDER_UNSPECIFIED" => {
+                std::option::Option::Some(Self::CLOUD_PROVIDER_UNSPECIFIED)
+            }
+            "GOOGLE_CLOUD_PLATFORM" => std::option::Option::Some(Self::GOOGLE_CLOUD_PLATFORM),
+            "AMAZON_WEB_SERVICES" => std::option::Option::Some(Self::AMAZON_WEB_SERVICES),
+            "MICROSOFT_AZURE" => std::option::Option::Some(Self::MICROSOFT_AZURE),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [CloudProvider](CloudProvider)
-pub mod cloud_provider {
-    use super::CloudProvider;
-
-    /// The cloud provider is unspecified.
-    pub const CLOUD_PROVIDER_UNSPECIFIED: CloudProvider =
-        CloudProvider::new("CLOUD_PROVIDER_UNSPECIFIED");
-
-    /// The cloud provider is Google Cloud Platform.
-    pub const GOOGLE_CLOUD_PLATFORM: CloudProvider = CloudProvider::new("GOOGLE_CLOUD_PLATFORM");
-
-    /// The cloud provider is Amazon Web Services.
-    pub const AMAZON_WEB_SERVICES: CloudProvider = CloudProvider::new("AMAZON_WEB_SERVICES");
-
-    /// The cloud provider is Microsoft Azure.
-    pub const MICROSOFT_AZURE: CloudProvider = CloudProvider::new("MICROSOFT_AZURE");
-}
-
-impl std::convert::From<std::string::String> for CloudProvider {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for CloudProvider {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for CloudProvider {
     fn default() -> Self {
-        cloud_provider::CLOUD_PROVIDER_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Value enum to map to a resource
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ResourceValue(std::borrow::Cow<'static, str>);
+pub struct ResourceValue(i32);
 
 impl ResourceValue {
+    /// Unspecific value
+    pub const RESOURCE_VALUE_UNSPECIFIED: ResourceValue = ResourceValue::new(0);
+
+    /// High resource value
+    pub const HIGH: ResourceValue = ResourceValue::new(1);
+
+    /// Medium resource value
+    pub const MEDIUM: ResourceValue = ResourceValue::new(2);
+
+    /// Low resource value
+    pub const LOW: ResourceValue = ResourceValue::new(3);
+
+    /// No resource value, e.g. ignore these resources
+    pub const NONE: ResourceValue = ResourceValue::new(4);
+
     /// Creates a new ResourceValue instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("RESOURCE_VALUE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("HIGH"),
+            2 => std::borrow::Cow::Borrowed("MEDIUM"),
+            3 => std::borrow::Cow::Borrowed("LOW"),
+            4 => std::borrow::Cow::Borrowed("NONE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "RESOURCE_VALUE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::RESOURCE_VALUE_UNSPECIFIED)
+            }
+            "HIGH" => std::option::Option::Some(Self::HIGH),
+            "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
+            "LOW" => std::option::Option::Some(Self::LOW),
+            "NONE" => std::option::Option::Some(Self::NONE),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [ResourceValue](ResourceValue)
-pub mod resource_value {
-    use super::ResourceValue;
-
-    /// Unspecific value
-    pub const RESOURCE_VALUE_UNSPECIFIED: ResourceValue =
-        ResourceValue::new("RESOURCE_VALUE_UNSPECIFIED");
-
-    /// High resource value
-    pub const HIGH: ResourceValue = ResourceValue::new("HIGH");
-
-    /// Medium resource value
-    pub const MEDIUM: ResourceValue = ResourceValue::new("MEDIUM");
-
-    /// Low resource value
-    pub const LOW: ResourceValue = ResourceValue::new("LOW");
-
-    /// No resource value, e.g. ignore these resources
-    pub const NONE: ResourceValue = ResourceValue::new("NONE");
-}
-
-impl std::convert::From<std::string::String> for ResourceValue {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ResourceValue {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ResourceValue {
     fn default() -> Self {
-        resource_value::RESOURCE_VALUE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/securitycenter/v2/src/transport.rs
+++ b/src/generated/cloud/securitycenter/v2/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                 reqwest::Method::POST,
                 format!("/v2/{}/resourceValueConfigs:batchCreate", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                 reqwest::Method::POST,
                 format!("/v2/{}/findings:bulkMute", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -92,7 +92,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                 reqwest::Method::POST,
                 format!("/v2/{}/bigQueryExports", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -115,7 +115,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                 reqwest::Method::POST,
                 format!("/v2/{}/findings", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -138,7 +138,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                 reqwest::Method::POST,
                 format!("/v2/{}/muteConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -161,7 +161,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                 reqwest::Method::POST,
                 format!("/v2/{}/notificationConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -181,7 +181,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}/sources", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -198,7 +198,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -217,7 +217,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -236,7 +236,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -255,7 +255,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -274,7 +274,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -293,7 +293,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -312,7 +312,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -334,7 +334,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                 reqwest::Method::POST,
                 format!("/v2/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -351,7 +351,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -370,7 +370,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -389,7 +389,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -408,7 +408,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -430,7 +430,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                 reqwest::Method::POST,
                 format!("/v2/{}/findings:group", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -450,7 +450,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                 reqwest::Method::GET,
                 format!("/v2/{}/attackPaths", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -475,7 +475,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                 reqwest::Method::GET,
                 format!("/v2/{}/bigQueryExports", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -496,7 +496,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/findings", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -532,7 +532,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                 reqwest::Method::GET,
                 format!("/v2/{}/muteConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -556,7 +556,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                 reqwest::Method::GET,
                 format!("/v2/{}/notificationConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -580,7 +580,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                 reqwest::Method::GET,
                 format!("/v2/{}/resourceValueConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -601,7 +601,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/sources", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -625,7 +625,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                 reqwest::Method::GET,
                 format!("/v2/{}/valuedResources", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -648,7 +648,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:setState", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -668,7 +668,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                 reqwest::Method::POST,
                 format!("/v2/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -685,7 +685,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:setMute", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -705,7 +705,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                 reqwest::Method::POST,
                 format!("/v2/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -731,7 +731,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -769,7 +769,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -807,7 +807,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -845,7 +845,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -883,7 +883,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -921,7 +921,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -959,7 +959,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -997,7 +997,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1024,7 +1024,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1046,7 +1046,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1065,7 +1065,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1084,7 +1084,7 @@ impl crate::stubs::SecurityCenter for SecurityCenter {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/securityposture/v1/src/model.rs
+++ b/src/generated/cloud/securityposture/v1/src/model.rs
@@ -421,89 +421,125 @@ pub mod custom_constraint {
     /// `UPDATE` only custom constraints are not supported. Use `CREATE` or
     /// `CREATE, UPDATE`.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MethodType(std::borrow::Cow<'static, str>);
+    pub struct MethodType(i32);
 
     impl MethodType {
-        /// Creates a new MethodType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [MethodType](MethodType)
-    pub mod method_type {
-        use super::MethodType;
-
         /// Unspecified. Results in an error.
-        pub const METHOD_TYPE_UNSPECIFIED: MethodType = MethodType::new("METHOD_TYPE_UNSPECIFIED");
+        pub const METHOD_TYPE_UNSPECIFIED: MethodType = MethodType::new(0);
 
         /// Constraint applied when creating the resource.
-        pub const CREATE: MethodType = MethodType::new("CREATE");
+        pub const CREATE: MethodType = MethodType::new(1);
 
         /// Constraint applied when updating the resource.
-        pub const UPDATE: MethodType = MethodType::new("UPDATE");
+        pub const UPDATE: MethodType = MethodType::new(2);
 
         /// Constraint applied when deleting the resource.
         /// Not supported yet.
-        pub const DELETE: MethodType = MethodType::new("DELETE");
+        pub const DELETE: MethodType = MethodType::new(3);
+
+        /// Creates a new MethodType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("METHOD_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATE"),
+                2 => std::borrow::Cow::Borrowed("UPDATE"),
+                3 => std::borrow::Cow::Borrowed("DELETE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "METHOD_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::METHOD_TYPE_UNSPECIFIED)
+                }
+                "CREATE" => std::option::Option::Some(Self::CREATE),
+                "UPDATE" => std::option::Option::Some(Self::UPDATE),
+                "DELETE" => std::option::Option::Some(Self::DELETE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for MethodType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MethodType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MethodType {
         fn default() -> Self {
-            method_type::METHOD_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Allow or deny type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ActionType(std::borrow::Cow<'static, str>);
+    pub struct ActionType(i32);
 
     impl ActionType {
+        /// Unspecified. Results in an error.
+        pub const ACTION_TYPE_UNSPECIFIED: ActionType = ActionType::new(0);
+
+        /// Allowed action type.
+        pub const ALLOW: ActionType = ActionType::new(1);
+
+        /// Deny action type.
+        pub const DENY: ActionType = ActionType::new(2);
+
         /// Creates a new ActionType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ACTION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALLOW"),
+                2 => std::borrow::Cow::Borrowed("DENY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ACTION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ACTION_TYPE_UNSPECIFIED)
+                }
+                "ALLOW" => std::option::Option::Some(Self::ALLOW),
+                "DENY" => std::option::Option::Some(Self::DENY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ActionType](ActionType)
-    pub mod action_type {
-        use super::ActionType;
-
-        /// Unspecified. Results in an error.
-        pub const ACTION_TYPE_UNSPECIFIED: ActionType = ActionType::new("ACTION_TYPE_UNSPECIFIED");
-
-        /// Allowed action type.
-        pub const ALLOW: ActionType = ActionType::new("ALLOW");
-
-        /// Deny action type.
-        pub const DENY: ActionType = ActionType::new("DENY");
-    }
-
-    impl std::convert::From<std::string::String> for ActionType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ActionType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ActionType {
         fn default() -> Self {
-            action_type::ACTION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -873,46 +909,63 @@ pub mod posture {
 
     /// State of a Posture.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified operation state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The Posture is marked deprecated when it is not in use by the user.
+        pub const DEPRECATED: State = State::new(1);
+
+        /// The Posture is created successfully but is not yet ready for usage.
+        pub const DRAFT: State = State::new(2);
+
+        /// The Posture state is active. Ready for use/deployments.
+        pub const ACTIVE: State = State::new(3);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DEPRECATED"),
+                2 => std::borrow::Cow::Borrowed("DRAFT"),
+                3 => std::borrow::Cow::Borrowed("ACTIVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "DEPRECATED" => std::option::Option::Some(Self::DEPRECATED),
+                "DRAFT" => std::option::Option::Some(Self::DRAFT),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified operation state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The Posture is marked deprecated when it is not in use by the user.
-        pub const DEPRECATED: State = State::new("DEPRECATED");
-
-        /// The Posture is created successfully but is not yet ready for usage.
-        pub const DRAFT: State = State::new("DRAFT");
-
-        /// The Posture state is active. Ready for use/deployments.
-        pub const ACTIVE: State = State::new("ACTIVE");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1956,58 +2009,83 @@ pub mod posture_deployment {
 
     /// State of a PostureDeployment.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified operation state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The PostureDeployment is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// The PostureDeployment is being deleted.
+        pub const DELETING: State = State::new(2);
+
+        /// The PostureDeployment state is being updated.
+        pub const UPDATING: State = State::new(3);
+
+        /// The PostureDeployment state is active and in use.
+        pub const ACTIVE: State = State::new(4);
+
+        /// The PostureDeployment creation failed.
+        pub const CREATE_FAILED: State = State::new(5);
+
+        /// The PostureDeployment update failed.
+        pub const UPDATE_FAILED: State = State::new(6);
+
+        /// The PostureDeployment deletion failed.
+        pub const DELETE_FAILED: State = State::new(7);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("DELETING"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("ACTIVE"),
+                5 => std::borrow::Cow::Borrowed("CREATE_FAILED"),
+                6 => std::borrow::Cow::Borrowed("UPDATE_FAILED"),
+                7 => std::borrow::Cow::Borrowed("DELETE_FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "CREATE_FAILED" => std::option::Option::Some(Self::CREATE_FAILED),
+                "UPDATE_FAILED" => std::option::Option::Some(Self::UPDATE_FAILED),
+                "DELETE_FAILED" => std::option::Option::Some(Self::DELETE_FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified operation state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The PostureDeployment is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The PostureDeployment is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// The PostureDeployment state is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// The PostureDeployment state is active and in use.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The PostureDeployment creation failed.
-        pub const CREATE_FAILED: State = State::new("CREATE_FAILED");
-
-        /// The PostureDeployment update failed.
-        pub const UPDATE_FAILED: State = State::new("UPDATE_FAILED");
-
-        /// The PostureDeployment deletion failed.
-        pub const DELETE_FAILED: State = State::new("DELETE_FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2408,44 +2486,59 @@ pub mod posture_template {
 
     /// State of a PostureTemplate
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified state
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// If the Posture template is adhering to the latest controls and standards.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(1);
 
         /// If the Posture template controls and standards are outdated and not
         /// recommended for use.
-        pub const DEPRECATED: State = State::new("DEPRECATED");
+        pub const DEPRECATED: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("DEPRECATED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DEPRECATED" => std::option::Option::Some(Self::DEPRECATED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2954,92 +3047,127 @@ pub mod custom_config {
 
     /// Defines the valid value options for the severity of a finding.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(std::borrow::Cow<'static, str>);
+    pub struct Severity(i32);
 
     impl Severity {
+        /// Unspecified severity.
+        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
+
+        /// Critical severity.
+        pub const CRITICAL: Severity = Severity::new(1);
+
+        /// High severity.
+        pub const HIGH: Severity = Severity::new(2);
+
+        /// Medium severity.
+        pub const MEDIUM: Severity = Severity::new(3);
+
+        /// Low severity.
+        pub const LOW: Severity = Severity::new(4);
+
         /// Creates a new Severity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CRITICAL"),
+                2 => std::borrow::Cow::Borrowed("HIGH"),
+                3 => std::borrow::Cow::Borrowed("MEDIUM"),
+                4 => std::borrow::Cow::Borrowed("LOW"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
+                "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
+                "HIGH" => std::option::Option::Some(Self::HIGH),
+                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
+                "LOW" => std::option::Option::Some(Self::LOW),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Severity](Severity)
-    pub mod severity {
-        use super::Severity;
-
-        /// Unspecified severity.
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new("SEVERITY_UNSPECIFIED");
-
-        /// Critical severity.
-        pub const CRITICAL: Severity = Severity::new("CRITICAL");
-
-        /// High severity.
-        pub const HIGH: Severity = Severity::new("HIGH");
-
-        /// Medium severity.
-        pub const MEDIUM: Severity = Severity::new("MEDIUM");
-
-        /// Low severity.
-        pub const LOW: Severity = Severity::new("LOW");
-    }
-
-    impl std::convert::From<std::string::String> for Severity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            severity::SEVERITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
 
 /// Possible enablement states of a service or module.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EnablementState(std::borrow::Cow<'static, str>);
+pub struct EnablementState(i32);
 
 impl EnablementState {
+    /// Default value. This value is unused.
+    pub const ENABLEMENT_STATE_UNSPECIFIED: EnablementState = EnablementState::new(0);
+
+    /// State is enabled.
+    pub const ENABLED: EnablementState = EnablementState::new(1);
+
+    /// State is disabled.
+    pub const DISABLED: EnablementState = EnablementState::new(2);
+
     /// Creates a new EnablementState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ENABLEMENT_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ENABLED"),
+            2 => std::borrow::Cow::Borrowed("DISABLED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ENABLEMENT_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::ENABLEMENT_STATE_UNSPECIFIED)
+            }
+            "ENABLED" => std::option::Option::Some(Self::ENABLED),
+            "DISABLED" => std::option::Option::Some(Self::DISABLED),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [EnablementState](EnablementState)
-pub mod enablement_state {
-    use super::EnablementState;
-
-    /// Default value. This value is unused.
-    pub const ENABLEMENT_STATE_UNSPECIFIED: EnablementState =
-        EnablementState::new("ENABLEMENT_STATE_UNSPECIFIED");
-
-    /// State is enabled.
-    pub const ENABLED: EnablementState = EnablementState::new("ENABLED");
-
-    /// State is disabled.
-    pub const DISABLED: EnablementState = EnablementState::new("DISABLED");
-}
-
-impl std::convert::From<std::string::String> for EnablementState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for EnablementState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for EnablementState {
     fn default() -> Self {
-        enablement_state::ENABLEMENT_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/securityposture/v1/src/transport.rs
+++ b/src/generated/cloud/securityposture/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::SecurityPosture for SecurityPosture {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/postures", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -73,7 +73,7 @@ impl crate::stubs::SecurityPosture for SecurityPosture {
                 reqwest::Method::GET,
                 format!("/v1/{}:listRevisions", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -94,7 +94,7 @@ impl crate::stubs::SecurityPosture for SecurityPosture {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -117,7 +117,7 @@ impl crate::stubs::SecurityPosture for SecurityPosture {
                 reqwest::Method::POST,
                 format!("/v1/{}/postures", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -146,7 +146,7 @@ impl crate::stubs::SecurityPosture for SecurityPosture {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -176,7 +176,7 @@ impl crate::stubs::SecurityPosture for SecurityPosture {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -199,7 +199,7 @@ impl crate::stubs::SecurityPosture for SecurityPosture {
                 reqwest::Method::POST,
                 format!("/v1/{}/postures:extract", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -219,7 +219,7 @@ impl crate::stubs::SecurityPosture for SecurityPosture {
                 reqwest::Method::GET,
                 format!("/v1/{}/postureDeployments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -241,7 +241,7 @@ impl crate::stubs::SecurityPosture for SecurityPosture {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -263,7 +263,7 @@ impl crate::stubs::SecurityPosture for SecurityPosture {
                 reqwest::Method::POST,
                 format!("/v1/{}/postureDeployments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -292,7 +292,7 @@ impl crate::stubs::SecurityPosture for SecurityPosture {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -321,7 +321,7 @@ impl crate::stubs::SecurityPosture for SecurityPosture {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -344,7 +344,7 @@ impl crate::stubs::SecurityPosture for SecurityPosture {
                 reqwest::Method::GET,
                 format!("/v1/{}/postureTemplates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -366,7 +366,7 @@ impl crate::stubs::SecurityPosture for SecurityPosture {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -386,7 +386,7 @@ impl crate::stubs::SecurityPosture for SecurityPosture {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -408,7 +408,7 @@ impl crate::stubs::SecurityPosture for SecurityPosture {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -427,7 +427,7 @@ impl crate::stubs::SecurityPosture for SecurityPosture {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -449,7 +449,7 @@ impl crate::stubs::SecurityPosture for SecurityPosture {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -468,7 +468,7 @@ impl crate::stubs::SecurityPosture for SecurityPosture {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -487,7 +487,7 @@ impl crate::stubs::SecurityPosture for SecurityPosture {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/servicedirectory/v1/src/transport.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::LookupService for LookupService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:resolve", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -66,7 +66,7 @@ impl crate::stubs::LookupService for LookupService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -88,7 +88,7 @@ impl crate::stubs::LookupService for LookupService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -133,7 +133,7 @@ impl crate::stubs::RegistrationService for RegistrationService {
                 reqwest::Method::POST,
                 format!("/v1/{}/namespaces", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -156,7 +156,7 @@ impl crate::stubs::RegistrationService for RegistrationService {
                 reqwest::Method::GET,
                 format!("/v1/{}/namespaces", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -179,7 +179,7 @@ impl crate::stubs::RegistrationService for RegistrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -207,7 +207,7 @@ impl crate::stubs::RegistrationService for RegistrationService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -236,7 +236,7 @@ impl crate::stubs::RegistrationService for RegistrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -258,7 +258,7 @@ impl crate::stubs::RegistrationService for RegistrationService {
                 reqwest::Method::POST,
                 format!("/v1/{}/services", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -278,7 +278,7 @@ impl crate::stubs::RegistrationService for RegistrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/services", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -301,7 +301,7 @@ impl crate::stubs::RegistrationService for RegistrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -329,7 +329,7 @@ impl crate::stubs::RegistrationService for RegistrationService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -358,7 +358,7 @@ impl crate::stubs::RegistrationService for RegistrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -380,7 +380,7 @@ impl crate::stubs::RegistrationService for RegistrationService {
                 reqwest::Method::POST,
                 format!("/v1/{}/endpoints", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -403,7 +403,7 @@ impl crate::stubs::RegistrationService for RegistrationService {
                 reqwest::Method::GET,
                 format!("/v1/{}/endpoints", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -426,7 +426,7 @@ impl crate::stubs::RegistrationService for RegistrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -454,7 +454,7 @@ impl crate::stubs::RegistrationService for RegistrationService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -483,7 +483,7 @@ impl crate::stubs::RegistrationService for RegistrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -505,7 +505,7 @@ impl crate::stubs::RegistrationService for RegistrationService {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -525,7 +525,7 @@ impl crate::stubs::RegistrationService for RegistrationService {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -545,7 +545,7 @@ impl crate::stubs::RegistrationService for RegistrationService {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -562,7 +562,7 @@ impl crate::stubs::RegistrationService for RegistrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -584,7 +584,7 @@ impl crate::stubs::RegistrationService for RegistrationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/servicehealth/v1/src/model.rs
+++ b/src/generated/cloud/servicehealth/v1/src/model.rs
@@ -243,176 +243,204 @@ pub mod event {
     /// The category of the event. This enum lists all possible categories of
     /// event.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EventCategory(std::borrow::Cow<'static, str>);
+    pub struct EventCategory(i32);
 
     impl EventCategory {
+        /// Unspecified category.
+        pub const EVENT_CATEGORY_UNSPECIFIED: EventCategory = EventCategory::new(0);
+
+        /// Event category for service outage or degradation.
+        pub const INCIDENT: EventCategory = EventCategory::new(2);
+
         /// Creates a new EventCategory instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EVENT_CATEGORY_UNSPECIFIED"),
+                2 => std::borrow::Cow::Borrowed("INCIDENT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EVENT_CATEGORY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::EVENT_CATEGORY_UNSPECIFIED)
+                }
+                "INCIDENT" => std::option::Option::Some(Self::INCIDENT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [EventCategory](EventCategory)
-    pub mod event_category {
-        use super::EventCategory;
-
-        /// Unspecified category.
-        pub const EVENT_CATEGORY_UNSPECIFIED: EventCategory =
-            EventCategory::new("EVENT_CATEGORY_UNSPECIFIED");
-
-        /// Event category for service outage or degradation.
-        pub const INCIDENT: EventCategory = EventCategory::new("INCIDENT");
-    }
-
-    impl std::convert::From<std::string::String> for EventCategory {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EventCategory {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EventCategory {
         fn default() -> Self {
-            event_category::EVENT_CATEGORY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The detailed category of an event. Contains all possible states for all
     /// event categories.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DetailedCategory(std::borrow::Cow<'static, str>);
+    pub struct DetailedCategory(i32);
 
     impl DetailedCategory {
-        /// Creates a new DetailedCategory instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DetailedCategory](DetailedCategory)
-    pub mod detailed_category {
-        use super::DetailedCategory;
-
         /// Unspecified detailed category.
-        pub const DETAILED_CATEGORY_UNSPECIFIED: DetailedCategory =
-            DetailedCategory::new("DETAILED_CATEGORY_UNSPECIFIED");
+        pub const DETAILED_CATEGORY_UNSPECIFIED: DetailedCategory = DetailedCategory::new(0);
 
         /// Indicates an event with category INCIDENT has a confirmed impact to at
         /// least one Google Cloud product.
-        pub const CONFIRMED_INCIDENT: DetailedCategory =
-            DetailedCategory::new("CONFIRMED_INCIDENT");
+        pub const CONFIRMED_INCIDENT: DetailedCategory = DetailedCategory::new(1);
 
         /// Indicates an event with category INCIDENT is under investigation to
         /// determine if it has a confirmed impact on any Google Cloud products.
-        pub const EMERGING_INCIDENT: DetailedCategory = DetailedCategory::new("EMERGING_INCIDENT");
+        pub const EMERGING_INCIDENT: DetailedCategory = DetailedCategory::new(2);
+
+        /// Creates a new DetailedCategory instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DETAILED_CATEGORY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CONFIRMED_INCIDENT"),
+                2 => std::borrow::Cow::Borrowed("EMERGING_INCIDENT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DETAILED_CATEGORY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DETAILED_CATEGORY_UNSPECIFIED)
+                }
+                "CONFIRMED_INCIDENT" => std::option::Option::Some(Self::CONFIRMED_INCIDENT),
+                "EMERGING_INCIDENT" => std::option::Option::Some(Self::EMERGING_INCIDENT),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DetailedCategory {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DetailedCategory {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DetailedCategory {
         fn default() -> Self {
-            detailed_category::DETAILED_CATEGORY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The state of the event. This enum lists all possible states of event.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Event is actively affecting a Google Cloud product and will continue to
         /// receive updates.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(1);
 
         /// Event is no longer affecting the Google Cloud product or has been merged
         /// with another event.
-        pub const CLOSED: State = State::new("CLOSED");
+        pub const CLOSED: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("CLOSED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "CLOSED" => std::option::Option::Some(Self::CLOSED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The detailed state of the incident. This enum lists all possible detailed
     /// states of an incident.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DetailedState(std::borrow::Cow<'static, str>);
+    pub struct DetailedState(i32);
 
     impl DetailedState {
-        /// Creates a new DetailedState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DetailedState](DetailedState)
-    pub mod detailed_state {
-        use super::DetailedState;
-
         /// Unspecified detail state.
-        pub const DETAILED_STATE_UNSPECIFIED: DetailedState =
-            DetailedState::new("DETAILED_STATE_UNSPECIFIED");
+        pub const DETAILED_STATE_UNSPECIFIED: DetailedState = DetailedState::new(0);
 
         /// Google engineers are actively investigating the event to determine the
         /// impact.
-        pub const EMERGING: DetailedState = DetailedState::new("EMERGING");
+        pub const EMERGING: DetailedState = DetailedState::new(1);
 
         /// The incident is confirmed and impacting at least one Google Cloud
         /// product. Ongoing status updates will be provided until it is resolved.
-        pub const CONFIRMED: DetailedState = DetailedState::new("CONFIRMED");
+        pub const CONFIRMED: DetailedState = DetailedState::new(2);
 
         /// The incident is no longer affecting any Google Cloud product, and there
         /// will be no further updates.
-        pub const RESOLVED: DetailedState = DetailedState::new("RESOLVED");
+        pub const RESOLVED: DetailedState = DetailedState::new(3);
 
         /// The incident was merged into a parent incident. All further updates will
         /// be published to the parent only. The `parent_event` field contains the
         /// name of the parent.
-        pub const MERGED: DetailedState = DetailedState::new("MERGED");
+        pub const MERGED: DetailedState = DetailedState::new(4);
 
         /// The incident was automatically closed because of the following reasons:
         ///
@@ -421,79 +449,140 @@ pub mod event {
         ///
         /// The incident does not have a resolution because no action or
         /// investigation happened. If it is intermittent, the incident may reopen.
-        pub const AUTO_CLOSED: DetailedState = DetailedState::new("AUTO_CLOSED");
+        pub const AUTO_CLOSED: DetailedState = DetailedState::new(9);
 
         /// Upon investigation, Google engineers concluded that the incident is not
         /// affecting a Google Cloud product. This state can change if the incident
         /// is reviewed again.
-        pub const FALSE_POSITIVE: DetailedState = DetailedState::new("FALSE_POSITIVE");
+        pub const FALSE_POSITIVE: DetailedState = DetailedState::new(10);
+
+        /// Creates a new DetailedState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DETAILED_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("EMERGING"),
+                2 => std::borrow::Cow::Borrowed("CONFIRMED"),
+                3 => std::borrow::Cow::Borrowed("RESOLVED"),
+                4 => std::borrow::Cow::Borrowed("MERGED"),
+                9 => std::borrow::Cow::Borrowed("AUTO_CLOSED"),
+                10 => std::borrow::Cow::Borrowed("FALSE_POSITIVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DETAILED_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DETAILED_STATE_UNSPECIFIED)
+                }
+                "EMERGING" => std::option::Option::Some(Self::EMERGING),
+                "CONFIRMED" => std::option::Option::Some(Self::CONFIRMED),
+                "RESOLVED" => std::option::Option::Some(Self::RESOLVED),
+                "MERGED" => std::option::Option::Some(Self::MERGED),
+                "AUTO_CLOSED" => std::option::Option::Some(Self::AUTO_CLOSED),
+                "FALSE_POSITIVE" => std::option::Option::Some(Self::FALSE_POSITIVE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DetailedState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DetailedState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DetailedState {
         fn default() -> Self {
-            detailed_state::DETAILED_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Communicates why a given incident is deemed relevant in the context of a
     /// given project. This enum lists all possible detailed states of relevance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Relevance(std::borrow::Cow<'static, str>);
+    pub struct Relevance(i32);
 
     impl Relevance {
-        /// Creates a new Relevance instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Relevance](Relevance)
-    pub mod relevance {
-        use super::Relevance;
-
         /// Unspecified relevance.
-        pub const RELEVANCE_UNSPECIFIED: Relevance = Relevance::new("RELEVANCE_UNSPECIFIED");
+        pub const RELEVANCE_UNSPECIFIED: Relevance = Relevance::new(0);
 
         /// The relevance of the incident to the project is unknown.
-        pub const UNKNOWN: Relevance = Relevance::new("UNKNOWN");
+        pub const UNKNOWN: Relevance = Relevance::new(2);
 
         /// The incident does not impact the project.
-        pub const NOT_IMPACTED: Relevance = Relevance::new("NOT_IMPACTED");
+        pub const NOT_IMPACTED: Relevance = Relevance::new(6);
 
         /// The incident is associated with a Google Cloud product your project uses,
         /// but the incident may not be impacting your project. For example, the
         /// incident may be impacting a Google Cloud product that your project uses,
         /// but in a location that your project does not use.
-        pub const PARTIALLY_RELATED: Relevance = Relevance::new("PARTIALLY_RELATED");
+        pub const PARTIALLY_RELATED: Relevance = Relevance::new(7);
 
         /// The incident has a direct connection with your project and impacts a
         /// Google Cloud product in a location your project uses.
-        pub const RELATED: Relevance = Relevance::new("RELATED");
+        pub const RELATED: Relevance = Relevance::new(8);
 
         /// The incident is verified to be impacting your project.
-        pub const IMPACTED: Relevance = Relevance::new("IMPACTED");
+        pub const IMPACTED: Relevance = Relevance::new(9);
+
+        /// Creates a new Relevance instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RELEVANCE_UNSPECIFIED"),
+                2 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                6 => std::borrow::Cow::Borrowed("NOT_IMPACTED"),
+                7 => std::borrow::Cow::Borrowed("PARTIALLY_RELATED"),
+                8 => std::borrow::Cow::Borrowed("RELATED"),
+                9 => std::borrow::Cow::Borrowed("IMPACTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RELEVANCE_UNSPECIFIED" => std::option::Option::Some(Self::RELEVANCE_UNSPECIFIED),
+                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                "NOT_IMPACTED" => std::option::Option::Some(Self::NOT_IMPACTED),
+                "PARTIALLY_RELATED" => std::option::Option::Some(Self::PARTIALLY_RELATED),
+                "RELATED" => std::option::Option::Some(Self::RELATED),
+                "IMPACTED" => std::option::Option::Some(Self::IMPACTED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Relevance {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Relevance {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Relevance {
         fn default() -> Self {
-            relevance::RELEVANCE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -713,177 +802,205 @@ pub mod organization_event {
     /// The category of the event. This enum lists all possible categories of
     /// event.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EventCategory(std::borrow::Cow<'static, str>);
+    pub struct EventCategory(i32);
 
     impl EventCategory {
+        /// Unspecified category.
+        pub const EVENT_CATEGORY_UNSPECIFIED: EventCategory = EventCategory::new(0);
+
+        /// Event category for service outage or degradation.
+        pub const INCIDENT: EventCategory = EventCategory::new(2);
+
         /// Creates a new EventCategory instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EVENT_CATEGORY_UNSPECIFIED"),
+                2 => std::borrow::Cow::Borrowed("INCIDENT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EVENT_CATEGORY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::EVENT_CATEGORY_UNSPECIFIED)
+                }
+                "INCIDENT" => std::option::Option::Some(Self::INCIDENT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [EventCategory](EventCategory)
-    pub mod event_category {
-        use super::EventCategory;
-
-        /// Unspecified category.
-        pub const EVENT_CATEGORY_UNSPECIFIED: EventCategory =
-            EventCategory::new("EVENT_CATEGORY_UNSPECIFIED");
-
-        /// Event category for service outage or degradation.
-        pub const INCIDENT: EventCategory = EventCategory::new("INCIDENT");
-    }
-
-    impl std::convert::From<std::string::String> for EventCategory {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EventCategory {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EventCategory {
         fn default() -> Self {
-            event_category::EVENT_CATEGORY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The detailed category of an event. Contains all possible states for all
     /// event categories.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DetailedCategory(std::borrow::Cow<'static, str>);
+    pub struct DetailedCategory(i32);
 
     impl DetailedCategory {
-        /// Creates a new DetailedCategory instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DetailedCategory](DetailedCategory)
-    pub mod detailed_category {
-        use super::DetailedCategory;
-
         /// Unspecified detailed category.
-        pub const DETAILED_CATEGORY_UNSPECIFIED: DetailedCategory =
-            DetailedCategory::new("DETAILED_CATEGORY_UNSPECIFIED");
+        pub const DETAILED_CATEGORY_UNSPECIFIED: DetailedCategory = DetailedCategory::new(0);
 
         /// Indicates an event with category INCIDENT has a confirmed impact to at
         /// least one Google Cloud product.
-        pub const CONFIRMED_INCIDENT: DetailedCategory =
-            DetailedCategory::new("CONFIRMED_INCIDENT");
+        pub const CONFIRMED_INCIDENT: DetailedCategory = DetailedCategory::new(1);
 
         /// Indicates an event with category INCIDENT is under investigation to
         /// determine if it has a confirmed impact on any Google Cloud products.
-        pub const EMERGING_INCIDENT: DetailedCategory = DetailedCategory::new("EMERGING_INCIDENT");
+        pub const EMERGING_INCIDENT: DetailedCategory = DetailedCategory::new(2);
+
+        /// Creates a new DetailedCategory instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DETAILED_CATEGORY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CONFIRMED_INCIDENT"),
+                2 => std::borrow::Cow::Borrowed("EMERGING_INCIDENT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DETAILED_CATEGORY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DETAILED_CATEGORY_UNSPECIFIED)
+                }
+                "CONFIRMED_INCIDENT" => std::option::Option::Some(Self::CONFIRMED_INCIDENT),
+                "EMERGING_INCIDENT" => std::option::Option::Some(Self::EMERGING_INCIDENT),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DetailedCategory {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DetailedCategory {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DetailedCategory {
         fn default() -> Self {
-            detailed_category::DETAILED_CATEGORY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The state of the organization event. This enum lists all possible states of
     /// event.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Event is actively affecting a Google Cloud product and will continue to
         /// receive updates.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(1);
 
         /// Event is no longer affecting the Google Cloud product or has been merged
         /// with another event.
-        pub const CLOSED: State = State::new("CLOSED");
+        pub const CLOSED: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("CLOSED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "CLOSED" => std::option::Option::Some(Self::CLOSED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The detailed state of the incident. This enum lists all possible detailed
     /// states of an incident.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DetailedState(std::borrow::Cow<'static, str>);
+    pub struct DetailedState(i32);
 
     impl DetailedState {
-        /// Creates a new DetailedState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DetailedState](DetailedState)
-    pub mod detailed_state {
-        use super::DetailedState;
-
         /// Unspecified detail state.
-        pub const DETAILED_STATE_UNSPECIFIED: DetailedState =
-            DetailedState::new("DETAILED_STATE_UNSPECIFIED");
+        pub const DETAILED_STATE_UNSPECIFIED: DetailedState = DetailedState::new(0);
 
         /// Google engineers are actively investigating the incident to determine the
         /// impact.
-        pub const EMERGING: DetailedState = DetailedState::new("EMERGING");
+        pub const EMERGING: DetailedState = DetailedState::new(1);
 
         /// The incident is confirmed and impacting at least one Google Cloud
         /// product. Ongoing status updates will be provided until it is resolved.
-        pub const CONFIRMED: DetailedState = DetailedState::new("CONFIRMED");
+        pub const CONFIRMED: DetailedState = DetailedState::new(2);
 
         /// The incident is no longer affecting any Google Cloud product, and there
         /// will be no further updates.
-        pub const RESOLVED: DetailedState = DetailedState::new("RESOLVED");
+        pub const RESOLVED: DetailedState = DetailedState::new(3);
 
         /// The incident was merged into a parent event. All further updates will be
         /// published to the parent only. The `parent_event` contains the name of the
         /// parent.
-        pub const MERGED: DetailedState = DetailedState::new("MERGED");
+        pub const MERGED: DetailedState = DetailedState::new(4);
 
         /// The incident was automatically closed because of the following reasons:
         ///
@@ -892,23 +1009,63 @@ pub mod organization_event {
         ///
         /// The incident does not have a resolution because no action or
         /// investigation happened. If it is intermittent, the incident may reopen.
-        pub const AUTO_CLOSED: DetailedState = DetailedState::new("AUTO_CLOSED");
+        pub const AUTO_CLOSED: DetailedState = DetailedState::new(9);
 
         /// Upon investigation, Google engineers concluded that the incident is not
         /// affecting a Google Cloud product. This state can change if the incident
         /// is reviewed again.
-        pub const FALSE_POSITIVE: DetailedState = DetailedState::new("FALSE_POSITIVE");
+        pub const FALSE_POSITIVE: DetailedState = DetailedState::new(10);
+
+        /// Creates a new DetailedState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DETAILED_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("EMERGING"),
+                2 => std::borrow::Cow::Borrowed("CONFIRMED"),
+                3 => std::borrow::Cow::Borrowed("RESOLVED"),
+                4 => std::borrow::Cow::Borrowed("MERGED"),
+                9 => std::borrow::Cow::Borrowed("AUTO_CLOSED"),
+                10 => std::borrow::Cow::Borrowed("FALSE_POSITIVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DETAILED_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DETAILED_STATE_UNSPECIFIED)
+                }
+                "EMERGING" => std::option::Option::Some(Self::EMERGING),
+                "CONFIRMED" => std::option::Option::Some(Self::CONFIRMED),
+                "RESOLVED" => std::option::Option::Some(Self::RESOLVED),
+                "MERGED" => std::option::Option::Some(Self::MERGED),
+                "AUTO_CLOSED" => std::option::Option::Some(Self::AUTO_CLOSED),
+                "FALSE_POSITIVE" => std::option::Option::Some(Self::FALSE_POSITIVE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DetailedState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DetailedState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DetailedState {
         fn default() -> Self {
-            detailed_state::DETAILED_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1856,90 +2013,124 @@ impl wkt::message::Message for GetOrganizationImpactRequest {
 /// The event fields to include in ListEvents API response. This enum lists all
 /// possible event views.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EventView(std::borrow::Cow<'static, str>);
+pub struct EventView(i32);
 
 impl EventView {
-    /// Creates a new EventView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [EventView](EventView)
-pub mod event_view {
-    use super::EventView;
-
     /// Unspecified event view. Default to `EVENT_VIEW_BASIC`.
-    pub const EVENT_VIEW_UNSPECIFIED: EventView = EventView::new("EVENT_VIEW_UNSPECIFIED");
+    pub const EVENT_VIEW_UNSPECIFIED: EventView = EventView::new(0);
 
     /// Includes all fields except `updates`. This view is the default for
     /// ListEvents API.
-    pub const EVENT_VIEW_BASIC: EventView = EventView::new("EVENT_VIEW_BASIC");
+    pub const EVENT_VIEW_BASIC: EventView = EventView::new(1);
 
     /// Includes all event fields.
-    pub const EVENT_VIEW_FULL: EventView = EventView::new("EVENT_VIEW_FULL");
+    pub const EVENT_VIEW_FULL: EventView = EventView::new(2);
+
+    /// Creates a new EventView instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("EVENT_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("EVENT_VIEW_BASIC"),
+            2 => std::borrow::Cow::Borrowed("EVENT_VIEW_FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "EVENT_VIEW_UNSPECIFIED" => std::option::Option::Some(Self::EVENT_VIEW_UNSPECIFIED),
+            "EVENT_VIEW_BASIC" => std::option::Option::Some(Self::EVENT_VIEW_BASIC),
+            "EVENT_VIEW_FULL" => std::option::Option::Some(Self::EVENT_VIEW_FULL),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for EventView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for EventView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for EventView {
     fn default() -> Self {
-        event_view::EVENT_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The organization event fields to include in ListOrganizationEvents API
 /// response. This enum lists all possible organization event views.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OrganizationEventView(std::borrow::Cow<'static, str>);
+pub struct OrganizationEventView(i32);
 
 impl OrganizationEventView {
-    /// Creates a new OrganizationEventView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [OrganizationEventView](OrganizationEventView)
-pub mod organization_event_view {
-    use super::OrganizationEventView;
-
     /// Unspecified event view. Default to `ORGANIZATION_EVENT_VIEW_BASIC`.
     pub const ORGANIZATION_EVENT_VIEW_UNSPECIFIED: OrganizationEventView =
-        OrganizationEventView::new("ORGANIZATION_EVENT_VIEW_UNSPECIFIED");
+        OrganizationEventView::new(0);
 
     /// Includes all organization event fields except `updates`. This view is the
     /// default for ListOrganizationEvents API.
-    pub const ORGANIZATION_EVENT_VIEW_BASIC: OrganizationEventView =
-        OrganizationEventView::new("ORGANIZATION_EVENT_VIEW_BASIC");
+    pub const ORGANIZATION_EVENT_VIEW_BASIC: OrganizationEventView = OrganizationEventView::new(1);
 
     /// Includes all organization event fields.
-    pub const ORGANIZATION_EVENT_VIEW_FULL: OrganizationEventView =
-        OrganizationEventView::new("ORGANIZATION_EVENT_VIEW_FULL");
+    pub const ORGANIZATION_EVENT_VIEW_FULL: OrganizationEventView = OrganizationEventView::new(2);
+
+    /// Creates a new OrganizationEventView instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ORGANIZATION_EVENT_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ORGANIZATION_EVENT_VIEW_BASIC"),
+            2 => std::borrow::Cow::Borrowed("ORGANIZATION_EVENT_VIEW_FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ORGANIZATION_EVENT_VIEW_UNSPECIFIED" => {
+                std::option::Option::Some(Self::ORGANIZATION_EVENT_VIEW_UNSPECIFIED)
+            }
+            "ORGANIZATION_EVENT_VIEW_BASIC" => {
+                std::option::Option::Some(Self::ORGANIZATION_EVENT_VIEW_BASIC)
+            }
+            "ORGANIZATION_EVENT_VIEW_FULL" => {
+                std::option::Option::Some(Self::ORGANIZATION_EVENT_VIEW_FULL)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for OrganizationEventView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for OrganizationEventView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for OrganizationEventView {
     fn default() -> Self {
-        organization_event_view::ORGANIZATION_EVENT_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/servicehealth/v1/src/transport.rs
+++ b/src/generated/cloud/servicehealth/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::ServiceHealth for ServiceHealth {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/events", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::ServiceHealth for ServiceHealth {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -94,7 +94,7 @@ impl crate::stubs::ServiceHealth for ServiceHealth {
                 reqwest::Method::GET,
                 format!("/v1/{}/organizationEvents", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -117,7 +117,7 @@ impl crate::stubs::ServiceHealth for ServiceHealth {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -139,7 +139,7 @@ impl crate::stubs::ServiceHealth for ServiceHealth {
                 reqwest::Method::GET,
                 format!("/v1/{}/organizationImpacts", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -161,7 +161,7 @@ impl crate::stubs::ServiceHealth for ServiceHealth {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -180,7 +180,7 @@ impl crate::stubs::ServiceHealth for ServiceHealth {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -202,7 +202,7 @@ impl crate::stubs::ServiceHealth for ServiceHealth {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/shell/v1/src/model.rs
+++ b/src/generated/cloud/shell/v1/src/model.rs
@@ -170,53 +170,72 @@ pub mod environment {
 
     /// Possible execution states for an environment.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The environment's states is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The environment is not running and can't be connected to. Starting the
         /// environment will transition it to the PENDING state.
-        pub const SUSPENDED: State = State::new("SUSPENDED");
+        pub const SUSPENDED: State = State::new(1);
 
         /// The environment is being started but is not yet ready to accept
         /// connections.
-        pub const PENDING: State = State::new("PENDING");
+        pub const PENDING: State = State::new(2);
 
         /// The environment is running and ready to accept connections. It will
         /// automatically transition back to DISABLED after a period of inactivity or
         /// if another environment is started.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(3);
 
         /// The environment is being deleted and can't be connected to.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(4);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SUSPENDED"),
+                2 => std::borrow::Cow::Borrowed("PENDING"),
+                3 => std::borrow::Cow::Borrowed("RUNNING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "SUSPENDED" => std::option::Option::Some(Self::SUSPENDED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -513,57 +532,78 @@ pub mod start_environment_metadata {
     /// through all of these states when starting. More states are likely to be
     /// added in the future.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The environment's start state is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The environment is in the process of being started, but no additional
         /// details are available.
-        pub const STARTING: State = State::new("STARTING");
+        pub const STARTING: State = State::new(1);
 
         /// Startup is waiting for the user's disk to be unarchived. This can happen
         /// when the user returns to Cloud Shell after not having used it for a
         /// while, and suggests that startup will take longer than normal.
-        pub const UNARCHIVING_DISK: State = State::new("UNARCHIVING_DISK");
+        pub const UNARCHIVING_DISK: State = State::new(2);
 
         /// Startup is waiting for compute resources to be assigned to the
         /// environment. This should normally happen very quickly, but an environment
         /// might stay in this state for an extended period of time if the system is
         /// experiencing heavy load.
-        pub const AWAITING_COMPUTE_RESOURCES: State = State::new("AWAITING_COMPUTE_RESOURCES");
+        pub const AWAITING_COMPUTE_RESOURCES: State = State::new(4);
 
         /// Startup has completed. If the start operation was successful, the user
         /// should be able to establish an SSH connection to their environment.
         /// Otherwise, the operation will contain details of the failure.
-        pub const FINISHED: State = State::new("FINISHED");
+        pub const FINISHED: State = State::new(3);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STARTING"),
+                2 => std::borrow::Cow::Borrowed("UNARCHIVING_DISK"),
+                3 => std::borrow::Cow::Borrowed("FINISHED"),
+                4 => std::borrow::Cow::Borrowed("AWAITING_COMPUTE_RESOURCES"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "STARTING" => std::option::Option::Some(Self::STARTING),
+                "UNARCHIVING_DISK" => std::option::Option::Some(Self::UNARCHIVING_DISK),
+                "AWAITING_COMPUTE_RESOURCES" => {
+                    std::option::Option::Some(Self::AWAITING_COMPUTE_RESOURCES)
+                }
+                "FINISHED" => std::option::Option::Some(Self::FINISHED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -836,61 +876,83 @@ pub mod cloud_shell_error_details {
 
     /// Set of possible errors returned from API calls.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CloudShellErrorCode(std::borrow::Cow<'static, str>);
+    pub struct CloudShellErrorCode(i32);
 
     impl CloudShellErrorCode {
-        /// Creates a new CloudShellErrorCode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CloudShellErrorCode](CloudShellErrorCode)
-    pub mod cloud_shell_error_code {
-        use super::CloudShellErrorCode;
-
         /// An unknown error occurred.
         pub const CLOUD_SHELL_ERROR_CODE_UNSPECIFIED: CloudShellErrorCode =
-            CloudShellErrorCode::new("CLOUD_SHELL_ERROR_CODE_UNSPECIFIED");
+            CloudShellErrorCode::new(0);
 
         /// The image used by the Cloud Shell environment either does not exist or
         /// the user does not have access to it.
-        pub const IMAGE_UNAVAILABLE: CloudShellErrorCode =
-            CloudShellErrorCode::new("IMAGE_UNAVAILABLE");
+        pub const IMAGE_UNAVAILABLE: CloudShellErrorCode = CloudShellErrorCode::new(1);
 
         /// Cloud Shell has been disabled by an administrator for the user making the
         /// request.
-        pub const CLOUD_SHELL_DISABLED: CloudShellErrorCode =
-            CloudShellErrorCode::new("CLOUD_SHELL_DISABLED");
+        pub const CLOUD_SHELL_DISABLED: CloudShellErrorCode = CloudShellErrorCode::new(2);
 
         /// Cloud Shell has been permanently disabled due to a Terms of Service
         /// violation by the user.
-        pub const TOS_VIOLATION: CloudShellErrorCode = CloudShellErrorCode::new("TOS_VIOLATION");
+        pub const TOS_VIOLATION: CloudShellErrorCode = CloudShellErrorCode::new(4);
 
         /// The user has exhausted their weekly Cloud Shell quota, and Cloud Shell
         /// will be disabled until the quota resets.
-        pub const QUOTA_EXCEEDED: CloudShellErrorCode = CloudShellErrorCode::new("QUOTA_EXCEEDED");
+        pub const QUOTA_EXCEEDED: CloudShellErrorCode = CloudShellErrorCode::new(5);
 
         /// The Cloud Shell environment is unavailable and cannot be connected to at
         /// the moment.
-        pub const ENVIRONMENT_UNAVAILABLE: CloudShellErrorCode =
-            CloudShellErrorCode::new("ENVIRONMENT_UNAVAILABLE");
+        pub const ENVIRONMENT_UNAVAILABLE: CloudShellErrorCode = CloudShellErrorCode::new(6);
+
+        /// Creates a new CloudShellErrorCode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CLOUD_SHELL_ERROR_CODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IMAGE_UNAVAILABLE"),
+                2 => std::borrow::Cow::Borrowed("CLOUD_SHELL_DISABLED"),
+                4 => std::borrow::Cow::Borrowed("TOS_VIOLATION"),
+                5 => std::borrow::Cow::Borrowed("QUOTA_EXCEEDED"),
+                6 => std::borrow::Cow::Borrowed("ENVIRONMENT_UNAVAILABLE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CLOUD_SHELL_ERROR_CODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CLOUD_SHELL_ERROR_CODE_UNSPECIFIED)
+                }
+                "IMAGE_UNAVAILABLE" => std::option::Option::Some(Self::IMAGE_UNAVAILABLE),
+                "CLOUD_SHELL_DISABLED" => std::option::Option::Some(Self::CLOUD_SHELL_DISABLED),
+                "TOS_VIOLATION" => std::option::Option::Some(Self::TOS_VIOLATION),
+                "QUOTA_EXCEEDED" => std::option::Option::Some(Self::QUOTA_EXCEEDED),
+                "ENVIRONMENT_UNAVAILABLE" => {
+                    std::option::Option::Some(Self::ENVIRONMENT_UNAVAILABLE)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CloudShellErrorCode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CloudShellErrorCode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CloudShellErrorCode {
         fn default() -> Self {
-            cloud_shell_error_code::CLOUD_SHELL_ERROR_CODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/shell/v1/src/transport.rs
+++ b/src/generated/cloud/shell/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::CloudShellService for CloudShellService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -68,7 +68,7 @@ impl crate::stubs::CloudShellService for CloudShellService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:start", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -85,7 +85,7 @@ impl crate::stubs::CloudShellService for CloudShellService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:authorize", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -105,7 +105,7 @@ impl crate::stubs::CloudShellService for CloudShellService {
                 reqwest::Method::POST,
                 format!("/v1/{}:addPublicKey", req.environment),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -125,7 +125,7 @@ impl crate::stubs::CloudShellService for CloudShellService {
                 reqwest::Method::POST,
                 format!("/v1/{}:removePublicKey", req.environment),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -142,7 +142,7 @@ impl crate::stubs::CloudShellService for CloudShellService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/speech/v2/src/model.rs
+++ b/src/generated/cloud/speech/v2/src/model.rs
@@ -1389,43 +1389,58 @@ pub mod recognizer {
 
     /// Set of states that define the lifecycle of a Recognizer.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The default value. This value is used if the state is omitted.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The Recognizer is active and ready for use.
+        pub const ACTIVE: State = State::new(2);
+
+        /// This Recognizer has been deleted.
+        pub const DELETED: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                4 => std::borrow::Cow::Borrowed("DELETED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DELETED" => std::option::Option::Some(Self::DELETED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The Recognizer is active and ready for use.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// This Recognizer has been deleted.
-        pub const DELETED: State = State::new("DELETED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1542,74 +1557,110 @@ pub mod explicit_decoding_config {
 
     /// Supported audio data encodings.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AudioEncoding(std::borrow::Cow<'static, str>);
+    pub struct AudioEncoding(i32);
 
     impl AudioEncoding {
+        /// Default value. This value is unused.
+        pub const AUDIO_ENCODING_UNSPECIFIED: AudioEncoding = AudioEncoding::new(0);
+
+        /// Headerless 16-bit signed little-endian PCM samples.
+        pub const LINEAR16: AudioEncoding = AudioEncoding::new(1);
+
+        /// Headerless 8-bit companded mulaw samples.
+        pub const MULAW: AudioEncoding = AudioEncoding::new(2);
+
+        /// Headerless 8-bit companded alaw samples.
+        pub const ALAW: AudioEncoding = AudioEncoding::new(3);
+
+        /// AMR frames with an rfc4867.5 header.
+        pub const AMR: AudioEncoding = AudioEncoding::new(4);
+
+        /// AMR-WB frames with an rfc4867.5 header.
+        pub const AMR_WB: AudioEncoding = AudioEncoding::new(5);
+
+        /// FLAC frames in the "native FLAC" container format.
+        pub const FLAC: AudioEncoding = AudioEncoding::new(6);
+
+        /// MPEG audio frames with optional (ignored) ID3 metadata.
+        pub const MP3: AudioEncoding = AudioEncoding::new(7);
+
+        /// Opus audio frames in an Ogg container.
+        pub const OGG_OPUS: AudioEncoding = AudioEncoding::new(8);
+
+        /// Opus audio frames in a WebM container.
+        pub const WEBM_OPUS: AudioEncoding = AudioEncoding::new(9);
+
+        /// AAC audio frames in an MP4 container.
+        pub const MP4_AAC: AudioEncoding = AudioEncoding::new(10);
+
+        /// AAC audio frames in an M4A container.
+        pub const M4A_AAC: AudioEncoding = AudioEncoding::new(11);
+
+        /// AAC audio frames in an MOV container.
+        pub const MOV_AAC: AudioEncoding = AudioEncoding::new(12);
+
         /// Creates a new AudioEncoding instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LINEAR16"),
+                2 => std::borrow::Cow::Borrowed("MULAW"),
+                3 => std::borrow::Cow::Borrowed("ALAW"),
+                4 => std::borrow::Cow::Borrowed("AMR"),
+                5 => std::borrow::Cow::Borrowed("AMR_WB"),
+                6 => std::borrow::Cow::Borrowed("FLAC"),
+                7 => std::borrow::Cow::Borrowed("MP3"),
+                8 => std::borrow::Cow::Borrowed("OGG_OPUS"),
+                9 => std::borrow::Cow::Borrowed("WEBM_OPUS"),
+                10 => std::borrow::Cow::Borrowed("MP4_AAC"),
+                11 => std::borrow::Cow::Borrowed("M4A_AAC"),
+                12 => std::borrow::Cow::Borrowed("MOV_AAC"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "AUDIO_ENCODING_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::AUDIO_ENCODING_UNSPECIFIED)
+                }
+                "LINEAR16" => std::option::Option::Some(Self::LINEAR16),
+                "MULAW" => std::option::Option::Some(Self::MULAW),
+                "ALAW" => std::option::Option::Some(Self::ALAW),
+                "AMR" => std::option::Option::Some(Self::AMR),
+                "AMR_WB" => std::option::Option::Some(Self::AMR_WB),
+                "FLAC" => std::option::Option::Some(Self::FLAC),
+                "MP3" => std::option::Option::Some(Self::MP3),
+                "OGG_OPUS" => std::option::Option::Some(Self::OGG_OPUS),
+                "WEBM_OPUS" => std::option::Option::Some(Self::WEBM_OPUS),
+                "MP4_AAC" => std::option::Option::Some(Self::MP4_AAC),
+                "M4A_AAC" => std::option::Option::Some(Self::M4A_AAC),
+                "MOV_AAC" => std::option::Option::Some(Self::MOV_AAC),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AudioEncoding](AudioEncoding)
-    pub mod audio_encoding {
-        use super::AudioEncoding;
-
-        /// Default value. This value is unused.
-        pub const AUDIO_ENCODING_UNSPECIFIED: AudioEncoding =
-            AudioEncoding::new("AUDIO_ENCODING_UNSPECIFIED");
-
-        /// Headerless 16-bit signed little-endian PCM samples.
-        pub const LINEAR16: AudioEncoding = AudioEncoding::new("LINEAR16");
-
-        /// Headerless 8-bit companded mulaw samples.
-        pub const MULAW: AudioEncoding = AudioEncoding::new("MULAW");
-
-        /// Headerless 8-bit companded alaw samples.
-        pub const ALAW: AudioEncoding = AudioEncoding::new("ALAW");
-
-        /// AMR frames with an rfc4867.5 header.
-        pub const AMR: AudioEncoding = AudioEncoding::new("AMR");
-
-        /// AMR-WB frames with an rfc4867.5 header.
-        pub const AMR_WB: AudioEncoding = AudioEncoding::new("AMR_WB");
-
-        /// FLAC frames in the "native FLAC" container format.
-        pub const FLAC: AudioEncoding = AudioEncoding::new("FLAC");
-
-        /// MPEG audio frames with optional (ignored) ID3 metadata.
-        pub const MP3: AudioEncoding = AudioEncoding::new("MP3");
-
-        /// Opus audio frames in an Ogg container.
-        pub const OGG_OPUS: AudioEncoding = AudioEncoding::new("OGG_OPUS");
-
-        /// Opus audio frames in a WebM container.
-        pub const WEBM_OPUS: AudioEncoding = AudioEncoding::new("WEBM_OPUS");
-
-        /// AAC audio frames in an MP4 container.
-        pub const MP4_AAC: AudioEncoding = AudioEncoding::new("MP4_AAC");
-
-        /// AAC audio frames in an M4A container.
-        pub const M4A_AAC: AudioEncoding = AudioEncoding::new("M4A_AAC");
-
-        /// AAC audio frames in an MOV container.
-        pub const MOV_AAC: AudioEncoding = AudioEncoding::new("MOV_AAC");
-    }
-
-    impl std::convert::From<std::string::String> for AudioEncoding {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AudioEncoding {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AudioEncoding {
         fn default() -> Self {
-            audio_encoding::AUDIO_ENCODING_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1803,48 +1854,63 @@ pub mod recognition_features {
 
     /// Options for how to recognize multi-channel audio.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MultiChannelMode(std::borrow::Cow<'static, str>);
+    pub struct MultiChannelMode(i32);
 
     impl MultiChannelMode {
-        /// Creates a new MultiChannelMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [MultiChannelMode](MultiChannelMode)
-    pub mod multi_channel_mode {
-        use super::MultiChannelMode;
-
         /// Default value for the multi-channel mode. If the audio contains
         /// multiple channels, only the first channel will be transcribed; other
         /// channels will be ignored.
-        pub const MULTI_CHANNEL_MODE_UNSPECIFIED: MultiChannelMode =
-            MultiChannelMode::new("MULTI_CHANNEL_MODE_UNSPECIFIED");
+        pub const MULTI_CHANNEL_MODE_UNSPECIFIED: MultiChannelMode = MultiChannelMode::new(0);
 
         /// If selected, each channel in the provided audio is transcribed
         /// independently. This cannot be selected if the selected
         /// [model][google.cloud.speech.v2.Recognizer.model] is `latest_short`.
         ///
         /// [google.cloud.speech.v2.Recognizer.model]: crate::model::Recognizer::model
-        pub const SEPARATE_RECOGNITION_PER_CHANNEL: MultiChannelMode =
-            MultiChannelMode::new("SEPARATE_RECOGNITION_PER_CHANNEL");
+        pub const SEPARATE_RECOGNITION_PER_CHANNEL: MultiChannelMode = MultiChannelMode::new(1);
+
+        /// Creates a new MultiChannelMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MULTI_CHANNEL_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SEPARATE_RECOGNITION_PER_CHANNEL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MULTI_CHANNEL_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MULTI_CHANNEL_MODE_UNSPECIFIED)
+                }
+                "SEPARATE_RECOGNITION_PER_CHANNEL" => {
+                    std::option::Option::Some(Self::SEPARATE_RECOGNITION_PER_CHANNEL)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for MultiChannelMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MultiChannelMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MultiChannelMode {
         fn default() -> Self {
-            multi_channel_mode::MULTI_CHANNEL_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3385,44 +3451,57 @@ pub mod batch_recognize_request {
 
     /// Possible processing strategies for batch requests.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ProcessingStrategy(std::borrow::Cow<'static, str>);
+    pub struct ProcessingStrategy(i32);
 
     impl ProcessingStrategy {
-        /// Creates a new ProcessingStrategy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ProcessingStrategy](ProcessingStrategy)
-    pub mod processing_strategy {
-        use super::ProcessingStrategy;
-
         /// Default value for the processing strategy. The request is processed as
         /// soon as its received.
-        pub const PROCESSING_STRATEGY_UNSPECIFIED: ProcessingStrategy =
-            ProcessingStrategy::new("PROCESSING_STRATEGY_UNSPECIFIED");
+        pub const PROCESSING_STRATEGY_UNSPECIFIED: ProcessingStrategy = ProcessingStrategy::new(0);
 
         /// If selected, processes the request during lower utilization periods for a
         /// price discount. The request is fulfilled within 24 hours.
-        pub const DYNAMIC_BATCHING: ProcessingStrategy =
-            ProcessingStrategy::new("DYNAMIC_BATCHING");
+        pub const DYNAMIC_BATCHING: ProcessingStrategy = ProcessingStrategy::new(1);
+
+        /// Creates a new ProcessingStrategy instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PROCESSING_STRATEGY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DYNAMIC_BATCHING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PROCESSING_STRATEGY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PROCESSING_STRATEGY_UNSPECIFIED)
+                }
+                "DYNAMIC_BATCHING" => std::option::Option::Some(Self::DYNAMIC_BATCHING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ProcessingStrategy {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ProcessingStrategy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ProcessingStrategy {
         fn default() -> Self {
-            processing_strategy::PROCESSING_STRATEGY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4598,27 +4677,11 @@ pub mod streaming_recognize_response {
 
     /// Indicates the type of speech event.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SpeechEventType(std::borrow::Cow<'static, str>);
+    pub struct SpeechEventType(i32);
 
     impl SpeechEventType {
-        /// Creates a new SpeechEventType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [SpeechEventType](SpeechEventType)
-    pub mod speech_event_type {
-        use super::SpeechEventType;
-
         /// No speech event specified.
-        pub const SPEECH_EVENT_TYPE_UNSPECIFIED: SpeechEventType =
-            SpeechEventType::new("SPEECH_EVENT_TYPE_UNSPECIFIED");
+        pub const SPEECH_EVENT_TYPE_UNSPECIFIED: SpeechEventType = SpeechEventType::new(0);
 
         /// This event indicates that the server has detected the end of the user's
         /// speech utterance and expects no additional speech. Therefore, the server
@@ -4628,33 +4691,66 @@ pub mod streaming_recognize_response {
         /// `latest_short` [model][google.cloud.speech.v2.Recognizer.model].
         ///
         /// [google.cloud.speech.v2.Recognizer.model]: crate::model::Recognizer::model
-        pub const END_OF_SINGLE_UTTERANCE: SpeechEventType =
-            SpeechEventType::new("END_OF_SINGLE_UTTERANCE");
+        pub const END_OF_SINGLE_UTTERANCE: SpeechEventType = SpeechEventType::new(1);
 
         /// This event indicates that the server has detected the beginning of human
         /// voice activity in the stream. This event can be returned multiple times
         /// if speech starts and stops repeatedly throughout the stream. This event
         /// is only sent if `voice_activity_events` is set to true.
-        pub const SPEECH_ACTIVITY_BEGIN: SpeechEventType =
-            SpeechEventType::new("SPEECH_ACTIVITY_BEGIN");
+        pub const SPEECH_ACTIVITY_BEGIN: SpeechEventType = SpeechEventType::new(2);
 
         /// This event indicates that the server has detected the end of human voice
         /// activity in the stream. This event can be returned multiple times if
         /// speech starts and stops repeatedly throughout the stream. This event is
         /// only sent if `voice_activity_events` is set to true.
-        pub const SPEECH_ACTIVITY_END: SpeechEventType =
-            SpeechEventType::new("SPEECH_ACTIVITY_END");
+        pub const SPEECH_ACTIVITY_END: SpeechEventType = SpeechEventType::new(3);
+
+        /// Creates a new SpeechEventType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SPEECH_EVENT_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("END_OF_SINGLE_UTTERANCE"),
+                2 => std::borrow::Cow::Borrowed("SPEECH_ACTIVITY_BEGIN"),
+                3 => std::borrow::Cow::Borrowed("SPEECH_ACTIVITY_END"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SPEECH_EVENT_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SPEECH_EVENT_TYPE_UNSPECIFIED)
+                }
+                "END_OF_SINGLE_UTTERANCE" => {
+                    std::option::Option::Some(Self::END_OF_SINGLE_UTTERANCE)
+                }
+                "SPEECH_ACTIVITY_BEGIN" => std::option::Option::Some(Self::SPEECH_ACTIVITY_BEGIN),
+                "SPEECH_ACTIVITY_END" => std::option::Option::Some(Self::SPEECH_ACTIVITY_END),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for SpeechEventType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SpeechEventType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SpeechEventType {
         fn default() -> Self {
-            speech_event_type::SPEECH_EVENT_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5043,44 +5139,59 @@ pub mod custom_class {
 
     /// Set of states that define the lifecycle of a CustomClass.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified state.  This is only used/useful for distinguishing
+        /// unset values.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The normal and active state.
+        pub const ACTIVE: State = State::new(2);
+
+        /// This CustomClass has been deleted.
+        pub const DELETED: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                4 => std::borrow::Cow::Borrowed("DELETED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DELETED" => std::option::Option::Some(Self::DELETED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified state.  This is only used/useful for distinguishing
-        /// unset values.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The normal and active state.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// This CustomClass has been deleted.
-        pub const DELETED: State = State::new("DELETED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5361,44 +5472,59 @@ pub mod phrase_set {
 
     /// Set of states that define the lifecycle of a PhraseSet.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified state.  This is only used/useful for distinguishing
+        /// unset values.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The normal and active state.
+        pub const ACTIVE: State = State::new(2);
+
+        /// This PhraseSet has been deleted.
+        pub const DELETED: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                4 => std::borrow::Cow::Borrowed("DELETED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DELETED" => std::option::Option::Some(Self::DELETED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified state.  This is only used/useful for distinguishing
-        /// unset values.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The normal and active state.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// This PhraseSet has been deleted.
-        pub const DELETED: State = State::new("DELETED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6443,42 +6569,58 @@ pub mod access_metadata {
     /// Describes the different types of constraints that can be applied on a
     /// region.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConstraintType(std::borrow::Cow<'static, str>);
+    pub struct ConstraintType(i32);
 
     impl ConstraintType {
-        /// Creates a new ConstraintType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ConstraintType](ConstraintType)
-    pub mod constraint_type {
-        use super::ConstraintType;
-
         /// Unspecified constraint applied.
-        pub const CONSTRAINT_TYPE_UNSPECIFIED: ConstraintType =
-            ConstraintType::new("CONSTRAINT_TYPE_UNSPECIFIED");
+        pub const CONSTRAINT_TYPE_UNSPECIFIED: ConstraintType = ConstraintType::new(0);
 
         /// The project's org policy disallows the given region.
         pub const RESOURCE_LOCATIONS_ORG_POLICY_CREATE_CONSTRAINT: ConstraintType =
-            ConstraintType::new("RESOURCE_LOCATIONS_ORG_POLICY_CREATE_CONSTRAINT");
+            ConstraintType::new(1);
+
+        /// Creates a new ConstraintType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CONSTRAINT_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RESOURCE_LOCATIONS_ORG_POLICY_CREATE_CONSTRAINT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CONSTRAINT_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CONSTRAINT_TYPE_UNSPECIFIED)
+                }
+                "RESOURCE_LOCATIONS_ORG_POLICY_CREATE_CONSTRAINT" => {
+                    std::option::Option::Some(Self::RESOURCE_LOCATIONS_ORG_POLICY_CREATE_CONSTRAINT)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ConstraintType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ConstraintType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ConstraintType {
         fn default() -> Self {
-            constraint_type::CONSTRAINT_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/speech/v2/src/transport.rs
+++ b/src/generated/cloud/speech/v2/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::Speech for Speech {
                 reqwest::Method::POST,
                 format!("/v2/{}/recognizers", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -76,7 +76,7 @@ impl crate::stubs::Speech for Speech {
                 reqwest::Method::GET,
                 format!("/v2/{}/recognizers", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -98,7 +98,7 @@ impl crate::stubs::Speech for Speech {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -126,7 +126,7 @@ impl crate::stubs::Speech for Speech {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -156,7 +156,7 @@ impl crate::stubs::Speech for Speech {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -178,7 +178,7 @@ impl crate::stubs::Speech for Speech {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:undelete", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -198,7 +198,7 @@ impl crate::stubs::Speech for Speech {
                 reqwest::Method::POST,
                 format!("/v2/{}:recognize", req.recognizer),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -218,7 +218,7 @@ impl crate::stubs::Speech for Speech {
                 reqwest::Method::POST,
                 format!("/v2/{}:batchRecognize", req.recognizer),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -235,7 +235,7 @@ impl crate::stubs::Speech for Speech {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -263,7 +263,7 @@ impl crate::stubs::Speech for Speech {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -293,7 +293,7 @@ impl crate::stubs::Speech for Speech {
                 reqwest::Method::POST,
                 format!("/v2/{}/customClasses", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -317,7 +317,7 @@ impl crate::stubs::Speech for Speech {
                 reqwest::Method::GET,
                 format!("/v2/{}/customClasses", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -339,7 +339,7 @@ impl crate::stubs::Speech for Speech {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -367,7 +367,7 @@ impl crate::stubs::Speech for Speech {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -397,7 +397,7 @@ impl crate::stubs::Speech for Speech {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -419,7 +419,7 @@ impl crate::stubs::Speech for Speech {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:undelete", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -439,7 +439,7 @@ impl crate::stubs::Speech for Speech {
                 reqwest::Method::POST,
                 format!("/v2/{}/phraseSets", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -463,7 +463,7 @@ impl crate::stubs::Speech for Speech {
                 reqwest::Method::GET,
                 format!("/v2/{}/phraseSets", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -485,7 +485,7 @@ impl crate::stubs::Speech for Speech {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -513,7 +513,7 @@ impl crate::stubs::Speech for Speech {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -543,7 +543,7 @@ impl crate::stubs::Speech for Speech {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -565,7 +565,7 @@ impl crate::stubs::Speech for Speech {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:undelete", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -582,7 +582,7 @@ impl crate::stubs::Speech for Speech {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -604,7 +604,7 @@ impl crate::stubs::Speech for Speech {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -623,7 +623,7 @@ impl crate::stubs::Speech for Speech {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -645,7 +645,7 @@ impl crate::stubs::Speech for Speech {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -664,7 +664,7 @@ impl crate::stubs::Speech for Speech {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -683,7 +683,7 @@ impl crate::stubs::Speech for Speech {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/sql/v1/src/model.rs
+++ b/src/generated/cloud/sql/v1/src/model.rs
@@ -693,45 +693,60 @@ pub mod connect_settings {
 
     /// Various Certificate Authority (CA) modes for certificate signing.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CaMode(std::borrow::Cow<'static, str>);
+    pub struct CaMode(i32);
 
     impl CaMode {
-        /// Creates a new CaMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CaMode](CaMode)
-    pub mod ca_mode {
-        use super::CaMode;
-        
 
         /// CA mode is unknown.
-        pub const CA_MODE_UNSPECIFIED: CaMode = CaMode::new("CA_MODE_UNSPECIFIED");
+        pub const CA_MODE_UNSPECIFIED: CaMode = CaMode::new(0);
 
         /// Google-managed self-signed internal CA.
-        pub const GOOGLE_MANAGED_INTERNAL_CA: CaMode = CaMode::new("GOOGLE_MANAGED_INTERNAL_CA");
+        pub const GOOGLE_MANAGED_INTERNAL_CA: CaMode = CaMode::new(1);
 
         /// Google-managed regional CA part of root CA hierarchy hosted on Google
         /// Cloud's Certificate Authority Service (CAS).
-        pub const GOOGLE_MANAGED_CAS_CA: CaMode = CaMode::new("GOOGLE_MANAGED_CAS_CA");
+        pub const GOOGLE_MANAGED_CAS_CA: CaMode = CaMode::new(2);
+
+        /// Creates a new CaMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CA_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GOOGLE_MANAGED_INTERNAL_CA"),
+                2 => std::borrow::Cow::Borrowed("GOOGLE_MANAGED_CAS_CA"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CA_MODE_UNSPECIFIED" => std::option::Option::Some(Self::CA_MODE_UNSPECIFIED),
+                "GOOGLE_MANAGED_INTERNAL_CA" => std::option::Option::Some(Self::GOOGLE_MANAGED_INTERNAL_CA),
+                "GOOGLE_MANAGED_CAS_CA" => std::option::Option::Some(Self::GOOGLE_MANAGED_CAS_CA),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CaMode {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for CaMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for CaMode {
         fn default() -> Self {
-            ca_mode::CA_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2676,44 +2691,59 @@ pub mod backup_reencryption_config {
 
     /// Backup type for re-encryption
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BackupType(std::borrow::Cow<'static, str>);
+    pub struct BackupType(i32);
 
     impl BackupType {
+
+        /// Unknown backup type, will be defaulted to AUTOMATIC backup type
+        pub const BACKUP_TYPE_UNSPECIFIED: BackupType = BackupType::new(0);
+
+        /// Reencrypt automatic backups
+        pub const AUTOMATED: BackupType = BackupType::new(1);
+
+        /// Reencrypt on-demand backups
+        pub const ON_DEMAND: BackupType = BackupType::new(2);
+
         /// Creates a new BackupType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("BACKUP_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AUTOMATED"),
+                2 => std::borrow::Cow::Borrowed("ON_DEMAND"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "BACKUP_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::BACKUP_TYPE_UNSPECIFIED),
+                "AUTOMATED" => std::option::Option::Some(Self::AUTOMATED),
+                "ON_DEMAND" => std::option::Option::Some(Self::ON_DEMAND),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [BackupType](BackupType)
-    pub mod backup_type {
-        use super::BackupType;
-        
-
-        /// Unknown backup type, will be defaulted to AUTOMATIC backup type
-        pub const BACKUP_TYPE_UNSPECIFIED: BackupType = BackupType::new("BACKUP_TYPE_UNSPECIFIED");
-
-        /// Reencrypt automatic backups
-        pub const AUTOMATED: BackupType = BackupType::new("AUTOMATED");
-
-        /// Reencrypt on-demand backups
-        pub const ON_DEMAND: BackupType = BackupType::new("ON_DEMAND");
-    }
-
-    impl std::convert::From<std::string::String> for BackupType {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for BackupType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for BackupType {
         fn default() -> Self {
-            backup_type::BACKUP_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2888,90 +2918,120 @@ pub mod sql_instances_verify_external_sync_settings_request {
 
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ExternalSyncMode(std::borrow::Cow<'static, str>);
+    pub struct ExternalSyncMode(i32);
 
     impl ExternalSyncMode {
-        /// Creates a new ExternalSyncMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ExternalSyncMode](ExternalSyncMode)
-    pub mod external_sync_mode {
-        use super::ExternalSyncMode;
-        
 
         /// Unknown external sync mode, will be defaulted to ONLINE mode
-        pub const EXTERNAL_SYNC_MODE_UNSPECIFIED: ExternalSyncMode = ExternalSyncMode::new("EXTERNAL_SYNC_MODE_UNSPECIFIED");
+        pub const EXTERNAL_SYNC_MODE_UNSPECIFIED: ExternalSyncMode = ExternalSyncMode::new(0);
 
         /// Online external sync will set up replication after initial data external
         /// sync
-        pub const ONLINE: ExternalSyncMode = ExternalSyncMode::new("ONLINE");
+        pub const ONLINE: ExternalSyncMode = ExternalSyncMode::new(1);
 
         /// Offline external sync only dumps and loads a one-time snapshot of
         /// the primary instance's data
-        pub const OFFLINE: ExternalSyncMode = ExternalSyncMode::new("OFFLINE");
+        pub const OFFLINE: ExternalSyncMode = ExternalSyncMode::new(2);
+
+        /// Creates a new ExternalSyncMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EXTERNAL_SYNC_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ONLINE"),
+                2 => std::borrow::Cow::Borrowed("OFFLINE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EXTERNAL_SYNC_MODE_UNSPECIFIED" => std::option::Option::Some(Self::EXTERNAL_SYNC_MODE_UNSPECIFIED),
+                "ONLINE" => std::option::Option::Some(Self::ONLINE),
+                "OFFLINE" => std::option::Option::Some(Self::OFFLINE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ExternalSyncMode {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for ExternalSyncMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for ExternalSyncMode {
         fn default() -> Self {
-            external_sync_mode::EXTERNAL_SYNC_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// MigrationType determines whether the migration is a physical file-based
     /// migration or a logical dump file-based migration.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MigrationType(std::borrow::Cow<'static, str>);
+    pub struct MigrationType(i32);
 
     impl MigrationType {
+
+        /// Default value is a logical dump file-based migration
+        pub const MIGRATION_TYPE_UNSPECIFIED: MigrationType = MigrationType::new(0);
+
+        /// Logical dump file-based migration
+        pub const LOGICAL: MigrationType = MigrationType::new(1);
+
+        /// Physical file-based migration
+        pub const PHYSICAL: MigrationType = MigrationType::new(2);
+
         /// Creates a new MigrationType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MIGRATION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LOGICAL"),
+                2 => std::borrow::Cow::Borrowed("PHYSICAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MIGRATION_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::MIGRATION_TYPE_UNSPECIFIED),
+                "LOGICAL" => std::option::Option::Some(Self::LOGICAL),
+                "PHYSICAL" => std::option::Option::Some(Self::PHYSICAL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [MigrationType](MigrationType)
-    pub mod migration_type {
-        use super::MigrationType;
-        
-
-        /// Default value is a logical dump file-based migration
-        pub const MIGRATION_TYPE_UNSPECIFIED: MigrationType = MigrationType::new("MIGRATION_TYPE_UNSPECIFIED");
-
-        /// Logical dump file-based migration
-        pub const LOGICAL: MigrationType = MigrationType::new("LOGICAL");
-
-        /// Physical file-based migration
-        pub const PHYSICAL: MigrationType = MigrationType::new("PHYSICAL");
-    }
-
-    impl std::convert::From<std::string::String> for MigrationType {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for MigrationType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for MigrationType {
         fn default() -> Self {
-            migration_type::MIGRATION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -4742,147 +4802,202 @@ pub mod database_instance {
 
         /// This enum lists all possible states regarding out-of-disk issues.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SqlOutOfDiskState(std::borrow::Cow<'static, str>);
+        pub struct SqlOutOfDiskState(i32);
 
         impl SqlOutOfDiskState {
-            /// Creates a new SqlOutOfDiskState instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [SqlOutOfDiskState](SqlOutOfDiskState)
-        pub mod sql_out_of_disk_state {
-            use super::SqlOutOfDiskState;
-            
 
             /// Unspecified state
-            pub const SQL_OUT_OF_DISK_STATE_UNSPECIFIED: SqlOutOfDiskState = SqlOutOfDiskState::new("SQL_OUT_OF_DISK_STATE_UNSPECIFIED");
+            pub const SQL_OUT_OF_DISK_STATE_UNSPECIFIED: SqlOutOfDiskState = SqlOutOfDiskState::new(0);
 
             /// The instance has plenty space on data disk
-            pub const NORMAL: SqlOutOfDiskState = SqlOutOfDiskState::new("NORMAL");
+            pub const NORMAL: SqlOutOfDiskState = SqlOutOfDiskState::new(1);
 
             /// Data disk is almost used up. It is shutdown to prevent data
             /// corruption.
-            pub const SOFT_SHUTDOWN: SqlOutOfDiskState = SqlOutOfDiskState::new("SOFT_SHUTDOWN");
+            pub const SOFT_SHUTDOWN: SqlOutOfDiskState = SqlOutOfDiskState::new(2);
+
+            /// Creates a new SqlOutOfDiskState instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+            
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("SQL_OUT_OF_DISK_STATE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("NORMAL"),
+                    2 => std::borrow::Cow::Borrowed("SOFT_SHUTDOWN"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "SQL_OUT_OF_DISK_STATE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_OUT_OF_DISK_STATE_UNSPECIFIED),
+                    "NORMAL" => std::option::Option::Some(Self::NORMAL),
+                    "SOFT_SHUTDOWN" => std::option::Option::Some(Self::SOFT_SHUTDOWN),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for SqlOutOfDiskState {
-          fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
-          }
+        impl std::convert::From<i32> for SqlOutOfDiskState {
+            fn from(value: i32) -> Self {
+                Self::new(value)
+            }
         }
 
         impl std::default::Default for SqlOutOfDiskState {
             fn default() -> Self {
-                sql_out_of_disk_state::SQL_OUT_OF_DISK_STATE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// The current serving state of the database instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlInstanceState(std::borrow::Cow<'static, str>);
+    pub struct SqlInstanceState(i32);
 
     impl SqlInstanceState {
-        /// Creates a new SqlInstanceState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [SqlInstanceState](SqlInstanceState)
-    pub mod sql_instance_state {
-        use super::SqlInstanceState;
-        
 
         /// The state of the instance is unknown.
-        pub const SQL_INSTANCE_STATE_UNSPECIFIED: SqlInstanceState = SqlInstanceState::new("SQL_INSTANCE_STATE_UNSPECIFIED");
+        pub const SQL_INSTANCE_STATE_UNSPECIFIED: SqlInstanceState = SqlInstanceState::new(0);
 
         /// The instance is running, or has been stopped by owner.
-        pub const RUNNABLE: SqlInstanceState = SqlInstanceState::new("RUNNABLE");
+        pub const RUNNABLE: SqlInstanceState = SqlInstanceState::new(1);
 
         /// The instance is not available, for example due to problems with billing.
-        pub const SUSPENDED: SqlInstanceState = SqlInstanceState::new("SUSPENDED");
+        pub const SUSPENDED: SqlInstanceState = SqlInstanceState::new(2);
 
         /// The instance is being deleted.
-        pub const PENDING_DELETE: SqlInstanceState = SqlInstanceState::new("PENDING_DELETE");
+        pub const PENDING_DELETE: SqlInstanceState = SqlInstanceState::new(3);
 
         /// The instance is being created.
-        pub const PENDING_CREATE: SqlInstanceState = SqlInstanceState::new("PENDING_CREATE");
+        pub const PENDING_CREATE: SqlInstanceState = SqlInstanceState::new(4);
 
         /// The instance is down for maintenance.
-        pub const MAINTENANCE: SqlInstanceState = SqlInstanceState::new("MAINTENANCE");
+        pub const MAINTENANCE: SqlInstanceState = SqlInstanceState::new(5);
 
         /// The creation of the instance failed or a fatal error occurred during
         /// maintenance.
-        pub const FAILED: SqlInstanceState = SqlInstanceState::new("FAILED");
+        pub const FAILED: SqlInstanceState = SqlInstanceState::new(6);
 
         /// Deprecated
-        pub const ONLINE_MAINTENANCE: SqlInstanceState = SqlInstanceState::new("ONLINE_MAINTENANCE");
+        pub const ONLINE_MAINTENANCE: SqlInstanceState = SqlInstanceState::new(7);
+
+        /// Creates a new SqlInstanceState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SQL_INSTANCE_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RUNNABLE"),
+                2 => std::borrow::Cow::Borrowed("SUSPENDED"),
+                3 => std::borrow::Cow::Borrowed("PENDING_DELETE"),
+                4 => std::borrow::Cow::Borrowed("PENDING_CREATE"),
+                5 => std::borrow::Cow::Borrowed("MAINTENANCE"),
+                6 => std::borrow::Cow::Borrowed("FAILED"),
+                7 => std::borrow::Cow::Borrowed("ONLINE_MAINTENANCE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SQL_INSTANCE_STATE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_INSTANCE_STATE_UNSPECIFIED),
+                "RUNNABLE" => std::option::Option::Some(Self::RUNNABLE),
+                "SUSPENDED" => std::option::Option::Some(Self::SUSPENDED),
+                "PENDING_DELETE" => std::option::Option::Some(Self::PENDING_DELETE),
+                "PENDING_CREATE" => std::option::Option::Some(Self::PENDING_CREATE),
+                "MAINTENANCE" => std::option::Option::Some(Self::MAINTENANCE),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "ONLINE_MAINTENANCE" => std::option::Option::Some(Self::ONLINE_MAINTENANCE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for SqlInstanceState {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for SqlInstanceState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for SqlInstanceState {
         fn default() -> Self {
-            sql_instance_state::SQL_INSTANCE_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The SQL network architecture for the instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlNetworkArchitecture(std::borrow::Cow<'static, str>);
+    pub struct SqlNetworkArchitecture(i32);
 
     impl SqlNetworkArchitecture {
+
+        pub const SQL_NETWORK_ARCHITECTURE_UNSPECIFIED: SqlNetworkArchitecture = SqlNetworkArchitecture::new(0);
+
+        /// The instance uses the new network architecture.
+        pub const NEW_NETWORK_ARCHITECTURE: SqlNetworkArchitecture = SqlNetworkArchitecture::new(1);
+
+        /// The instance uses the old network architecture.
+        pub const OLD_NETWORK_ARCHITECTURE: SqlNetworkArchitecture = SqlNetworkArchitecture::new(2);
+
         /// Creates a new SqlNetworkArchitecture instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SQL_NETWORK_ARCHITECTURE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NEW_NETWORK_ARCHITECTURE"),
+                2 => std::borrow::Cow::Borrowed("OLD_NETWORK_ARCHITECTURE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SQL_NETWORK_ARCHITECTURE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_NETWORK_ARCHITECTURE_UNSPECIFIED),
+                "NEW_NETWORK_ARCHITECTURE" => std::option::Option::Some(Self::NEW_NETWORK_ARCHITECTURE),
+                "OLD_NETWORK_ARCHITECTURE" => std::option::Option::Some(Self::OLD_NETWORK_ARCHITECTURE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SqlNetworkArchitecture](SqlNetworkArchitecture)
-    pub mod sql_network_architecture {
-        use super::SqlNetworkArchitecture;
-        
-
-        pub const SQL_NETWORK_ARCHITECTURE_UNSPECIFIED: SqlNetworkArchitecture = SqlNetworkArchitecture::new("SQL_NETWORK_ARCHITECTURE_UNSPECIFIED");
-
-        /// The instance uses the new network architecture.
-        pub const NEW_NETWORK_ARCHITECTURE: SqlNetworkArchitecture = SqlNetworkArchitecture::new("NEW_NETWORK_ARCHITECTURE");
-
-        /// The instance uses the old network architecture.
-        pub const OLD_NETWORK_ARCHITECTURE: SqlNetworkArchitecture = SqlNetworkArchitecture::new("OLD_NETWORK_ARCHITECTURE");
-    }
-
-    impl std::convert::From<std::string::String> for SqlNetworkArchitecture {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for SqlNetworkArchitecture {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for SqlNetworkArchitecture {
         fn default() -> Self {
-            sql_network_architecture::SQL_NETWORK_ARCHITECTURE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5160,47 +5275,64 @@ pub mod sql_instances_reschedule_maintenance_request_body {
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RescheduleType(std::borrow::Cow<'static, str>);
+    pub struct RescheduleType(i32);
 
     impl RescheduleType {
-        /// Creates a new RescheduleType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
 
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RescheduleType](RescheduleType)
-    pub mod reschedule_type {
-        use super::RescheduleType;
-        
-
-        pub const RESCHEDULE_TYPE_UNSPECIFIED: RescheduleType = RescheduleType::new("RESCHEDULE_TYPE_UNSPECIFIED");
+        pub const RESCHEDULE_TYPE_UNSPECIFIED: RescheduleType = RescheduleType::new(0);
 
         /// Reschedules maintenance to happen now (within 5 minutes).
-        pub const IMMEDIATE: RescheduleType = RescheduleType::new("IMMEDIATE");
+        pub const IMMEDIATE: RescheduleType = RescheduleType::new(1);
 
         /// Reschedules maintenance to occur within one week from the originally
         /// scheduled day and time.
-        pub const NEXT_AVAILABLE_WINDOW: RescheduleType = RescheduleType::new("NEXT_AVAILABLE_WINDOW");
+        pub const NEXT_AVAILABLE_WINDOW: RescheduleType = RescheduleType::new(2);
 
         /// Reschedules maintenance to a specific time and day.
-        pub const SPECIFIC_TIME: RescheduleType = RescheduleType::new("SPECIFIC_TIME");
+        pub const SPECIFIC_TIME: RescheduleType = RescheduleType::new(3);
+
+        /// Creates a new RescheduleType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RESCHEDULE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IMMEDIATE"),
+                2 => std::borrow::Cow::Borrowed("NEXT_AVAILABLE_WINDOW"),
+                3 => std::borrow::Cow::Borrowed("SPECIFIC_TIME"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RESCHEDULE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::RESCHEDULE_TYPE_UNSPECIFIED),
+                "IMMEDIATE" => std::option::Option::Some(Self::IMMEDIATE),
+                "NEXT_AVAILABLE_WINDOW" => std::option::Option::Some(Self::NEXT_AVAILABLE_WINDOW),
+                "SPECIFIC_TIME" => std::option::Option::Some(Self::SPECIFIC_TIME),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RescheduleType {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for RescheduleType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for RescheduleType {
         fn default() -> Self {
-            reschedule_type::RESCHEDULE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5566,201 +5698,310 @@ pub mod sql_external_sync_setting_error {
 
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlExternalSyncSettingErrorType(std::borrow::Cow<'static, str>);
+    pub struct SqlExternalSyncSettingErrorType(i32);
 
     impl SqlExternalSyncSettingErrorType {
-        /// Creates a new SqlExternalSyncSettingErrorType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
 
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
+        pub const SQL_EXTERNAL_SYNC_SETTING_ERROR_TYPE_UNSPECIFIED: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(0);
 
-    /// Useful constants to work with [SqlExternalSyncSettingErrorType](SqlExternalSyncSettingErrorType)
-    pub mod sql_external_sync_setting_error_type {
-        use super::SqlExternalSyncSettingErrorType;
-        
+        pub const CONNECTION_FAILURE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(1);
 
-        pub const SQL_EXTERNAL_SYNC_SETTING_ERROR_TYPE_UNSPECIFIED: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("SQL_EXTERNAL_SYNC_SETTING_ERROR_TYPE_UNSPECIFIED");
+        pub const BINLOG_NOT_ENABLED: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(2);
 
-        pub const CONNECTION_FAILURE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("CONNECTION_FAILURE");
+        pub const INCOMPATIBLE_DATABASE_VERSION: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(3);
 
-        pub const BINLOG_NOT_ENABLED: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("BINLOG_NOT_ENABLED");
-
-        pub const INCOMPATIBLE_DATABASE_VERSION: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("INCOMPATIBLE_DATABASE_VERSION");
-
-        pub const REPLICA_ALREADY_SETUP: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("REPLICA_ALREADY_SETUP");
+        pub const REPLICA_ALREADY_SETUP: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(4);
 
         /// The replication user is missing privileges that are required.
-        pub const INSUFFICIENT_PRIVILEGE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("INSUFFICIENT_PRIVILEGE");
+        pub const INSUFFICIENT_PRIVILEGE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(5);
 
         /// Unsupported migration type.
-        pub const UNSUPPORTED_MIGRATION_TYPE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("UNSUPPORTED_MIGRATION_TYPE");
+        pub const UNSUPPORTED_MIGRATION_TYPE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(6);
 
         /// No pglogical extension installed on databases, applicable for postgres.
-        pub const NO_PGLOGICAL_INSTALLED: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("NO_PGLOGICAL_INSTALLED");
+        pub const NO_PGLOGICAL_INSTALLED: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(7);
 
         /// pglogical node already exists on databases, applicable for postgres.
-        pub const PGLOGICAL_NODE_ALREADY_EXISTS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("PGLOGICAL_NODE_ALREADY_EXISTS");
+        pub const PGLOGICAL_NODE_ALREADY_EXISTS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(8);
 
         /// The value of parameter wal_level is not set to logical.
-        pub const INVALID_WAL_LEVEL: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("INVALID_WAL_LEVEL");
+        pub const INVALID_WAL_LEVEL: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(9);
 
         /// The value of parameter shared_preload_libraries does not include
         /// pglogical.
-        pub const INVALID_SHARED_PRELOAD_LIBRARY: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("INVALID_SHARED_PRELOAD_LIBRARY");
+        pub const INVALID_SHARED_PRELOAD_LIBRARY: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(10);
 
         /// The value of parameter max_replication_slots is not sufficient.
-        pub const INSUFFICIENT_MAX_REPLICATION_SLOTS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("INSUFFICIENT_MAX_REPLICATION_SLOTS");
+        pub const INSUFFICIENT_MAX_REPLICATION_SLOTS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(11);
 
         /// The value of parameter max_wal_senders is not sufficient.
-        pub const INSUFFICIENT_MAX_WAL_SENDERS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("INSUFFICIENT_MAX_WAL_SENDERS");
+        pub const INSUFFICIENT_MAX_WAL_SENDERS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(12);
 
         /// The value of parameter max_worker_processes is not sufficient.
-        pub const INSUFFICIENT_MAX_WORKER_PROCESSES: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("INSUFFICIENT_MAX_WORKER_PROCESSES");
+        pub const INSUFFICIENT_MAX_WORKER_PROCESSES: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(13);
 
         /// Extensions installed are either not supported or having unsupported
         /// versions.
-        pub const UNSUPPORTED_EXTENSIONS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("UNSUPPORTED_EXTENSIONS");
+        pub const UNSUPPORTED_EXTENSIONS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(14);
 
         /// The value of parameter rds.logical_replication is not set to 1.
-        pub const INVALID_RDS_LOGICAL_REPLICATION: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("INVALID_RDS_LOGICAL_REPLICATION");
+        pub const INVALID_RDS_LOGICAL_REPLICATION: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(15);
 
         /// The primary instance logging setup doesn't allow EM sync.
-        pub const INVALID_LOGGING_SETUP: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("INVALID_LOGGING_SETUP");
+        pub const INVALID_LOGGING_SETUP: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(16);
 
         /// The primary instance database parameter setup doesn't allow EM sync.
-        pub const INVALID_DB_PARAM: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("INVALID_DB_PARAM");
+        pub const INVALID_DB_PARAM: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(17);
 
         /// The gtid_mode is not supported, applicable for MySQL.
-        pub const UNSUPPORTED_GTID_MODE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("UNSUPPORTED_GTID_MODE");
+        pub const UNSUPPORTED_GTID_MODE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(18);
 
         /// SQL Server Agent is not running.
-        pub const SQLSERVER_AGENT_NOT_RUNNING: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("SQLSERVER_AGENT_NOT_RUNNING");
+        pub const SQLSERVER_AGENT_NOT_RUNNING: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(19);
 
         /// The table definition is not support due to missing primary key or replica
         /// identity, applicable for postgres.
-        pub const UNSUPPORTED_TABLE_DEFINITION: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("UNSUPPORTED_TABLE_DEFINITION");
+        pub const UNSUPPORTED_TABLE_DEFINITION: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(20);
 
         /// The customer has a definer that will break EM setup.
-        pub const UNSUPPORTED_DEFINER: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("UNSUPPORTED_DEFINER");
+        pub const UNSUPPORTED_DEFINER: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(21);
 
         /// SQL Server @@SERVERNAME does not match actual host name.
-        pub const SQLSERVER_SERVERNAME_MISMATCH: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("SQLSERVER_SERVERNAME_MISMATCH");
+        pub const SQLSERVER_SERVERNAME_MISMATCH: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(22);
 
         /// The primary instance has been setup and will fail the setup.
-        pub const PRIMARY_ALREADY_SETUP: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("PRIMARY_ALREADY_SETUP");
+        pub const PRIMARY_ALREADY_SETUP: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(23);
 
         /// The primary instance has unsupported binary log format.
-        pub const UNSUPPORTED_BINLOG_FORMAT: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("UNSUPPORTED_BINLOG_FORMAT");
+        pub const UNSUPPORTED_BINLOG_FORMAT: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(24);
 
         /// The primary instance's binary log retention setting.
-        pub const BINLOG_RETENTION_SETTING: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("BINLOG_RETENTION_SETTING");
+        pub const BINLOG_RETENTION_SETTING: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(25);
 
         /// The primary instance has tables with unsupported storage engine.
-        pub const UNSUPPORTED_STORAGE_ENGINE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("UNSUPPORTED_STORAGE_ENGINE");
+        pub const UNSUPPORTED_STORAGE_ENGINE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(26);
 
         /// Source has tables with limited support
         /// eg: PostgreSQL tables without primary keys.
-        pub const LIMITED_SUPPORT_TABLES: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("LIMITED_SUPPORT_TABLES");
+        pub const LIMITED_SUPPORT_TABLES: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(27);
 
         /// The replica instance contains existing data.
-        pub const EXISTING_DATA_IN_REPLICA: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("EXISTING_DATA_IN_REPLICA");
+        pub const EXISTING_DATA_IN_REPLICA: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(28);
 
         /// The replication user is missing privileges that are optional.
-        pub const MISSING_OPTIONAL_PRIVILEGES: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("MISSING_OPTIONAL_PRIVILEGES");
+        pub const MISSING_OPTIONAL_PRIVILEGES: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(29);
 
         /// Additional BACKUP_ADMIN privilege is granted to the replication user
         /// which may lock source MySQL 8 instance for DDLs during initial sync.
-        pub const RISKY_BACKUP_ADMIN_PRIVILEGE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("RISKY_BACKUP_ADMIN_PRIVILEGE");
+        pub const RISKY_BACKUP_ADMIN_PRIVILEGE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(30);
 
         /// The Cloud Storage bucket is missing necessary permissions.
-        pub const INSUFFICIENT_GCS_PERMISSIONS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("INSUFFICIENT_GCS_PERMISSIONS");
+        pub const INSUFFICIENT_GCS_PERMISSIONS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(31);
 
         /// The Cloud Storage bucket has an error in the file or contains invalid
         /// file information.
-        pub const INVALID_FILE_INFO: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("INVALID_FILE_INFO");
+        pub const INVALID_FILE_INFO: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(32);
 
         /// The source instance has unsupported database settings for migration.
-        pub const UNSUPPORTED_DATABASE_SETTINGS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("UNSUPPORTED_DATABASE_SETTINGS");
+        pub const UNSUPPORTED_DATABASE_SETTINGS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(33);
 
         /// The replication user is missing parallel import specific privileges.
         /// (e.g. LOCK TABLES) for MySQL.
-        pub const MYSQL_PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("MYSQL_PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE");
+        pub const MYSQL_PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(34);
 
         /// The global variable local_infile is off on external server replica.
-        pub const LOCAL_INFILE_OFF: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("LOCAL_INFILE_OFF");
+        pub const LOCAL_INFILE_OFF: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(35);
 
         /// This code instructs customers to turn on point-in-time recovery manually
         /// for the instance after promoting the Cloud SQL for PostgreSQL instance.
-        pub const TURN_ON_PITR_AFTER_PROMOTE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("TURN_ON_PITR_AFTER_PROMOTE");
+        pub const TURN_ON_PITR_AFTER_PROMOTE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(36);
 
         /// The minor version of replica database is incompatible with the source.
-        pub const INCOMPATIBLE_DATABASE_MINOR_VERSION: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("INCOMPATIBLE_DATABASE_MINOR_VERSION");
+        pub const INCOMPATIBLE_DATABASE_MINOR_VERSION: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(37);
 
         /// This warning message indicates that Cloud SQL uses the maximum number of
         /// subscriptions to migrate data from the source to the destination.
-        pub const SOURCE_MAX_SUBSCRIPTIONS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("SOURCE_MAX_SUBSCRIPTIONS");
+        pub const SOURCE_MAX_SUBSCRIPTIONS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(38);
 
         /// Unable to verify definers on the source for MySQL.
-        pub const UNABLE_TO_VERIFY_DEFINERS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("UNABLE_TO_VERIFY_DEFINERS");
+        pub const UNABLE_TO_VERIFY_DEFINERS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(39);
 
         /// If a time out occurs while the subscription counts are calculated, then
         /// this value is set to 1. Otherwise, this value is set to 2.
-        pub const SUBSCRIPTION_CALCULATION_STATUS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("SUBSCRIPTION_CALCULATION_STATUS");
+        pub const SUBSCRIPTION_CALCULATION_STATUS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(40);
 
         /// Count of subscriptions needed to sync source data for PostgreSQL
         /// database.
-        pub const PG_SUBSCRIPTION_COUNT: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("PG_SUBSCRIPTION_COUNT");
+        pub const PG_SUBSCRIPTION_COUNT: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(41);
 
         /// Final parallel level that is used to do migration.
-        pub const PG_SYNC_PARALLEL_LEVEL: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("PG_SYNC_PARALLEL_LEVEL");
+        pub const PG_SYNC_PARALLEL_LEVEL: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(42);
 
         /// The disk size of the replica instance is smaller than the data size of
         /// the source instance.
-        pub const INSUFFICIENT_DISK_SIZE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("INSUFFICIENT_DISK_SIZE");
+        pub const INSUFFICIENT_DISK_SIZE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(43);
 
         /// The data size of the source instance is greater than 1 TB, the number of
         /// cores of the replica instance is less than 8, and the memory of the
         /// replica is less than 32 GB.
-        pub const INSUFFICIENT_MACHINE_TIER: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("INSUFFICIENT_MACHINE_TIER");
+        pub const INSUFFICIENT_MACHINE_TIER: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(44);
 
         /// The warning message indicates the unsupported extensions will not be
         /// migrated to the destination.
-        pub const UNSUPPORTED_EXTENSIONS_NOT_MIGRATED: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("UNSUPPORTED_EXTENSIONS_NOT_MIGRATED");
+        pub const UNSUPPORTED_EXTENSIONS_NOT_MIGRATED: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(45);
 
         /// The warning message indicates the pg_cron extension and settings will not
         /// be migrated to the destination.
-        pub const EXTENSIONS_NOT_MIGRATED: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("EXTENSIONS_NOT_MIGRATED");
+        pub const EXTENSIONS_NOT_MIGRATED: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(46);
 
         /// The error message indicates that pg_cron flags are enabled on the
         /// destination which is not supported during the migration.
-        pub const PG_CRON_FLAG_ENABLED_IN_REPLICA: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("PG_CRON_FLAG_ENABLED_IN_REPLICA");
+        pub const PG_CRON_FLAG_ENABLED_IN_REPLICA: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(47);
 
         /// This error message indicates that the specified extensions are not
         /// enabled on destination instance. For example, before you can migrate
         /// data to the destination instance, you must enable the PGAudit extension
         /// on the instance.
-        pub const EXTENSIONS_NOT_ENABLED_IN_REPLICA: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("EXTENSIONS_NOT_ENABLED_IN_REPLICA");
+        pub const EXTENSIONS_NOT_ENABLED_IN_REPLICA: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(48);
 
         /// The source database has generated columns that can't be migrated. Please
         /// change them to regular columns before migration.
-        pub const UNSUPPORTED_COLUMNS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new("UNSUPPORTED_COLUMNS");
+        pub const UNSUPPORTED_COLUMNS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(49);
+
+        /// Creates a new SqlExternalSyncSettingErrorType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SQL_EXTERNAL_SYNC_SETTING_ERROR_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CONNECTION_FAILURE"),
+                2 => std::borrow::Cow::Borrowed("BINLOG_NOT_ENABLED"),
+                3 => std::borrow::Cow::Borrowed("INCOMPATIBLE_DATABASE_VERSION"),
+                4 => std::borrow::Cow::Borrowed("REPLICA_ALREADY_SETUP"),
+                5 => std::borrow::Cow::Borrowed("INSUFFICIENT_PRIVILEGE"),
+                6 => std::borrow::Cow::Borrowed("UNSUPPORTED_MIGRATION_TYPE"),
+                7 => std::borrow::Cow::Borrowed("NO_PGLOGICAL_INSTALLED"),
+                8 => std::borrow::Cow::Borrowed("PGLOGICAL_NODE_ALREADY_EXISTS"),
+                9 => std::borrow::Cow::Borrowed("INVALID_WAL_LEVEL"),
+                10 => std::borrow::Cow::Borrowed("INVALID_SHARED_PRELOAD_LIBRARY"),
+                11 => std::borrow::Cow::Borrowed("INSUFFICIENT_MAX_REPLICATION_SLOTS"),
+                12 => std::borrow::Cow::Borrowed("INSUFFICIENT_MAX_WAL_SENDERS"),
+                13 => std::borrow::Cow::Borrowed("INSUFFICIENT_MAX_WORKER_PROCESSES"),
+                14 => std::borrow::Cow::Borrowed("UNSUPPORTED_EXTENSIONS"),
+                15 => std::borrow::Cow::Borrowed("INVALID_RDS_LOGICAL_REPLICATION"),
+                16 => std::borrow::Cow::Borrowed("INVALID_LOGGING_SETUP"),
+                17 => std::borrow::Cow::Borrowed("INVALID_DB_PARAM"),
+                18 => std::borrow::Cow::Borrowed("UNSUPPORTED_GTID_MODE"),
+                19 => std::borrow::Cow::Borrowed("SQLSERVER_AGENT_NOT_RUNNING"),
+                20 => std::borrow::Cow::Borrowed("UNSUPPORTED_TABLE_DEFINITION"),
+                21 => std::borrow::Cow::Borrowed("UNSUPPORTED_DEFINER"),
+                22 => std::borrow::Cow::Borrowed("SQLSERVER_SERVERNAME_MISMATCH"),
+                23 => std::borrow::Cow::Borrowed("PRIMARY_ALREADY_SETUP"),
+                24 => std::borrow::Cow::Borrowed("UNSUPPORTED_BINLOG_FORMAT"),
+                25 => std::borrow::Cow::Borrowed("BINLOG_RETENTION_SETTING"),
+                26 => std::borrow::Cow::Borrowed("UNSUPPORTED_STORAGE_ENGINE"),
+                27 => std::borrow::Cow::Borrowed("LIMITED_SUPPORT_TABLES"),
+                28 => std::borrow::Cow::Borrowed("EXISTING_DATA_IN_REPLICA"),
+                29 => std::borrow::Cow::Borrowed("MISSING_OPTIONAL_PRIVILEGES"),
+                30 => std::borrow::Cow::Borrowed("RISKY_BACKUP_ADMIN_PRIVILEGE"),
+                31 => std::borrow::Cow::Borrowed("INSUFFICIENT_GCS_PERMISSIONS"),
+                32 => std::borrow::Cow::Borrowed("INVALID_FILE_INFO"),
+                33 => std::borrow::Cow::Borrowed("UNSUPPORTED_DATABASE_SETTINGS"),
+                34 => std::borrow::Cow::Borrowed("MYSQL_PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE"),
+                35 => std::borrow::Cow::Borrowed("LOCAL_INFILE_OFF"),
+                36 => std::borrow::Cow::Borrowed("TURN_ON_PITR_AFTER_PROMOTE"),
+                37 => std::borrow::Cow::Borrowed("INCOMPATIBLE_DATABASE_MINOR_VERSION"),
+                38 => std::borrow::Cow::Borrowed("SOURCE_MAX_SUBSCRIPTIONS"),
+                39 => std::borrow::Cow::Borrowed("UNABLE_TO_VERIFY_DEFINERS"),
+                40 => std::borrow::Cow::Borrowed("SUBSCRIPTION_CALCULATION_STATUS"),
+                41 => std::borrow::Cow::Borrowed("PG_SUBSCRIPTION_COUNT"),
+                42 => std::borrow::Cow::Borrowed("PG_SYNC_PARALLEL_LEVEL"),
+                43 => std::borrow::Cow::Borrowed("INSUFFICIENT_DISK_SIZE"),
+                44 => std::borrow::Cow::Borrowed("INSUFFICIENT_MACHINE_TIER"),
+                45 => std::borrow::Cow::Borrowed("UNSUPPORTED_EXTENSIONS_NOT_MIGRATED"),
+                46 => std::borrow::Cow::Borrowed("EXTENSIONS_NOT_MIGRATED"),
+                47 => std::borrow::Cow::Borrowed("PG_CRON_FLAG_ENABLED_IN_REPLICA"),
+                48 => std::borrow::Cow::Borrowed("EXTENSIONS_NOT_ENABLED_IN_REPLICA"),
+                49 => std::borrow::Cow::Borrowed("UNSUPPORTED_COLUMNS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SQL_EXTERNAL_SYNC_SETTING_ERROR_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_EXTERNAL_SYNC_SETTING_ERROR_TYPE_UNSPECIFIED),
+                "CONNECTION_FAILURE" => std::option::Option::Some(Self::CONNECTION_FAILURE),
+                "BINLOG_NOT_ENABLED" => std::option::Option::Some(Self::BINLOG_NOT_ENABLED),
+                "INCOMPATIBLE_DATABASE_VERSION" => std::option::Option::Some(Self::INCOMPATIBLE_DATABASE_VERSION),
+                "REPLICA_ALREADY_SETUP" => std::option::Option::Some(Self::REPLICA_ALREADY_SETUP),
+                "INSUFFICIENT_PRIVILEGE" => std::option::Option::Some(Self::INSUFFICIENT_PRIVILEGE),
+                "UNSUPPORTED_MIGRATION_TYPE" => std::option::Option::Some(Self::UNSUPPORTED_MIGRATION_TYPE),
+                "NO_PGLOGICAL_INSTALLED" => std::option::Option::Some(Self::NO_PGLOGICAL_INSTALLED),
+                "PGLOGICAL_NODE_ALREADY_EXISTS" => std::option::Option::Some(Self::PGLOGICAL_NODE_ALREADY_EXISTS),
+                "INVALID_WAL_LEVEL" => std::option::Option::Some(Self::INVALID_WAL_LEVEL),
+                "INVALID_SHARED_PRELOAD_LIBRARY" => std::option::Option::Some(Self::INVALID_SHARED_PRELOAD_LIBRARY),
+                "INSUFFICIENT_MAX_REPLICATION_SLOTS" => std::option::Option::Some(Self::INSUFFICIENT_MAX_REPLICATION_SLOTS),
+                "INSUFFICIENT_MAX_WAL_SENDERS" => std::option::Option::Some(Self::INSUFFICIENT_MAX_WAL_SENDERS),
+                "INSUFFICIENT_MAX_WORKER_PROCESSES" => std::option::Option::Some(Self::INSUFFICIENT_MAX_WORKER_PROCESSES),
+                "UNSUPPORTED_EXTENSIONS" => std::option::Option::Some(Self::UNSUPPORTED_EXTENSIONS),
+                "INVALID_RDS_LOGICAL_REPLICATION" => std::option::Option::Some(Self::INVALID_RDS_LOGICAL_REPLICATION),
+                "INVALID_LOGGING_SETUP" => std::option::Option::Some(Self::INVALID_LOGGING_SETUP),
+                "INVALID_DB_PARAM" => std::option::Option::Some(Self::INVALID_DB_PARAM),
+                "UNSUPPORTED_GTID_MODE" => std::option::Option::Some(Self::UNSUPPORTED_GTID_MODE),
+                "SQLSERVER_AGENT_NOT_RUNNING" => std::option::Option::Some(Self::SQLSERVER_AGENT_NOT_RUNNING),
+                "UNSUPPORTED_TABLE_DEFINITION" => std::option::Option::Some(Self::UNSUPPORTED_TABLE_DEFINITION),
+                "UNSUPPORTED_DEFINER" => std::option::Option::Some(Self::UNSUPPORTED_DEFINER),
+                "SQLSERVER_SERVERNAME_MISMATCH" => std::option::Option::Some(Self::SQLSERVER_SERVERNAME_MISMATCH),
+                "PRIMARY_ALREADY_SETUP" => std::option::Option::Some(Self::PRIMARY_ALREADY_SETUP),
+                "UNSUPPORTED_BINLOG_FORMAT" => std::option::Option::Some(Self::UNSUPPORTED_BINLOG_FORMAT),
+                "BINLOG_RETENTION_SETTING" => std::option::Option::Some(Self::BINLOG_RETENTION_SETTING),
+                "UNSUPPORTED_STORAGE_ENGINE" => std::option::Option::Some(Self::UNSUPPORTED_STORAGE_ENGINE),
+                "LIMITED_SUPPORT_TABLES" => std::option::Option::Some(Self::LIMITED_SUPPORT_TABLES),
+                "EXISTING_DATA_IN_REPLICA" => std::option::Option::Some(Self::EXISTING_DATA_IN_REPLICA),
+                "MISSING_OPTIONAL_PRIVILEGES" => std::option::Option::Some(Self::MISSING_OPTIONAL_PRIVILEGES),
+                "RISKY_BACKUP_ADMIN_PRIVILEGE" => std::option::Option::Some(Self::RISKY_BACKUP_ADMIN_PRIVILEGE),
+                "INSUFFICIENT_GCS_PERMISSIONS" => std::option::Option::Some(Self::INSUFFICIENT_GCS_PERMISSIONS),
+                "INVALID_FILE_INFO" => std::option::Option::Some(Self::INVALID_FILE_INFO),
+                "UNSUPPORTED_DATABASE_SETTINGS" => std::option::Option::Some(Self::UNSUPPORTED_DATABASE_SETTINGS),
+                "MYSQL_PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE" => std::option::Option::Some(Self::MYSQL_PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE),
+                "LOCAL_INFILE_OFF" => std::option::Option::Some(Self::LOCAL_INFILE_OFF),
+                "TURN_ON_PITR_AFTER_PROMOTE" => std::option::Option::Some(Self::TURN_ON_PITR_AFTER_PROMOTE),
+                "INCOMPATIBLE_DATABASE_MINOR_VERSION" => std::option::Option::Some(Self::INCOMPATIBLE_DATABASE_MINOR_VERSION),
+                "SOURCE_MAX_SUBSCRIPTIONS" => std::option::Option::Some(Self::SOURCE_MAX_SUBSCRIPTIONS),
+                "UNABLE_TO_VERIFY_DEFINERS" => std::option::Option::Some(Self::UNABLE_TO_VERIFY_DEFINERS),
+                "SUBSCRIPTION_CALCULATION_STATUS" => std::option::Option::Some(Self::SUBSCRIPTION_CALCULATION_STATUS),
+                "PG_SUBSCRIPTION_COUNT" => std::option::Option::Some(Self::PG_SUBSCRIPTION_COUNT),
+                "PG_SYNC_PARALLEL_LEVEL" => std::option::Option::Some(Self::PG_SYNC_PARALLEL_LEVEL),
+                "INSUFFICIENT_DISK_SIZE" => std::option::Option::Some(Self::INSUFFICIENT_DISK_SIZE),
+                "INSUFFICIENT_MACHINE_TIER" => std::option::Option::Some(Self::INSUFFICIENT_MACHINE_TIER),
+                "UNSUPPORTED_EXTENSIONS_NOT_MIGRATED" => std::option::Option::Some(Self::UNSUPPORTED_EXTENSIONS_NOT_MIGRATED),
+                "EXTENSIONS_NOT_MIGRATED" => std::option::Option::Some(Self::EXTENSIONS_NOT_MIGRATED),
+                "PG_CRON_FLAG_ENABLED_IN_REPLICA" => std::option::Option::Some(Self::PG_CRON_FLAG_ENABLED_IN_REPLICA),
+                "EXTENSIONS_NOT_ENABLED_IN_REPLICA" => std::option::Option::Some(Self::EXTENSIONS_NOT_ENABLED_IN_REPLICA),
+                "UNSUPPORTED_COLUMNS" => std::option::Option::Some(Self::UNSUPPORTED_COLUMNS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for SqlExternalSyncSettingErrorType {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for SqlExternalSyncSettingErrorType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for SqlExternalSyncSettingErrorType {
         fn default() -> Self {
-            sql_external_sync_setting_error_type::SQL_EXTERNAL_SYNC_SETTING_ERROR_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6418,54 +6659,73 @@ pub mod api_warning {
 
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlApiWarningCode(std::borrow::Cow<'static, str>);
+    pub struct SqlApiWarningCode(i32);
 
     impl SqlApiWarningCode {
-        /// Creates a new SqlApiWarningCode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [SqlApiWarningCode](SqlApiWarningCode)
-    pub mod sql_api_warning_code {
-        use super::SqlApiWarningCode;
-        
 
         /// An unknown or unset warning type from Cloud SQL API.
-        pub const SQL_API_WARNING_CODE_UNSPECIFIED: SqlApiWarningCode = SqlApiWarningCode::new("SQL_API_WARNING_CODE_UNSPECIFIED");
+        pub const SQL_API_WARNING_CODE_UNSPECIFIED: SqlApiWarningCode = SqlApiWarningCode::new(0);
 
         /// Warning when one or more regions are not reachable.  The returned result
         /// set may be incomplete.
-        pub const REGION_UNREACHABLE: SqlApiWarningCode = SqlApiWarningCode::new("REGION_UNREACHABLE");
+        pub const REGION_UNREACHABLE: SqlApiWarningCode = SqlApiWarningCode::new(1);
 
         /// Warning when user provided maxResults parameter exceeds the limit.  The
         /// returned result set may be incomplete.
-        pub const MAX_RESULTS_EXCEEDS_LIMIT: SqlApiWarningCode = SqlApiWarningCode::new("MAX_RESULTS_EXCEEDS_LIMIT");
+        pub const MAX_RESULTS_EXCEEDS_LIMIT: SqlApiWarningCode = SqlApiWarningCode::new(2);
 
         /// Warning when user tries to create/update a user with credentials that
         /// have previously been compromised by a public data breach.
-        pub const COMPROMISED_CREDENTIALS: SqlApiWarningCode = SqlApiWarningCode::new("COMPROMISED_CREDENTIALS");
+        pub const COMPROMISED_CREDENTIALS: SqlApiWarningCode = SqlApiWarningCode::new(3);
 
         /// Warning when the operation succeeds but some non-critical workflow state
         /// failed.
-        pub const INTERNAL_STATE_FAILURE: SqlApiWarningCode = SqlApiWarningCode::new("INTERNAL_STATE_FAILURE");
+        pub const INTERNAL_STATE_FAILURE: SqlApiWarningCode = SqlApiWarningCode::new(4);
+
+        /// Creates a new SqlApiWarningCode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SQL_API_WARNING_CODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REGION_UNREACHABLE"),
+                2 => std::borrow::Cow::Borrowed("MAX_RESULTS_EXCEEDS_LIMIT"),
+                3 => std::borrow::Cow::Borrowed("COMPROMISED_CREDENTIALS"),
+                4 => std::borrow::Cow::Borrowed("INTERNAL_STATE_FAILURE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SQL_API_WARNING_CODE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_API_WARNING_CODE_UNSPECIFIED),
+                "REGION_UNREACHABLE" => std::option::Option::Some(Self::REGION_UNREACHABLE),
+                "MAX_RESULTS_EXCEEDS_LIMIT" => std::option::Option::Some(Self::MAX_RESULTS_EXCEEDS_LIMIT),
+                "COMPROMISED_CREDENTIALS" => std::option::Option::Some(Self::COMPROMISED_CREDENTIALS),
+                "INTERNAL_STATE_FAILURE" => std::option::Option::Some(Self::INTERNAL_STATE_FAILURE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for SqlApiWarningCode {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for SqlApiWarningCode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for SqlApiWarningCode {
         fn default() -> Self {
-            sql_api_warning_code::SQL_API_WARNING_CODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6520,41 +6780,54 @@ pub mod backup_retention_settings {
 
     /// The units that retained_backups specifies, we only support COUNT.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RetentionUnit(std::borrow::Cow<'static, str>);
+    pub struct RetentionUnit(i32);
 
     impl RetentionUnit {
+
+        /// Backup retention unit is unspecified, will be treated as COUNT.
+        pub const RETENTION_UNIT_UNSPECIFIED: RetentionUnit = RetentionUnit::new(0);
+
+        /// Retention will be by count, eg. "retain the most recent 7 backups".
+        pub const COUNT: RetentionUnit = RetentionUnit::new(1);
+
         /// Creates a new RetentionUnit instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RETENTION_UNIT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("COUNT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RETENTION_UNIT_UNSPECIFIED" => std::option::Option::Some(Self::RETENTION_UNIT_UNSPECIFIED),
+                "COUNT" => std::option::Option::Some(Self::COUNT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RetentionUnit](RetentionUnit)
-    pub mod retention_unit {
-        use super::RetentionUnit;
-        
-
-        /// Backup retention unit is unspecified, will be treated as COUNT.
-        pub const RETENTION_UNIT_UNSPECIFIED: RetentionUnit = RetentionUnit::new("RETENTION_UNIT_UNSPECIFIED");
-
-        /// Retention will be by count, eg. "retain the most recent 7 backups".
-        pub const COUNT: RetentionUnit = RetentionUnit::new("COUNT");
-    }
-
-    impl std::convert::From<std::string::String> for RetentionUnit {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for RetentionUnit {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for RetentionUnit {
         fn default() -> Self {
-            retention_unit::RETENTION_UNIT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6692,56 +6965,75 @@ pub mod backup_configuration {
     /// This value contains the storage location of the transactional logs
     /// used to perform point-in-time recovery (PITR) for the database.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TransactionalLogStorageState(std::borrow::Cow<'static, str>);
+    pub struct TransactionalLogStorageState(i32);
 
     impl TransactionalLogStorageState {
-        /// Creates a new TransactionalLogStorageState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [TransactionalLogStorageState](TransactionalLogStorageState)
-    pub mod transactional_log_storage_state {
-        use super::TransactionalLogStorageState;
-        
 
         /// Unspecified.
-        pub const TRANSACTIONAL_LOG_STORAGE_STATE_UNSPECIFIED: TransactionalLogStorageState = TransactionalLogStorageState::new("TRANSACTIONAL_LOG_STORAGE_STATE_UNSPECIFIED");
+        pub const TRANSACTIONAL_LOG_STORAGE_STATE_UNSPECIFIED: TransactionalLogStorageState = TransactionalLogStorageState::new(0);
 
         /// The transaction logs used for PITR for the instance are stored
         /// on a data disk.
-        pub const DISK: TransactionalLogStorageState = TransactionalLogStorageState::new("DISK");
+        pub const DISK: TransactionalLogStorageState = TransactionalLogStorageState::new(1);
 
         /// The transaction logs used for PITR for the instance are switching from
         /// being stored on a data disk to being stored in Cloud Storage.
         /// Only applicable to MySQL.
-        pub const SWITCHING_TO_CLOUD_STORAGE: TransactionalLogStorageState = TransactionalLogStorageState::new("SWITCHING_TO_CLOUD_STORAGE");
+        pub const SWITCHING_TO_CLOUD_STORAGE: TransactionalLogStorageState = TransactionalLogStorageState::new(2);
 
         /// The transaction logs used for PITR for the instance are now stored
         /// in Cloud Storage. Previously, they were stored on a data disk.
         /// Only applicable to MySQL.
-        pub const SWITCHED_TO_CLOUD_STORAGE: TransactionalLogStorageState = TransactionalLogStorageState::new("SWITCHED_TO_CLOUD_STORAGE");
+        pub const SWITCHED_TO_CLOUD_STORAGE: TransactionalLogStorageState = TransactionalLogStorageState::new(3);
 
         /// The transaction logs used for PITR for the instance are stored in
         /// Cloud Storage. Only applicable to MySQL and PostgreSQL.
-        pub const CLOUD_STORAGE: TransactionalLogStorageState = TransactionalLogStorageState::new("CLOUD_STORAGE");
+        pub const CLOUD_STORAGE: TransactionalLogStorageState = TransactionalLogStorageState::new(4);
+
+        /// Creates a new TransactionalLogStorageState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TRANSACTIONAL_LOG_STORAGE_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DISK"),
+                2 => std::borrow::Cow::Borrowed("SWITCHING_TO_CLOUD_STORAGE"),
+                3 => std::borrow::Cow::Borrowed("SWITCHED_TO_CLOUD_STORAGE"),
+                4 => std::borrow::Cow::Borrowed("CLOUD_STORAGE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TRANSACTIONAL_LOG_STORAGE_STATE_UNSPECIFIED" => std::option::Option::Some(Self::TRANSACTIONAL_LOG_STORAGE_STATE_UNSPECIFIED),
+                "DISK" => std::option::Option::Some(Self::DISK),
+                "SWITCHING_TO_CLOUD_STORAGE" => std::option::Option::Some(Self::SWITCHING_TO_CLOUD_STORAGE),
+                "SWITCHED_TO_CLOUD_STORAGE" => std::option::Option::Some(Self::SWITCHED_TO_CLOUD_STORAGE),
+                "CLOUD_STORAGE" => std::option::Option::Some(Self::CLOUD_STORAGE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for TransactionalLogStorageState {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for TransactionalLogStorageState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for TransactionalLogStorageState {
         fn default() -> Self {
-            transactional_log_storage_state::TRANSACTIONAL_LOG_STORAGE_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8369,27 +8661,12 @@ pub mod ip_configuration {
 
     /// The SSL options for database connections.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SslMode(std::borrow::Cow<'static, str>);
+    pub struct SslMode(i32);
 
     impl SslMode {
-        /// Creates a new SslMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [SslMode](SslMode)
-    pub mod ssl_mode {
-        use super::SslMode;
-        
 
         /// The SSL mode is unknown.
-        pub const SSL_MODE_UNSPECIFIED: SslMode = SslMode::new("SSL_MODE_UNSPECIFIED");
+        pub const SSL_MODE_UNSPECIFIED: SslMode = SslMode::new(0);
 
         /// Allow non-SSL/non-TLS and SSL/TLS connections.
         /// For SSL connections to MySQL and PostgreSQL, the client certificate
@@ -8397,7 +8674,7 @@ pub mod ip_configuration {
         ///
         /// When this value is used, the legacy `require_ssl` flag must be false or
         /// cleared to avoid a conflict between the values of the two flags.
-        pub const ALLOW_UNENCRYPTED_AND_ENCRYPTED: SslMode = SslMode::new("ALLOW_UNENCRYPTED_AND_ENCRYPTED");
+        pub const ALLOW_UNENCRYPTED_AND_ENCRYPTED: SslMode = SslMode::new(1);
 
         /// Only allow connections encrypted with SSL/TLS.
         /// For SSL connections to MySQL and PostgreSQL, the client certificate
@@ -8405,7 +8682,7 @@ pub mod ip_configuration {
         ///
         /// When this value is used, the legacy `require_ssl` flag must be false or
         /// cleared to avoid a conflict between the values of the two flags.
-        pub const ENCRYPTED_ONLY: SslMode = SslMode::new("ENCRYPTED_ONLY");
+        pub const ENCRYPTED_ONLY: SslMode = SslMode::new(2);
 
         /// Only allow connections encrypted with SSL/TLS and with valid
         /// client certificates.
@@ -8421,62 +8698,109 @@ pub mod ip_configuration {
         /// to enforce client identity verification.
         ///
         /// Only applicable to MySQL and PostgreSQL. Not applicable to SQL Server.
-        pub const TRUSTED_CLIENT_CERTIFICATE_REQUIRED: SslMode = SslMode::new("TRUSTED_CLIENT_CERTIFICATE_REQUIRED");
+        pub const TRUSTED_CLIENT_CERTIFICATE_REQUIRED: SslMode = SslMode::new(3);
+
+        /// Creates a new SslMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SSL_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALLOW_UNENCRYPTED_AND_ENCRYPTED"),
+                2 => std::borrow::Cow::Borrowed("ENCRYPTED_ONLY"),
+                3 => std::borrow::Cow::Borrowed("TRUSTED_CLIENT_CERTIFICATE_REQUIRED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SSL_MODE_UNSPECIFIED" => std::option::Option::Some(Self::SSL_MODE_UNSPECIFIED),
+                "ALLOW_UNENCRYPTED_AND_ENCRYPTED" => std::option::Option::Some(Self::ALLOW_UNENCRYPTED_AND_ENCRYPTED),
+                "ENCRYPTED_ONLY" => std::option::Option::Some(Self::ENCRYPTED_ONLY),
+                "TRUSTED_CLIENT_CERTIFICATE_REQUIRED" => std::option::Option::Some(Self::TRUSTED_CLIENT_CERTIFICATE_REQUIRED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for SslMode {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for SslMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for SslMode {
         fn default() -> Self {
-            ssl_mode::SSL_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Various Certificate Authority (CA) modes for certificate signing.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CaMode(std::borrow::Cow<'static, str>);
+    pub struct CaMode(i32);
 
     impl CaMode {
-        /// Creates a new CaMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CaMode](CaMode)
-    pub mod ca_mode {
-        use super::CaMode;
-        
 
         /// CA mode is unknown.
-        pub const CA_MODE_UNSPECIFIED: CaMode = CaMode::new("CA_MODE_UNSPECIFIED");
+        pub const CA_MODE_UNSPECIFIED: CaMode = CaMode::new(0);
 
         /// Google-managed self-signed internal CA.
-        pub const GOOGLE_MANAGED_INTERNAL_CA: CaMode = CaMode::new("GOOGLE_MANAGED_INTERNAL_CA");
+        pub const GOOGLE_MANAGED_INTERNAL_CA: CaMode = CaMode::new(1);
 
         /// Google-managed regional CA part of root CA hierarchy hosted on Google
         /// Cloud's Certificate Authority Service (CAS).
-        pub const GOOGLE_MANAGED_CAS_CA: CaMode = CaMode::new("GOOGLE_MANAGED_CAS_CA");
+        pub const GOOGLE_MANAGED_CAS_CA: CaMode = CaMode::new(2);
+
+        /// Creates a new CaMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CA_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GOOGLE_MANAGED_INTERNAL_CA"),
+                2 => std::borrow::Cow::Borrowed("GOOGLE_MANAGED_CAS_CA"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CA_MODE_UNSPECIFIED" => std::option::Option::Some(Self::CA_MODE_UNSPECIFIED),
+                "GOOGLE_MANAGED_INTERNAL_CA" => std::option::Option::Some(Self::GOOGLE_MANAGED_INTERNAL_CA),
+                "GOOGLE_MANAGED_CAS_CA" => std::option::Option::Some(Self::GOOGLE_MANAGED_CAS_CA),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CaMode {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for CaMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for CaMode {
         fn default() -> Self {
-            ca_mode::CA_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -9296,233 +9620,351 @@ pub mod operation {
 
     /// The type of Cloud SQL operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlOperationType(std::borrow::Cow<'static, str>);
+    pub struct SqlOperationType(i32);
 
     impl SqlOperationType {
-        /// Creates a new SqlOperationType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [SqlOperationType](SqlOperationType)
-    pub mod sql_operation_type {
-        use super::SqlOperationType;
-        
 
         /// Unknown operation type.
-        pub const SQL_OPERATION_TYPE_UNSPECIFIED: SqlOperationType = SqlOperationType::new("SQL_OPERATION_TYPE_UNSPECIFIED");
+        pub const SQL_OPERATION_TYPE_UNSPECIFIED: SqlOperationType = SqlOperationType::new(0);
 
         /// Imports data into a Cloud SQL instance.
-        pub const IMPORT: SqlOperationType = SqlOperationType::new("IMPORT");
+        pub const IMPORT: SqlOperationType = SqlOperationType::new(1);
 
         /// Exports data from a Cloud SQL instance to a Cloud Storage
         /// bucket.
-        pub const EXPORT: SqlOperationType = SqlOperationType::new("EXPORT");
+        pub const EXPORT: SqlOperationType = SqlOperationType::new(2);
 
         /// Creates a new Cloud SQL instance.
-        pub const CREATE: SqlOperationType = SqlOperationType::new("CREATE");
+        pub const CREATE: SqlOperationType = SqlOperationType::new(3);
 
         /// Updates the settings of a Cloud SQL instance.
-        pub const UPDATE: SqlOperationType = SqlOperationType::new("UPDATE");
+        pub const UPDATE: SqlOperationType = SqlOperationType::new(4);
 
         /// Deletes a Cloud SQL instance.
-        pub const DELETE: SqlOperationType = SqlOperationType::new("DELETE");
+        pub const DELETE: SqlOperationType = SqlOperationType::new(5);
 
         /// Restarts the Cloud SQL instance.
-        pub const RESTART: SqlOperationType = SqlOperationType::new("RESTART");
+        pub const RESTART: SqlOperationType = SqlOperationType::new(6);
 
-        pub const BACKUP: SqlOperationType = SqlOperationType::new("BACKUP");
+        pub const BACKUP: SqlOperationType = SqlOperationType::new(7);
 
-        pub const SNAPSHOT: SqlOperationType = SqlOperationType::new("SNAPSHOT");
+        pub const SNAPSHOT: SqlOperationType = SqlOperationType::new(8);
 
         /// Performs instance backup.
-        pub const BACKUP_VOLUME: SqlOperationType = SqlOperationType::new("BACKUP_VOLUME");
+        pub const BACKUP_VOLUME: SqlOperationType = SqlOperationType::new(9);
 
         /// Deletes an instance backup.
-        pub const DELETE_VOLUME: SqlOperationType = SqlOperationType::new("DELETE_VOLUME");
+        pub const DELETE_VOLUME: SqlOperationType = SqlOperationType::new(10);
 
         /// Restores an instance backup.
-        pub const RESTORE_VOLUME: SqlOperationType = SqlOperationType::new("RESTORE_VOLUME");
+        pub const RESTORE_VOLUME: SqlOperationType = SqlOperationType::new(11);
 
         /// Injects a privileged user in mysql for MOB instances.
-        pub const INJECT_USER: SqlOperationType = SqlOperationType::new("INJECT_USER");
+        pub const INJECT_USER: SqlOperationType = SqlOperationType::new(12);
 
         /// Clones a Cloud SQL instance.
-        pub const CLONE: SqlOperationType = SqlOperationType::new("CLONE");
+        pub const CLONE: SqlOperationType = SqlOperationType::new(14);
 
         /// Stops replication on a Cloud SQL read replica instance.
-        pub const STOP_REPLICA: SqlOperationType = SqlOperationType::new("STOP_REPLICA");
+        pub const STOP_REPLICA: SqlOperationType = SqlOperationType::new(15);
 
         /// Starts replication on a Cloud SQL read replica instance.
-        pub const START_REPLICA: SqlOperationType = SqlOperationType::new("START_REPLICA");
+        pub const START_REPLICA: SqlOperationType = SqlOperationType::new(16);
 
         /// Promotes a Cloud SQL replica instance.
-        pub const PROMOTE_REPLICA: SqlOperationType = SqlOperationType::new("PROMOTE_REPLICA");
+        pub const PROMOTE_REPLICA: SqlOperationType = SqlOperationType::new(17);
 
         /// Creates a Cloud SQL replica instance.
-        pub const CREATE_REPLICA: SqlOperationType = SqlOperationType::new("CREATE_REPLICA");
+        pub const CREATE_REPLICA: SqlOperationType = SqlOperationType::new(18);
 
         /// Creates a new user in a Cloud SQL instance.
-        pub const CREATE_USER: SqlOperationType = SqlOperationType::new("CREATE_USER");
+        pub const CREATE_USER: SqlOperationType = SqlOperationType::new(19);
 
         /// Deletes a user from a Cloud SQL instance.
-        pub const DELETE_USER: SqlOperationType = SqlOperationType::new("DELETE_USER");
+        pub const DELETE_USER: SqlOperationType = SqlOperationType::new(20);
 
         /// Updates an existing user in a Cloud SQL instance.
-        pub const UPDATE_USER: SqlOperationType = SqlOperationType::new("UPDATE_USER");
+        pub const UPDATE_USER: SqlOperationType = SqlOperationType::new(21);
 
         /// Creates a database in the Cloud SQL instance.
-        pub const CREATE_DATABASE: SqlOperationType = SqlOperationType::new("CREATE_DATABASE");
+        pub const CREATE_DATABASE: SqlOperationType = SqlOperationType::new(22);
 
         /// Deletes a database in the Cloud SQL instance.
-        pub const DELETE_DATABASE: SqlOperationType = SqlOperationType::new("DELETE_DATABASE");
+        pub const DELETE_DATABASE: SqlOperationType = SqlOperationType::new(23);
 
         /// Updates a database in the Cloud SQL instance.
-        pub const UPDATE_DATABASE: SqlOperationType = SqlOperationType::new("UPDATE_DATABASE");
+        pub const UPDATE_DATABASE: SqlOperationType = SqlOperationType::new(24);
 
         /// Performs failover of an HA-enabled Cloud SQL
         /// failover replica.
-        pub const FAILOVER: SqlOperationType = SqlOperationType::new("FAILOVER");
+        pub const FAILOVER: SqlOperationType = SqlOperationType::new(25);
 
         /// Deletes the backup taken by a backup run.
-        pub const DELETE_BACKUP: SqlOperationType = SqlOperationType::new("DELETE_BACKUP");
+        pub const DELETE_BACKUP: SqlOperationType = SqlOperationType::new(26);
 
-        pub const RECREATE_REPLICA: SqlOperationType = SqlOperationType::new("RECREATE_REPLICA");
+        pub const RECREATE_REPLICA: SqlOperationType = SqlOperationType::new(27);
 
         /// Truncates a general or slow log table in MySQL.
-        pub const TRUNCATE_LOG: SqlOperationType = SqlOperationType::new("TRUNCATE_LOG");
+        pub const TRUNCATE_LOG: SqlOperationType = SqlOperationType::new(28);
 
         /// Demotes the stand-alone instance to be a Cloud SQL
         /// read replica for an external database server.
-        pub const DEMOTE_MASTER: SqlOperationType = SqlOperationType::new("DEMOTE_MASTER");
+        pub const DEMOTE_MASTER: SqlOperationType = SqlOperationType::new(29);
 
         /// Indicates that the instance is currently in maintenance. Maintenance
         /// typically causes the instance to be unavailable for 1-3 minutes.
-        pub const MAINTENANCE: SqlOperationType = SqlOperationType::new("MAINTENANCE");
+        pub const MAINTENANCE: SqlOperationType = SqlOperationType::new(30);
 
         /// This field is deprecated, and will be removed in future version of API.
-        pub const ENABLE_PRIVATE_IP: SqlOperationType = SqlOperationType::new("ENABLE_PRIVATE_IP");
+        pub const ENABLE_PRIVATE_IP: SqlOperationType = SqlOperationType::new(31);
 
-        pub const DEFER_MAINTENANCE: SqlOperationType = SqlOperationType::new("DEFER_MAINTENANCE");
+        pub const DEFER_MAINTENANCE: SqlOperationType = SqlOperationType::new(32);
 
         /// Creates clone instance.
-        pub const CREATE_CLONE: SqlOperationType = SqlOperationType::new("CREATE_CLONE");
+        pub const CREATE_CLONE: SqlOperationType = SqlOperationType::new(33);
 
         /// Reschedule maintenance to another time.
-        pub const RESCHEDULE_MAINTENANCE: SqlOperationType = SqlOperationType::new("RESCHEDULE_MAINTENANCE");
+        pub const RESCHEDULE_MAINTENANCE: SqlOperationType = SqlOperationType::new(34);
 
         /// Starts external sync of a Cloud SQL EM replica to an external primary
         /// instance.
-        pub const START_EXTERNAL_SYNC: SqlOperationType = SqlOperationType::new("START_EXTERNAL_SYNC");
+        pub const START_EXTERNAL_SYNC: SqlOperationType = SqlOperationType::new(35);
 
         /// Recovers logs from an instance's old data disk.
-        pub const LOG_CLEANUP: SqlOperationType = SqlOperationType::new("LOG_CLEANUP");
+        pub const LOG_CLEANUP: SqlOperationType = SqlOperationType::new(36);
 
         /// Performs auto-restart of an HA-enabled Cloud SQL database for auto
         /// recovery.
-        pub const AUTO_RESTART: SqlOperationType = SqlOperationType::new("AUTO_RESTART");
+        pub const AUTO_RESTART: SqlOperationType = SqlOperationType::new(37);
 
         /// Re-encrypts CMEK instances with latest key version.
-        pub const REENCRYPT: SqlOperationType = SqlOperationType::new("REENCRYPT");
+        pub const REENCRYPT: SqlOperationType = SqlOperationType::new(38);
 
         /// Switches the roles of the primary and replica pair. The target instance
         /// should be the replica.
-        pub const SWITCHOVER: SqlOperationType = SqlOperationType::new("SWITCHOVER");
+        pub const SWITCHOVER: SqlOperationType = SqlOperationType::new(39);
 
         /// Acquire a lease for the setup of SQL Server Reporting Services (SSRS).
-        pub const ACQUIRE_SSRS_LEASE: SqlOperationType = SqlOperationType::new("ACQUIRE_SSRS_LEASE");
+        pub const ACQUIRE_SSRS_LEASE: SqlOperationType = SqlOperationType::new(42);
 
         /// Release a lease for the setup of SQL Server Reporting Services (SSRS).
-        pub const RELEASE_SSRS_LEASE: SqlOperationType = SqlOperationType::new("RELEASE_SSRS_LEASE");
+        pub const RELEASE_SSRS_LEASE: SqlOperationType = SqlOperationType::new(43);
 
         /// Reconfigures old primary after a promote replica operation. Effect of a
         /// promote operation to the old primary is executed in this operation,
         /// asynchronously from the promote replica operation executed to the
         /// replica.
-        pub const RECONFIGURE_OLD_PRIMARY: SqlOperationType = SqlOperationType::new("RECONFIGURE_OLD_PRIMARY");
+        pub const RECONFIGURE_OLD_PRIMARY: SqlOperationType = SqlOperationType::new(44);
 
         /// Indicates that the instance, its read replicas, and its cascading
         /// replicas are in maintenance. Maintenance typically gets initiated on
         /// groups of replicas first, followed by the primary instance. For each
         /// instance, maintenance typically causes the instance to be unavailable for
         /// 1-3 minutes.
-        pub const CLUSTER_MAINTENANCE: SqlOperationType = SqlOperationType::new("CLUSTER_MAINTENANCE");
+        pub const CLUSTER_MAINTENANCE: SqlOperationType = SqlOperationType::new(45);
 
         /// Indicates that the instance (and any of its replicas) are currently in
         /// maintenance. This is initiated as a self-service request by using SSM.
         /// Maintenance typically causes the instance to be unavailable for 1-3
         /// minutes.
-        pub const SELF_SERVICE_MAINTENANCE: SqlOperationType = SqlOperationType::new("SELF_SERVICE_MAINTENANCE");
+        pub const SELF_SERVICE_MAINTENANCE: SqlOperationType = SqlOperationType::new(46);
 
         /// Switches a primary instance to a replica. This operation runs as part of
         /// a switchover operation to the original primary instance.
-        pub const SWITCHOVER_TO_REPLICA: SqlOperationType = SqlOperationType::new("SWITCHOVER_TO_REPLICA");
+        pub const SWITCHOVER_TO_REPLICA: SqlOperationType = SqlOperationType::new(47);
 
         /// Updates the major version of a Cloud SQL instance.
-        pub const MAJOR_VERSION_UPGRADE: SqlOperationType = SqlOperationType::new("MAJOR_VERSION_UPGRADE");
+        pub const MAJOR_VERSION_UPGRADE: SqlOperationType = SqlOperationType::new(48);
+
+        /// Creates a new SqlOperationType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SQL_OPERATION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IMPORT"),
+                2 => std::borrow::Cow::Borrowed("EXPORT"),
+                3 => std::borrow::Cow::Borrowed("CREATE"),
+                4 => std::borrow::Cow::Borrowed("UPDATE"),
+                5 => std::borrow::Cow::Borrowed("DELETE"),
+                6 => std::borrow::Cow::Borrowed("RESTART"),
+                7 => std::borrow::Cow::Borrowed("BACKUP"),
+                8 => std::borrow::Cow::Borrowed("SNAPSHOT"),
+                9 => std::borrow::Cow::Borrowed("BACKUP_VOLUME"),
+                10 => std::borrow::Cow::Borrowed("DELETE_VOLUME"),
+                11 => std::borrow::Cow::Borrowed("RESTORE_VOLUME"),
+                12 => std::borrow::Cow::Borrowed("INJECT_USER"),
+                14 => std::borrow::Cow::Borrowed("CLONE"),
+                15 => std::borrow::Cow::Borrowed("STOP_REPLICA"),
+                16 => std::borrow::Cow::Borrowed("START_REPLICA"),
+                17 => std::borrow::Cow::Borrowed("PROMOTE_REPLICA"),
+                18 => std::borrow::Cow::Borrowed("CREATE_REPLICA"),
+                19 => std::borrow::Cow::Borrowed("CREATE_USER"),
+                20 => std::borrow::Cow::Borrowed("DELETE_USER"),
+                21 => std::borrow::Cow::Borrowed("UPDATE_USER"),
+                22 => std::borrow::Cow::Borrowed("CREATE_DATABASE"),
+                23 => std::borrow::Cow::Borrowed("DELETE_DATABASE"),
+                24 => std::borrow::Cow::Borrowed("UPDATE_DATABASE"),
+                25 => std::borrow::Cow::Borrowed("FAILOVER"),
+                26 => std::borrow::Cow::Borrowed("DELETE_BACKUP"),
+                27 => std::borrow::Cow::Borrowed("RECREATE_REPLICA"),
+                28 => std::borrow::Cow::Borrowed("TRUNCATE_LOG"),
+                29 => std::borrow::Cow::Borrowed("DEMOTE_MASTER"),
+                30 => std::borrow::Cow::Borrowed("MAINTENANCE"),
+                31 => std::borrow::Cow::Borrowed("ENABLE_PRIVATE_IP"),
+                32 => std::borrow::Cow::Borrowed("DEFER_MAINTENANCE"),
+                33 => std::borrow::Cow::Borrowed("CREATE_CLONE"),
+                34 => std::borrow::Cow::Borrowed("RESCHEDULE_MAINTENANCE"),
+                35 => std::borrow::Cow::Borrowed("START_EXTERNAL_SYNC"),
+                36 => std::borrow::Cow::Borrowed("LOG_CLEANUP"),
+                37 => std::borrow::Cow::Borrowed("AUTO_RESTART"),
+                38 => std::borrow::Cow::Borrowed("REENCRYPT"),
+                39 => std::borrow::Cow::Borrowed("SWITCHOVER"),
+                42 => std::borrow::Cow::Borrowed("ACQUIRE_SSRS_LEASE"),
+                43 => std::borrow::Cow::Borrowed("RELEASE_SSRS_LEASE"),
+                44 => std::borrow::Cow::Borrowed("RECONFIGURE_OLD_PRIMARY"),
+                45 => std::borrow::Cow::Borrowed("CLUSTER_MAINTENANCE"),
+                46 => std::borrow::Cow::Borrowed("SELF_SERVICE_MAINTENANCE"),
+                47 => std::borrow::Cow::Borrowed("SWITCHOVER_TO_REPLICA"),
+                48 => std::borrow::Cow::Borrowed("MAJOR_VERSION_UPGRADE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SQL_OPERATION_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_OPERATION_TYPE_UNSPECIFIED),
+                "IMPORT" => std::option::Option::Some(Self::IMPORT),
+                "EXPORT" => std::option::Option::Some(Self::EXPORT),
+                "CREATE" => std::option::Option::Some(Self::CREATE),
+                "UPDATE" => std::option::Option::Some(Self::UPDATE),
+                "DELETE" => std::option::Option::Some(Self::DELETE),
+                "RESTART" => std::option::Option::Some(Self::RESTART),
+                "BACKUP" => std::option::Option::Some(Self::BACKUP),
+                "SNAPSHOT" => std::option::Option::Some(Self::SNAPSHOT),
+                "BACKUP_VOLUME" => std::option::Option::Some(Self::BACKUP_VOLUME),
+                "DELETE_VOLUME" => std::option::Option::Some(Self::DELETE_VOLUME),
+                "RESTORE_VOLUME" => std::option::Option::Some(Self::RESTORE_VOLUME),
+                "INJECT_USER" => std::option::Option::Some(Self::INJECT_USER),
+                "CLONE" => std::option::Option::Some(Self::CLONE),
+                "STOP_REPLICA" => std::option::Option::Some(Self::STOP_REPLICA),
+                "START_REPLICA" => std::option::Option::Some(Self::START_REPLICA),
+                "PROMOTE_REPLICA" => std::option::Option::Some(Self::PROMOTE_REPLICA),
+                "CREATE_REPLICA" => std::option::Option::Some(Self::CREATE_REPLICA),
+                "CREATE_USER" => std::option::Option::Some(Self::CREATE_USER),
+                "DELETE_USER" => std::option::Option::Some(Self::DELETE_USER),
+                "UPDATE_USER" => std::option::Option::Some(Self::UPDATE_USER),
+                "CREATE_DATABASE" => std::option::Option::Some(Self::CREATE_DATABASE),
+                "DELETE_DATABASE" => std::option::Option::Some(Self::DELETE_DATABASE),
+                "UPDATE_DATABASE" => std::option::Option::Some(Self::UPDATE_DATABASE),
+                "FAILOVER" => std::option::Option::Some(Self::FAILOVER),
+                "DELETE_BACKUP" => std::option::Option::Some(Self::DELETE_BACKUP),
+                "RECREATE_REPLICA" => std::option::Option::Some(Self::RECREATE_REPLICA),
+                "TRUNCATE_LOG" => std::option::Option::Some(Self::TRUNCATE_LOG),
+                "DEMOTE_MASTER" => std::option::Option::Some(Self::DEMOTE_MASTER),
+                "MAINTENANCE" => std::option::Option::Some(Self::MAINTENANCE),
+                "ENABLE_PRIVATE_IP" => std::option::Option::Some(Self::ENABLE_PRIVATE_IP),
+                "DEFER_MAINTENANCE" => std::option::Option::Some(Self::DEFER_MAINTENANCE),
+                "CREATE_CLONE" => std::option::Option::Some(Self::CREATE_CLONE),
+                "RESCHEDULE_MAINTENANCE" => std::option::Option::Some(Self::RESCHEDULE_MAINTENANCE),
+                "START_EXTERNAL_SYNC" => std::option::Option::Some(Self::START_EXTERNAL_SYNC),
+                "LOG_CLEANUP" => std::option::Option::Some(Self::LOG_CLEANUP),
+                "AUTO_RESTART" => std::option::Option::Some(Self::AUTO_RESTART),
+                "REENCRYPT" => std::option::Option::Some(Self::REENCRYPT),
+                "SWITCHOVER" => std::option::Option::Some(Self::SWITCHOVER),
+                "ACQUIRE_SSRS_LEASE" => std::option::Option::Some(Self::ACQUIRE_SSRS_LEASE),
+                "RELEASE_SSRS_LEASE" => std::option::Option::Some(Self::RELEASE_SSRS_LEASE),
+                "RECONFIGURE_OLD_PRIMARY" => std::option::Option::Some(Self::RECONFIGURE_OLD_PRIMARY),
+                "CLUSTER_MAINTENANCE" => std::option::Option::Some(Self::CLUSTER_MAINTENANCE),
+                "SELF_SERVICE_MAINTENANCE" => std::option::Option::Some(Self::SELF_SERVICE_MAINTENANCE),
+                "SWITCHOVER_TO_REPLICA" => std::option::Option::Some(Self::SWITCHOVER_TO_REPLICA),
+                "MAJOR_VERSION_UPGRADE" => std::option::Option::Some(Self::MAJOR_VERSION_UPGRADE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for SqlOperationType {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for SqlOperationType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for SqlOperationType {
         fn default() -> Self {
-            sql_operation_type::SQL_OPERATION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The status of an operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlOperationStatus(std::borrow::Cow<'static, str>);
+    pub struct SqlOperationStatus(i32);
 
     impl SqlOperationStatus {
+
+        /// The state of the operation is unknown.
+        pub const SQL_OPERATION_STATUS_UNSPECIFIED: SqlOperationStatus = SqlOperationStatus::new(0);
+
+        /// The operation has been queued, but has not started yet.
+        pub const PENDING: SqlOperationStatus = SqlOperationStatus::new(1);
+
+        /// The operation is running.
+        pub const RUNNING: SqlOperationStatus = SqlOperationStatus::new(2);
+
+        /// The operation completed.
+        pub const DONE: SqlOperationStatus = SqlOperationStatus::new(3);
+
         /// Creates a new SqlOperationStatus instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SQL_OPERATION_STATUS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("DONE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SQL_OPERATION_STATUS_UNSPECIFIED" => std::option::Option::Some(Self::SQL_OPERATION_STATUS_UNSPECIFIED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "DONE" => std::option::Option::Some(Self::DONE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SqlOperationStatus](SqlOperationStatus)
-    pub mod sql_operation_status {
-        use super::SqlOperationStatus;
-        
-
-        /// The state of the operation is unknown.
-        pub const SQL_OPERATION_STATUS_UNSPECIFIED: SqlOperationStatus = SqlOperationStatus::new("SQL_OPERATION_STATUS_UNSPECIFIED");
-
-        /// The operation has been queued, but has not started yet.
-        pub const PENDING: SqlOperationStatus = SqlOperationStatus::new("PENDING");
-
-        /// The operation is running.
-        pub const RUNNING: SqlOperationStatus = SqlOperationStatus::new("RUNNING");
-
-        /// The operation completed.
-        pub const DONE: SqlOperationStatus = SqlOperationStatus::new("DONE");
-    }
-
-    impl std::convert::From<std::string::String> for SqlOperationStatus {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for SqlOperationStatus {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for SqlOperationStatus {
         fn default() -> Self {
-            sql_operation_status::SQL_OPERATION_STATUS_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -9721,42 +10163,55 @@ pub mod password_validation_policy {
 
     /// The complexity choices of the password.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Complexity(std::borrow::Cow<'static, str>);
+    pub struct Complexity(i32);
 
     impl Complexity {
-        /// Creates a new Complexity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Complexity](Complexity)
-    pub mod complexity {
-        use super::Complexity;
-        
 
         /// Complexity check is not specified.
-        pub const COMPLEXITY_UNSPECIFIED: Complexity = Complexity::new("COMPLEXITY_UNSPECIFIED");
+        pub const COMPLEXITY_UNSPECIFIED: Complexity = Complexity::new(0);
 
         /// A combination of lowercase, uppercase, numeric, and non-alphanumeric
         /// characters.
-        pub const COMPLEXITY_DEFAULT: Complexity = Complexity::new("COMPLEXITY_DEFAULT");
+        pub const COMPLEXITY_DEFAULT: Complexity = Complexity::new(1);
+
+        /// Creates a new Complexity instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COMPLEXITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("COMPLEXITY_DEFAULT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COMPLEXITY_UNSPECIFIED" => std::option::Option::Some(Self::COMPLEXITY_UNSPECIFIED),
+                "COMPLEXITY_DEFAULT" => std::option::Option::Some(Self::COMPLEXITY_DEFAULT),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Complexity {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for Complexity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for Complexity {
         fn default() -> Self {
-            complexity::COMPLEXITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -10226,135 +10681,182 @@ pub mod settings {
 
     /// Specifies when the instance is activated.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlActivationPolicy(std::borrow::Cow<'static, str>);
+    pub struct SqlActivationPolicy(i32);
 
     impl SqlActivationPolicy {
+
+        /// Unknown activation plan.
+        pub const SQL_ACTIVATION_POLICY_UNSPECIFIED: SqlActivationPolicy = SqlActivationPolicy::new(0);
+
+        /// The instance is always up and running.
+        pub const ALWAYS: SqlActivationPolicy = SqlActivationPolicy::new(1);
+
+        /// The instance never starts.
+        pub const NEVER: SqlActivationPolicy = SqlActivationPolicy::new(2);
+
+        /// The instance starts upon receiving requests.
+        pub const ON_DEMAND: SqlActivationPolicy = SqlActivationPolicy::new(3);
+
         /// Creates a new SqlActivationPolicy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SQL_ACTIVATION_POLICY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALWAYS"),
+                2 => std::borrow::Cow::Borrowed("NEVER"),
+                3 => std::borrow::Cow::Borrowed("ON_DEMAND"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SQL_ACTIVATION_POLICY_UNSPECIFIED" => std::option::Option::Some(Self::SQL_ACTIVATION_POLICY_UNSPECIFIED),
+                "ALWAYS" => std::option::Option::Some(Self::ALWAYS),
+                "NEVER" => std::option::Option::Some(Self::NEVER),
+                "ON_DEMAND" => std::option::Option::Some(Self::ON_DEMAND),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SqlActivationPolicy](SqlActivationPolicy)
-    pub mod sql_activation_policy {
-        use super::SqlActivationPolicy;
-        
-
-        /// Unknown activation plan.
-        pub const SQL_ACTIVATION_POLICY_UNSPECIFIED: SqlActivationPolicy = SqlActivationPolicy::new("SQL_ACTIVATION_POLICY_UNSPECIFIED");
-
-        /// The instance is always up and running.
-        pub const ALWAYS: SqlActivationPolicy = SqlActivationPolicy::new("ALWAYS");
-
-        /// The instance never starts.
-        pub const NEVER: SqlActivationPolicy = SqlActivationPolicy::new("NEVER");
-
-        /// The instance starts upon receiving requests.
-        pub const ON_DEMAND: SqlActivationPolicy = SqlActivationPolicy::new("ON_DEMAND");
-    }
-
-    impl std::convert::From<std::string::String> for SqlActivationPolicy {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for SqlActivationPolicy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for SqlActivationPolicy {
         fn default() -> Self {
-            sql_activation_policy::SQL_ACTIVATION_POLICY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The edition of the instance, can be ENTERPRISE or ENTERPRISE_PLUS.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Edition(std::borrow::Cow<'static, str>);
+    pub struct Edition(i32);
 
     impl Edition {
+
+        /// The instance did not specify the edition.
+        pub const EDITION_UNSPECIFIED: Edition = Edition::new(0);
+
+        /// The instance is an enterprise edition.
+        pub const ENTERPRISE: Edition = Edition::new(2);
+
+        /// The instance is an Enterprise Plus edition.
+        pub const ENTERPRISE_PLUS: Edition = Edition::new(3);
+
         /// Creates a new Edition instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EDITION_UNSPECIFIED"),
+                2 => std::borrow::Cow::Borrowed("ENTERPRISE"),
+                3 => std::borrow::Cow::Borrowed("ENTERPRISE_PLUS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EDITION_UNSPECIFIED" => std::option::Option::Some(Self::EDITION_UNSPECIFIED),
+                "ENTERPRISE" => std::option::Option::Some(Self::ENTERPRISE),
+                "ENTERPRISE_PLUS" => std::option::Option::Some(Self::ENTERPRISE_PLUS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Edition](Edition)
-    pub mod edition {
-        use super::Edition;
-        
-
-        /// The instance did not specify the edition.
-        pub const EDITION_UNSPECIFIED: Edition = Edition::new("EDITION_UNSPECIFIED");
-
-        /// The instance is an enterprise edition.
-        pub const ENTERPRISE: Edition = Edition::new("ENTERPRISE");
-
-        /// The instance is an Enterprise Plus edition.
-        pub const ENTERPRISE_PLUS: Edition = Edition::new("ENTERPRISE_PLUS");
-    }
-
-    impl std::convert::From<std::string::String> for Edition {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for Edition {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for Edition {
         fn default() -> Self {
-            edition::EDITION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The options for enforcing Cloud SQL connectors in the instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConnectorEnforcement(std::borrow::Cow<'static, str>);
+    pub struct ConnectorEnforcement(i32);
 
     impl ConnectorEnforcement {
-        /// Creates a new ConnectorEnforcement instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ConnectorEnforcement](ConnectorEnforcement)
-    pub mod connector_enforcement {
-        use super::ConnectorEnforcement;
-        
 
         /// The requirement for Cloud SQL connectors is unknown.
-        pub const CONNECTOR_ENFORCEMENT_UNSPECIFIED: ConnectorEnforcement = ConnectorEnforcement::new("CONNECTOR_ENFORCEMENT_UNSPECIFIED");
+        pub const CONNECTOR_ENFORCEMENT_UNSPECIFIED: ConnectorEnforcement = ConnectorEnforcement::new(0);
 
         /// Do not require Cloud SQL connectors.
-        pub const NOT_REQUIRED: ConnectorEnforcement = ConnectorEnforcement::new("NOT_REQUIRED");
+        pub const NOT_REQUIRED: ConnectorEnforcement = ConnectorEnforcement::new(1);
 
         /// Require all connections to use Cloud SQL connectors, including the
         /// Cloud SQL Auth Proxy and Cloud SQL Java, Python, and Go connectors.
         /// Note: This disables all existing authorized networks.
-        pub const REQUIRED: ConnectorEnforcement = ConnectorEnforcement::new("REQUIRED");
+        pub const REQUIRED: ConnectorEnforcement = ConnectorEnforcement::new(2);
+
+        /// Creates a new ConnectorEnforcement instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CONNECTOR_ENFORCEMENT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NOT_REQUIRED"),
+                2 => std::borrow::Cow::Borrowed("REQUIRED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CONNECTOR_ENFORCEMENT_UNSPECIFIED" => std::option::Option::Some(Self::CONNECTOR_ENFORCEMENT_UNSPECIFIED),
+                "NOT_REQUIRED" => std::option::Option::Some(Self::NOT_REQUIRED),
+                "REQUIRED" => std::option::Option::Some(Self::REQUIRED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ConnectorEnforcement {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for ConnectorEnforcement {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for ConnectorEnforcement {
         fn default() -> Self {
-            connector_enforcement::CONNECTOR_ENFORCEMENT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -11737,99 +12239,137 @@ pub mod user {
 
     /// The user type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlUserType(std::borrow::Cow<'static, str>);
+    pub struct SqlUserType(i32);
 
     impl SqlUserType {
+
+        /// The database's built-in user type.
+        pub const BUILT_IN: SqlUserType = SqlUserType::new(0);
+
+        /// Cloud IAM user.
+        pub const CLOUD_IAM_USER: SqlUserType = SqlUserType::new(1);
+
+        /// Cloud IAM service account.
+        pub const CLOUD_IAM_SERVICE_ACCOUNT: SqlUserType = SqlUserType::new(2);
+
+        /// Cloud IAM group non-login user.
+        pub const CLOUD_IAM_GROUP: SqlUserType = SqlUserType::new(3);
+
+        /// Cloud IAM group login user.
+        pub const CLOUD_IAM_GROUP_USER: SqlUserType = SqlUserType::new(4);
+
+        /// Cloud IAM group login service account.
+        pub const CLOUD_IAM_GROUP_SERVICE_ACCOUNT: SqlUserType = SqlUserType::new(5);
+
         /// Creates a new SqlUserType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("BUILT_IN"),
+                1 => std::borrow::Cow::Borrowed("CLOUD_IAM_USER"),
+                2 => std::borrow::Cow::Borrowed("CLOUD_IAM_SERVICE_ACCOUNT"),
+                3 => std::borrow::Cow::Borrowed("CLOUD_IAM_GROUP"),
+                4 => std::borrow::Cow::Borrowed("CLOUD_IAM_GROUP_USER"),
+                5 => std::borrow::Cow::Borrowed("CLOUD_IAM_GROUP_SERVICE_ACCOUNT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "BUILT_IN" => std::option::Option::Some(Self::BUILT_IN),
+                "CLOUD_IAM_USER" => std::option::Option::Some(Self::CLOUD_IAM_USER),
+                "CLOUD_IAM_SERVICE_ACCOUNT" => std::option::Option::Some(Self::CLOUD_IAM_SERVICE_ACCOUNT),
+                "CLOUD_IAM_GROUP" => std::option::Option::Some(Self::CLOUD_IAM_GROUP),
+                "CLOUD_IAM_GROUP_USER" => std::option::Option::Some(Self::CLOUD_IAM_GROUP_USER),
+                "CLOUD_IAM_GROUP_SERVICE_ACCOUNT" => std::option::Option::Some(Self::CLOUD_IAM_GROUP_SERVICE_ACCOUNT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SqlUserType](SqlUserType)
-    pub mod sql_user_type {
-        use super::SqlUserType;
-        
-
-        /// The database's built-in user type.
-        pub const BUILT_IN: SqlUserType = SqlUserType::new("BUILT_IN");
-
-        /// Cloud IAM user.
-        pub const CLOUD_IAM_USER: SqlUserType = SqlUserType::new("CLOUD_IAM_USER");
-
-        /// Cloud IAM service account.
-        pub const CLOUD_IAM_SERVICE_ACCOUNT: SqlUserType = SqlUserType::new("CLOUD_IAM_SERVICE_ACCOUNT");
-
-        /// Cloud IAM group non-login user.
-        pub const CLOUD_IAM_GROUP: SqlUserType = SqlUserType::new("CLOUD_IAM_GROUP");
-
-        /// Cloud IAM group login user.
-        pub const CLOUD_IAM_GROUP_USER: SqlUserType = SqlUserType::new("CLOUD_IAM_GROUP_USER");
-
-        /// Cloud IAM group login service account.
-        pub const CLOUD_IAM_GROUP_SERVICE_ACCOUNT: SqlUserType = SqlUserType::new("CLOUD_IAM_GROUP_SERVICE_ACCOUNT");
-    }
-
-    impl std::convert::From<std::string::String> for SqlUserType {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for SqlUserType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for SqlUserType {
         fn default() -> Self {
-            sql_user_type::BUILT_IN
+            Self::new(0)
         }
     }
 
     /// The type of retained password.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DualPasswordType(std::borrow::Cow<'static, str>);
+    pub struct DualPasswordType(i32);
 
     impl DualPasswordType {
+
+        /// The default value.
+        pub const DUAL_PASSWORD_TYPE_UNSPECIFIED: DualPasswordType = DualPasswordType::new(0);
+
+        /// Do not update the user's dual password status.
+        pub const NO_MODIFY_DUAL_PASSWORD: DualPasswordType = DualPasswordType::new(1);
+
+        /// No dual password usable for connecting using this user.
+        pub const NO_DUAL_PASSWORD: DualPasswordType = DualPasswordType::new(2);
+
+        /// Dual password usable for connecting using this user.
+        pub const DUAL_PASSWORD: DualPasswordType = DualPasswordType::new(3);
+
         /// Creates a new DualPasswordType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+        
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DUAL_PASSWORD_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NO_MODIFY_DUAL_PASSWORD"),
+                2 => std::borrow::Cow::Borrowed("NO_DUAL_PASSWORD"),
+                3 => std::borrow::Cow::Borrowed("DUAL_PASSWORD"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DUAL_PASSWORD_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::DUAL_PASSWORD_TYPE_UNSPECIFIED),
+                "NO_MODIFY_DUAL_PASSWORD" => std::option::Option::Some(Self::NO_MODIFY_DUAL_PASSWORD),
+                "NO_DUAL_PASSWORD" => std::option::Option::Some(Self::NO_DUAL_PASSWORD),
+                "DUAL_PASSWORD" => std::option::Option::Some(Self::DUAL_PASSWORD),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DualPasswordType](DualPasswordType)
-    pub mod dual_password_type {
-        use super::DualPasswordType;
-        
-
-        /// The default value.
-        pub const DUAL_PASSWORD_TYPE_UNSPECIFIED: DualPasswordType = DualPasswordType::new("DUAL_PASSWORD_TYPE_UNSPECIFIED");
-
-        /// Do not update the user's dual password status.
-        pub const NO_MODIFY_DUAL_PASSWORD: DualPasswordType = DualPasswordType::new("NO_MODIFY_DUAL_PASSWORD");
-
-        /// No dual password usable for connecting using this user.
-        pub const NO_DUAL_PASSWORD: DualPasswordType = DualPasswordType::new("NO_DUAL_PASSWORD");
-
-        /// Dual password usable for connecting using this user.
-        pub const DUAL_PASSWORD: DualPasswordType = DualPasswordType::new("DUAL_PASSWORD");
-    }
-
-    impl std::convert::From<std::string::String> for DualPasswordType {
-      fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
-      }
+    impl std::convert::From<i32> for DualPasswordType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
+        }
     }
 
     impl std::default::Default for DualPasswordType {
         fn default() -> Self {
-            dual_password_type::DUAL_PASSWORD_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -11943,942 +12483,1325 @@ impl wkt::message::Message for UsersListResponse {
 
 /// The status of a backup run.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlBackupRunStatus(std::borrow::Cow<'static, str>);
+pub struct SqlBackupRunStatus(i32);
 
 impl SqlBackupRunStatus {
-    /// Creates a new SqlBackupRunStatus instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [SqlBackupRunStatus](SqlBackupRunStatus)
-pub mod sql_backup_run_status {
-    use super::SqlBackupRunStatus;
-    
 
     /// The status of the run is unknown.
-    pub const SQL_BACKUP_RUN_STATUS_UNSPECIFIED: SqlBackupRunStatus = SqlBackupRunStatus::new("SQL_BACKUP_RUN_STATUS_UNSPECIFIED");
+    pub const SQL_BACKUP_RUN_STATUS_UNSPECIFIED: SqlBackupRunStatus = SqlBackupRunStatus::new(0);
 
     /// The backup operation was enqueued.
-    pub const ENQUEUED: SqlBackupRunStatus = SqlBackupRunStatus::new("ENQUEUED");
+    pub const ENQUEUED: SqlBackupRunStatus = SqlBackupRunStatus::new(1);
 
     /// The backup is overdue across a given backup window. Indicates a
     /// problem. Example: Long-running operation in progress during
     /// the whole window.
-    pub const OVERDUE: SqlBackupRunStatus = SqlBackupRunStatus::new("OVERDUE");
+    pub const OVERDUE: SqlBackupRunStatus = SqlBackupRunStatus::new(2);
 
     /// The backup is in progress.
-    pub const RUNNING: SqlBackupRunStatus = SqlBackupRunStatus::new("RUNNING");
+    pub const RUNNING: SqlBackupRunStatus = SqlBackupRunStatus::new(3);
 
     /// The backup failed.
-    pub const FAILED: SqlBackupRunStatus = SqlBackupRunStatus::new("FAILED");
+    pub const FAILED: SqlBackupRunStatus = SqlBackupRunStatus::new(4);
 
     /// The backup was successful.
-    pub const SUCCESSFUL: SqlBackupRunStatus = SqlBackupRunStatus::new("SUCCESSFUL");
+    pub const SUCCESSFUL: SqlBackupRunStatus = SqlBackupRunStatus::new(5);
 
     /// The backup was skipped (without problems) for a given backup
     /// window. Example: Instance was idle.
-    pub const SKIPPED: SqlBackupRunStatus = SqlBackupRunStatus::new("SKIPPED");
+    pub const SKIPPED: SqlBackupRunStatus = SqlBackupRunStatus::new(6);
 
     /// The backup is about to be deleted.
-    pub const DELETION_PENDING: SqlBackupRunStatus = SqlBackupRunStatus::new("DELETION_PENDING");
+    pub const DELETION_PENDING: SqlBackupRunStatus = SqlBackupRunStatus::new(7);
 
     /// The backup deletion failed.
-    pub const DELETION_FAILED: SqlBackupRunStatus = SqlBackupRunStatus::new("DELETION_FAILED");
+    pub const DELETION_FAILED: SqlBackupRunStatus = SqlBackupRunStatus::new(8);
 
     /// The backup has been deleted.
-    pub const DELETED: SqlBackupRunStatus = SqlBackupRunStatus::new("DELETED");
+    pub const DELETED: SqlBackupRunStatus = SqlBackupRunStatus::new(9);
+
+    /// Creates a new SqlBackupRunStatus instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+    
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SQL_BACKUP_RUN_STATUS_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ENQUEUED"),
+            2 => std::borrow::Cow::Borrowed("OVERDUE"),
+            3 => std::borrow::Cow::Borrowed("RUNNING"),
+            4 => std::borrow::Cow::Borrowed("FAILED"),
+            5 => std::borrow::Cow::Borrowed("SUCCESSFUL"),
+            6 => std::borrow::Cow::Borrowed("SKIPPED"),
+            7 => std::borrow::Cow::Borrowed("DELETION_PENDING"),
+            8 => std::borrow::Cow::Borrowed("DELETION_FAILED"),
+            9 => std::borrow::Cow::Borrowed("DELETED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SQL_BACKUP_RUN_STATUS_UNSPECIFIED" => std::option::Option::Some(Self::SQL_BACKUP_RUN_STATUS_UNSPECIFIED),
+            "ENQUEUED" => std::option::Option::Some(Self::ENQUEUED),
+            "OVERDUE" => std::option::Option::Some(Self::OVERDUE),
+            "RUNNING" => std::option::Option::Some(Self::RUNNING),
+            "FAILED" => std::option::Option::Some(Self::FAILED),
+            "SUCCESSFUL" => std::option::Option::Some(Self::SUCCESSFUL),
+            "SKIPPED" => std::option::Option::Some(Self::SKIPPED),
+            "DELETION_PENDING" => std::option::Option::Some(Self::DELETION_PENDING),
+            "DELETION_FAILED" => std::option::Option::Some(Self::DELETION_FAILED),
+            "DELETED" => std::option::Option::Some(Self::DELETED),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for SqlBackupRunStatus {
-  fn from(value: std::string::String) -> Self {
-    Self(std::borrow::Cow::Owned(value))
-  }
+impl std::convert::From<i32> for SqlBackupRunStatus {
+    fn from(value: i32) -> Self {
+        Self::new(value)
+    }
 }
 
 impl std::default::Default for SqlBackupRunStatus {
     fn default() -> Self {
-        sql_backup_run_status::SQL_BACKUP_RUN_STATUS_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Defines the supported backup kinds.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlBackupKind(std::borrow::Cow<'static, str>);
+pub struct SqlBackupKind(i32);
 
 impl SqlBackupKind {
+
+    /// This is an unknown BackupKind.
+    pub const SQL_BACKUP_KIND_UNSPECIFIED: SqlBackupKind = SqlBackupKind::new(0);
+
+    /// The snapshot based backups
+    pub const SNAPSHOT: SqlBackupKind = SqlBackupKind::new(1);
+
+    /// Physical backups
+    pub const PHYSICAL: SqlBackupKind = SqlBackupKind::new(2);
+
     /// Creates a new SqlBackupKind instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+    
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SQL_BACKUP_KIND_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SNAPSHOT"),
+            2 => std::borrow::Cow::Borrowed("PHYSICAL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SQL_BACKUP_KIND_UNSPECIFIED" => std::option::Option::Some(Self::SQL_BACKUP_KIND_UNSPECIFIED),
+            "SNAPSHOT" => std::option::Option::Some(Self::SNAPSHOT),
+            "PHYSICAL" => std::option::Option::Some(Self::PHYSICAL),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [SqlBackupKind](SqlBackupKind)
-pub mod sql_backup_kind {
-    use super::SqlBackupKind;
-    
-
-    /// This is an unknown BackupKind.
-    pub const SQL_BACKUP_KIND_UNSPECIFIED: SqlBackupKind = SqlBackupKind::new("SQL_BACKUP_KIND_UNSPECIFIED");
-
-    /// The snapshot based backups
-    pub const SNAPSHOT: SqlBackupKind = SqlBackupKind::new("SNAPSHOT");
-
-    /// Physical backups
-    pub const PHYSICAL: SqlBackupKind = SqlBackupKind::new("PHYSICAL");
-}
-
-impl std::convert::From<std::string::String> for SqlBackupKind {
-  fn from(value: std::string::String) -> Self {
-    Self(std::borrow::Cow::Owned(value))
-  }
+impl std::convert::From<i32> for SqlBackupKind {
+    fn from(value: i32) -> Self {
+        Self::new(value)
+    }
 }
 
 impl std::default::Default for SqlBackupKind {
     fn default() -> Self {
-        sql_backup_kind::SQL_BACKUP_KIND_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Type of backup (i.e. automated, on demand, etc).
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlBackupRunType(std::borrow::Cow<'static, str>);
+pub struct SqlBackupRunType(i32);
 
 impl SqlBackupRunType {
+
+    /// This is an unknown BackupRun type.
+    pub const SQL_BACKUP_RUN_TYPE_UNSPECIFIED: SqlBackupRunType = SqlBackupRunType::new(0);
+
+    /// The backup schedule automatically triggers a backup.
+    pub const AUTOMATED: SqlBackupRunType = SqlBackupRunType::new(1);
+
+    /// The user manually triggers a backup.
+    pub const ON_DEMAND: SqlBackupRunType = SqlBackupRunType::new(2);
+
     /// Creates a new SqlBackupRunType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+    
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SQL_BACKUP_RUN_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("AUTOMATED"),
+            2 => std::borrow::Cow::Borrowed("ON_DEMAND"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SQL_BACKUP_RUN_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_BACKUP_RUN_TYPE_UNSPECIFIED),
+            "AUTOMATED" => std::option::Option::Some(Self::AUTOMATED),
+            "ON_DEMAND" => std::option::Option::Some(Self::ON_DEMAND),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [SqlBackupRunType](SqlBackupRunType)
-pub mod sql_backup_run_type {
-    use super::SqlBackupRunType;
-    
-
-    /// This is an unknown BackupRun type.
-    pub const SQL_BACKUP_RUN_TYPE_UNSPECIFIED: SqlBackupRunType = SqlBackupRunType::new("SQL_BACKUP_RUN_TYPE_UNSPECIFIED");
-
-    /// The backup schedule automatically triggers a backup.
-    pub const AUTOMATED: SqlBackupRunType = SqlBackupRunType::new("AUTOMATED");
-
-    /// The user manually triggers a backup.
-    pub const ON_DEMAND: SqlBackupRunType = SqlBackupRunType::new("ON_DEMAND");
-}
-
-impl std::convert::From<std::string::String> for SqlBackupRunType {
-  fn from(value: std::string::String) -> Self {
-    Self(std::borrow::Cow::Owned(value))
-  }
+impl std::convert::From<i32> for SqlBackupRunType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
+    }
 }
 
 impl std::default::Default for SqlBackupRunType {
     fn default() -> Self {
-        sql_backup_run_type::SQL_BACKUP_RUN_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlFlagType(std::borrow::Cow<'static, str>);
+pub struct SqlFlagType(i32);
 
 impl SqlFlagType {
-    /// Creates a new SqlFlagType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [SqlFlagType](SqlFlagType)
-pub mod sql_flag_type {
-    use super::SqlFlagType;
-    
 
     /// This is an unknown flag type.
-    pub const SQL_FLAG_TYPE_UNSPECIFIED: SqlFlagType = SqlFlagType::new("SQL_FLAG_TYPE_UNSPECIFIED");
+    pub const SQL_FLAG_TYPE_UNSPECIFIED: SqlFlagType = SqlFlagType::new(0);
 
     /// Boolean type flag.
-    pub const BOOLEAN: SqlFlagType = SqlFlagType::new("BOOLEAN");
+    pub const BOOLEAN: SqlFlagType = SqlFlagType::new(1);
 
     /// String type flag.
-    pub const STRING: SqlFlagType = SqlFlagType::new("STRING");
+    pub const STRING: SqlFlagType = SqlFlagType::new(2);
 
     /// Integer type flag.
-    pub const INTEGER: SqlFlagType = SqlFlagType::new("INTEGER");
+    pub const INTEGER: SqlFlagType = SqlFlagType::new(3);
 
     /// Flag type used for a server startup option.
-    pub const NONE: SqlFlagType = SqlFlagType::new("NONE");
+    pub const NONE: SqlFlagType = SqlFlagType::new(4);
 
     /// Type introduced specially for MySQL TimeZone offset. Accept a string value
     /// with the format [-12:59, 13:00].
-    pub const MYSQL_TIMEZONE_OFFSET: SqlFlagType = SqlFlagType::new("MYSQL_TIMEZONE_OFFSET");
+    pub const MYSQL_TIMEZONE_OFFSET: SqlFlagType = SqlFlagType::new(5);
 
     /// Float type flag.
-    pub const FLOAT: SqlFlagType = SqlFlagType::new("FLOAT");
+    pub const FLOAT: SqlFlagType = SqlFlagType::new(6);
 
     /// Comma-separated list of the strings in a SqlFlagType enum.
-    pub const REPEATED_STRING: SqlFlagType = SqlFlagType::new("REPEATED_STRING");
+    pub const REPEATED_STRING: SqlFlagType = SqlFlagType::new(7);
+
+    /// Creates a new SqlFlagType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+    
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SQL_FLAG_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("BOOLEAN"),
+            2 => std::borrow::Cow::Borrowed("STRING"),
+            3 => std::borrow::Cow::Borrowed("INTEGER"),
+            4 => std::borrow::Cow::Borrowed("NONE"),
+            5 => std::borrow::Cow::Borrowed("MYSQL_TIMEZONE_OFFSET"),
+            6 => std::borrow::Cow::Borrowed("FLOAT"),
+            7 => std::borrow::Cow::Borrowed("REPEATED_STRING"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SQL_FLAG_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_FLAG_TYPE_UNSPECIFIED),
+            "BOOLEAN" => std::option::Option::Some(Self::BOOLEAN),
+            "STRING" => std::option::Option::Some(Self::STRING),
+            "INTEGER" => std::option::Option::Some(Self::INTEGER),
+            "NONE" => std::option::Option::Some(Self::NONE),
+            "MYSQL_TIMEZONE_OFFSET" => std::option::Option::Some(Self::MYSQL_TIMEZONE_OFFSET),
+            "FLOAT" => std::option::Option::Some(Self::FLOAT),
+            "REPEATED_STRING" => std::option::Option::Some(Self::REPEATED_STRING),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for SqlFlagType {
-  fn from(value: std::string::String) -> Self {
-    Self(std::borrow::Cow::Owned(value))
-  }
+impl std::convert::From<i32> for SqlFlagType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
+    }
 }
 
 impl std::default::Default for SqlFlagType {
     fn default() -> Self {
-        sql_flag_type::SQL_FLAG_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// External Sync parallel level.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ExternalSyncParallelLevel(std::borrow::Cow<'static, str>);
+pub struct ExternalSyncParallelLevel(i32);
 
 impl ExternalSyncParallelLevel {
+
+    /// Unknown sync parallel level. Will be defaulted to OPTIMAL.
+    pub const EXTERNAL_SYNC_PARALLEL_LEVEL_UNSPECIFIED: ExternalSyncParallelLevel = ExternalSyncParallelLevel::new(0);
+
+    /// Minimal parallel level.
+    pub const MIN: ExternalSyncParallelLevel = ExternalSyncParallelLevel::new(1);
+
+    /// Optimal parallel level.
+    pub const OPTIMAL: ExternalSyncParallelLevel = ExternalSyncParallelLevel::new(2);
+
+    /// Maximum parallel level.
+    pub const MAX: ExternalSyncParallelLevel = ExternalSyncParallelLevel::new(3);
+
     /// Creates a new ExternalSyncParallelLevel instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+    
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("EXTERNAL_SYNC_PARALLEL_LEVEL_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("MIN"),
+            2 => std::borrow::Cow::Borrowed("OPTIMAL"),
+            3 => std::borrow::Cow::Borrowed("MAX"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "EXTERNAL_SYNC_PARALLEL_LEVEL_UNSPECIFIED" => std::option::Option::Some(Self::EXTERNAL_SYNC_PARALLEL_LEVEL_UNSPECIFIED),
+            "MIN" => std::option::Option::Some(Self::MIN),
+            "OPTIMAL" => std::option::Option::Some(Self::OPTIMAL),
+            "MAX" => std::option::Option::Some(Self::MAX),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [ExternalSyncParallelLevel](ExternalSyncParallelLevel)
-pub mod external_sync_parallel_level {
-    use super::ExternalSyncParallelLevel;
-    
-
-    /// Unknown sync parallel level. Will be defaulted to OPTIMAL.
-    pub const EXTERNAL_SYNC_PARALLEL_LEVEL_UNSPECIFIED: ExternalSyncParallelLevel = ExternalSyncParallelLevel::new("EXTERNAL_SYNC_PARALLEL_LEVEL_UNSPECIFIED");
-
-    /// Minimal parallel level.
-    pub const MIN: ExternalSyncParallelLevel = ExternalSyncParallelLevel::new("MIN");
-
-    /// Optimal parallel level.
-    pub const OPTIMAL: ExternalSyncParallelLevel = ExternalSyncParallelLevel::new("OPTIMAL");
-
-    /// Maximum parallel level.
-    pub const MAX: ExternalSyncParallelLevel = ExternalSyncParallelLevel::new("MAX");
-}
-
-impl std::convert::From<std::string::String> for ExternalSyncParallelLevel {
-  fn from(value: std::string::String) -> Self {
-    Self(std::borrow::Cow::Owned(value))
-  }
+impl std::convert::From<i32> for ExternalSyncParallelLevel {
+    fn from(value: i32) -> Self {
+        Self::new(value)
+    }
 }
 
 impl std::default::Default for ExternalSyncParallelLevel {
     fn default() -> Self {
-        external_sync_parallel_level::EXTERNAL_SYNC_PARALLEL_LEVEL_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlInstanceType(std::borrow::Cow<'static, str>);
+pub struct SqlInstanceType(i32);
 
 impl SqlInstanceType {
-    /// Creates a new SqlInstanceType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [SqlInstanceType](SqlInstanceType)
-pub mod sql_instance_type {
-    use super::SqlInstanceType;
-    
 
     /// This is an unknown Cloud SQL instance type.
-    pub const SQL_INSTANCE_TYPE_UNSPECIFIED: SqlInstanceType = SqlInstanceType::new("SQL_INSTANCE_TYPE_UNSPECIFIED");
+    pub const SQL_INSTANCE_TYPE_UNSPECIFIED: SqlInstanceType = SqlInstanceType::new(0);
 
     /// A regular Cloud SQL instance that is not replicating from a primary
     /// instance.
-    pub const CLOUD_SQL_INSTANCE: SqlInstanceType = SqlInstanceType::new("CLOUD_SQL_INSTANCE");
+    pub const CLOUD_SQL_INSTANCE: SqlInstanceType = SqlInstanceType::new(1);
 
     /// An instance running on the customer's premises that is not managed by
     /// Cloud SQL.
-    pub const ON_PREMISES_INSTANCE: SqlInstanceType = SqlInstanceType::new("ON_PREMISES_INSTANCE");
+    pub const ON_PREMISES_INSTANCE: SqlInstanceType = SqlInstanceType::new(2);
 
     /// A Cloud SQL instance acting as a read-replica.
-    pub const READ_REPLICA_INSTANCE: SqlInstanceType = SqlInstanceType::new("READ_REPLICA_INSTANCE");
+    pub const READ_REPLICA_INSTANCE: SqlInstanceType = SqlInstanceType::new(3);
+
+    /// Creates a new SqlInstanceType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+    
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SQL_INSTANCE_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("CLOUD_SQL_INSTANCE"),
+            2 => std::borrow::Cow::Borrowed("ON_PREMISES_INSTANCE"),
+            3 => std::borrow::Cow::Borrowed("READ_REPLICA_INSTANCE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SQL_INSTANCE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_INSTANCE_TYPE_UNSPECIFIED),
+            "CLOUD_SQL_INSTANCE" => std::option::Option::Some(Self::CLOUD_SQL_INSTANCE),
+            "ON_PREMISES_INSTANCE" => std::option::Option::Some(Self::ON_PREMISES_INSTANCE),
+            "READ_REPLICA_INSTANCE" => std::option::Option::Some(Self::READ_REPLICA_INSTANCE),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for SqlInstanceType {
-  fn from(value: std::string::String) -> Self {
-    Self(std::borrow::Cow::Owned(value))
-  }
+impl std::convert::From<i32> for SqlInstanceType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
+    }
 }
 
 impl std::default::Default for SqlInstanceType {
     fn default() -> Self {
-        sql_instance_type::SQL_INSTANCE_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The suspension reason of the database instance if the state is SUSPENDED.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlSuspensionReason(std::borrow::Cow<'static, str>);
+pub struct SqlSuspensionReason(i32);
 
 impl SqlSuspensionReason {
-    /// Creates a new SqlSuspensionReason instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [SqlSuspensionReason](SqlSuspensionReason)
-pub mod sql_suspension_reason {
-    use super::SqlSuspensionReason;
-    
 
     /// This is an unknown suspension reason.
-    pub const SQL_SUSPENSION_REASON_UNSPECIFIED: SqlSuspensionReason = SqlSuspensionReason::new("SQL_SUSPENSION_REASON_UNSPECIFIED");
+    pub const SQL_SUSPENSION_REASON_UNSPECIFIED: SqlSuspensionReason = SqlSuspensionReason::new(0);
 
     /// The instance is suspended due to billing issues (for example:, GCP account
     /// issue)
-    pub const BILLING_ISSUE: SqlSuspensionReason = SqlSuspensionReason::new("BILLING_ISSUE");
+    pub const BILLING_ISSUE: SqlSuspensionReason = SqlSuspensionReason::new(2);
 
     /// The instance is suspended due to illegal content (for example:, child
     /// pornography, copyrighted material, etc.).
-    pub const LEGAL_ISSUE: SqlSuspensionReason = SqlSuspensionReason::new("LEGAL_ISSUE");
+    pub const LEGAL_ISSUE: SqlSuspensionReason = SqlSuspensionReason::new(3);
 
     /// The instance is causing operational issues (for example:, causing the
     /// database to crash).
-    pub const OPERATIONAL_ISSUE: SqlSuspensionReason = SqlSuspensionReason::new("OPERATIONAL_ISSUE");
+    pub const OPERATIONAL_ISSUE: SqlSuspensionReason = SqlSuspensionReason::new(4);
 
     /// The KMS key used by the instance is either revoked or denied access to
-    pub const KMS_KEY_ISSUE: SqlSuspensionReason = SqlSuspensionReason::new("KMS_KEY_ISSUE");
+    pub const KMS_KEY_ISSUE: SqlSuspensionReason = SqlSuspensionReason::new(5);
+
+    /// Creates a new SqlSuspensionReason instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+    
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SQL_SUSPENSION_REASON_UNSPECIFIED"),
+            2 => std::borrow::Cow::Borrowed("BILLING_ISSUE"),
+            3 => std::borrow::Cow::Borrowed("LEGAL_ISSUE"),
+            4 => std::borrow::Cow::Borrowed("OPERATIONAL_ISSUE"),
+            5 => std::borrow::Cow::Borrowed("KMS_KEY_ISSUE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SQL_SUSPENSION_REASON_UNSPECIFIED" => std::option::Option::Some(Self::SQL_SUSPENSION_REASON_UNSPECIFIED),
+            "BILLING_ISSUE" => std::option::Option::Some(Self::BILLING_ISSUE),
+            "LEGAL_ISSUE" => std::option::Option::Some(Self::LEGAL_ISSUE),
+            "OPERATIONAL_ISSUE" => std::option::Option::Some(Self::OPERATIONAL_ISSUE),
+            "KMS_KEY_ISSUE" => std::option::Option::Some(Self::KMS_KEY_ISSUE),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for SqlSuspensionReason {
-  fn from(value: std::string::String) -> Self {
-    Self(std::borrow::Cow::Owned(value))
-  }
+impl std::convert::From<i32> for SqlSuspensionReason {
+    fn from(value: i32) -> Self {
+        Self::new(value)
+    }
 }
 
 impl std::default::Default for SqlSuspensionReason {
     fn default() -> Self {
-        sql_suspension_reason::SQL_SUSPENSION_REASON_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlFileType(std::borrow::Cow<'static, str>);
+pub struct SqlFileType(i32);
 
 impl SqlFileType {
+
+    /// Unknown file type.
+    pub const SQL_FILE_TYPE_UNSPECIFIED: SqlFileType = SqlFileType::new(0);
+
+    /// File containing SQL statements.
+    pub const SQL: SqlFileType = SqlFileType::new(1);
+
+    /// File in CSV format.
+    pub const CSV: SqlFileType = SqlFileType::new(2);
+
+    pub const BAK: SqlFileType = SqlFileType::new(4);
+
     /// Creates a new SqlFileType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+    
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SQL_FILE_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SQL"),
+            2 => std::borrow::Cow::Borrowed("CSV"),
+            4 => std::borrow::Cow::Borrowed("BAK"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SQL_FILE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_FILE_TYPE_UNSPECIFIED),
+            "SQL" => std::option::Option::Some(Self::SQL),
+            "CSV" => std::option::Option::Some(Self::CSV),
+            "BAK" => std::option::Option::Some(Self::BAK),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [SqlFileType](SqlFileType)
-pub mod sql_file_type {
-    use super::SqlFileType;
-    
-
-    /// Unknown file type.
-    pub const SQL_FILE_TYPE_UNSPECIFIED: SqlFileType = SqlFileType::new("SQL_FILE_TYPE_UNSPECIFIED");
-
-    /// File containing SQL statements.
-    pub const SQL: SqlFileType = SqlFileType::new("SQL");
-
-    /// File in CSV format.
-    pub const CSV: SqlFileType = SqlFileType::new("CSV");
-
-    pub const BAK: SqlFileType = SqlFileType::new("BAK");
-}
-
-impl std::convert::From<std::string::String> for SqlFileType {
-  fn from(value: std::string::String) -> Self {
-    Self(std::borrow::Cow::Owned(value))
-  }
+impl std::convert::From<i32> for SqlFileType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
+    }
 }
 
 impl std::default::Default for SqlFileType {
     fn default() -> Self {
-        sql_file_type::SQL_FILE_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct BakType(std::borrow::Cow<'static, str>);
+pub struct BakType(i32);
 
 impl BakType {
+
+    /// Default type.
+    pub const BAK_TYPE_UNSPECIFIED: BakType = BakType::new(0);
+
+    /// Full backup.
+    pub const FULL: BakType = BakType::new(1);
+
+    /// Differential backup.
+    pub const DIFF: BakType = BakType::new(2);
+
+    /// Transaction Log backup
+    pub const TLOG: BakType = BakType::new(3);
+
     /// Creates a new BakType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+    
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("BAK_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("FULL"),
+            2 => std::borrow::Cow::Borrowed("DIFF"),
+            3 => std::borrow::Cow::Borrowed("TLOG"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "BAK_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::BAK_TYPE_UNSPECIFIED),
+            "FULL" => std::option::Option::Some(Self::FULL),
+            "DIFF" => std::option::Option::Some(Self::DIFF),
+            "TLOG" => std::option::Option::Some(Self::TLOG),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [BakType](BakType)
-pub mod bak_type {
-    use super::BakType;
-    
-
-    /// Default type.
-    pub const BAK_TYPE_UNSPECIFIED: BakType = BakType::new("BAK_TYPE_UNSPECIFIED");
-
-    /// Full backup.
-    pub const FULL: BakType = BakType::new("FULL");
-
-    /// Differential backup.
-    pub const DIFF: BakType = BakType::new("DIFF");
-
-    /// Transaction Log backup
-    pub const TLOG: BakType = BakType::new("TLOG");
-}
-
-impl std::convert::From<std::string::String> for BakType {
-  fn from(value: std::string::String) -> Self {
-    Self(std::borrow::Cow::Owned(value))
-  }
+impl std::convert::From<i32> for BakType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
+    }
 }
 
 impl std::default::Default for BakType {
     fn default() -> Self {
-        bak_type::BAK_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlBackendType(std::borrow::Cow<'static, str>);
+pub struct SqlBackendType(i32);
 
 impl SqlBackendType {
+
+    /// This is an unknown backend type for instance.
+    pub const SQL_BACKEND_TYPE_UNSPECIFIED: SqlBackendType = SqlBackendType::new(0);
+
+    /// V1 speckle instance.
+    pub const FIRST_GEN: SqlBackendType = SqlBackendType::new(1);
+
+    /// V2 speckle instance.
+    pub const SECOND_GEN: SqlBackendType = SqlBackendType::new(2);
+
+    /// On premises instance.
+    pub const EXTERNAL: SqlBackendType = SqlBackendType::new(3);
+
     /// Creates a new SqlBackendType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+    
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SQL_BACKEND_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("FIRST_GEN"),
+            2 => std::borrow::Cow::Borrowed("SECOND_GEN"),
+            3 => std::borrow::Cow::Borrowed("EXTERNAL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SQL_BACKEND_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_BACKEND_TYPE_UNSPECIFIED),
+            "FIRST_GEN" => std::option::Option::Some(Self::FIRST_GEN),
+            "SECOND_GEN" => std::option::Option::Some(Self::SECOND_GEN),
+            "EXTERNAL" => std::option::Option::Some(Self::EXTERNAL),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [SqlBackendType](SqlBackendType)
-pub mod sql_backend_type {
-    use super::SqlBackendType;
-    
-
-    /// This is an unknown backend type for instance.
-    pub const SQL_BACKEND_TYPE_UNSPECIFIED: SqlBackendType = SqlBackendType::new("SQL_BACKEND_TYPE_UNSPECIFIED");
-
-    /// V1 speckle instance.
-    pub const FIRST_GEN: SqlBackendType = SqlBackendType::new("FIRST_GEN");
-
-    /// V2 speckle instance.
-    pub const SECOND_GEN: SqlBackendType = SqlBackendType::new("SECOND_GEN");
-
-    /// On premises instance.
-    pub const EXTERNAL: SqlBackendType = SqlBackendType::new("EXTERNAL");
-}
-
-impl std::convert::From<std::string::String> for SqlBackendType {
-  fn from(value: std::string::String) -> Self {
-    Self(std::borrow::Cow::Owned(value))
-  }
+impl std::convert::From<i32> for SqlBackendType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
+    }
 }
 
 impl std::default::Default for SqlBackendType {
     fn default() -> Self {
-        sql_backend_type::SQL_BACKEND_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlIpAddressType(std::borrow::Cow<'static, str>);
+pub struct SqlIpAddressType(i32);
 
 impl SqlIpAddressType {
-    /// Creates a new SqlIpAddressType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [SqlIpAddressType](SqlIpAddressType)
-pub mod sql_ip_address_type {
-    use super::SqlIpAddressType;
-    
 
     /// This is an unknown IP address type.
-    pub const SQL_IP_ADDRESS_TYPE_UNSPECIFIED: SqlIpAddressType = SqlIpAddressType::new("SQL_IP_ADDRESS_TYPE_UNSPECIFIED");
+    pub const SQL_IP_ADDRESS_TYPE_UNSPECIFIED: SqlIpAddressType = SqlIpAddressType::new(0);
 
     /// IP address the customer is supposed to connect to. Usually this is the
     /// load balancer's IP address
-    pub const PRIMARY: SqlIpAddressType = SqlIpAddressType::new("PRIMARY");
+    pub const PRIMARY: SqlIpAddressType = SqlIpAddressType::new(1);
 
     /// Source IP address of the connection a read replica establishes to its
     /// external primary instance. This IP address can be allowlisted by the
     /// customer in case it has a firewall that filters incoming connection to its
     /// on premises primary instance.
-    pub const OUTGOING: SqlIpAddressType = SqlIpAddressType::new("OUTGOING");
+    pub const OUTGOING: SqlIpAddressType = SqlIpAddressType::new(2);
 
     /// Private IP used when using private IPs and network peering.
-    pub const PRIVATE: SqlIpAddressType = SqlIpAddressType::new("PRIVATE");
+    pub const PRIVATE: SqlIpAddressType = SqlIpAddressType::new(3);
 
     /// V1 IP of a migrated instance. We want the user to
     /// decommission this IP as soon as the migration is complete.
     /// Note: V1 instances with V1 ip addresses will be counted as PRIMARY.
-    pub const MIGRATED_1ST_GEN: SqlIpAddressType = SqlIpAddressType::new("MIGRATED_1ST_GEN");
+    pub const MIGRATED_1ST_GEN: SqlIpAddressType = SqlIpAddressType::new(4);
+
+    /// Creates a new SqlIpAddressType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+    
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SQL_IP_ADDRESS_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PRIMARY"),
+            2 => std::borrow::Cow::Borrowed("OUTGOING"),
+            3 => std::borrow::Cow::Borrowed("PRIVATE"),
+            4 => std::borrow::Cow::Borrowed("MIGRATED_1ST_GEN"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SQL_IP_ADDRESS_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_IP_ADDRESS_TYPE_UNSPECIFIED),
+            "PRIMARY" => std::option::Option::Some(Self::PRIMARY),
+            "OUTGOING" => std::option::Option::Some(Self::OUTGOING),
+            "PRIVATE" => std::option::Option::Some(Self::PRIVATE),
+            "MIGRATED_1ST_GEN" => std::option::Option::Some(Self::MIGRATED_1ST_GEN),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for SqlIpAddressType {
-  fn from(value: std::string::String) -> Self {
-    Self(std::borrow::Cow::Owned(value))
-  }
+impl std::convert::From<i32> for SqlIpAddressType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
+    }
 }
 
 impl std::default::Default for SqlIpAddressType {
     fn default() -> Self {
-        sql_ip_address_type::SQL_IP_ADDRESS_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The database engine type and version.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlDatabaseVersion(std::borrow::Cow<'static, str>);
+pub struct SqlDatabaseVersion(i32);
 
 impl SqlDatabaseVersion {
+
+    /// This is an unknown database version.
+    pub const SQL_DATABASE_VERSION_UNSPECIFIED: SqlDatabaseVersion = SqlDatabaseVersion::new(0);
+
+    /// The database version is MySQL 5.1.
+    pub const MYSQL_5_1: SqlDatabaseVersion = SqlDatabaseVersion::new(2);
+
+    /// The database version is MySQL 5.5.
+    pub const MYSQL_5_5: SqlDatabaseVersion = SqlDatabaseVersion::new(3);
+
+    /// The database version is MySQL 5.6.
+    pub const MYSQL_5_6: SqlDatabaseVersion = SqlDatabaseVersion::new(5);
+
+    /// The database version is MySQL 5.7.
+    pub const MYSQL_5_7: SqlDatabaseVersion = SqlDatabaseVersion::new(6);
+
+    /// The database version is SQL Server 2017 Standard.
+    pub const SQLSERVER_2017_STANDARD: SqlDatabaseVersion = SqlDatabaseVersion::new(11);
+
+    /// The database version is SQL Server 2017 Enterprise.
+    pub const SQLSERVER_2017_ENTERPRISE: SqlDatabaseVersion = SqlDatabaseVersion::new(14);
+
+    /// The database version is SQL Server 2017 Express.
+    pub const SQLSERVER_2017_EXPRESS: SqlDatabaseVersion = SqlDatabaseVersion::new(15);
+
+    /// The database version is SQL Server 2017 Web.
+    pub const SQLSERVER_2017_WEB: SqlDatabaseVersion = SqlDatabaseVersion::new(16);
+
+    /// The database version is PostgreSQL 9.6.
+    pub const POSTGRES_9_6: SqlDatabaseVersion = SqlDatabaseVersion::new(9);
+
+    /// The database version is PostgreSQL 10.
+    pub const POSTGRES_10: SqlDatabaseVersion = SqlDatabaseVersion::new(18);
+
+    /// The database version is PostgreSQL 11.
+    pub const POSTGRES_11: SqlDatabaseVersion = SqlDatabaseVersion::new(10);
+
+    /// The database version is PostgreSQL 12.
+    pub const POSTGRES_12: SqlDatabaseVersion = SqlDatabaseVersion::new(19);
+
+    /// The database version is PostgreSQL 13.
+    pub const POSTGRES_13: SqlDatabaseVersion = SqlDatabaseVersion::new(23);
+
+    /// The database version is PostgreSQL 14.
+    pub const POSTGRES_14: SqlDatabaseVersion = SqlDatabaseVersion::new(110);
+
+    /// The database version is PostgreSQL 15.
+    pub const POSTGRES_15: SqlDatabaseVersion = SqlDatabaseVersion::new(172);
+
+    /// The database version is PostgreSQL 16.
+    pub const POSTGRES_16: SqlDatabaseVersion = SqlDatabaseVersion::new(272);
+
+    /// The database version is MySQL 8.
+    pub const MYSQL_8_0: SqlDatabaseVersion = SqlDatabaseVersion::new(20);
+
+    /// The database major version is MySQL 8.0 and the minor version is 18.
+    pub const MYSQL_8_0_18: SqlDatabaseVersion = SqlDatabaseVersion::new(41);
+
+    /// The database major version is MySQL 8.0 and the minor version is 26.
+    pub const MYSQL_8_0_26: SqlDatabaseVersion = SqlDatabaseVersion::new(85);
+
+    /// The database major version is MySQL 8.0 and the minor version is 27.
+    pub const MYSQL_8_0_27: SqlDatabaseVersion = SqlDatabaseVersion::new(111);
+
+    /// The database major version is MySQL 8.0 and the minor version is 28.
+    pub const MYSQL_8_0_28: SqlDatabaseVersion = SqlDatabaseVersion::new(132);
+
+    /// The database major version is MySQL 8.0 and the minor version is 29.
+    pub const MYSQL_8_0_29: SqlDatabaseVersion = SqlDatabaseVersion::new(148);
+
+    /// The database major version is MySQL 8.0 and the minor version is 30.
+    pub const MYSQL_8_0_30: SqlDatabaseVersion = SqlDatabaseVersion::new(174);
+
+    /// The database major version is MySQL 8.0 and the minor version is 31.
+    pub const MYSQL_8_0_31: SqlDatabaseVersion = SqlDatabaseVersion::new(197);
+
+    /// The database major version is MySQL 8.0 and the minor version is 32.
+    pub const MYSQL_8_0_32: SqlDatabaseVersion = SqlDatabaseVersion::new(213);
+
+    /// The database major version is MySQL 8.0 and the minor version is 33.
+    pub const MYSQL_8_0_33: SqlDatabaseVersion = SqlDatabaseVersion::new(238);
+
+    /// The database major version is MySQL 8.0 and the minor version is 34.
+    pub const MYSQL_8_0_34: SqlDatabaseVersion = SqlDatabaseVersion::new(239);
+
+    /// The database major version is MySQL 8.0 and the minor version is 35.
+    pub const MYSQL_8_0_35: SqlDatabaseVersion = SqlDatabaseVersion::new(240);
+
+    /// The database major version is MySQL 8.0 and the minor version is 36.
+    pub const MYSQL_8_0_36: SqlDatabaseVersion = SqlDatabaseVersion::new(241);
+
+    /// The database major version is MySQL 8.0 and the minor version is 37.
+    pub const MYSQL_8_0_37: SqlDatabaseVersion = SqlDatabaseVersion::new(355);
+
+    /// The database major version is MySQL 8.0 and the minor version is 38.
+    pub const MYSQL_8_0_38: SqlDatabaseVersion = SqlDatabaseVersion::new(356);
+
+    /// The database major version is MySQL 8.0 and the minor version is 39.
+    pub const MYSQL_8_0_39: SqlDatabaseVersion = SqlDatabaseVersion::new(357);
+
+    /// The database major version is MySQL 8.0 and the minor version is 40.
+    pub const MYSQL_8_0_40: SqlDatabaseVersion = SqlDatabaseVersion::new(358);
+
+    /// The database version is MySQL 8.4.
+    pub const MYSQL_8_4: SqlDatabaseVersion = SqlDatabaseVersion::new(398);
+
+    /// The database version is MySQL 8.4 and the patch version is 0.
+    pub const MYSQL_8_4_0: SqlDatabaseVersion = SqlDatabaseVersion::new(399);
+
+    /// The database version is SQL Server 2019 Standard.
+    pub const SQLSERVER_2019_STANDARD: SqlDatabaseVersion = SqlDatabaseVersion::new(26);
+
+    /// The database version is SQL Server 2019 Enterprise.
+    pub const SQLSERVER_2019_ENTERPRISE: SqlDatabaseVersion = SqlDatabaseVersion::new(27);
+
+    /// The database version is SQL Server 2019 Express.
+    pub const SQLSERVER_2019_EXPRESS: SqlDatabaseVersion = SqlDatabaseVersion::new(28);
+
+    /// The database version is SQL Server 2019 Web.
+    pub const SQLSERVER_2019_WEB: SqlDatabaseVersion = SqlDatabaseVersion::new(29);
+
+    /// The database version is SQL Server 2022 Standard.
+    pub const SQLSERVER_2022_STANDARD: SqlDatabaseVersion = SqlDatabaseVersion::new(199);
+
+    /// The database version is SQL Server 2022 Enterprise.
+    pub const SQLSERVER_2022_ENTERPRISE: SqlDatabaseVersion = SqlDatabaseVersion::new(200);
+
+    /// The database version is SQL Server 2022 Express.
+    pub const SQLSERVER_2022_EXPRESS: SqlDatabaseVersion = SqlDatabaseVersion::new(201);
+
+    /// The database version is SQL Server 2022 Web.
+    pub const SQLSERVER_2022_WEB: SqlDatabaseVersion = SqlDatabaseVersion::new(202);
+
     /// Creates a new SqlDatabaseVersion instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+    
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SQL_DATABASE_VERSION_UNSPECIFIED"),
+            2 => std::borrow::Cow::Borrowed("MYSQL_5_1"),
+            3 => std::borrow::Cow::Borrowed("MYSQL_5_5"),
+            5 => std::borrow::Cow::Borrowed("MYSQL_5_6"),
+            6 => std::borrow::Cow::Borrowed("MYSQL_5_7"),
+            9 => std::borrow::Cow::Borrowed("POSTGRES_9_6"),
+            10 => std::borrow::Cow::Borrowed("POSTGRES_11"),
+            11 => std::borrow::Cow::Borrowed("SQLSERVER_2017_STANDARD"),
+            14 => std::borrow::Cow::Borrowed("SQLSERVER_2017_ENTERPRISE"),
+            15 => std::borrow::Cow::Borrowed("SQLSERVER_2017_EXPRESS"),
+            16 => std::borrow::Cow::Borrowed("SQLSERVER_2017_WEB"),
+            18 => std::borrow::Cow::Borrowed("POSTGRES_10"),
+            19 => std::borrow::Cow::Borrowed("POSTGRES_12"),
+            20 => std::borrow::Cow::Borrowed("MYSQL_8_0"),
+            23 => std::borrow::Cow::Borrowed("POSTGRES_13"),
+            26 => std::borrow::Cow::Borrowed("SQLSERVER_2019_STANDARD"),
+            27 => std::borrow::Cow::Borrowed("SQLSERVER_2019_ENTERPRISE"),
+            28 => std::borrow::Cow::Borrowed("SQLSERVER_2019_EXPRESS"),
+            29 => std::borrow::Cow::Borrowed("SQLSERVER_2019_WEB"),
+            41 => std::borrow::Cow::Borrowed("MYSQL_8_0_18"),
+            85 => std::borrow::Cow::Borrowed("MYSQL_8_0_26"),
+            110 => std::borrow::Cow::Borrowed("POSTGRES_14"),
+            111 => std::borrow::Cow::Borrowed("MYSQL_8_0_27"),
+            132 => std::borrow::Cow::Borrowed("MYSQL_8_0_28"),
+            148 => std::borrow::Cow::Borrowed("MYSQL_8_0_29"),
+            172 => std::borrow::Cow::Borrowed("POSTGRES_15"),
+            174 => std::borrow::Cow::Borrowed("MYSQL_8_0_30"),
+            197 => std::borrow::Cow::Borrowed("MYSQL_8_0_31"),
+            199 => std::borrow::Cow::Borrowed("SQLSERVER_2022_STANDARD"),
+            200 => std::borrow::Cow::Borrowed("SQLSERVER_2022_ENTERPRISE"),
+            201 => std::borrow::Cow::Borrowed("SQLSERVER_2022_EXPRESS"),
+            202 => std::borrow::Cow::Borrowed("SQLSERVER_2022_WEB"),
+            213 => std::borrow::Cow::Borrowed("MYSQL_8_0_32"),
+            238 => std::borrow::Cow::Borrowed("MYSQL_8_0_33"),
+            239 => std::borrow::Cow::Borrowed("MYSQL_8_0_34"),
+            240 => std::borrow::Cow::Borrowed("MYSQL_8_0_35"),
+            241 => std::borrow::Cow::Borrowed("MYSQL_8_0_36"),
+            272 => std::borrow::Cow::Borrowed("POSTGRES_16"),
+            355 => std::borrow::Cow::Borrowed("MYSQL_8_0_37"),
+            356 => std::borrow::Cow::Borrowed("MYSQL_8_0_38"),
+            357 => std::borrow::Cow::Borrowed("MYSQL_8_0_39"),
+            358 => std::borrow::Cow::Borrowed("MYSQL_8_0_40"),
+            398 => std::borrow::Cow::Borrowed("MYSQL_8_4"),
+            399 => std::borrow::Cow::Borrowed("MYSQL_8_4_0"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SQL_DATABASE_VERSION_UNSPECIFIED" => std::option::Option::Some(Self::SQL_DATABASE_VERSION_UNSPECIFIED),
+            "MYSQL_5_1" => std::option::Option::Some(Self::MYSQL_5_1),
+            "MYSQL_5_5" => std::option::Option::Some(Self::MYSQL_5_5),
+            "MYSQL_5_6" => std::option::Option::Some(Self::MYSQL_5_6),
+            "MYSQL_5_7" => std::option::Option::Some(Self::MYSQL_5_7),
+            "SQLSERVER_2017_STANDARD" => std::option::Option::Some(Self::SQLSERVER_2017_STANDARD),
+            "SQLSERVER_2017_ENTERPRISE" => std::option::Option::Some(Self::SQLSERVER_2017_ENTERPRISE),
+            "SQLSERVER_2017_EXPRESS" => std::option::Option::Some(Self::SQLSERVER_2017_EXPRESS),
+            "SQLSERVER_2017_WEB" => std::option::Option::Some(Self::SQLSERVER_2017_WEB),
+            "POSTGRES_9_6" => std::option::Option::Some(Self::POSTGRES_9_6),
+            "POSTGRES_10" => std::option::Option::Some(Self::POSTGRES_10),
+            "POSTGRES_11" => std::option::Option::Some(Self::POSTGRES_11),
+            "POSTGRES_12" => std::option::Option::Some(Self::POSTGRES_12),
+            "POSTGRES_13" => std::option::Option::Some(Self::POSTGRES_13),
+            "POSTGRES_14" => std::option::Option::Some(Self::POSTGRES_14),
+            "POSTGRES_15" => std::option::Option::Some(Self::POSTGRES_15),
+            "POSTGRES_16" => std::option::Option::Some(Self::POSTGRES_16),
+            "MYSQL_8_0" => std::option::Option::Some(Self::MYSQL_8_0),
+            "MYSQL_8_0_18" => std::option::Option::Some(Self::MYSQL_8_0_18),
+            "MYSQL_8_0_26" => std::option::Option::Some(Self::MYSQL_8_0_26),
+            "MYSQL_8_0_27" => std::option::Option::Some(Self::MYSQL_8_0_27),
+            "MYSQL_8_0_28" => std::option::Option::Some(Self::MYSQL_8_0_28),
+            "MYSQL_8_0_29" => std::option::Option::Some(Self::MYSQL_8_0_29),
+            "MYSQL_8_0_30" => std::option::Option::Some(Self::MYSQL_8_0_30),
+            "MYSQL_8_0_31" => std::option::Option::Some(Self::MYSQL_8_0_31),
+            "MYSQL_8_0_32" => std::option::Option::Some(Self::MYSQL_8_0_32),
+            "MYSQL_8_0_33" => std::option::Option::Some(Self::MYSQL_8_0_33),
+            "MYSQL_8_0_34" => std::option::Option::Some(Self::MYSQL_8_0_34),
+            "MYSQL_8_0_35" => std::option::Option::Some(Self::MYSQL_8_0_35),
+            "MYSQL_8_0_36" => std::option::Option::Some(Self::MYSQL_8_0_36),
+            "MYSQL_8_0_37" => std::option::Option::Some(Self::MYSQL_8_0_37),
+            "MYSQL_8_0_38" => std::option::Option::Some(Self::MYSQL_8_0_38),
+            "MYSQL_8_0_39" => std::option::Option::Some(Self::MYSQL_8_0_39),
+            "MYSQL_8_0_40" => std::option::Option::Some(Self::MYSQL_8_0_40),
+            "MYSQL_8_4" => std::option::Option::Some(Self::MYSQL_8_4),
+            "MYSQL_8_4_0" => std::option::Option::Some(Self::MYSQL_8_4_0),
+            "SQLSERVER_2019_STANDARD" => std::option::Option::Some(Self::SQLSERVER_2019_STANDARD),
+            "SQLSERVER_2019_ENTERPRISE" => std::option::Option::Some(Self::SQLSERVER_2019_ENTERPRISE),
+            "SQLSERVER_2019_EXPRESS" => std::option::Option::Some(Self::SQLSERVER_2019_EXPRESS),
+            "SQLSERVER_2019_WEB" => std::option::Option::Some(Self::SQLSERVER_2019_WEB),
+            "SQLSERVER_2022_STANDARD" => std::option::Option::Some(Self::SQLSERVER_2022_STANDARD),
+            "SQLSERVER_2022_ENTERPRISE" => std::option::Option::Some(Self::SQLSERVER_2022_ENTERPRISE),
+            "SQLSERVER_2022_EXPRESS" => std::option::Option::Some(Self::SQLSERVER_2022_EXPRESS),
+            "SQLSERVER_2022_WEB" => std::option::Option::Some(Self::SQLSERVER_2022_WEB),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [SqlDatabaseVersion](SqlDatabaseVersion)
-pub mod sql_database_version {
-    use super::SqlDatabaseVersion;
-    
-
-    /// This is an unknown database version.
-    pub const SQL_DATABASE_VERSION_UNSPECIFIED: SqlDatabaseVersion = SqlDatabaseVersion::new("SQL_DATABASE_VERSION_UNSPECIFIED");
-
-    /// The database version is MySQL 5.1.
-    pub const MYSQL_5_1: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_5_1");
-
-    /// The database version is MySQL 5.5.
-    pub const MYSQL_5_5: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_5_5");
-
-    /// The database version is MySQL 5.6.
-    pub const MYSQL_5_6: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_5_6");
-
-    /// The database version is MySQL 5.7.
-    pub const MYSQL_5_7: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_5_7");
-
-    /// The database version is SQL Server 2017 Standard.
-    pub const SQLSERVER_2017_STANDARD: SqlDatabaseVersion = SqlDatabaseVersion::new("SQLSERVER_2017_STANDARD");
-
-    /// The database version is SQL Server 2017 Enterprise.
-    pub const SQLSERVER_2017_ENTERPRISE: SqlDatabaseVersion = SqlDatabaseVersion::new("SQLSERVER_2017_ENTERPRISE");
-
-    /// The database version is SQL Server 2017 Express.
-    pub const SQLSERVER_2017_EXPRESS: SqlDatabaseVersion = SqlDatabaseVersion::new("SQLSERVER_2017_EXPRESS");
-
-    /// The database version is SQL Server 2017 Web.
-    pub const SQLSERVER_2017_WEB: SqlDatabaseVersion = SqlDatabaseVersion::new("SQLSERVER_2017_WEB");
-
-    /// The database version is PostgreSQL 9.6.
-    pub const POSTGRES_9_6: SqlDatabaseVersion = SqlDatabaseVersion::new("POSTGRES_9_6");
-
-    /// The database version is PostgreSQL 10.
-    pub const POSTGRES_10: SqlDatabaseVersion = SqlDatabaseVersion::new("POSTGRES_10");
-
-    /// The database version is PostgreSQL 11.
-    pub const POSTGRES_11: SqlDatabaseVersion = SqlDatabaseVersion::new("POSTGRES_11");
-
-    /// The database version is PostgreSQL 12.
-    pub const POSTGRES_12: SqlDatabaseVersion = SqlDatabaseVersion::new("POSTGRES_12");
-
-    /// The database version is PostgreSQL 13.
-    pub const POSTGRES_13: SqlDatabaseVersion = SqlDatabaseVersion::new("POSTGRES_13");
-
-    /// The database version is PostgreSQL 14.
-    pub const POSTGRES_14: SqlDatabaseVersion = SqlDatabaseVersion::new("POSTGRES_14");
-
-    /// The database version is PostgreSQL 15.
-    pub const POSTGRES_15: SqlDatabaseVersion = SqlDatabaseVersion::new("POSTGRES_15");
-
-    /// The database version is PostgreSQL 16.
-    pub const POSTGRES_16: SqlDatabaseVersion = SqlDatabaseVersion::new("POSTGRES_16");
-
-    /// The database version is MySQL 8.
-    pub const MYSQL_8_0: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_8_0");
-
-    /// The database major version is MySQL 8.0 and the minor version is 18.
-    pub const MYSQL_8_0_18: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_8_0_18");
-
-    /// The database major version is MySQL 8.0 and the minor version is 26.
-    pub const MYSQL_8_0_26: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_8_0_26");
-
-    /// The database major version is MySQL 8.0 and the minor version is 27.
-    pub const MYSQL_8_0_27: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_8_0_27");
-
-    /// The database major version is MySQL 8.0 and the minor version is 28.
-    pub const MYSQL_8_0_28: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_8_0_28");
-
-    /// The database major version is MySQL 8.0 and the minor version is 29.
-    pub const MYSQL_8_0_29: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_8_0_29");
-
-    /// The database major version is MySQL 8.0 and the minor version is 30.
-    pub const MYSQL_8_0_30: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_8_0_30");
-
-    /// The database major version is MySQL 8.0 and the minor version is 31.
-    pub const MYSQL_8_0_31: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_8_0_31");
-
-    /// The database major version is MySQL 8.0 and the minor version is 32.
-    pub const MYSQL_8_0_32: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_8_0_32");
-
-    /// The database major version is MySQL 8.0 and the minor version is 33.
-    pub const MYSQL_8_0_33: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_8_0_33");
-
-    /// The database major version is MySQL 8.0 and the minor version is 34.
-    pub const MYSQL_8_0_34: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_8_0_34");
-
-    /// The database major version is MySQL 8.0 and the minor version is 35.
-    pub const MYSQL_8_0_35: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_8_0_35");
-
-    /// The database major version is MySQL 8.0 and the minor version is 36.
-    pub const MYSQL_8_0_36: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_8_0_36");
-
-    /// The database major version is MySQL 8.0 and the minor version is 37.
-    pub const MYSQL_8_0_37: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_8_0_37");
-
-    /// The database major version is MySQL 8.0 and the minor version is 38.
-    pub const MYSQL_8_0_38: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_8_0_38");
-
-    /// The database major version is MySQL 8.0 and the minor version is 39.
-    pub const MYSQL_8_0_39: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_8_0_39");
-
-    /// The database major version is MySQL 8.0 and the minor version is 40.
-    pub const MYSQL_8_0_40: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_8_0_40");
-
-    /// The database version is MySQL 8.4.
-    pub const MYSQL_8_4: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_8_4");
-
-    /// The database version is MySQL 8.4 and the patch version is 0.
-    pub const MYSQL_8_4_0: SqlDatabaseVersion = SqlDatabaseVersion::new("MYSQL_8_4_0");
-
-    /// The database version is SQL Server 2019 Standard.
-    pub const SQLSERVER_2019_STANDARD: SqlDatabaseVersion = SqlDatabaseVersion::new("SQLSERVER_2019_STANDARD");
-
-    /// The database version is SQL Server 2019 Enterprise.
-    pub const SQLSERVER_2019_ENTERPRISE: SqlDatabaseVersion = SqlDatabaseVersion::new("SQLSERVER_2019_ENTERPRISE");
-
-    /// The database version is SQL Server 2019 Express.
-    pub const SQLSERVER_2019_EXPRESS: SqlDatabaseVersion = SqlDatabaseVersion::new("SQLSERVER_2019_EXPRESS");
-
-    /// The database version is SQL Server 2019 Web.
-    pub const SQLSERVER_2019_WEB: SqlDatabaseVersion = SqlDatabaseVersion::new("SQLSERVER_2019_WEB");
-
-    /// The database version is SQL Server 2022 Standard.
-    pub const SQLSERVER_2022_STANDARD: SqlDatabaseVersion = SqlDatabaseVersion::new("SQLSERVER_2022_STANDARD");
-
-    /// The database version is SQL Server 2022 Enterprise.
-    pub const SQLSERVER_2022_ENTERPRISE: SqlDatabaseVersion = SqlDatabaseVersion::new("SQLSERVER_2022_ENTERPRISE");
-
-    /// The database version is SQL Server 2022 Express.
-    pub const SQLSERVER_2022_EXPRESS: SqlDatabaseVersion = SqlDatabaseVersion::new("SQLSERVER_2022_EXPRESS");
-
-    /// The database version is SQL Server 2022 Web.
-    pub const SQLSERVER_2022_WEB: SqlDatabaseVersion = SqlDatabaseVersion::new("SQLSERVER_2022_WEB");
-}
-
-impl std::convert::From<std::string::String> for SqlDatabaseVersion {
-  fn from(value: std::string::String) -> Self {
-    Self(std::borrow::Cow::Owned(value))
-  }
+impl std::convert::From<i32> for SqlDatabaseVersion {
+    fn from(value: i32) -> Self {
+        Self::new(value)
+    }
 }
 
 impl std::default::Default for SqlDatabaseVersion {
     fn default() -> Self {
-        sql_database_version::SQL_DATABASE_VERSION_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The pricing plan for this instance.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlPricingPlan(std::borrow::Cow<'static, str>);
+pub struct SqlPricingPlan(i32);
 
 impl SqlPricingPlan {
+
+    /// This is an unknown pricing plan for this instance.
+    pub const SQL_PRICING_PLAN_UNSPECIFIED: SqlPricingPlan = SqlPricingPlan::new(0);
+
+    /// The instance is billed at a monthly flat rate.
+    pub const PACKAGE: SqlPricingPlan = SqlPricingPlan::new(1);
+
+    /// The instance is billed per usage.
+    pub const PER_USE: SqlPricingPlan = SqlPricingPlan::new(2);
+
     /// Creates a new SqlPricingPlan instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+    
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SQL_PRICING_PLAN_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PACKAGE"),
+            2 => std::borrow::Cow::Borrowed("PER_USE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SQL_PRICING_PLAN_UNSPECIFIED" => std::option::Option::Some(Self::SQL_PRICING_PLAN_UNSPECIFIED),
+            "PACKAGE" => std::option::Option::Some(Self::PACKAGE),
+            "PER_USE" => std::option::Option::Some(Self::PER_USE),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [SqlPricingPlan](SqlPricingPlan)
-pub mod sql_pricing_plan {
-    use super::SqlPricingPlan;
-    
-
-    /// This is an unknown pricing plan for this instance.
-    pub const SQL_PRICING_PLAN_UNSPECIFIED: SqlPricingPlan = SqlPricingPlan::new("SQL_PRICING_PLAN_UNSPECIFIED");
-
-    /// The instance is billed at a monthly flat rate.
-    pub const PACKAGE: SqlPricingPlan = SqlPricingPlan::new("PACKAGE");
-
-    /// The instance is billed per usage.
-    pub const PER_USE: SqlPricingPlan = SqlPricingPlan::new("PER_USE");
-}
-
-impl std::convert::From<std::string::String> for SqlPricingPlan {
-  fn from(value: std::string::String) -> Self {
-    Self(std::borrow::Cow::Owned(value))
-  }
+impl std::convert::From<i32> for SqlPricingPlan {
+    fn from(value: i32) -> Self {
+        Self::new(value)
+    }
 }
 
 impl std::default::Default for SqlPricingPlan {
     fn default() -> Self {
-        sql_pricing_plan::SQL_PRICING_PLAN_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlReplicationType(std::borrow::Cow<'static, str>);
+pub struct SqlReplicationType(i32);
 
 impl SqlReplicationType {
-    /// Creates a new SqlReplicationType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [SqlReplicationType](SqlReplicationType)
-pub mod sql_replication_type {
-    use super::SqlReplicationType;
-    
 
     /// This is an unknown replication type for a Cloud SQL instance.
-    pub const SQL_REPLICATION_TYPE_UNSPECIFIED: SqlReplicationType = SqlReplicationType::new("SQL_REPLICATION_TYPE_UNSPECIFIED");
+    pub const SQL_REPLICATION_TYPE_UNSPECIFIED: SqlReplicationType = SqlReplicationType::new(0);
 
     /// The synchronous replication mode for First Generation instances. It is the
     /// default value.
-    pub const SYNCHRONOUS: SqlReplicationType = SqlReplicationType::new("SYNCHRONOUS");
+    pub const SYNCHRONOUS: SqlReplicationType = SqlReplicationType::new(1);
 
     /// The asynchronous replication mode for First Generation instances. It
     /// provides a slight performance gain, but if an outage occurs while this
     /// option is set to asynchronous, you can lose up to a few seconds of updates
     /// to your data.
-    pub const ASYNCHRONOUS: SqlReplicationType = SqlReplicationType::new("ASYNCHRONOUS");
+    pub const ASYNCHRONOUS: SqlReplicationType = SqlReplicationType::new(2);
+
+    /// Creates a new SqlReplicationType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+    
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SQL_REPLICATION_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SYNCHRONOUS"),
+            2 => std::borrow::Cow::Borrowed("ASYNCHRONOUS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SQL_REPLICATION_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_REPLICATION_TYPE_UNSPECIFIED),
+            "SYNCHRONOUS" => std::option::Option::Some(Self::SYNCHRONOUS),
+            "ASYNCHRONOUS" => std::option::Option::Some(Self::ASYNCHRONOUS),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for SqlReplicationType {
-  fn from(value: std::string::String) -> Self {
-    Self(std::borrow::Cow::Owned(value))
-  }
+impl std::convert::From<i32> for SqlReplicationType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
+    }
 }
 
 impl std::default::Default for SqlReplicationType {
     fn default() -> Self {
-        sql_replication_type::SQL_REPLICATION_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The type of disk that is used for a v2 instance to use.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlDataDiskType(std::borrow::Cow<'static, str>);
+pub struct SqlDataDiskType(i32);
 
 impl SqlDataDiskType {
-    /// Creates a new SqlDataDiskType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [SqlDataDiskType](SqlDataDiskType)
-pub mod sql_data_disk_type {
-    use super::SqlDataDiskType;
-    
 
     /// This is an unknown data disk type.
-    pub const SQL_DATA_DISK_TYPE_UNSPECIFIED: SqlDataDiskType = SqlDataDiskType::new("SQL_DATA_DISK_TYPE_UNSPECIFIED");
+    pub const SQL_DATA_DISK_TYPE_UNSPECIFIED: SqlDataDiskType = SqlDataDiskType::new(0);
 
     /// An SSD data disk.
-    pub const PD_SSD: SqlDataDiskType = SqlDataDiskType::new("PD_SSD");
+    pub const PD_SSD: SqlDataDiskType = SqlDataDiskType::new(1);
 
     /// An HDD data disk.
-    pub const PD_HDD: SqlDataDiskType = SqlDataDiskType::new("PD_HDD");
+    pub const PD_HDD: SqlDataDiskType = SqlDataDiskType::new(2);
 
     /// This field is deprecated and will be removed from a future version of the
     /// API.
-    pub const OBSOLETE_LOCAL_SSD: SqlDataDiskType = SqlDataDiskType::new("OBSOLETE_LOCAL_SSD");
+    pub const OBSOLETE_LOCAL_SSD: SqlDataDiskType = SqlDataDiskType::new(3);
+
+    /// Creates a new SqlDataDiskType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+    
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SQL_DATA_DISK_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PD_SSD"),
+            2 => std::borrow::Cow::Borrowed("PD_HDD"),
+            3 => std::borrow::Cow::Borrowed("OBSOLETE_LOCAL_SSD"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SQL_DATA_DISK_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_DATA_DISK_TYPE_UNSPECIFIED),
+            "PD_SSD" => std::option::Option::Some(Self::PD_SSD),
+            "PD_HDD" => std::option::Option::Some(Self::PD_HDD),
+            "OBSOLETE_LOCAL_SSD" => std::option::Option::Some(Self::OBSOLETE_LOCAL_SSD),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for SqlDataDiskType {
-  fn from(value: std::string::String) -> Self {
-    Self(std::borrow::Cow::Owned(value))
-  }
+impl std::convert::From<i32> for SqlDataDiskType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
+    }
 }
 
 impl std::default::Default for SqlDataDiskType {
     fn default() -> Self {
-        sql_data_disk_type::SQL_DATA_DISK_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The availability type of the given Cloud SQL instance.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlAvailabilityType(std::borrow::Cow<'static, str>);
+pub struct SqlAvailabilityType(i32);
 
 impl SqlAvailabilityType {
+
+    /// This is an unknown Availability type.
+    pub const SQL_AVAILABILITY_TYPE_UNSPECIFIED: SqlAvailabilityType = SqlAvailabilityType::new(0);
+
+    /// Zonal available instance.
+    pub const ZONAL: SqlAvailabilityType = SqlAvailabilityType::new(1);
+
+    /// Regional available instance.
+    pub const REGIONAL: SqlAvailabilityType = SqlAvailabilityType::new(2);
+
     /// Creates a new SqlAvailabilityType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+    
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SQL_AVAILABILITY_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ZONAL"),
+            2 => std::borrow::Cow::Borrowed("REGIONAL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SQL_AVAILABILITY_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_AVAILABILITY_TYPE_UNSPECIFIED),
+            "ZONAL" => std::option::Option::Some(Self::ZONAL),
+            "REGIONAL" => std::option::Option::Some(Self::REGIONAL),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [SqlAvailabilityType](SqlAvailabilityType)
-pub mod sql_availability_type {
-    use super::SqlAvailabilityType;
-    
-
-    /// This is an unknown Availability type.
-    pub const SQL_AVAILABILITY_TYPE_UNSPECIFIED: SqlAvailabilityType = SqlAvailabilityType::new("SQL_AVAILABILITY_TYPE_UNSPECIFIED");
-
-    /// Zonal available instance.
-    pub const ZONAL: SqlAvailabilityType = SqlAvailabilityType::new("ZONAL");
-
-    /// Regional available instance.
-    pub const REGIONAL: SqlAvailabilityType = SqlAvailabilityType::new("REGIONAL");
-}
-
-impl std::convert::From<std::string::String> for SqlAvailabilityType {
-  fn from(value: std::string::String) -> Self {
-    Self(std::borrow::Cow::Owned(value))
-  }
+impl std::convert::From<i32> for SqlAvailabilityType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
+    }
 }
 
 impl std::default::Default for SqlAvailabilityType {
     fn default() -> Self {
-        sql_availability_type::SQL_AVAILABILITY_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlUpdateTrack(std::borrow::Cow<'static, str>);
+pub struct SqlUpdateTrack(i32);
 
 impl SqlUpdateTrack {
-    /// Creates a new SqlUpdateTrack instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [SqlUpdateTrack](SqlUpdateTrack)
-pub mod sql_update_track {
-    use super::SqlUpdateTrack;
-    
 
     /// This is an unknown maintenance timing preference.
-    pub const SQL_UPDATE_TRACK_UNSPECIFIED: SqlUpdateTrack = SqlUpdateTrack::new("SQL_UPDATE_TRACK_UNSPECIFIED");
+    pub const SQL_UPDATE_TRACK_UNSPECIFIED: SqlUpdateTrack = SqlUpdateTrack::new(0);
 
     /// For an instance with a scheduled maintenance window, this maintenance
     /// timing indicates that the maintenance update is scheduled 7 to 14 days
     /// after the notification is sent out. Also referred to as `Week 1` (Console)
     /// and `preview` (gcloud CLI).
-    pub const CANARY: SqlUpdateTrack = SqlUpdateTrack::new("CANARY");
+    pub const CANARY: SqlUpdateTrack = SqlUpdateTrack::new(1);
 
     /// For an instance with a scheduled maintenance window, this maintenance
     /// timing indicates that the maintenance update is scheduled 15 to 21 days
     /// after the notification is sent out. Also referred to as `Week 2` (Console)
     /// and `production` (gcloud CLI).
-    pub const STABLE: SqlUpdateTrack = SqlUpdateTrack::new("STABLE");
+    pub const STABLE: SqlUpdateTrack = SqlUpdateTrack::new(2);
 
     /// For instance with a scheduled maintenance window, this maintenance
     /// timing indicates that the maintenance update is scheduled 35 to 42 days
     /// after the notification is sent out.
-    pub const WEEK_5: SqlUpdateTrack = SqlUpdateTrack::new("WEEK_5");
+    pub const WEEK_5: SqlUpdateTrack = SqlUpdateTrack::new(3);
+
+    /// Creates a new SqlUpdateTrack instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+    
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SQL_UPDATE_TRACK_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("canary"),
+            2 => std::borrow::Cow::Borrowed("stable"),
+            3 => std::borrow::Cow::Borrowed("week5"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SQL_UPDATE_TRACK_UNSPECIFIED" => std::option::Option::Some(Self::SQL_UPDATE_TRACK_UNSPECIFIED),
+            "canary" => std::option::Option::Some(Self::CANARY),
+            "stable" => std::option::Option::Some(Self::STABLE),
+            "week5" => std::option::Option::Some(Self::WEEK_5),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for SqlUpdateTrack {
-  fn from(value: std::string::String) -> Self {
-    Self(std::borrow::Cow::Owned(value))
-  }
+impl std::convert::From<i32> for SqlUpdateTrack {
+    fn from(value: i32) -> Self {
+        Self::new(value)
+    }
 }
 
 impl std::default::Default for SqlUpdateTrack {
     fn default() -> Self {
-        sql_update_track::SQL_UPDATE_TRACK_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/sql/v1/src/transport.rs
+++ b/src/generated/cloud/sql/v1/src/transport.rs
@@ -56,7 +56,7 @@ impl crate::stubs::SqlBackupRunsService for SqlBackupRunsService {
                         , req.id
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -82,7 +82,7 @@ impl crate::stubs::SqlBackupRunsService for SqlBackupRunsService {
                         , req.id
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -107,7 +107,7 @@ impl crate::stubs::SqlBackupRunsService for SqlBackupRunsService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -132,7 +132,7 @@ impl crate::stubs::SqlBackupRunsService for SqlBackupRunsService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("maxResults", &req.max_results)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
@@ -183,7 +183,7 @@ impl crate::stubs::SqlConnectService for SqlConnectService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.read_time.as_ref().map(|p| serde_json::to_value(p).map_err(Error::serde) ).transpose()?.into_iter().fold(builder, |builder, v| { use gax::query_parameter::QueryParameter; v.add(builder, "readTime") });
         self.inner.execute(
@@ -209,7 +209,7 @@ impl crate::stubs::SqlConnectService for SqlConnectService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -259,7 +259,7 @@ impl crate::stubs::SqlDatabasesService for SqlDatabasesService {
                         , req.database
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -285,7 +285,7 @@ impl crate::stubs::SqlDatabasesService for SqlDatabasesService {
                         , req.database
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -310,7 +310,7 @@ impl crate::stubs::SqlDatabasesService for SqlDatabasesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -335,7 +335,7 @@ impl crate::stubs::SqlDatabasesService for SqlDatabasesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -361,7 +361,7 @@ impl crate::stubs::SqlDatabasesService for SqlDatabasesService {
                         , req.database
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -387,7 +387,7 @@ impl crate::stubs::SqlDatabasesService for SqlDatabasesService {
                         , req.database
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -433,7 +433,7 @@ impl crate::stubs::SqlFlagsService for SqlFlagsService {
                 reqwest::Method::GET,
                 "/v1/flags".to_string()
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("databaseVersion", &req.database_version)]);
         self.inner.execute(
@@ -483,7 +483,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -508,7 +508,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -533,7 +533,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -558,7 +558,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -583,7 +583,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -608,7 +608,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -633,7 +633,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -658,7 +658,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -683,7 +683,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -708,7 +708,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -732,7 +732,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.project
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -756,7 +756,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.project
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("filter", &req.filter)]);
         let builder = builder.query(&[("maxResults", &req.max_results)]);
@@ -784,7 +784,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -809,7 +809,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -834,7 +834,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("failover", &req.failover)]);
         self.inner.execute(
@@ -860,7 +860,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.db_timeout.as_ref().map(|p| serde_json::to_value(p).map_err(Error::serde) ).transpose()?.into_iter().fold(builder, |builder, v| { use gax::query_parameter::QueryParameter; v.add(builder, "dbTimeout") });
         self.inner.execute(
@@ -886,7 +886,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -911,7 +911,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -936,7 +936,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -961,7 +961,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -986,7 +986,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -1011,7 +1011,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -1036,7 +1036,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -1061,7 +1061,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -1086,7 +1086,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -1111,7 +1111,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -1136,7 +1136,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -1161,7 +1161,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -1186,7 +1186,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -1211,7 +1211,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -1236,7 +1236,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -1261,7 +1261,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -1286,7 +1286,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -1311,7 +1311,7 @@ impl crate::stubs::SqlInstancesService for SqlInstancesService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -1360,7 +1360,7 @@ impl crate::stubs::SqlOperationsService for SqlOperationsService {
                         , req.operation
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -1384,7 +1384,7 @@ impl crate::stubs::SqlOperationsService for SqlOperationsService {
                         , req.project
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("instance", &req.instance)]);
         let builder = builder.query(&[("maxResults", &req.max_results)]);
@@ -1412,7 +1412,7 @@ impl crate::stubs::SqlOperationsService for SqlOperationsService {
                         , req.operation
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -1462,7 +1462,7 @@ impl crate::stubs::SqlSslCertsService for SqlSslCertsService {
                         , req.sha1_fingerprint
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -1488,7 +1488,7 @@ impl crate::stubs::SqlSslCertsService for SqlSslCertsService {
                         , req.sha1_fingerprint
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -1513,7 +1513,7 @@ impl crate::stubs::SqlSslCertsService for SqlSslCertsService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -1538,7 +1538,7 @@ impl crate::stubs::SqlSslCertsService for SqlSslCertsService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -1586,7 +1586,7 @@ impl crate::stubs::SqlTiersService for SqlTiersService {
                         , req.project
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -1635,7 +1635,7 @@ impl crate::stubs::SqlUsersService for SqlUsersService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("host", &req.host)]);
         let builder = builder.query(&[("name", &req.name)]);
@@ -1663,7 +1663,7 @@ impl crate::stubs::SqlUsersService for SqlUsersService {
                         , req.name
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("host", &req.host)]);
         self.inner.execute(
@@ -1689,7 +1689,7 @@ impl crate::stubs::SqlUsersService for SqlUsersService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -1714,7 +1714,7 @@ impl crate::stubs::SqlUsersService for SqlUsersService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
@@ -1739,7 +1739,7 @@ impl crate::stubs::SqlUsersService for SqlUsersService {
                         , req.instance
                 )
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("host", &req.host)]);
         let builder = builder.query(&[("name", &req.name)]);

--- a/src/generated/cloud/storageinsights/v1/src/model.rs
+++ b/src/generated/cloud/storageinsights/v1/src/model.rs
@@ -910,43 +910,58 @@ pub mod frequency_options {
 
     /// This ENUM specifies possible frequencies of report generation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Frequency(std::borrow::Cow<'static, str>);
+    pub struct Frequency(i32);
 
     impl Frequency {
+        /// Unspecified.
+        pub const FREQUENCY_UNSPECIFIED: Frequency = Frequency::new(0);
+
+        /// Report will be generated daily.
+        pub const DAILY: Frequency = Frequency::new(1);
+
+        /// Report will be generated weekly.
+        pub const WEEKLY: Frequency = Frequency::new(2);
+
         /// Creates a new Frequency instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FREQUENCY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DAILY"),
+                2 => std::borrow::Cow::Borrowed("WEEKLY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FREQUENCY_UNSPECIFIED" => std::option::Option::Some(Self::FREQUENCY_UNSPECIFIED),
+                "DAILY" => std::option::Option::Some(Self::DAILY),
+                "WEEKLY" => std::option::Option::Some(Self::WEEKLY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Frequency](Frequency)
-    pub mod frequency {
-        use super::Frequency;
-
-        /// Unspecified.
-        pub const FREQUENCY_UNSPECIFIED: Frequency = Frequency::new("FREQUENCY_UNSPECIFIED");
-
-        /// Report will be generated daily.
-        pub const DAILY: Frequency = Frequency::new("DAILY");
-
-        /// Report will be generated weekly.
-        pub const WEEKLY: Frequency = Frequency::new("WEEKLY");
-    }
-
-    impl std::convert::From<std::string::String> for Frequency {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Frequency {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Frequency {
         fn default() -> Self {
-            frequency::FREQUENCY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/storageinsights/v1/src/transport.rs
+++ b/src/generated/cloud/storageinsights/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::StorageInsights for StorageInsights {
                 reqwest::Method::GET,
                 format!("/v1/{}/reportConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::StorageInsights for StorageInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::StorageInsights for StorageInsights {
                 reqwest::Method::POST,
                 format!("/v1/{}/reportConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -126,7 +126,7 @@ impl crate::stubs::StorageInsights for StorageInsights {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -156,7 +156,7 @@ impl crate::stubs::StorageInsights for StorageInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -180,7 +180,7 @@ impl crate::stubs::StorageInsights for StorageInsights {
                 reqwest::Method::GET,
                 format!("/v1/{}/reportDetails", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -203,7 +203,7 @@ impl crate::stubs::StorageInsights for StorageInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -222,7 +222,7 @@ impl crate::stubs::StorageInsights for StorageInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -244,7 +244,7 @@ impl crate::stubs::StorageInsights for StorageInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -263,7 +263,7 @@ impl crate::stubs::StorageInsights for StorageInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -285,7 +285,7 @@ impl crate::stubs::StorageInsights for StorageInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -304,7 +304,7 @@ impl crate::stubs::StorageInsights for StorageInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -323,7 +323,7 @@ impl crate::stubs::StorageInsights for StorageInsights {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/support/v2/src/model.rs
+++ b/src/generated/cloud/support/v2/src/model.rs
@@ -491,106 +491,150 @@ pub mod case {
 
     /// The status of a support case.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Case is in an unknown state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The case has been created but no one is assigned to work on it yet.
+        pub const NEW: State = State::new(1);
+
+        /// The case is currently being handled by Google support.
+        pub const IN_PROGRESS_GOOGLE_SUPPORT: State = State::new(2);
+
+        /// Google is waiting for a response.
+        pub const ACTION_REQUIRED: State = State::new(3);
+
+        /// A solution has been offered for the case, but it isn't yet closed.
+        pub const SOLUTION_PROVIDED: State = State::new(4);
+
+        /// The case has been resolved.
+        pub const CLOSED: State = State::new(5);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NEW"),
+                2 => std::borrow::Cow::Borrowed("IN_PROGRESS_GOOGLE_SUPPORT"),
+                3 => std::borrow::Cow::Borrowed("ACTION_REQUIRED"),
+                4 => std::borrow::Cow::Borrowed("SOLUTION_PROVIDED"),
+                5 => std::borrow::Cow::Borrowed("CLOSED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "NEW" => std::option::Option::Some(Self::NEW),
+                "IN_PROGRESS_GOOGLE_SUPPORT" => {
+                    std::option::Option::Some(Self::IN_PROGRESS_GOOGLE_SUPPORT)
+                }
+                "ACTION_REQUIRED" => std::option::Option::Some(Self::ACTION_REQUIRED),
+                "SOLUTION_PROVIDED" => std::option::Option::Some(Self::SOLUTION_PROVIDED),
+                "CLOSED" => std::option::Option::Some(Self::CLOSED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Case is in an unknown state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The case has been created but no one is assigned to work on it yet.
-        pub const NEW: State = State::new("NEW");
-
-        /// The case is currently being handled by Google support.
-        pub const IN_PROGRESS_GOOGLE_SUPPORT: State = State::new("IN_PROGRESS_GOOGLE_SUPPORT");
-
-        /// Google is waiting for a response.
-        pub const ACTION_REQUIRED: State = State::new("ACTION_REQUIRED");
-
-        /// A solution has been offered for the case, but it isn't yet closed.
-        pub const SOLUTION_PROVIDED: State = State::new("SOLUTION_PROVIDED");
-
-        /// The case has been resolved.
-        pub const CLOSED: State = State::new("CLOSED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The case Priority. P0 is most urgent and P4 the least.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Priority(std::borrow::Cow<'static, str>);
+    pub struct Priority(i32);
 
     impl Priority {
-        /// Creates a new Priority instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Priority](Priority)
-    pub mod priority {
-        use super::Priority;
-
         /// Priority is undefined or has not been set yet.
-        pub const PRIORITY_UNSPECIFIED: Priority = Priority::new("PRIORITY_UNSPECIFIED");
+        pub const PRIORITY_UNSPECIFIED: Priority = Priority::new(0);
 
         /// Extreme impact on a production service. Service is hard down.
-        pub const P0: Priority = Priority::new("P0");
+        pub const P0: Priority = Priority::new(1);
 
         /// Critical impact on a production service. Service is currently unusable.
-        pub const P1: Priority = Priority::new("P1");
+        pub const P1: Priority = Priority::new(2);
 
         /// Severe impact on a production service. Service is usable but greatly
         /// impaired.
-        pub const P2: Priority = Priority::new("P2");
+        pub const P2: Priority = Priority::new(3);
 
         /// Medium impact on a production service.  Service is available, but
         /// moderately impaired.
-        pub const P3: Priority = Priority::new("P3");
+        pub const P3: Priority = Priority::new(4);
 
         /// General questions or minor issues.  Production service is fully
         /// available.
-        pub const P4: Priority = Priority::new("P4");
+        pub const P4: Priority = Priority::new(5);
+
+        /// Creates a new Priority instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PRIORITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("P0"),
+                2 => std::borrow::Cow::Borrowed("P1"),
+                3 => std::borrow::Cow::Borrowed("P2"),
+                4 => std::borrow::Cow::Borrowed("P3"),
+                5 => std::borrow::Cow::Borrowed("P4"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PRIORITY_UNSPECIFIED" => std::option::Option::Some(Self::PRIORITY_UNSPECIFIED),
+                "P0" => std::option::Option::Some(Self::P0),
+                "P1" => std::option::Option::Some(Self::P1),
+                "P2" => std::option::Option::Some(Self::P2),
+                "P3" => std::option::Option::Some(Self::P3),
+                "P4" => std::option::Option::Some(Self::P4),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Priority {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Priority {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Priority {
         fn default() -> Self {
-            priority::PRIORITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1509,47 +1553,64 @@ pub mod escalation {
 
     /// An enum detailing the possible reasons a case may be escalated.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Reason(std::borrow::Cow<'static, str>);
+    pub struct Reason(i32);
 
     impl Reason {
-        /// Creates a new Reason instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Reason](Reason)
-    pub mod reason {
-        use super::Reason;
-
         /// The escalation reason is in an unknown state or has not been specified.
-        pub const REASON_UNSPECIFIED: Reason = Reason::new("REASON_UNSPECIFIED");
+        pub const REASON_UNSPECIFIED: Reason = Reason::new(0);
 
         /// The case is taking too long to resolve.
-        pub const RESOLUTION_TIME: Reason = Reason::new("RESOLUTION_TIME");
+        pub const RESOLUTION_TIME: Reason = Reason::new(1);
 
         /// The support agent does not have the expertise required to successfully
         /// resolve the issue.
-        pub const TECHNICAL_EXPERTISE: Reason = Reason::new("TECHNICAL_EXPERTISE");
+        pub const TECHNICAL_EXPERTISE: Reason = Reason::new(2);
 
         /// The issue is having a significant business impact.
-        pub const BUSINESS_IMPACT: Reason = Reason::new("BUSINESS_IMPACT");
+        pub const BUSINESS_IMPACT: Reason = Reason::new(3);
+
+        /// Creates a new Reason instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("REASON_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RESOLUTION_TIME"),
+                2 => std::borrow::Cow::Borrowed("TECHNICAL_EXPERTISE"),
+                3 => std::borrow::Cow::Borrowed("BUSINESS_IMPACT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "REASON_UNSPECIFIED" => std::option::Option::Some(Self::REASON_UNSPECIFIED),
+                "RESOLUTION_TIME" => std::option::Option::Some(Self::RESOLUTION_TIME),
+                "TECHNICAL_EXPERTISE" => std::option::Option::Some(Self::TECHNICAL_EXPERTISE),
+                "BUSINESS_IMPACT" => std::option::Option::Some(Self::BUSINESS_IMPACT),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Reason {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Reason {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Reason {
         fn default() -> Self {
-            reason::REASON_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/support/v2/src/transport.rs
+++ b/src/generated/cloud/support/v2/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::CaseAttachmentService for CaseAttachmentService {
                 reqwest::Method::GET,
                 format!("/v2/{}/attachments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -96,7 +96,7 @@ impl crate::stubs::CaseService for CaseService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -115,7 +115,7 @@ impl crate::stubs::CaseService for CaseService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/cases", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -140,7 +140,7 @@ impl crate::stubs::CaseService for CaseService {
                 reqwest::Method::GET,
                 format!("/v2/{}/cases:search", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -162,7 +162,7 @@ impl crate::stubs::CaseService for CaseService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}/cases", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -188,7 +188,7 @@ impl crate::stubs::CaseService for CaseService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -215,7 +215,7 @@ impl crate::stubs::CaseService for CaseService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:escalate", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -232,7 +232,7 @@ impl crate::stubs::CaseService for CaseService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:close", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -252,7 +252,7 @@ impl crate::stubs::CaseService for CaseService {
                 reqwest::Method::GET,
                 "/v2/caseClassifications:search".to_string(),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -297,7 +297,7 @@ impl crate::stubs::CommentService for CommentService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/comments", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -321,7 +321,7 @@ impl crate::stubs::CommentService for CommentService {
                 reqwest::Method::POST,
                 format!("/v2/{}/comments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/talent/v4/src/model.rs
+++ b/src/generated/cloud/talent/v4/src/model.rs
@@ -171,73 +171,106 @@ pub mod location {
 
     /// An enum which represents the type of a location.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LocationType(std::borrow::Cow<'static, str>);
+    pub struct LocationType(i32);
 
     impl LocationType {
-        /// Creates a new LocationType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [LocationType](LocationType)
-    pub mod location_type {
-        use super::LocationType;
-
         /// Default value if the type isn't specified.
-        pub const LOCATION_TYPE_UNSPECIFIED: LocationType =
-            LocationType::new("LOCATION_TYPE_UNSPECIFIED");
+        pub const LOCATION_TYPE_UNSPECIFIED: LocationType = LocationType::new(0);
 
         /// A country level location.
-        pub const COUNTRY: LocationType = LocationType::new("COUNTRY");
+        pub const COUNTRY: LocationType = LocationType::new(1);
 
         /// A state or equivalent level location.
-        pub const ADMINISTRATIVE_AREA: LocationType = LocationType::new("ADMINISTRATIVE_AREA");
+        pub const ADMINISTRATIVE_AREA: LocationType = LocationType::new(2);
 
         /// A county or equivalent level location.
-        pub const SUB_ADMINISTRATIVE_AREA: LocationType =
-            LocationType::new("SUB_ADMINISTRATIVE_AREA");
+        pub const SUB_ADMINISTRATIVE_AREA: LocationType = LocationType::new(3);
 
         /// A city or equivalent level location.
-        pub const LOCALITY: LocationType = LocationType::new("LOCALITY");
+        pub const LOCALITY: LocationType = LocationType::new(4);
 
         /// A postal code level location.
-        pub const POSTAL_CODE: LocationType = LocationType::new("POSTAL_CODE");
+        pub const POSTAL_CODE: LocationType = LocationType::new(5);
 
         /// A sublocality is a subdivision of a locality, for example a city borough,
         /// ward, or arrondissement. Sublocalities are usually recognized by a local
         /// political authority. For example, Manhattan and Brooklyn are recognized
         /// as boroughs by the City of New York, and are therefore modeled as
         /// sublocalities.
-        pub const SUB_LOCALITY: LocationType = LocationType::new("SUB_LOCALITY");
+        pub const SUB_LOCALITY: LocationType = LocationType::new(6);
 
         /// A district or equivalent level location.
-        pub const SUB_LOCALITY_1: LocationType = LocationType::new("SUB_LOCALITY_1");
+        pub const SUB_LOCALITY_1: LocationType = LocationType::new(7);
 
         /// A smaller district or equivalent level display.
-        pub const SUB_LOCALITY_2: LocationType = LocationType::new("SUB_LOCALITY_2");
+        pub const SUB_LOCALITY_2: LocationType = LocationType::new(8);
 
         /// A neighborhood level location.
-        pub const NEIGHBORHOOD: LocationType = LocationType::new("NEIGHBORHOOD");
+        pub const NEIGHBORHOOD: LocationType = LocationType::new(9);
 
         /// A street address level location.
-        pub const STREET_ADDRESS: LocationType = LocationType::new("STREET_ADDRESS");
+        pub const STREET_ADDRESS: LocationType = LocationType::new(10);
+
+        /// Creates a new LocationType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LOCATION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("COUNTRY"),
+                2 => std::borrow::Cow::Borrowed("ADMINISTRATIVE_AREA"),
+                3 => std::borrow::Cow::Borrowed("SUB_ADMINISTRATIVE_AREA"),
+                4 => std::borrow::Cow::Borrowed("LOCALITY"),
+                5 => std::borrow::Cow::Borrowed("POSTAL_CODE"),
+                6 => std::borrow::Cow::Borrowed("SUB_LOCALITY"),
+                7 => std::borrow::Cow::Borrowed("SUB_LOCALITY_1"),
+                8 => std::borrow::Cow::Borrowed("SUB_LOCALITY_2"),
+                9 => std::borrow::Cow::Borrowed("NEIGHBORHOOD"),
+                10 => std::borrow::Cow::Borrowed("STREET_ADDRESS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LOCATION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::LOCATION_TYPE_UNSPECIFIED)
+                }
+                "COUNTRY" => std::option::Option::Some(Self::COUNTRY),
+                "ADMINISTRATIVE_AREA" => std::option::Option::Some(Self::ADMINISTRATIVE_AREA),
+                "SUB_ADMINISTRATIVE_AREA" => {
+                    std::option::Option::Some(Self::SUB_ADMINISTRATIVE_AREA)
+                }
+                "LOCALITY" => std::option::Option::Some(Self::LOCALITY),
+                "POSTAL_CODE" => std::option::Option::Some(Self::POSTAL_CODE),
+                "SUB_LOCALITY" => std::option::Option::Some(Self::SUB_LOCALITY),
+                "SUB_LOCALITY_1" => std::option::Option::Some(Self::SUB_LOCALITY_1),
+                "SUB_LOCALITY_2" => std::option::Option::Some(Self::SUB_LOCALITY_2),
+                "NEIGHBORHOOD" => std::option::Option::Some(Self::NEIGHBORHOOD),
+                "STREET_ADDRESS" => std::option::Option::Some(Self::STREET_ADDRESS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for LocationType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LocationType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LocationType {
         fn default() -> Self {
-            location_type::LOCATION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -457,58 +490,83 @@ pub mod device_info {
 
     /// An enumeration describing an API access portal and exposure mechanism.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DeviceType(std::borrow::Cow<'static, str>);
+    pub struct DeviceType(i32);
 
     impl DeviceType {
-        /// Creates a new DeviceType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DeviceType](DeviceType)
-    pub mod device_type {
-        use super::DeviceType;
-
         /// The device type isn't specified.
-        pub const DEVICE_TYPE_UNSPECIFIED: DeviceType = DeviceType::new("DEVICE_TYPE_UNSPECIFIED");
+        pub const DEVICE_TYPE_UNSPECIFIED: DeviceType = DeviceType::new(0);
 
         /// A desktop web browser, such as, Chrome, Firefox, Safari, or Internet
         /// Explorer)
-        pub const WEB: DeviceType = DeviceType::new("WEB");
+        pub const WEB: DeviceType = DeviceType::new(1);
 
         /// A mobile device web browser, such as a phone or tablet with a Chrome
         /// browser.
-        pub const MOBILE_WEB: DeviceType = DeviceType::new("MOBILE_WEB");
+        pub const MOBILE_WEB: DeviceType = DeviceType::new(2);
 
         /// An Android device native application.
-        pub const ANDROID: DeviceType = DeviceType::new("ANDROID");
+        pub const ANDROID: DeviceType = DeviceType::new(3);
 
         /// An iOS device native application.
-        pub const IOS: DeviceType = DeviceType::new("IOS");
+        pub const IOS: DeviceType = DeviceType::new(4);
 
         /// A bot, as opposed to a device operated by human beings, such as a web
         /// crawler.
-        pub const BOT: DeviceType = DeviceType::new("BOT");
+        pub const BOT: DeviceType = DeviceType::new(5);
 
         /// Other devices types.
-        pub const OTHER: DeviceType = DeviceType::new("OTHER");
+        pub const OTHER: DeviceType = DeviceType::new(6);
+
+        /// Creates a new DeviceType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DEVICE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("WEB"),
+                2 => std::borrow::Cow::Borrowed("MOBILE_WEB"),
+                3 => std::borrow::Cow::Borrowed("ANDROID"),
+                4 => std::borrow::Cow::Borrowed("IOS"),
+                5 => std::borrow::Cow::Borrowed("BOT"),
+                6 => std::borrow::Cow::Borrowed("OTHER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DEVICE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DEVICE_TYPE_UNSPECIFIED)
+                }
+                "WEB" => std::option::Option::Some(Self::WEB),
+                "MOBILE_WEB" => std::option::Option::Some(Self::MOBILE_WEB),
+                "ANDROID" => std::option::Option::Some(Self::ANDROID),
+                "IOS" => std::option::Option::Some(Self::IOS),
+                "BOT" => std::option::Option::Some(Self::BOT),
+                "OTHER" => std::option::Option::Some(Self::OTHER),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DeviceType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DeviceType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DeviceType {
         fn default() -> Self {
-            device_type::DEVICE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1087,125 +1145,181 @@ pub mod compensation_info {
     /// [google.cloud.talent.v4.CompensationInfo.CompensationEntry.range]: crate::model::compensation_info::CompensationEntry::compensation_amount
     /// [google.cloud.talent.v4.CompensationInfo.CompensationUnit.COMPENSATION_UNIT_UNSPECIFIED]: crate::model::compensation_info::compensation_unit::COMPENSATION_UNIT_UNSPECIFIED
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CompensationType(std::borrow::Cow<'static, str>);
+    pub struct CompensationType(i32);
 
     impl CompensationType {
-        /// Creates a new CompensationType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CompensationType](CompensationType)
-    pub mod compensation_type {
-        use super::CompensationType;
-
         /// Default value.
-        pub const COMPENSATION_TYPE_UNSPECIFIED: CompensationType =
-            CompensationType::new("COMPENSATION_TYPE_UNSPECIFIED");
+        pub const COMPENSATION_TYPE_UNSPECIFIED: CompensationType = CompensationType::new(0);
 
         /// Base compensation: Refers to the fixed amount of money paid to an
         /// employee by an employer in return for work performed. Base compensation
         /// does not include benefits, bonuses or any other potential compensation
         /// from an employer.
-        pub const BASE: CompensationType = CompensationType::new("BASE");
+        pub const BASE: CompensationType = CompensationType::new(1);
 
         /// Bonus.
-        pub const BONUS: CompensationType = CompensationType::new("BONUS");
+        pub const BONUS: CompensationType = CompensationType::new(2);
 
         /// Signing bonus.
-        pub const SIGNING_BONUS: CompensationType = CompensationType::new("SIGNING_BONUS");
+        pub const SIGNING_BONUS: CompensationType = CompensationType::new(3);
 
         /// Equity.
-        pub const EQUITY: CompensationType = CompensationType::new("EQUITY");
+        pub const EQUITY: CompensationType = CompensationType::new(4);
 
         /// Profit sharing.
-        pub const PROFIT_SHARING: CompensationType = CompensationType::new("PROFIT_SHARING");
+        pub const PROFIT_SHARING: CompensationType = CompensationType::new(5);
 
         /// Commission.
-        pub const COMMISSIONS: CompensationType = CompensationType::new("COMMISSIONS");
+        pub const COMMISSIONS: CompensationType = CompensationType::new(6);
 
         /// Tips.
-        pub const TIPS: CompensationType = CompensationType::new("TIPS");
+        pub const TIPS: CompensationType = CompensationType::new(7);
 
         /// Other compensation type.
-        pub const OTHER_COMPENSATION_TYPE: CompensationType =
-            CompensationType::new("OTHER_COMPENSATION_TYPE");
+        pub const OTHER_COMPENSATION_TYPE: CompensationType = CompensationType::new(8);
+
+        /// Creates a new CompensationType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COMPENSATION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BASE"),
+                2 => std::borrow::Cow::Borrowed("BONUS"),
+                3 => std::borrow::Cow::Borrowed("SIGNING_BONUS"),
+                4 => std::borrow::Cow::Borrowed("EQUITY"),
+                5 => std::borrow::Cow::Borrowed("PROFIT_SHARING"),
+                6 => std::borrow::Cow::Borrowed("COMMISSIONS"),
+                7 => std::borrow::Cow::Borrowed("TIPS"),
+                8 => std::borrow::Cow::Borrowed("OTHER_COMPENSATION_TYPE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COMPENSATION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::COMPENSATION_TYPE_UNSPECIFIED)
+                }
+                "BASE" => std::option::Option::Some(Self::BASE),
+                "BONUS" => std::option::Option::Some(Self::BONUS),
+                "SIGNING_BONUS" => std::option::Option::Some(Self::SIGNING_BONUS),
+                "EQUITY" => std::option::Option::Some(Self::EQUITY),
+                "PROFIT_SHARING" => std::option::Option::Some(Self::PROFIT_SHARING),
+                "COMMISSIONS" => std::option::Option::Some(Self::COMMISSIONS),
+                "TIPS" => std::option::Option::Some(Self::TIPS),
+                "OTHER_COMPENSATION_TYPE" => {
+                    std::option::Option::Some(Self::OTHER_COMPENSATION_TYPE)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CompensationType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CompensationType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CompensationType {
         fn default() -> Self {
-            compensation_type::COMPENSATION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Pay frequency.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CompensationUnit(std::borrow::Cow<'static, str>);
+    pub struct CompensationUnit(i32);
 
     impl CompensationUnit {
+        /// Default value.
+        pub const COMPENSATION_UNIT_UNSPECIFIED: CompensationUnit = CompensationUnit::new(0);
+
+        /// Hourly.
+        pub const HOURLY: CompensationUnit = CompensationUnit::new(1);
+
+        /// Daily.
+        pub const DAILY: CompensationUnit = CompensationUnit::new(2);
+
+        /// Weekly
+        pub const WEEKLY: CompensationUnit = CompensationUnit::new(3);
+
+        /// Monthly.
+        pub const MONTHLY: CompensationUnit = CompensationUnit::new(4);
+
+        /// Yearly.
+        pub const YEARLY: CompensationUnit = CompensationUnit::new(5);
+
+        /// One time.
+        pub const ONE_TIME: CompensationUnit = CompensationUnit::new(6);
+
+        /// Other compensation units.
+        pub const OTHER_COMPENSATION_UNIT: CompensationUnit = CompensationUnit::new(7);
+
         /// Creates a new CompensationUnit instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COMPENSATION_UNIT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("HOURLY"),
+                2 => std::borrow::Cow::Borrowed("DAILY"),
+                3 => std::borrow::Cow::Borrowed("WEEKLY"),
+                4 => std::borrow::Cow::Borrowed("MONTHLY"),
+                5 => std::borrow::Cow::Borrowed("YEARLY"),
+                6 => std::borrow::Cow::Borrowed("ONE_TIME"),
+                7 => std::borrow::Cow::Borrowed("OTHER_COMPENSATION_UNIT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COMPENSATION_UNIT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::COMPENSATION_UNIT_UNSPECIFIED)
+                }
+                "HOURLY" => std::option::Option::Some(Self::HOURLY),
+                "DAILY" => std::option::Option::Some(Self::DAILY),
+                "WEEKLY" => std::option::Option::Some(Self::WEEKLY),
+                "MONTHLY" => std::option::Option::Some(Self::MONTHLY),
+                "YEARLY" => std::option::Option::Some(Self::YEARLY),
+                "ONE_TIME" => std::option::Option::Some(Self::ONE_TIME),
+                "OTHER_COMPENSATION_UNIT" => {
+                    std::option::Option::Some(Self::OTHER_COMPENSATION_UNIT)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [CompensationUnit](CompensationUnit)
-    pub mod compensation_unit {
-        use super::CompensationUnit;
-
-        /// Default value.
-        pub const COMPENSATION_UNIT_UNSPECIFIED: CompensationUnit =
-            CompensationUnit::new("COMPENSATION_UNIT_UNSPECIFIED");
-
-        /// Hourly.
-        pub const HOURLY: CompensationUnit = CompensationUnit::new("HOURLY");
-
-        /// Daily.
-        pub const DAILY: CompensationUnit = CompensationUnit::new("DAILY");
-
-        /// Weekly
-        pub const WEEKLY: CompensationUnit = CompensationUnit::new("WEEKLY");
-
-        /// Monthly.
-        pub const MONTHLY: CompensationUnit = CompensationUnit::new("MONTHLY");
-
-        /// Yearly.
-        pub const YEARLY: CompensationUnit = CompensationUnit::new("YEARLY");
-
-        /// One time.
-        pub const ONE_TIME: CompensationUnit = CompensationUnit::new("ONE_TIME");
-
-        /// Other compensation units.
-        pub const OTHER_COMPENSATION_UNIT: CompensationUnit =
-            CompensationUnit::new("OTHER_COMPENSATION_UNIT");
-    }
-
-    impl std::convert::From<std::string::String> for CompensationUnit {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CompensationUnit {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CompensationUnit {
         fn default() -> Self {
-            compensation_unit::COMPENSATION_UNIT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1338,61 +1452,84 @@ pub mod batch_operation_metadata {
     use super::*;
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Default value.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The batch operation is being prepared for processing.
-        pub const INITIALIZING: State = State::new("INITIALIZING");
+        pub const INITIALIZING: State = State::new(1);
 
         /// The batch operation is actively being processed.
-        pub const PROCESSING: State = State::new("PROCESSING");
+        pub const PROCESSING: State = State::new(2);
 
         /// The batch operation is processed, and at least one item has been
         /// successfully processed.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
+        pub const SUCCEEDED: State = State::new(3);
 
         /// The batch operation is done and no item has been successfully processed.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(4);
 
         /// The batch operation is in the process of cancelling after
         /// [google.longrunning.Operations.CancelOperation][google.longrunning.Operations.CancelOperation]
         /// is called.
-        pub const CANCELLING: State = State::new("CANCELLING");
+        pub const CANCELLING: State = State::new(5);
 
         /// The batch operation is done after
         /// [google.longrunning.Operations.CancelOperation][google.longrunning.Operations.CancelOperation]
         /// is called. Any items processed before cancelling are returned in the
         /// response.
-        pub const CANCELLED: State = State::new("CANCELLED");
+        pub const CANCELLED: State = State::new(6);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INITIALIZING"),
+                2 => std::borrow::Cow::Borrowed("PROCESSING"),
+                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                5 => std::borrow::Cow::Borrowed("CANCELLING"),
+                6 => std::borrow::Cow::Borrowed("CANCELLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "INITIALIZING" => std::option::Option::Some(Self::INITIALIZING),
+                "PROCESSING" => std::option::Option::Some(Self::PROCESSING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2085,71 +2222,71 @@ pub mod complete_query_request {
 
     /// Enum to specify the scope of completion.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CompletionScope(std::borrow::Cow<'static, str>);
+    pub struct CompletionScope(i32);
 
     impl CompletionScope {
-        /// Creates a new CompletionScope instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CompletionScope](CompletionScope)
-    pub mod completion_scope {
-        use super::CompletionScope;
-
         /// Default value.
-        pub const COMPLETION_SCOPE_UNSPECIFIED: CompletionScope =
-            CompletionScope::new("COMPLETION_SCOPE_UNSPECIFIED");
+        pub const COMPLETION_SCOPE_UNSPECIFIED: CompletionScope = CompletionScope::new(0);
 
         /// Suggestions are based only on the data provided by the client.
-        pub const TENANT: CompletionScope = CompletionScope::new("TENANT");
+        pub const TENANT: CompletionScope = CompletionScope::new(1);
 
         /// Suggestions are based on all jobs data in the system that's visible to
         /// the client
-        pub const PUBLIC: CompletionScope = CompletionScope::new("PUBLIC");
+        pub const PUBLIC: CompletionScope = CompletionScope::new(2);
+
+        /// Creates a new CompletionScope instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COMPLETION_SCOPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TENANT"),
+                2 => std::borrow::Cow::Borrowed("PUBLIC"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COMPLETION_SCOPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::COMPLETION_SCOPE_UNSPECIFIED)
+                }
+                "TENANT" => std::option::Option::Some(Self::TENANT),
+                "PUBLIC" => std::option::Option::Some(Self::PUBLIC),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CompletionScope {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CompletionScope {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CompletionScope {
         fn default() -> Self {
-            completion_scope::COMPLETION_SCOPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Enum to specify auto-completion topics.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CompletionType(std::borrow::Cow<'static, str>);
+    pub struct CompletionType(i32);
 
     impl CompletionType {
-        /// Creates a new CompletionType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CompletionType](CompletionType)
-    pub mod completion_type {
-        use super::CompletionType;
-
         /// Default value.
-        pub const COMPLETION_TYPE_UNSPECIFIED: CompletionType =
-            CompletionType::new("COMPLETION_TYPE_UNSPECIFIED");
+        pub const COMPLETION_TYPE_UNSPECIFIED: CompletionType = CompletionType::new(0);
 
         /// Suggest job titles for jobs autocomplete.
         ///
@@ -2161,7 +2298,7 @@ pub mod complete_query_request {
         ///
         /// [google.cloud.talent.v4.CompleteQueryRequest.CompletionType.JOB_TITLE]: crate::model::complete_query_request::completion_type::JOB_TITLE
         /// [google.cloud.talent.v4.CompleteQueryRequest.language_codes]: crate::model::CompleteQueryRequest::language_codes
-        pub const JOB_TITLE: CompletionType = CompletionType::new("JOB_TITLE");
+        pub const JOB_TITLE: CompletionType = CompletionType::new(1);
 
         /// Suggest company names for jobs autocomplete.
         ///
@@ -2173,7 +2310,7 @@ pub mod complete_query_request {
         ///
         /// [google.cloud.talent.v4.CompleteQueryRequest.CompletionType.COMPANY_NAME]: crate::model::complete_query_request::completion_type::COMPANY_NAME
         /// [google.cloud.talent.v4.CompleteQueryRequest.language_codes]: crate::model::CompleteQueryRequest::language_codes
-        pub const COMPANY_NAME: CompletionType = CompletionType::new("COMPANY_NAME");
+        pub const COMPANY_NAME: CompletionType = CompletionType::new(2);
 
         /// Suggest both job titles and company names for jobs autocomplete.
         ///
@@ -2187,18 +2324,52 @@ pub mod complete_query_request {
         ///
         /// [google.cloud.talent.v4.CompleteQueryRequest.CompletionType.COMBINED]: crate::model::complete_query_request::completion_type::COMBINED
         /// [google.cloud.talent.v4.CompleteQueryRequest.language_codes]: crate::model::CompleteQueryRequest::language_codes
-        pub const COMBINED: CompletionType = CompletionType::new("COMBINED");
+        pub const COMBINED: CompletionType = CompletionType::new(3);
+
+        /// Creates a new CompletionType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COMPLETION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("JOB_TITLE"),
+                2 => std::borrow::Cow::Borrowed("COMPANY_NAME"),
+                3 => std::borrow::Cow::Borrowed("COMBINED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COMPLETION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::COMPLETION_TYPE_UNSPECIFIED)
+                }
+                "JOB_TITLE" => std::option::Option::Some(Self::JOB_TITLE),
+                "COMPANY_NAME" => std::option::Option::Some(Self::COMPANY_NAME),
+                "COMBINED" => std::option::Option::Some(Self::COMBINED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CompletionType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CompletionType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CompletionType {
         fn default() -> Self {
-            completion_type::COMPLETION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2521,33 +2692,17 @@ pub mod job_event {
     /// An enumeration of an event attributed to the behavior of the end user,
     /// such as a job seeker.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct JobEventType(std::borrow::Cow<'static, str>);
+    pub struct JobEventType(i32);
 
     impl JobEventType {
-        /// Creates a new JobEventType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [JobEventType](JobEventType)
-    pub mod job_event_type {
-        use super::JobEventType;
-
         /// The event is unspecified by other provided values.
-        pub const JOB_EVENT_TYPE_UNSPECIFIED: JobEventType =
-            JobEventType::new("JOB_EVENT_TYPE_UNSPECIFIED");
+        pub const JOB_EVENT_TYPE_UNSPECIFIED: JobEventType = JobEventType::new(0);
 
         /// The job seeker or other entity interacting with the service has
         /// had a job rendered in their view, such as in a list of search results in
         /// a compressed or clipped format. This event is typically associated with
         /// the viewing of a jobs list on a single page by a job seeker.
-        pub const IMPRESSION: JobEventType = JobEventType::new("IMPRESSION");
+        pub const IMPRESSION: JobEventType = JobEventType::new(1);
 
         /// The job seeker, or other entity interacting with the service, has
         /// viewed the details of a job, including the full description. This
@@ -2556,20 +2711,20 @@ pub mod job_event {
         /// [impression][google.cloud.talent.v4.JobEvent.JobEventType.IMPRESSION]).
         ///
         /// [google.cloud.talent.v4.JobEvent.JobEventType.IMPRESSION]: crate::model::job_event::job_event_type::IMPRESSION
-        pub const VIEW: JobEventType = JobEventType::new("VIEW");
+        pub const VIEW: JobEventType = JobEventType::new(2);
 
         /// The job seeker or other entity interacting with the service
         /// performed an action to view a job and was redirected to a different
         /// website for job.
-        pub const VIEW_REDIRECT: JobEventType = JobEventType::new("VIEW_REDIRECT");
+        pub const VIEW_REDIRECT: JobEventType = JobEventType::new(3);
 
         /// The job seeker or other entity interacting with the service
         /// began the process or demonstrated the intention of applying for a job.
-        pub const APPLICATION_START: JobEventType = JobEventType::new("APPLICATION_START");
+        pub const APPLICATION_START: JobEventType = JobEventType::new(4);
 
         /// The job seeker or other entity interacting with the service
         /// submitted an application for a job.
-        pub const APPLICATION_FINISH: JobEventType = JobEventType::new("APPLICATION_FINISH");
+        pub const APPLICATION_FINISH: JobEventType = JobEventType::new(5);
 
         /// The job seeker or other entity interacting with the service
         /// submitted an application for a job with a single click without
@@ -2582,20 +2737,18 @@ pub mod job_event {
         ///
         /// [google.cloud.talent.v4.JobEvent.JobEventType.APPLICATION_FINISH]: crate::model::job_event::job_event_type::APPLICATION_FINISH
         /// [google.cloud.talent.v4.JobEvent.JobEventType.APPLICATION_START]: crate::model::job_event::job_event_type::APPLICATION_START
-        pub const APPLICATION_QUICK_SUBMISSION: JobEventType =
-            JobEventType::new("APPLICATION_QUICK_SUBMISSION");
+        pub const APPLICATION_QUICK_SUBMISSION: JobEventType = JobEventType::new(6);
 
         /// The job seeker or other entity interacting with the service
         /// performed an action to apply to a job and was redirected to a different
         /// website to complete the application.
-        pub const APPLICATION_REDIRECT: JobEventType = JobEventType::new("APPLICATION_REDIRECT");
+        pub const APPLICATION_REDIRECT: JobEventType = JobEventType::new(7);
 
         /// The job seeker or other entity interacting with the service began the
         /// process or demonstrated the intention of applying for a job from the
         /// search results page without viewing the details of the job posting.
         /// If sending this event, JobEventType.VIEW event shouldn't be sent.
-        pub const APPLICATION_START_FROM_SEARCH: JobEventType =
-            JobEventType::new("APPLICATION_START_FROM_SEARCH");
+        pub const APPLICATION_START_FROM_SEARCH: JobEventType = JobEventType::new(8);
 
         /// The job seeker, or other entity interacting with the service, performs an
         /// action with a single click from the search results page to apply to a job
@@ -2611,53 +2764,117 @@ pub mod job_event {
         /// [google.cloud.talent.v4.JobEvent.JobEventType.APPLICATION_FINISH]: crate::model::job_event::job_event_type::APPLICATION_FINISH
         /// [google.cloud.talent.v4.JobEvent.JobEventType.APPLICATION_START]: crate::model::job_event::job_event_type::APPLICATION_START
         /// [google.cloud.talent.v4.JobEvent.JobEventType.VIEW]: crate::model::job_event::job_event_type::VIEW
-        pub const APPLICATION_REDIRECT_FROM_SEARCH: JobEventType =
-            JobEventType::new("APPLICATION_REDIRECT_FROM_SEARCH");
+        pub const APPLICATION_REDIRECT_FROM_SEARCH: JobEventType = JobEventType::new(9);
 
         /// This event should be used when a company submits an application
         /// on behalf of a job seeker. This event is intended for use by staffing
         /// agencies attempting to place candidates.
-        pub const APPLICATION_COMPANY_SUBMIT: JobEventType =
-            JobEventType::new("APPLICATION_COMPANY_SUBMIT");
+        pub const APPLICATION_COMPANY_SUBMIT: JobEventType = JobEventType::new(10);
 
         /// The job seeker or other entity interacting with the service demonstrated
         /// an interest in a job by bookmarking or saving it.
-        pub const BOOKMARK: JobEventType = JobEventType::new("BOOKMARK");
+        pub const BOOKMARK: JobEventType = JobEventType::new(11);
 
         /// The job seeker or other entity interacting with the service was
         /// sent a notification, such as an email alert or device notification,
         /// containing one or more jobs listings generated by the service.
-        pub const NOTIFICATION: JobEventType = JobEventType::new("NOTIFICATION");
+        pub const NOTIFICATION: JobEventType = JobEventType::new(12);
 
         /// The job seeker or other entity interacting with the service was
         /// employed by the hiring entity (employer). Send this event
         /// only if the job seeker was hired through an application that was
         /// initiated by a search conducted through the Cloud Talent Solution
         /// service.
-        pub const HIRED: JobEventType = JobEventType::new("HIRED");
+        pub const HIRED: JobEventType = JobEventType::new(13);
 
         /// A recruiter or staffing agency submitted an application on behalf of the
         /// candidate after interacting with the service to identify a suitable job
         /// posting.
-        pub const SENT_CV: JobEventType = JobEventType::new("SENT_CV");
+        pub const SENT_CV: JobEventType = JobEventType::new(14);
 
         /// The entity interacting with the service (for example, the job seeker),
         /// was granted an initial interview by the hiring entity (employer). This
         /// event should only be sent if the job seeker was granted an interview as
         /// part of an application that was initiated by a search conducted through /
         /// recommendation provided by the Cloud Talent Solution service.
-        pub const INTERVIEW_GRANTED: JobEventType = JobEventType::new("INTERVIEW_GRANTED");
+        pub const INTERVIEW_GRANTED: JobEventType = JobEventType::new(15);
+
+        /// Creates a new JobEventType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("JOB_EVENT_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IMPRESSION"),
+                2 => std::borrow::Cow::Borrowed("VIEW"),
+                3 => std::borrow::Cow::Borrowed("VIEW_REDIRECT"),
+                4 => std::borrow::Cow::Borrowed("APPLICATION_START"),
+                5 => std::borrow::Cow::Borrowed("APPLICATION_FINISH"),
+                6 => std::borrow::Cow::Borrowed("APPLICATION_QUICK_SUBMISSION"),
+                7 => std::borrow::Cow::Borrowed("APPLICATION_REDIRECT"),
+                8 => std::borrow::Cow::Borrowed("APPLICATION_START_FROM_SEARCH"),
+                9 => std::borrow::Cow::Borrowed("APPLICATION_REDIRECT_FROM_SEARCH"),
+                10 => std::borrow::Cow::Borrowed("APPLICATION_COMPANY_SUBMIT"),
+                11 => std::borrow::Cow::Borrowed("BOOKMARK"),
+                12 => std::borrow::Cow::Borrowed("NOTIFICATION"),
+                13 => std::borrow::Cow::Borrowed("HIRED"),
+                14 => std::borrow::Cow::Borrowed("SENT_CV"),
+                15 => std::borrow::Cow::Borrowed("INTERVIEW_GRANTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "JOB_EVENT_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::JOB_EVENT_TYPE_UNSPECIFIED)
+                }
+                "IMPRESSION" => std::option::Option::Some(Self::IMPRESSION),
+                "VIEW" => std::option::Option::Some(Self::VIEW),
+                "VIEW_REDIRECT" => std::option::Option::Some(Self::VIEW_REDIRECT),
+                "APPLICATION_START" => std::option::Option::Some(Self::APPLICATION_START),
+                "APPLICATION_FINISH" => std::option::Option::Some(Self::APPLICATION_FINISH),
+                "APPLICATION_QUICK_SUBMISSION" => {
+                    std::option::Option::Some(Self::APPLICATION_QUICK_SUBMISSION)
+                }
+                "APPLICATION_REDIRECT" => std::option::Option::Some(Self::APPLICATION_REDIRECT),
+                "APPLICATION_START_FROM_SEARCH" => {
+                    std::option::Option::Some(Self::APPLICATION_START_FROM_SEARCH)
+                }
+                "APPLICATION_REDIRECT_FROM_SEARCH" => {
+                    std::option::Option::Some(Self::APPLICATION_REDIRECT_FROM_SEARCH)
+                }
+                "APPLICATION_COMPANY_SUBMIT" => {
+                    std::option::Option::Some(Self::APPLICATION_COMPANY_SUBMIT)
+                }
+                "BOOKMARK" => std::option::Option::Some(Self::BOOKMARK),
+                "NOTIFICATION" => std::option::Option::Some(Self::NOTIFICATION),
+                "HIRED" => std::option::Option::Some(Self::HIRED),
+                "SENT_CV" => std::option::Option::Some(Self::SENT_CV),
+                "INTERVIEW_GRANTED" => std::option::Option::Some(Self::INTERVIEW_GRANTED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for JobEventType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for JobEventType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for JobEventType {
         fn default() -> Self {
-            job_event_type::JOB_EVENT_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3200,51 +3417,69 @@ pub mod location_filter {
 
     /// Specify whether to include telecommute jobs.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TelecommutePreference(std::borrow::Cow<'static, str>);
+    pub struct TelecommutePreference(i32);
 
     impl TelecommutePreference {
-        /// Creates a new TelecommutePreference instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [TelecommutePreference](TelecommutePreference)
-    pub mod telecommute_preference {
-        use super::TelecommutePreference;
-
         /// Default value if the telecommute preference isn't specified.
         pub const TELECOMMUTE_PREFERENCE_UNSPECIFIED: TelecommutePreference =
-            TelecommutePreference::new("TELECOMMUTE_PREFERENCE_UNSPECIFIED");
+            TelecommutePreference::new(0);
 
         /// Deprecated: Ignore telecommute status of jobs. Use
         /// TELECOMMUTE_JOBS_EXCLUDED if want to exclude telecommute jobs.
-        pub const TELECOMMUTE_EXCLUDED: TelecommutePreference =
-            TelecommutePreference::new("TELECOMMUTE_EXCLUDED");
+        pub const TELECOMMUTE_EXCLUDED: TelecommutePreference = TelecommutePreference::new(1);
 
         /// Allow telecommute jobs.
-        pub const TELECOMMUTE_ALLOWED: TelecommutePreference =
-            TelecommutePreference::new("TELECOMMUTE_ALLOWED");
+        pub const TELECOMMUTE_ALLOWED: TelecommutePreference = TelecommutePreference::new(2);
 
         /// Exclude telecommute jobs.
-        pub const TELECOMMUTE_JOBS_EXCLUDED: TelecommutePreference =
-            TelecommutePreference::new("TELECOMMUTE_JOBS_EXCLUDED");
+        pub const TELECOMMUTE_JOBS_EXCLUDED: TelecommutePreference = TelecommutePreference::new(3);
+
+        /// Creates a new TelecommutePreference instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TELECOMMUTE_PREFERENCE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TELECOMMUTE_EXCLUDED"),
+                2 => std::borrow::Cow::Borrowed("TELECOMMUTE_ALLOWED"),
+                3 => std::borrow::Cow::Borrowed("TELECOMMUTE_JOBS_EXCLUDED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TELECOMMUTE_PREFERENCE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::TELECOMMUTE_PREFERENCE_UNSPECIFIED)
+                }
+                "TELECOMMUTE_EXCLUDED" => std::option::Option::Some(Self::TELECOMMUTE_EXCLUDED),
+                "TELECOMMUTE_ALLOWED" => std::option::Option::Some(Self::TELECOMMUTE_ALLOWED),
+                "TELECOMMUTE_JOBS_EXCLUDED" => {
+                    std::option::Option::Some(Self::TELECOMMUTE_JOBS_EXCLUDED)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for TelecommutePreference {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TelecommutePreference {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TelecommutePreference {
         fn default() -> Self {
-            telecommute_preference::TELECOMMUTE_PREFERENCE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3334,26 +3569,11 @@ pub mod compensation_filter {
 
     /// Specify the type of filtering.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FilterType(std::borrow::Cow<'static, str>);
+    pub struct FilterType(i32);
 
     impl FilterType {
-        /// Creates a new FilterType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [FilterType](FilterType)
-    pub mod filter_type {
-        use super::FilterType;
-
         /// Filter type unspecified. Position holder, INVALID, should never be used.
-        pub const FILTER_TYPE_UNSPECIFIED: FilterType = FilterType::new("FILTER_TYPE_UNSPECIFIED");
+        pub const FILTER_TYPE_UNSPECIFIED: FilterType = FilterType::new(0);
 
         /// Filter by `base compensation entry's` unit. A job is a match if and
         /// only if the job contains a base CompensationEntry and the base
@@ -3367,7 +3587,7 @@ pub mod compensation_filter {
         ///
         /// [google.cloud.talent.v4.CompensationFilter.units]: crate::model::CompensationFilter::units
         /// [google.cloud.talent.v4.CompensationInfo.CompensationEntry]: crate::model::compensation_info::CompensationEntry
-        pub const UNIT_ONLY: FilterType = FilterType::new("UNIT_ONLY");
+        pub const UNIT_ONLY: FilterType = FilterType::new(1);
 
         /// Filter by `base compensation entry's` unit and amount / range. A job
         /// is a match if and only if the job contains a base CompensationEntry, and
@@ -3388,7 +3608,7 @@ pub mod compensation_filter {
         /// [google.cloud.talent.v4.CompensationInfo.CompensationEntry]: crate::model::compensation_info::CompensationEntry
         /// [google.cloud.talent.v4.CompensationInfo.CompensationRange]: crate::model::compensation_info::CompensationRange
         /// [google.cloud.talent.v4.CompensationInfo.CompensationUnit]: crate::model::compensation_info::CompensationUnit
-        pub const UNIT_AND_AMOUNT: FilterType = FilterType::new("UNIT_AND_AMOUNT");
+        pub const UNIT_AND_AMOUNT: FilterType = FilterType::new(2);
 
         /// Filter by annualized base compensation amount and `base compensation
         /// entry's` unit. Populate
@@ -3397,7 +3617,7 @@ pub mod compensation_filter {
         ///
         /// [google.cloud.talent.v4.CompensationFilter.range]: crate::model::CompensationFilter::range
         /// [google.cloud.talent.v4.CompensationFilter.units]: crate::model::CompensationFilter::units
-        pub const ANNUALIZED_BASE_AMOUNT: FilterType = FilterType::new("ANNUALIZED_BASE_AMOUNT");
+        pub const ANNUALIZED_BASE_AMOUNT: FilterType = FilterType::new(3);
 
         /// Filter by annualized total compensation amount and `base compensation
         /// entry's` unit . Populate
@@ -3406,18 +3626,56 @@ pub mod compensation_filter {
         ///
         /// [google.cloud.talent.v4.CompensationFilter.range]: crate::model::CompensationFilter::range
         /// [google.cloud.talent.v4.CompensationFilter.units]: crate::model::CompensationFilter::units
-        pub const ANNUALIZED_TOTAL_AMOUNT: FilterType = FilterType::new("ANNUALIZED_TOTAL_AMOUNT");
+        pub const ANNUALIZED_TOTAL_AMOUNT: FilterType = FilterType::new(4);
+
+        /// Creates a new FilterType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FILTER_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("UNIT_ONLY"),
+                2 => std::borrow::Cow::Borrowed("UNIT_AND_AMOUNT"),
+                3 => std::borrow::Cow::Borrowed("ANNUALIZED_BASE_AMOUNT"),
+                4 => std::borrow::Cow::Borrowed("ANNUALIZED_TOTAL_AMOUNT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FILTER_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::FILTER_TYPE_UNSPECIFIED)
+                }
+                "UNIT_ONLY" => std::option::Option::Some(Self::UNIT_ONLY),
+                "UNIT_AND_AMOUNT" => std::option::Option::Some(Self::UNIT_AND_AMOUNT),
+                "ANNUALIZED_BASE_AMOUNT" => std::option::Option::Some(Self::ANNUALIZED_BASE_AMOUNT),
+                "ANNUALIZED_TOTAL_AMOUNT" => {
+                    std::option::Option::Some(Self::ANNUALIZED_TOTAL_AMOUNT)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for FilterType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for FilterType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for FilterType {
         fn default() -> Self {
-            filter_type::FILTER_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3578,44 +3836,60 @@ pub mod commute_filter {
 
     /// The traffic density to use when calculating commute time.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RoadTraffic(std::borrow::Cow<'static, str>);
+    pub struct RoadTraffic(i32);
 
     impl RoadTraffic {
+        /// Road traffic situation isn't specified.
+        pub const ROAD_TRAFFIC_UNSPECIFIED: RoadTraffic = RoadTraffic::new(0);
+
+        /// Optimal commute time without considering any traffic impact.
+        pub const TRAFFIC_FREE: RoadTraffic = RoadTraffic::new(1);
+
+        /// Commute time calculation takes in account the peak traffic impact.
+        pub const BUSY_HOUR: RoadTraffic = RoadTraffic::new(2);
+
         /// Creates a new RoadTraffic instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ROAD_TRAFFIC_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TRAFFIC_FREE"),
+                2 => std::borrow::Cow::Borrowed("BUSY_HOUR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ROAD_TRAFFIC_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ROAD_TRAFFIC_UNSPECIFIED)
+                }
+                "TRAFFIC_FREE" => std::option::Option::Some(Self::TRAFFIC_FREE),
+                "BUSY_HOUR" => std::option::Option::Some(Self::BUSY_HOUR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RoadTraffic](RoadTraffic)
-    pub mod road_traffic {
-        use super::RoadTraffic;
-
-        /// Road traffic situation isn't specified.
-        pub const ROAD_TRAFFIC_UNSPECIFIED: RoadTraffic =
-            RoadTraffic::new("ROAD_TRAFFIC_UNSPECIFIED");
-
-        /// Optimal commute time without considering any traffic impact.
-        pub const TRAFFIC_FREE: RoadTraffic = RoadTraffic::new("TRAFFIC_FREE");
-
-        /// Commute time calculation takes in account the peak traffic impact.
-        pub const BUSY_HOUR: RoadTraffic = RoadTraffic::new("BUSY_HOUR");
-    }
-
-    impl std::convert::From<std::string::String> for RoadTraffic {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RoadTraffic {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RoadTraffic {
         fn default() -> Self {
-            road_traffic::ROAD_TRAFFIC_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -5500,68 +5774,92 @@ pub mod search_jobs_request {
         ///
         /// [google.cloud.talent.v4.SearchJobsRequest.CustomRankingInfo.ranking_expression]: crate::model::search_jobs_request::CustomRankingInfo::ranking_expression
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ImportanceLevel(std::borrow::Cow<'static, str>);
+        pub struct ImportanceLevel(i32);
 
         impl ImportanceLevel {
-            /// Creates a new ImportanceLevel instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [ImportanceLevel](ImportanceLevel)
-        pub mod importance_level {
-            use super::ImportanceLevel;
-
             /// Default value if the importance level isn't specified.
-            pub const IMPORTANCE_LEVEL_UNSPECIFIED: ImportanceLevel =
-                ImportanceLevel::new("IMPORTANCE_LEVEL_UNSPECIFIED");
+            pub const IMPORTANCE_LEVEL_UNSPECIFIED: ImportanceLevel = ImportanceLevel::new(0);
 
             /// The given ranking expression is of None importance, existing relevance
             /// score (determined by API algorithm) dominates job's final ranking
             /// position.
-            pub const NONE: ImportanceLevel = ImportanceLevel::new("NONE");
+            pub const NONE: ImportanceLevel = ImportanceLevel::new(1);
 
             /// The given ranking expression is of Low importance in terms of job's
             /// final ranking position compared to existing relevance
             /// score (determined by API algorithm).
-            pub const LOW: ImportanceLevel = ImportanceLevel::new("LOW");
+            pub const LOW: ImportanceLevel = ImportanceLevel::new(2);
 
             /// The given ranking expression is of Mild importance in terms of job's
             /// final ranking position compared to existing relevance
             /// score (determined by API algorithm).
-            pub const MILD: ImportanceLevel = ImportanceLevel::new("MILD");
+            pub const MILD: ImportanceLevel = ImportanceLevel::new(3);
 
             /// The given ranking expression is of Medium importance in terms of job's
             /// final ranking position compared to existing relevance
             /// score (determined by API algorithm).
-            pub const MEDIUM: ImportanceLevel = ImportanceLevel::new("MEDIUM");
+            pub const MEDIUM: ImportanceLevel = ImportanceLevel::new(4);
 
             /// The given ranking expression is of High importance in terms of job's
             /// final ranking position compared to existing relevance
             /// score (determined by API algorithm).
-            pub const HIGH: ImportanceLevel = ImportanceLevel::new("HIGH");
+            pub const HIGH: ImportanceLevel = ImportanceLevel::new(5);
 
             /// The given ranking expression is of Extreme importance, and dominates
             /// job's final ranking position with existing relevance
             /// score (determined by API algorithm) ignored.
-            pub const EXTREME: ImportanceLevel = ImportanceLevel::new("EXTREME");
+            pub const EXTREME: ImportanceLevel = ImportanceLevel::new(6);
+
+            /// Creates a new ImportanceLevel instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("IMPORTANCE_LEVEL_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("NONE"),
+                    2 => std::borrow::Cow::Borrowed("LOW"),
+                    3 => std::borrow::Cow::Borrowed("MILD"),
+                    4 => std::borrow::Cow::Borrowed("MEDIUM"),
+                    5 => std::borrow::Cow::Borrowed("HIGH"),
+                    6 => std::borrow::Cow::Borrowed("EXTREME"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "IMPORTANCE_LEVEL_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::IMPORTANCE_LEVEL_UNSPECIFIED)
+                    }
+                    "NONE" => std::option::Option::Some(Self::NONE),
+                    "LOW" => std::option::Option::Some(Self::LOW),
+                    "MILD" => std::option::Option::Some(Self::MILD),
+                    "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
+                    "HIGH" => std::option::Option::Some(Self::HIGH),
+                    "EXTREME" => std::option::Option::Some(Self::EXTREME),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for ImportanceLevel {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for ImportanceLevel {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for ImportanceLevel {
             fn default() -> Self {
-                importance_level::IMPORTANCE_LEVEL_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -5569,49 +5867,66 @@ pub mod search_jobs_request {
     /// A string-represented enumeration of the job search mode. The service
     /// operate differently for different modes of service.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SearchMode(std::borrow::Cow<'static, str>);
+    pub struct SearchMode(i32);
 
     impl SearchMode {
-        /// Creates a new SearchMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [SearchMode](SearchMode)
-    pub mod search_mode {
-        use super::SearchMode;
-
         /// The mode of the search method isn't specified. The default search
         /// behavior is identical to JOB_SEARCH search behavior.
-        pub const SEARCH_MODE_UNSPECIFIED: SearchMode = SearchMode::new("SEARCH_MODE_UNSPECIFIED");
+        pub const SEARCH_MODE_UNSPECIFIED: SearchMode = SearchMode::new(0);
 
         /// The job search matches against all jobs, and featured jobs
         /// (jobs with promotionValue > 0) are not specially handled.
-        pub const JOB_SEARCH: SearchMode = SearchMode::new("JOB_SEARCH");
+        pub const JOB_SEARCH: SearchMode = SearchMode::new(1);
 
         /// The job search matches only against featured jobs (jobs with a
         /// promotionValue > 0). This method doesn't return any jobs having a
         /// promotionValue <= 0. The search results order is determined by the
         /// promotionValue (jobs with a higher promotionValue are returned higher up
         /// in the search results), with relevance being used as a tiebreaker.
-        pub const FEATURED_JOB_SEARCH: SearchMode = SearchMode::new("FEATURED_JOB_SEARCH");
+        pub const FEATURED_JOB_SEARCH: SearchMode = SearchMode::new(2);
+
+        /// Creates a new SearchMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SEARCH_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("JOB_SEARCH"),
+                2 => std::borrow::Cow::Borrowed("FEATURED_JOB_SEARCH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SEARCH_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SEARCH_MODE_UNSPECIFIED)
+                }
+                "JOB_SEARCH" => std::option::Option::Some(Self::JOB_SEARCH),
+                "FEATURED_JOB_SEARCH" => std::option::Option::Some(Self::FEATURED_JOB_SEARCH),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for SearchMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SearchMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SearchMode {
         fn default() -> Self {
-            search_mode::SEARCH_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -5627,72 +5942,96 @@ pub mod search_jobs_request {
     /// returned. If you are using page offset, latency might be higher but all
     /// results are returned.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DiversificationLevel(std::borrow::Cow<'static, str>);
+    pub struct DiversificationLevel(i32);
 
     impl DiversificationLevel {
-        /// Creates a new DiversificationLevel instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DiversificationLevel](DiversificationLevel)
-    pub mod diversification_level {
-        use super::DiversificationLevel;
-
         /// The diversification level isn't specified.
         pub const DIVERSIFICATION_LEVEL_UNSPECIFIED: DiversificationLevel =
-            DiversificationLevel::new("DIVERSIFICATION_LEVEL_UNSPECIFIED");
+            DiversificationLevel::new(0);
 
         /// Disables diversification. Jobs that would normally be pushed to the last
         /// page would not have their positions altered. This may result in highly
         /// similar jobs appearing in sequence in the search results.
-        pub const DISABLED: DiversificationLevel = DiversificationLevel::new("DISABLED");
+        pub const DISABLED: DiversificationLevel = DiversificationLevel::new(1);
 
         /// Default diversifying behavior. The result list is ordered so that
         /// highly similar results are pushed to the end of the last page of search
         /// results.
-        pub const SIMPLE: DiversificationLevel = DiversificationLevel::new("SIMPLE");
+        pub const SIMPLE: DiversificationLevel = DiversificationLevel::new(2);
 
         /// Only one job from the same company will be shown at once, other jobs
         /// under same company are pushed to the end of the last page of search
         /// result.
-        pub const ONE_PER_COMPANY: DiversificationLevel =
-            DiversificationLevel::new("ONE_PER_COMPANY");
+        pub const ONE_PER_COMPANY: DiversificationLevel = DiversificationLevel::new(3);
 
         /// Similar to ONE_PER_COMPANY, but it allows at most two jobs in the
         /// same company to be shown at once, the other jobs under same company are
         /// pushed to the end of the last page of search result.
-        pub const TWO_PER_COMPANY: DiversificationLevel =
-            DiversificationLevel::new("TWO_PER_COMPANY");
+        pub const TWO_PER_COMPANY: DiversificationLevel = DiversificationLevel::new(4);
 
         /// Similar to ONE_PER_COMPANY, but it allows at most three jobs in the
         /// same company to be shown at once, the other jobs under same company are
         /// dropped.
-        pub const MAX_THREE_PER_COMPANY: DiversificationLevel =
-            DiversificationLevel::new("MAX_THREE_PER_COMPANY");
+        pub const MAX_THREE_PER_COMPANY: DiversificationLevel = DiversificationLevel::new(6);
 
         /// The result list is ordered such that somewhat similar results are pushed
         /// to the end of the last page of the search results. This option is
         /// recommended if SIMPLE diversification does not diversify enough.
         pub const DIVERSIFY_BY_LOOSER_SIMILARITY: DiversificationLevel =
-            DiversificationLevel::new("DIVERSIFY_BY_LOOSER_SIMILARITY");
+            DiversificationLevel::new(5);
+
+        /// Creates a new DiversificationLevel instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DIVERSIFICATION_LEVEL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DISABLED"),
+                2 => std::borrow::Cow::Borrowed("SIMPLE"),
+                3 => std::borrow::Cow::Borrowed("ONE_PER_COMPANY"),
+                4 => std::borrow::Cow::Borrowed("TWO_PER_COMPANY"),
+                5 => std::borrow::Cow::Borrowed("DIVERSIFY_BY_LOOSER_SIMILARITY"),
+                6 => std::borrow::Cow::Borrowed("MAX_THREE_PER_COMPANY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DIVERSIFICATION_LEVEL_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DIVERSIFICATION_LEVEL_UNSPECIFIED)
+                }
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "SIMPLE" => std::option::Option::Some(Self::SIMPLE),
+                "ONE_PER_COMPANY" => std::option::Option::Some(Self::ONE_PER_COMPANY),
+                "TWO_PER_COMPANY" => std::option::Option::Some(Self::TWO_PER_COMPANY),
+                "MAX_THREE_PER_COMPANY" => std::option::Option::Some(Self::MAX_THREE_PER_COMPANY),
+                "DIVERSIFY_BY_LOOSER_SIMILARITY" => {
+                    std::option::Option::Some(Self::DIVERSIFY_BY_LOOSER_SIMILARITY)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DiversificationLevel {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DiversificationLevel {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DiversificationLevel {
         fn default() -> Self {
-            diversification_level::DIVERSIFICATION_LEVEL_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -5716,35 +6055,18 @@ pub mod search_jobs_request {
     ///
     /// [google.cloud.talent.v4.Company.keyword_searchable_job_custom_attributes]: crate::model::Company::keyword_searchable_job_custom_attributes
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct KeywordMatchMode(std::borrow::Cow<'static, str>);
+    pub struct KeywordMatchMode(i32);
 
     impl KeywordMatchMode {
-        /// Creates a new KeywordMatchMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [KeywordMatchMode](KeywordMatchMode)
-    pub mod keyword_match_mode {
-        use super::KeywordMatchMode;
-
         /// The keyword match option isn't specified. Defaults to
         /// [KeywordMatchMode.KEYWORD_MATCH_ALL][google.cloud.talent.v4.SearchJobsRequest.KeywordMatchMode.KEYWORD_MATCH_ALL]
         /// behavior.
         ///
         /// [google.cloud.talent.v4.SearchJobsRequest.KeywordMatchMode.KEYWORD_MATCH_ALL]: crate::model::search_jobs_request::keyword_match_mode::KEYWORD_MATCH_ALL
-        pub const KEYWORD_MATCH_MODE_UNSPECIFIED: KeywordMatchMode =
-            KeywordMatchMode::new("KEYWORD_MATCH_MODE_UNSPECIFIED");
+        pub const KEYWORD_MATCH_MODE_UNSPECIFIED: KeywordMatchMode = KeywordMatchMode::new(0);
 
         /// Disables keyword matching.
-        pub const KEYWORD_MATCH_DISABLED: KeywordMatchMode =
-            KeywordMatchMode::new("KEYWORD_MATCH_DISABLED");
+        pub const KEYWORD_MATCH_DISABLED: KeywordMatchMode = KeywordMatchMode::new(1);
 
         /// Enable keyword matching over
         /// [Job.title][google.cloud.talent.v4.Job.title],
@@ -5762,25 +6084,60 @@ pub mod search_jobs_request {
         /// [google.cloud.talent.v4.Job.description]: crate::model::Job::description
         /// [google.cloud.talent.v4.Job.qualifications]: crate::model::Job::qualifications
         /// [google.cloud.talent.v4.Job.title]: crate::model::Job::title
-        pub const KEYWORD_MATCH_ALL: KeywordMatchMode = KeywordMatchMode::new("KEYWORD_MATCH_ALL");
+        pub const KEYWORD_MATCH_ALL: KeywordMatchMode = KeywordMatchMode::new(2);
 
         /// Only enable keyword matching over
         /// [Job.title][google.cloud.talent.v4.Job.title].
         ///
         /// [google.cloud.talent.v4.Job.title]: crate::model::Job::title
-        pub const KEYWORD_MATCH_TITLE_ONLY: KeywordMatchMode =
-            KeywordMatchMode::new("KEYWORD_MATCH_TITLE_ONLY");
+        pub const KEYWORD_MATCH_TITLE_ONLY: KeywordMatchMode = KeywordMatchMode::new(3);
+
+        /// Creates a new KeywordMatchMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("KEYWORD_MATCH_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("KEYWORD_MATCH_DISABLED"),
+                2 => std::borrow::Cow::Borrowed("KEYWORD_MATCH_ALL"),
+                3 => std::borrow::Cow::Borrowed("KEYWORD_MATCH_TITLE_ONLY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "KEYWORD_MATCH_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::KEYWORD_MATCH_MODE_UNSPECIFIED)
+                }
+                "KEYWORD_MATCH_DISABLED" => std::option::Option::Some(Self::KEYWORD_MATCH_DISABLED),
+                "KEYWORD_MATCH_ALL" => std::option::Option::Some(Self::KEYWORD_MATCH_ALL),
+                "KEYWORD_MATCH_TITLE_ONLY" => {
+                    std::option::Option::Some(Self::KEYWORD_MATCH_TITLE_ONLY)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for KeywordMatchMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for KeywordMatchMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for KeywordMatchMode {
         fn default() -> Self {
-            keyword_match_mode::KEYWORD_MATCH_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -5788,51 +6145,71 @@ pub mod search_jobs_request {
     /// threshold is, the higher relevant results are shown and the less number of
     /// results are returned.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RelevanceThreshold(std::borrow::Cow<'static, str>);
+    pub struct RelevanceThreshold(i32);
 
     impl RelevanceThreshold {
+        /// Default value. In this case, server behavior defaults to Google defined
+        /// threshold.
+        pub const RELEVANCE_THRESHOLD_UNSPECIFIED: RelevanceThreshold = RelevanceThreshold::new(0);
+
+        /// Lowest relevance threshold.
+        pub const LOWEST: RelevanceThreshold = RelevanceThreshold::new(1);
+
+        /// Low relevance threshold.
+        pub const LOW: RelevanceThreshold = RelevanceThreshold::new(2);
+
+        /// Medium relevance threshold.
+        pub const MEDIUM: RelevanceThreshold = RelevanceThreshold::new(3);
+
+        /// High relevance threshold.
+        pub const HIGH: RelevanceThreshold = RelevanceThreshold::new(4);
+
         /// Creates a new RelevanceThreshold instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RELEVANCE_THRESHOLD_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LOWEST"),
+                2 => std::borrow::Cow::Borrowed("LOW"),
+                3 => std::borrow::Cow::Borrowed("MEDIUM"),
+                4 => std::borrow::Cow::Borrowed("HIGH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RELEVANCE_THRESHOLD_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RELEVANCE_THRESHOLD_UNSPECIFIED)
+                }
+                "LOWEST" => std::option::Option::Some(Self::LOWEST),
+                "LOW" => std::option::Option::Some(Self::LOW),
+                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
+                "HIGH" => std::option::Option::Some(Self::HIGH),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RelevanceThreshold](RelevanceThreshold)
-    pub mod relevance_threshold {
-        use super::RelevanceThreshold;
-
-        /// Default value. In this case, server behavior defaults to Google defined
-        /// threshold.
-        pub const RELEVANCE_THRESHOLD_UNSPECIFIED: RelevanceThreshold =
-            RelevanceThreshold::new("RELEVANCE_THRESHOLD_UNSPECIFIED");
-
-        /// Lowest relevance threshold.
-        pub const LOWEST: RelevanceThreshold = RelevanceThreshold::new("LOWEST");
-
-        /// Low relevance threshold.
-        pub const LOW: RelevanceThreshold = RelevanceThreshold::new("LOW");
-
-        /// Medium relevance threshold.
-        pub const MEDIUM: RelevanceThreshold = RelevanceThreshold::new("MEDIUM");
-
-        /// High relevance threshold.
-        pub const HIGH: RelevanceThreshold = RelevanceThreshold::new("HIGH");
-    }
-
-    impl std::convert::From<std::string::String> for RelevanceThreshold {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RelevanceThreshold {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RelevanceThreshold {
         fn default() -> Self {
-            relevance_threshold::RELEVANCE_THRESHOLD_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6855,256 +7232,329 @@ impl gax::paginator::PageableResponse for ListTenantsResponse {
 
 /// An enum that represents the size of the company.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct CompanySize(std::borrow::Cow<'static, str>);
+pub struct CompanySize(i32);
 
 impl CompanySize {
+    /// Default value if the size isn't specified.
+    pub const COMPANY_SIZE_UNSPECIFIED: CompanySize = CompanySize::new(0);
+
+    /// The company has less than 50 employees.
+    pub const MINI: CompanySize = CompanySize::new(1);
+
+    /// The company has between 50 and 99 employees.
+    pub const SMALL: CompanySize = CompanySize::new(2);
+
+    /// The company has between 100 and 499 employees.
+    pub const SMEDIUM: CompanySize = CompanySize::new(3);
+
+    /// The company has between 500 and 999 employees.
+    pub const MEDIUM: CompanySize = CompanySize::new(4);
+
+    /// The company has between 1,000 and 4,999 employees.
+    pub const BIG: CompanySize = CompanySize::new(5);
+
+    /// The company has between 5,000 and 9,999 employees.
+    pub const BIGGER: CompanySize = CompanySize::new(6);
+
+    /// The company has 10,000 or more employees.
+    pub const GIANT: CompanySize = CompanySize::new(7);
+
     /// Creates a new CompanySize instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("COMPANY_SIZE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("MINI"),
+            2 => std::borrow::Cow::Borrowed("SMALL"),
+            3 => std::borrow::Cow::Borrowed("SMEDIUM"),
+            4 => std::borrow::Cow::Borrowed("MEDIUM"),
+            5 => std::borrow::Cow::Borrowed("BIG"),
+            6 => std::borrow::Cow::Borrowed("BIGGER"),
+            7 => std::borrow::Cow::Borrowed("GIANT"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "COMPANY_SIZE_UNSPECIFIED" => std::option::Option::Some(Self::COMPANY_SIZE_UNSPECIFIED),
+            "MINI" => std::option::Option::Some(Self::MINI),
+            "SMALL" => std::option::Option::Some(Self::SMALL),
+            "SMEDIUM" => std::option::Option::Some(Self::SMEDIUM),
+            "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
+            "BIG" => std::option::Option::Some(Self::BIG),
+            "BIGGER" => std::option::Option::Some(Self::BIGGER),
+            "GIANT" => std::option::Option::Some(Self::GIANT),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [CompanySize](CompanySize)
-pub mod company_size {
-    use super::CompanySize;
-
-    /// Default value if the size isn't specified.
-    pub const COMPANY_SIZE_UNSPECIFIED: CompanySize = CompanySize::new("COMPANY_SIZE_UNSPECIFIED");
-
-    /// The company has less than 50 employees.
-    pub const MINI: CompanySize = CompanySize::new("MINI");
-
-    /// The company has between 50 and 99 employees.
-    pub const SMALL: CompanySize = CompanySize::new("SMALL");
-
-    /// The company has between 100 and 499 employees.
-    pub const SMEDIUM: CompanySize = CompanySize::new("SMEDIUM");
-
-    /// The company has between 500 and 999 employees.
-    pub const MEDIUM: CompanySize = CompanySize::new("MEDIUM");
-
-    /// The company has between 1,000 and 4,999 employees.
-    pub const BIG: CompanySize = CompanySize::new("BIG");
-
-    /// The company has between 5,000 and 9,999 employees.
-    pub const BIGGER: CompanySize = CompanySize::new("BIGGER");
-
-    /// The company has 10,000 or more employees.
-    pub const GIANT: CompanySize = CompanySize::new("GIANT");
-}
-
-impl std::convert::From<std::string::String> for CompanySize {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for CompanySize {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for CompanySize {
     fn default() -> Self {
-        company_size::COMPANY_SIZE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// An enum that represents employee benefits included with the job.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct JobBenefit(std::borrow::Cow<'static, str>);
+pub struct JobBenefit(i32);
 
 impl JobBenefit {
-    /// Creates a new JobBenefit instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [JobBenefit](JobBenefit)
-pub mod job_benefit {
-    use super::JobBenefit;
-
     /// Default value if the type isn't specified.
-    pub const JOB_BENEFIT_UNSPECIFIED: JobBenefit = JobBenefit::new("JOB_BENEFIT_UNSPECIFIED");
+    pub const JOB_BENEFIT_UNSPECIFIED: JobBenefit = JobBenefit::new(0);
 
     /// The job includes access to programs that support child care, such
     /// as daycare.
-    pub const CHILD_CARE: JobBenefit = JobBenefit::new("CHILD_CARE");
+    pub const CHILD_CARE: JobBenefit = JobBenefit::new(1);
 
     /// The job includes dental services covered by a dental
     /// insurance plan.
-    pub const DENTAL: JobBenefit = JobBenefit::new("DENTAL");
+    pub const DENTAL: JobBenefit = JobBenefit::new(2);
 
     /// The job offers specific benefits to domestic partners.
-    pub const DOMESTIC_PARTNER: JobBenefit = JobBenefit::new("DOMESTIC_PARTNER");
+    pub const DOMESTIC_PARTNER: JobBenefit = JobBenefit::new(3);
 
     /// The job allows for a flexible work schedule.
-    pub const FLEXIBLE_HOURS: JobBenefit = JobBenefit::new("FLEXIBLE_HOURS");
+    pub const FLEXIBLE_HOURS: JobBenefit = JobBenefit::new(4);
 
     /// The job includes health services covered by a medical insurance plan.
-    pub const MEDICAL: JobBenefit = JobBenefit::new("MEDICAL");
+    pub const MEDICAL: JobBenefit = JobBenefit::new(5);
 
     /// The job includes a life insurance plan provided by the employer or
     /// available for purchase by the employee.
-    pub const LIFE_INSURANCE: JobBenefit = JobBenefit::new("LIFE_INSURANCE");
+    pub const LIFE_INSURANCE: JobBenefit = JobBenefit::new(6);
 
     /// The job allows for a leave of absence to a parent to care for a newborn
     /// child.
-    pub const PARENTAL_LEAVE: JobBenefit = JobBenefit::new("PARENTAL_LEAVE");
+    pub const PARENTAL_LEAVE: JobBenefit = JobBenefit::new(7);
 
     /// The job includes a workplace retirement plan provided by the
     /// employer or available for purchase by the employee.
-    pub const RETIREMENT_PLAN: JobBenefit = JobBenefit::new("RETIREMENT_PLAN");
+    pub const RETIREMENT_PLAN: JobBenefit = JobBenefit::new(8);
 
     /// The job allows for paid time off due to illness.
-    pub const SICK_DAYS: JobBenefit = JobBenefit::new("SICK_DAYS");
+    pub const SICK_DAYS: JobBenefit = JobBenefit::new(9);
 
     /// The job includes paid time off for vacation.
-    pub const VACATION: JobBenefit = JobBenefit::new("VACATION");
+    pub const VACATION: JobBenefit = JobBenefit::new(10);
 
     /// The job includes vision services covered by a vision
     /// insurance plan.
-    pub const VISION: JobBenefit = JobBenefit::new("VISION");
+    pub const VISION: JobBenefit = JobBenefit::new(11);
+
+    /// Creates a new JobBenefit instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("JOB_BENEFIT_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("CHILD_CARE"),
+            2 => std::borrow::Cow::Borrowed("DENTAL"),
+            3 => std::borrow::Cow::Borrowed("DOMESTIC_PARTNER"),
+            4 => std::borrow::Cow::Borrowed("FLEXIBLE_HOURS"),
+            5 => std::borrow::Cow::Borrowed("MEDICAL"),
+            6 => std::borrow::Cow::Borrowed("LIFE_INSURANCE"),
+            7 => std::borrow::Cow::Borrowed("PARENTAL_LEAVE"),
+            8 => std::borrow::Cow::Borrowed("RETIREMENT_PLAN"),
+            9 => std::borrow::Cow::Borrowed("SICK_DAYS"),
+            10 => std::borrow::Cow::Borrowed("VACATION"),
+            11 => std::borrow::Cow::Borrowed("VISION"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "JOB_BENEFIT_UNSPECIFIED" => std::option::Option::Some(Self::JOB_BENEFIT_UNSPECIFIED),
+            "CHILD_CARE" => std::option::Option::Some(Self::CHILD_CARE),
+            "DENTAL" => std::option::Option::Some(Self::DENTAL),
+            "DOMESTIC_PARTNER" => std::option::Option::Some(Self::DOMESTIC_PARTNER),
+            "FLEXIBLE_HOURS" => std::option::Option::Some(Self::FLEXIBLE_HOURS),
+            "MEDICAL" => std::option::Option::Some(Self::MEDICAL),
+            "LIFE_INSURANCE" => std::option::Option::Some(Self::LIFE_INSURANCE),
+            "PARENTAL_LEAVE" => std::option::Option::Some(Self::PARENTAL_LEAVE),
+            "RETIREMENT_PLAN" => std::option::Option::Some(Self::RETIREMENT_PLAN),
+            "SICK_DAYS" => std::option::Option::Some(Self::SICK_DAYS),
+            "VACATION" => std::option::Option::Some(Self::VACATION),
+            "VISION" => std::option::Option::Some(Self::VISION),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for JobBenefit {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for JobBenefit {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for JobBenefit {
     fn default() -> Self {
-        job_benefit::JOB_BENEFIT_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Educational degree level defined in International Standard Classification
 /// of Education (ISCED).
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DegreeType(std::borrow::Cow<'static, str>);
+pub struct DegreeType(i32);
 
 impl DegreeType {
-    /// Creates a new DegreeType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [DegreeType](DegreeType)
-pub mod degree_type {
-    use super::DegreeType;
-
     /// Default value. Represents no degree, or early childhood education.
     /// Maps to ISCED code 0.
     /// Ex) Kindergarten
-    pub const DEGREE_TYPE_UNSPECIFIED: DegreeType = DegreeType::new("DEGREE_TYPE_UNSPECIFIED");
+    pub const DEGREE_TYPE_UNSPECIFIED: DegreeType = DegreeType::new(0);
 
     /// Primary education which is typically the first stage of compulsory
     /// education. ISCED code 1.
     /// Ex) Elementary school
-    pub const PRIMARY_EDUCATION: DegreeType = DegreeType::new("PRIMARY_EDUCATION");
+    pub const PRIMARY_EDUCATION: DegreeType = DegreeType::new(1);
 
     /// Lower secondary education; First stage of secondary education building on
     /// primary education, typically with a more subject-oriented curriculum.
     /// ISCED code 2.
     /// Ex) Middle school
-    pub const LOWER_SECONDARY_EDUCATION: DegreeType = DegreeType::new("LOWER_SECONDARY_EDUCATION");
+    pub const LOWER_SECONDARY_EDUCATION: DegreeType = DegreeType::new(2);
 
     /// Middle education; Second/final stage of secondary education preparing for
     /// tertiary education and/or providing skills relevant to employment.
     /// Usually with an increased range of subject options and streams. ISCED
     /// code 3.
     /// Ex) High school
-    pub const UPPER_SECONDARY_EDUCATION: DegreeType = DegreeType::new("UPPER_SECONDARY_EDUCATION");
+    pub const UPPER_SECONDARY_EDUCATION: DegreeType = DegreeType::new(3);
 
     /// Adult Remedial Education; Programmes providing learning experiences that
     /// build on secondary education and prepare for labour market entry and/or
     /// tertiary education. The content is broader than secondary but not as
     /// complex as tertiary education. ISCED code 4.
-    pub const ADULT_REMEDIAL_EDUCATION: DegreeType = DegreeType::new("ADULT_REMEDIAL_EDUCATION");
+    pub const ADULT_REMEDIAL_EDUCATION: DegreeType = DegreeType::new(4);
 
     /// Associate's or equivalent; Short first tertiary programmes that are
     /// typically practically-based, occupationally-specific and prepare for
     /// labour market entry. These programmes may also provide a pathway to other
     /// tertiary programmes. ISCED code 5.
-    pub const ASSOCIATES_OR_EQUIVALENT: DegreeType = DegreeType::new("ASSOCIATES_OR_EQUIVALENT");
+    pub const ASSOCIATES_OR_EQUIVALENT: DegreeType = DegreeType::new(5);
 
     /// Bachelor's or equivalent; Programmes designed to provide intermediate
     /// academic and/or professional knowledge, skills and competencies leading
     /// to a first tertiary degree or equivalent qualification. ISCED code 6.
-    pub const BACHELORS_OR_EQUIVALENT: DegreeType = DegreeType::new("BACHELORS_OR_EQUIVALENT");
+    pub const BACHELORS_OR_EQUIVALENT: DegreeType = DegreeType::new(6);
 
     /// Master's or equivalent; Programmes designed to provide advanced academic
     /// and/or professional knowledge, skills and competencies leading to a
     /// second tertiary degree or equivalent qualification. ISCED code 7.
-    pub const MASTERS_OR_EQUIVALENT: DegreeType = DegreeType::new("MASTERS_OR_EQUIVALENT");
+    pub const MASTERS_OR_EQUIVALENT: DegreeType = DegreeType::new(7);
 
     /// Doctoral or equivalent; Programmes designed primarily to lead to an
     /// advanced research qualification, usually concluding with the submission
     /// and defense of a substantive dissertation of publishable quality based on
     /// original research. ISCED code 8.
-    pub const DOCTORAL_OR_EQUIVALENT: DegreeType = DegreeType::new("DOCTORAL_OR_EQUIVALENT");
+    pub const DOCTORAL_OR_EQUIVALENT: DegreeType = DegreeType::new(8);
+
+    /// Creates a new DegreeType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DEGREE_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PRIMARY_EDUCATION"),
+            2 => std::borrow::Cow::Borrowed("LOWER_SECONDARY_EDUCATION"),
+            3 => std::borrow::Cow::Borrowed("UPPER_SECONDARY_EDUCATION"),
+            4 => std::borrow::Cow::Borrowed("ADULT_REMEDIAL_EDUCATION"),
+            5 => std::borrow::Cow::Borrowed("ASSOCIATES_OR_EQUIVALENT"),
+            6 => std::borrow::Cow::Borrowed("BACHELORS_OR_EQUIVALENT"),
+            7 => std::borrow::Cow::Borrowed("MASTERS_OR_EQUIVALENT"),
+            8 => std::borrow::Cow::Borrowed("DOCTORAL_OR_EQUIVALENT"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DEGREE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::DEGREE_TYPE_UNSPECIFIED),
+            "PRIMARY_EDUCATION" => std::option::Option::Some(Self::PRIMARY_EDUCATION),
+            "LOWER_SECONDARY_EDUCATION" => {
+                std::option::Option::Some(Self::LOWER_SECONDARY_EDUCATION)
+            }
+            "UPPER_SECONDARY_EDUCATION" => {
+                std::option::Option::Some(Self::UPPER_SECONDARY_EDUCATION)
+            }
+            "ADULT_REMEDIAL_EDUCATION" => std::option::Option::Some(Self::ADULT_REMEDIAL_EDUCATION),
+            "ASSOCIATES_OR_EQUIVALENT" => std::option::Option::Some(Self::ASSOCIATES_OR_EQUIVALENT),
+            "BACHELORS_OR_EQUIVALENT" => std::option::Option::Some(Self::BACHELORS_OR_EQUIVALENT),
+            "MASTERS_OR_EQUIVALENT" => std::option::Option::Some(Self::MASTERS_OR_EQUIVALENT),
+            "DOCTORAL_OR_EQUIVALENT" => std::option::Option::Some(Self::DOCTORAL_OR_EQUIVALENT),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for DegreeType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DegreeType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DegreeType {
     fn default() -> Self {
-        degree_type::DEGREE_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// An enum that represents the employment type of a job.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EmploymentType(std::borrow::Cow<'static, str>);
+pub struct EmploymentType(i32);
 
 impl EmploymentType {
-    /// Creates a new EmploymentType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [EmploymentType](EmploymentType)
-pub mod employment_type {
-    use super::EmploymentType;
-
     /// The default value if the employment type isn't specified.
-    pub const EMPLOYMENT_TYPE_UNSPECIFIED: EmploymentType =
-        EmploymentType::new("EMPLOYMENT_TYPE_UNSPECIFIED");
+    pub const EMPLOYMENT_TYPE_UNSPECIFIED: EmploymentType = EmploymentType::new(0);
 
     /// The job requires working a number of hours that constitute full
     /// time employment, typically 40 or more hours per week.
-    pub const FULL_TIME: EmploymentType = EmploymentType::new("FULL_TIME");
+    pub const FULL_TIME: EmploymentType = EmploymentType::new(1);
 
     /// The job entails working fewer hours than a full time job,
     /// typically less than 40 hours a week.
-    pub const PART_TIME: EmploymentType = EmploymentType::new("PART_TIME");
+    pub const PART_TIME: EmploymentType = EmploymentType::new(2);
 
     /// The job is offered as a contracted, as opposed to a salaried employee,
     /// position.
-    pub const CONTRACTOR: EmploymentType = EmploymentType::new("CONTRACTOR");
+    pub const CONTRACTOR: EmploymentType = EmploymentType::new(3);
 
     /// The job is offered as a contracted position with the understanding
     /// that it's converted into a full-time position at the end of the
@@ -7113,96 +7563,165 @@ pub mod employment_type {
     /// jobs.
     ///
     /// [google.cloud.talent.v4.EmploymentType.CONTRACTOR]: crate::model::employment_type::CONTRACTOR
-    pub const CONTRACT_TO_HIRE: EmploymentType = EmploymentType::new("CONTRACT_TO_HIRE");
+    pub const CONTRACT_TO_HIRE: EmploymentType = EmploymentType::new(4);
 
     /// The job is offered as a temporary employment opportunity, usually
     /// a short-term engagement.
-    pub const TEMPORARY: EmploymentType = EmploymentType::new("TEMPORARY");
+    pub const TEMPORARY: EmploymentType = EmploymentType::new(5);
 
     /// The job is a fixed-term opportunity for students or entry-level job
     /// seekers to obtain on-the-job training, typically offered as a summer
     /// position.
-    pub const INTERN: EmploymentType = EmploymentType::new("INTERN");
+    pub const INTERN: EmploymentType = EmploymentType::new(6);
 
     /// The is an opportunity for an individual to volunteer, where there's no
     /// expectation of compensation for the provided services.
-    pub const VOLUNTEER: EmploymentType = EmploymentType::new("VOLUNTEER");
+    pub const VOLUNTEER: EmploymentType = EmploymentType::new(7);
 
     /// The job requires an employee to work on an as-needed basis with a
     /// flexible schedule.
-    pub const PER_DIEM: EmploymentType = EmploymentType::new("PER_DIEM");
+    pub const PER_DIEM: EmploymentType = EmploymentType::new(8);
 
     /// The job involves employing people in remote areas and flying them
     /// temporarily to the work site instead of relocating employees and their
     /// families permanently.
-    pub const FLY_IN_FLY_OUT: EmploymentType = EmploymentType::new("FLY_IN_FLY_OUT");
+    pub const FLY_IN_FLY_OUT: EmploymentType = EmploymentType::new(9);
 
     /// The job does not fit any of the other listed types.
-    pub const OTHER_EMPLOYMENT_TYPE: EmploymentType = EmploymentType::new("OTHER_EMPLOYMENT_TYPE");
+    pub const OTHER_EMPLOYMENT_TYPE: EmploymentType = EmploymentType::new(10);
+
+    /// Creates a new EmploymentType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("EMPLOYMENT_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("FULL_TIME"),
+            2 => std::borrow::Cow::Borrowed("PART_TIME"),
+            3 => std::borrow::Cow::Borrowed("CONTRACTOR"),
+            4 => std::borrow::Cow::Borrowed("CONTRACT_TO_HIRE"),
+            5 => std::borrow::Cow::Borrowed("TEMPORARY"),
+            6 => std::borrow::Cow::Borrowed("INTERN"),
+            7 => std::borrow::Cow::Borrowed("VOLUNTEER"),
+            8 => std::borrow::Cow::Borrowed("PER_DIEM"),
+            9 => std::borrow::Cow::Borrowed("FLY_IN_FLY_OUT"),
+            10 => std::borrow::Cow::Borrowed("OTHER_EMPLOYMENT_TYPE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "EMPLOYMENT_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::EMPLOYMENT_TYPE_UNSPECIFIED)
+            }
+            "FULL_TIME" => std::option::Option::Some(Self::FULL_TIME),
+            "PART_TIME" => std::option::Option::Some(Self::PART_TIME),
+            "CONTRACTOR" => std::option::Option::Some(Self::CONTRACTOR),
+            "CONTRACT_TO_HIRE" => std::option::Option::Some(Self::CONTRACT_TO_HIRE),
+            "TEMPORARY" => std::option::Option::Some(Self::TEMPORARY),
+            "INTERN" => std::option::Option::Some(Self::INTERN),
+            "VOLUNTEER" => std::option::Option::Some(Self::VOLUNTEER),
+            "PER_DIEM" => std::option::Option::Some(Self::PER_DIEM),
+            "FLY_IN_FLY_OUT" => std::option::Option::Some(Self::FLY_IN_FLY_OUT),
+            "OTHER_EMPLOYMENT_TYPE" => std::option::Option::Some(Self::OTHER_EMPLOYMENT_TYPE),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for EmploymentType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for EmploymentType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for EmploymentType {
     fn default() -> Self {
-        employment_type::EMPLOYMENT_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// An enum that represents the required experience level required for the job.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct JobLevel(std::borrow::Cow<'static, str>);
+pub struct JobLevel(i32);
 
 impl JobLevel {
-    /// Creates a new JobLevel instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [JobLevel](JobLevel)
-pub mod job_level {
-    use super::JobLevel;
-
     /// The default value if the level isn't specified.
-    pub const JOB_LEVEL_UNSPECIFIED: JobLevel = JobLevel::new("JOB_LEVEL_UNSPECIFIED");
+    pub const JOB_LEVEL_UNSPECIFIED: JobLevel = JobLevel::new(0);
 
     /// Entry-level individual contributors, typically with less than 2 years of
     /// experience in a similar role. Includes interns.
-    pub const ENTRY_LEVEL: JobLevel = JobLevel::new("ENTRY_LEVEL");
+    pub const ENTRY_LEVEL: JobLevel = JobLevel::new(1);
 
     /// Experienced individual contributors, typically with 2+ years of
     /// experience in a similar role.
-    pub const EXPERIENCED: JobLevel = JobLevel::new("EXPERIENCED");
+    pub const EXPERIENCED: JobLevel = JobLevel::new(2);
 
     /// Entry- to mid-level managers responsible for managing a team of people.
-    pub const MANAGER: JobLevel = JobLevel::new("MANAGER");
+    pub const MANAGER: JobLevel = JobLevel::new(3);
 
     /// Senior-level managers responsible for managing teams of managers.
-    pub const DIRECTOR: JobLevel = JobLevel::new("DIRECTOR");
+    pub const DIRECTOR: JobLevel = JobLevel::new(4);
 
     /// Executive-level managers and above, including C-level positions.
-    pub const EXECUTIVE: JobLevel = JobLevel::new("EXECUTIVE");
+    pub const EXECUTIVE: JobLevel = JobLevel::new(5);
+
+    /// Creates a new JobLevel instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("JOB_LEVEL_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ENTRY_LEVEL"),
+            2 => std::borrow::Cow::Borrowed("EXPERIENCED"),
+            3 => std::borrow::Cow::Borrowed("MANAGER"),
+            4 => std::borrow::Cow::Borrowed("DIRECTOR"),
+            5 => std::borrow::Cow::Borrowed("EXECUTIVE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "JOB_LEVEL_UNSPECIFIED" => std::option::Option::Some(Self::JOB_LEVEL_UNSPECIFIED),
+            "ENTRY_LEVEL" => std::option::Option::Some(Self::ENTRY_LEVEL),
+            "EXPERIENCED" => std::option::Option::Some(Self::EXPERIENCED),
+            "MANAGER" => std::option::Option::Some(Self::MANAGER),
+            "DIRECTOR" => std::option::Option::Some(Self::DIRECTOR),
+            "EXECUTIVE" => std::option::Option::Some(Self::EXECUTIVE),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for JobLevel {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for JobLevel {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for JobLevel {
     fn default() -> Self {
-        job_level::JOB_LEVEL_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -7210,138 +7729,219 @@ impl std::default::Default for JobLevel {
 /// role. This value is different than the "industry" associated with a role,
 /// which is related to the categorization of the company listing the job.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct JobCategory(std::borrow::Cow<'static, str>);
+pub struct JobCategory(i32);
 
 impl JobCategory {
-    /// Creates a new JobCategory instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [JobCategory](JobCategory)
-pub mod job_category {
-    use super::JobCategory;
-
     /// The default value if the category isn't specified.
-    pub const JOB_CATEGORY_UNSPECIFIED: JobCategory = JobCategory::new("JOB_CATEGORY_UNSPECIFIED");
+    pub const JOB_CATEGORY_UNSPECIFIED: JobCategory = JobCategory::new(0);
 
     /// An accounting and finance job, such as an Accountant.
-    pub const ACCOUNTING_AND_FINANCE: JobCategory = JobCategory::new("ACCOUNTING_AND_FINANCE");
+    pub const ACCOUNTING_AND_FINANCE: JobCategory = JobCategory::new(1);
 
     /// An administrative and office job, such as an Administrative Assistant.
-    pub const ADMINISTRATIVE_AND_OFFICE: JobCategory =
-        JobCategory::new("ADMINISTRATIVE_AND_OFFICE");
+    pub const ADMINISTRATIVE_AND_OFFICE: JobCategory = JobCategory::new(2);
 
     /// An advertising and marketing job, such as Marketing Manager.
-    pub const ADVERTISING_AND_MARKETING: JobCategory =
-        JobCategory::new("ADVERTISING_AND_MARKETING");
+    pub const ADVERTISING_AND_MARKETING: JobCategory = JobCategory::new(3);
 
     /// An animal care job, such as Veterinarian.
-    pub const ANIMAL_CARE: JobCategory = JobCategory::new("ANIMAL_CARE");
+    pub const ANIMAL_CARE: JobCategory = JobCategory::new(4);
 
     /// An art, fashion, or design job, such as Designer.
-    pub const ART_FASHION_AND_DESIGN: JobCategory = JobCategory::new("ART_FASHION_AND_DESIGN");
+    pub const ART_FASHION_AND_DESIGN: JobCategory = JobCategory::new(5);
 
     /// A business operations job, such as Business Operations Manager.
-    pub const BUSINESS_OPERATIONS: JobCategory = JobCategory::new("BUSINESS_OPERATIONS");
+    pub const BUSINESS_OPERATIONS: JobCategory = JobCategory::new(6);
 
     /// A cleaning and facilities job, such as Custodial Staff.
-    pub const CLEANING_AND_FACILITIES: JobCategory = JobCategory::new("CLEANING_AND_FACILITIES");
+    pub const CLEANING_AND_FACILITIES: JobCategory = JobCategory::new(7);
 
     /// A computer and IT job, such as Systems Administrator.
-    pub const COMPUTER_AND_IT: JobCategory = JobCategory::new("COMPUTER_AND_IT");
+    pub const COMPUTER_AND_IT: JobCategory = JobCategory::new(8);
 
     /// A construction job, such as General Laborer.
-    pub const CONSTRUCTION: JobCategory = JobCategory::new("CONSTRUCTION");
+    pub const CONSTRUCTION: JobCategory = JobCategory::new(9);
 
     /// A customer service job, such s Cashier.
-    pub const CUSTOMER_SERVICE: JobCategory = JobCategory::new("CUSTOMER_SERVICE");
+    pub const CUSTOMER_SERVICE: JobCategory = JobCategory::new(10);
 
     /// An education job, such as School Teacher.
-    pub const EDUCATION: JobCategory = JobCategory::new("EDUCATION");
+    pub const EDUCATION: JobCategory = JobCategory::new(11);
 
     /// An entertainment and travel job, such as Flight Attendant.
-    pub const ENTERTAINMENT_AND_TRAVEL: JobCategory = JobCategory::new("ENTERTAINMENT_AND_TRAVEL");
+    pub const ENTERTAINMENT_AND_TRAVEL: JobCategory = JobCategory::new(12);
 
     /// A farming or outdoor job, such as Park Ranger.
-    pub const FARMING_AND_OUTDOORS: JobCategory = JobCategory::new("FARMING_AND_OUTDOORS");
+    pub const FARMING_AND_OUTDOORS: JobCategory = JobCategory::new(13);
 
     /// A healthcare job, such as Registered Nurse.
-    pub const HEALTHCARE: JobCategory = JobCategory::new("HEALTHCARE");
+    pub const HEALTHCARE: JobCategory = JobCategory::new(14);
 
     /// A human resources job, such as Human Resources Director.
-    pub const HUMAN_RESOURCES: JobCategory = JobCategory::new("HUMAN_RESOURCES");
+    pub const HUMAN_RESOURCES: JobCategory = JobCategory::new(15);
 
     /// An installation, maintenance, or repair job, such as Electrician.
-    pub const INSTALLATION_MAINTENANCE_AND_REPAIR: JobCategory =
-        JobCategory::new("INSTALLATION_MAINTENANCE_AND_REPAIR");
+    pub const INSTALLATION_MAINTENANCE_AND_REPAIR: JobCategory = JobCategory::new(16);
 
     /// A legal job, such as Law Clerk.
-    pub const LEGAL: JobCategory = JobCategory::new("LEGAL");
+    pub const LEGAL: JobCategory = JobCategory::new(17);
 
     /// A management job, often used in conjunction with another category,
     /// such as Store Manager.
-    pub const MANAGEMENT: JobCategory = JobCategory::new("MANAGEMENT");
+    pub const MANAGEMENT: JobCategory = JobCategory::new(18);
 
     /// A manufacturing or warehouse job, such as Assembly Technician.
-    pub const MANUFACTURING_AND_WAREHOUSE: JobCategory =
-        JobCategory::new("MANUFACTURING_AND_WAREHOUSE");
+    pub const MANUFACTURING_AND_WAREHOUSE: JobCategory = JobCategory::new(19);
 
     /// A media, communications, or writing job, such as Media Relations.
-    pub const MEDIA_COMMUNICATIONS_AND_WRITING: JobCategory =
-        JobCategory::new("MEDIA_COMMUNICATIONS_AND_WRITING");
+    pub const MEDIA_COMMUNICATIONS_AND_WRITING: JobCategory = JobCategory::new(20);
 
     /// An oil, gas or mining job, such as Offshore Driller.
-    pub const OIL_GAS_AND_MINING: JobCategory = JobCategory::new("OIL_GAS_AND_MINING");
+    pub const OIL_GAS_AND_MINING: JobCategory = JobCategory::new(21);
 
     /// A personal care and services job, such as Hair Stylist.
-    pub const PERSONAL_CARE_AND_SERVICES: JobCategory =
-        JobCategory::new("PERSONAL_CARE_AND_SERVICES");
+    pub const PERSONAL_CARE_AND_SERVICES: JobCategory = JobCategory::new(22);
 
     /// A protective services job, such as Security Guard.
-    pub const PROTECTIVE_SERVICES: JobCategory = JobCategory::new("PROTECTIVE_SERVICES");
+    pub const PROTECTIVE_SERVICES: JobCategory = JobCategory::new(23);
 
     /// A real estate job, such as Buyer's Agent.
-    pub const REAL_ESTATE: JobCategory = JobCategory::new("REAL_ESTATE");
+    pub const REAL_ESTATE: JobCategory = JobCategory::new(24);
 
     /// A restaurant and hospitality job, such as Restaurant Server.
-    pub const RESTAURANT_AND_HOSPITALITY: JobCategory =
-        JobCategory::new("RESTAURANT_AND_HOSPITALITY");
+    pub const RESTAURANT_AND_HOSPITALITY: JobCategory = JobCategory::new(25);
 
     /// A sales and/or retail job, such Sales Associate.
-    pub const SALES_AND_RETAIL: JobCategory = JobCategory::new("SALES_AND_RETAIL");
+    pub const SALES_AND_RETAIL: JobCategory = JobCategory::new(26);
 
     /// A science and engineering job, such as Lab Technician.
-    pub const SCIENCE_AND_ENGINEERING: JobCategory = JobCategory::new("SCIENCE_AND_ENGINEERING");
+    pub const SCIENCE_AND_ENGINEERING: JobCategory = JobCategory::new(27);
 
     /// A social services or non-profit job, such as Case Worker.
-    pub const SOCIAL_SERVICES_AND_NON_PROFIT: JobCategory =
-        JobCategory::new("SOCIAL_SERVICES_AND_NON_PROFIT");
+    pub const SOCIAL_SERVICES_AND_NON_PROFIT: JobCategory = JobCategory::new(28);
 
     /// A sports, fitness, or recreation job, such as Personal Trainer.
-    pub const SPORTS_FITNESS_AND_RECREATION: JobCategory =
-        JobCategory::new("SPORTS_FITNESS_AND_RECREATION");
+    pub const SPORTS_FITNESS_AND_RECREATION: JobCategory = JobCategory::new(29);
 
     /// A transportation or logistics job, such as Truck Driver.
-    pub const TRANSPORTATION_AND_LOGISTICS: JobCategory =
-        JobCategory::new("TRANSPORTATION_AND_LOGISTICS");
+    pub const TRANSPORTATION_AND_LOGISTICS: JobCategory = JobCategory::new(30);
+
+    /// Creates a new JobCategory instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("JOB_CATEGORY_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ACCOUNTING_AND_FINANCE"),
+            2 => std::borrow::Cow::Borrowed("ADMINISTRATIVE_AND_OFFICE"),
+            3 => std::borrow::Cow::Borrowed("ADVERTISING_AND_MARKETING"),
+            4 => std::borrow::Cow::Borrowed("ANIMAL_CARE"),
+            5 => std::borrow::Cow::Borrowed("ART_FASHION_AND_DESIGN"),
+            6 => std::borrow::Cow::Borrowed("BUSINESS_OPERATIONS"),
+            7 => std::borrow::Cow::Borrowed("CLEANING_AND_FACILITIES"),
+            8 => std::borrow::Cow::Borrowed("COMPUTER_AND_IT"),
+            9 => std::borrow::Cow::Borrowed("CONSTRUCTION"),
+            10 => std::borrow::Cow::Borrowed("CUSTOMER_SERVICE"),
+            11 => std::borrow::Cow::Borrowed("EDUCATION"),
+            12 => std::borrow::Cow::Borrowed("ENTERTAINMENT_AND_TRAVEL"),
+            13 => std::borrow::Cow::Borrowed("FARMING_AND_OUTDOORS"),
+            14 => std::borrow::Cow::Borrowed("HEALTHCARE"),
+            15 => std::borrow::Cow::Borrowed("HUMAN_RESOURCES"),
+            16 => std::borrow::Cow::Borrowed("INSTALLATION_MAINTENANCE_AND_REPAIR"),
+            17 => std::borrow::Cow::Borrowed("LEGAL"),
+            18 => std::borrow::Cow::Borrowed("MANAGEMENT"),
+            19 => std::borrow::Cow::Borrowed("MANUFACTURING_AND_WAREHOUSE"),
+            20 => std::borrow::Cow::Borrowed("MEDIA_COMMUNICATIONS_AND_WRITING"),
+            21 => std::borrow::Cow::Borrowed("OIL_GAS_AND_MINING"),
+            22 => std::borrow::Cow::Borrowed("PERSONAL_CARE_AND_SERVICES"),
+            23 => std::borrow::Cow::Borrowed("PROTECTIVE_SERVICES"),
+            24 => std::borrow::Cow::Borrowed("REAL_ESTATE"),
+            25 => std::borrow::Cow::Borrowed("RESTAURANT_AND_HOSPITALITY"),
+            26 => std::borrow::Cow::Borrowed("SALES_AND_RETAIL"),
+            27 => std::borrow::Cow::Borrowed("SCIENCE_AND_ENGINEERING"),
+            28 => std::borrow::Cow::Borrowed("SOCIAL_SERVICES_AND_NON_PROFIT"),
+            29 => std::borrow::Cow::Borrowed("SPORTS_FITNESS_AND_RECREATION"),
+            30 => std::borrow::Cow::Borrowed("TRANSPORTATION_AND_LOGISTICS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "JOB_CATEGORY_UNSPECIFIED" => std::option::Option::Some(Self::JOB_CATEGORY_UNSPECIFIED),
+            "ACCOUNTING_AND_FINANCE" => std::option::Option::Some(Self::ACCOUNTING_AND_FINANCE),
+            "ADMINISTRATIVE_AND_OFFICE" => {
+                std::option::Option::Some(Self::ADMINISTRATIVE_AND_OFFICE)
+            }
+            "ADVERTISING_AND_MARKETING" => {
+                std::option::Option::Some(Self::ADVERTISING_AND_MARKETING)
+            }
+            "ANIMAL_CARE" => std::option::Option::Some(Self::ANIMAL_CARE),
+            "ART_FASHION_AND_DESIGN" => std::option::Option::Some(Self::ART_FASHION_AND_DESIGN),
+            "BUSINESS_OPERATIONS" => std::option::Option::Some(Self::BUSINESS_OPERATIONS),
+            "CLEANING_AND_FACILITIES" => std::option::Option::Some(Self::CLEANING_AND_FACILITIES),
+            "COMPUTER_AND_IT" => std::option::Option::Some(Self::COMPUTER_AND_IT),
+            "CONSTRUCTION" => std::option::Option::Some(Self::CONSTRUCTION),
+            "CUSTOMER_SERVICE" => std::option::Option::Some(Self::CUSTOMER_SERVICE),
+            "EDUCATION" => std::option::Option::Some(Self::EDUCATION),
+            "ENTERTAINMENT_AND_TRAVEL" => std::option::Option::Some(Self::ENTERTAINMENT_AND_TRAVEL),
+            "FARMING_AND_OUTDOORS" => std::option::Option::Some(Self::FARMING_AND_OUTDOORS),
+            "HEALTHCARE" => std::option::Option::Some(Self::HEALTHCARE),
+            "HUMAN_RESOURCES" => std::option::Option::Some(Self::HUMAN_RESOURCES),
+            "INSTALLATION_MAINTENANCE_AND_REPAIR" => {
+                std::option::Option::Some(Self::INSTALLATION_MAINTENANCE_AND_REPAIR)
+            }
+            "LEGAL" => std::option::Option::Some(Self::LEGAL),
+            "MANAGEMENT" => std::option::Option::Some(Self::MANAGEMENT),
+            "MANUFACTURING_AND_WAREHOUSE" => {
+                std::option::Option::Some(Self::MANUFACTURING_AND_WAREHOUSE)
+            }
+            "MEDIA_COMMUNICATIONS_AND_WRITING" => {
+                std::option::Option::Some(Self::MEDIA_COMMUNICATIONS_AND_WRITING)
+            }
+            "OIL_GAS_AND_MINING" => std::option::Option::Some(Self::OIL_GAS_AND_MINING),
+            "PERSONAL_CARE_AND_SERVICES" => {
+                std::option::Option::Some(Self::PERSONAL_CARE_AND_SERVICES)
+            }
+            "PROTECTIVE_SERVICES" => std::option::Option::Some(Self::PROTECTIVE_SERVICES),
+            "REAL_ESTATE" => std::option::Option::Some(Self::REAL_ESTATE),
+            "RESTAURANT_AND_HOSPITALITY" => {
+                std::option::Option::Some(Self::RESTAURANT_AND_HOSPITALITY)
+            }
+            "SALES_AND_RETAIL" => std::option::Option::Some(Self::SALES_AND_RETAIL),
+            "SCIENCE_AND_ENGINEERING" => std::option::Option::Some(Self::SCIENCE_AND_ENGINEERING),
+            "SOCIAL_SERVICES_AND_NON_PROFIT" => {
+                std::option::Option::Some(Self::SOCIAL_SERVICES_AND_NON_PROFIT)
+            }
+            "SPORTS_FITNESS_AND_RECREATION" => {
+                std::option::Option::Some(Self::SPORTS_FITNESS_AND_RECREATION)
+            }
+            "TRANSPORTATION_AND_LOGISTICS" => {
+                std::option::Option::Some(Self::TRANSPORTATION_AND_LOGISTICS)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for JobCategory {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for JobCategory {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for JobCategory {
     fn default() -> Self {
-        job_category::JOB_CATEGORY_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -7349,30 +7949,14 @@ impl std::default::Default for JobCategory {
 /// don't need to specify a region. If a region is given, jobs are
 /// eligible for searches in the specified region.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PostingRegion(std::borrow::Cow<'static, str>);
+pub struct PostingRegion(i32);
 
 impl PostingRegion {
-    /// Creates a new PostingRegion instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [PostingRegion](PostingRegion)
-pub mod posting_region {
-    use super::PostingRegion;
-
     /// If the region is unspecified, the job is only returned if it
     /// matches the [LocationFilter][google.cloud.talent.v4.LocationFilter].
     ///
     /// [google.cloud.talent.v4.LocationFilter]: crate::model::LocationFilter
-    pub const POSTING_REGION_UNSPECIFIED: PostingRegion =
-        PostingRegion::new("POSTING_REGION_UNSPECIFIED");
+    pub const POSTING_REGION_UNSPECIFIED: PostingRegion = PostingRegion::new(0);
 
     /// In addition to exact location matching, job posting is returned when the
     /// [LocationFilter][google.cloud.talent.v4.LocationFilter] in the search query
@@ -7386,7 +7970,7 @@ pub mod posting_region {
     /// JP prefecture.
     ///
     /// [google.cloud.talent.v4.LocationFilter]: crate::model::LocationFilter
-    pub const ADMINISTRATIVE_AREA: PostingRegion = PostingRegion::new("ADMINISTRATIVE_AREA");
+    pub const ADMINISTRATIVE_AREA: PostingRegion = PostingRegion::new(1);
 
     /// In addition to exact location matching, job is returned when
     /// [LocationFilter][google.cloud.talent.v4.LocationFilter] in search query is
@@ -7396,23 +7980,57 @@ pub mod posting_region {
     /// View'.
     ///
     /// [google.cloud.talent.v4.LocationFilter]: crate::model::LocationFilter
-    pub const NATION: PostingRegion = PostingRegion::new("NATION");
+    pub const NATION: PostingRegion = PostingRegion::new(2);
 
     /// Job allows employees to work remotely (telecommute).
     /// If locations are provided with this value, the job is
     /// considered as having a location, but telecommuting is allowed.
-    pub const TELECOMMUTE: PostingRegion = PostingRegion::new("TELECOMMUTE");
+    pub const TELECOMMUTE: PostingRegion = PostingRegion::new(3);
+
+    /// Creates a new PostingRegion instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("POSTING_REGION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ADMINISTRATIVE_AREA"),
+            2 => std::borrow::Cow::Borrowed("NATION"),
+            3 => std::borrow::Cow::Borrowed("TELECOMMUTE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "POSTING_REGION_UNSPECIFIED" => {
+                std::option::Option::Some(Self::POSTING_REGION_UNSPECIFIED)
+            }
+            "ADMINISTRATIVE_AREA" => std::option::Option::Some(Self::ADMINISTRATIVE_AREA),
+            "NATION" => std::option::Option::Some(Self::NATION),
+            "TELECOMMUTE" => std::option::Option::Some(Self::TELECOMMUTE),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for PostingRegion {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for PostingRegion {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for PostingRegion {
     fn default() -> Self {
-        posting_region::POSTING_REGION_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -7420,48 +8038,65 @@ impl std::default::Default for PostingRegion {
 ///
 /// An enum that represents who has view access to the resource.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Visibility(std::borrow::Cow<'static, str>);
+pub struct Visibility(i32);
 
 impl Visibility {
-    /// Creates a new Visibility instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [Visibility](Visibility)
-pub mod visibility {
-    use super::Visibility;
-
     /// Default value.
-    pub const VISIBILITY_UNSPECIFIED: Visibility = Visibility::new("VISIBILITY_UNSPECIFIED");
+    pub const VISIBILITY_UNSPECIFIED: Visibility = Visibility::new(0);
 
     /// The resource is only visible to the GCP account who owns it.
-    pub const ACCOUNT_ONLY: Visibility = Visibility::new("ACCOUNT_ONLY");
+    pub const ACCOUNT_ONLY: Visibility = Visibility::new(1);
 
     /// The resource is visible to the owner and may be visible to other
     /// applications and processes at Google.
-    pub const SHARED_WITH_GOOGLE: Visibility = Visibility::new("SHARED_WITH_GOOGLE");
+    pub const SHARED_WITH_GOOGLE: Visibility = Visibility::new(2);
 
     /// The resource is visible to the owner and may be visible to all other API
     /// clients.
-    pub const SHARED_WITH_PUBLIC: Visibility = Visibility::new("SHARED_WITH_PUBLIC");
+    pub const SHARED_WITH_PUBLIC: Visibility = Visibility::new(3);
+
+    /// Creates a new Visibility instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("VISIBILITY_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ACCOUNT_ONLY"),
+            2 => std::borrow::Cow::Borrowed("SHARED_WITH_GOOGLE"),
+            3 => std::borrow::Cow::Borrowed("SHARED_WITH_PUBLIC"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "VISIBILITY_UNSPECIFIED" => std::option::Option::Some(Self::VISIBILITY_UNSPECIFIED),
+            "ACCOUNT_ONLY" => std::option::Option::Some(Self::ACCOUNT_ONLY),
+            "SHARED_WITH_GOOGLE" => std::option::Option::Some(Self::SHARED_WITH_GOOGLE),
+            "SHARED_WITH_PUBLIC" => std::option::Option::Some(Self::SHARED_WITH_PUBLIC),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for Visibility {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Visibility {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Visibility {
     fn default() -> Self {
-        visibility::VISIBILITY_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -7469,102 +8104,140 @@ impl std::default::Default for Visibility {
 /// description. By setting this option, user can determine whether and how
 /// sanitization is performed on these fields.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct HtmlSanitization(std::borrow::Cow<'static, str>);
+pub struct HtmlSanitization(i32);
 
 impl HtmlSanitization {
-    /// Creates a new HtmlSanitization instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [HtmlSanitization](HtmlSanitization)
-pub mod html_sanitization {
-    use super::HtmlSanitization;
-
     /// Default value.
-    pub const HTML_SANITIZATION_UNSPECIFIED: HtmlSanitization =
-        HtmlSanitization::new("HTML_SANITIZATION_UNSPECIFIED");
+    pub const HTML_SANITIZATION_UNSPECIFIED: HtmlSanitization = HtmlSanitization::new(0);
 
     /// Disables sanitization on HTML input.
-    pub const HTML_SANITIZATION_DISABLED: HtmlSanitization =
-        HtmlSanitization::new("HTML_SANITIZATION_DISABLED");
+    pub const HTML_SANITIZATION_DISABLED: HtmlSanitization = HtmlSanitization::new(1);
 
     /// Sanitizes HTML input, only accepts bold, italic, ordered list, and
     /// unordered list markup tags.
-    pub const SIMPLE_FORMATTING_ONLY: HtmlSanitization =
-        HtmlSanitization::new("SIMPLE_FORMATTING_ONLY");
+    pub const SIMPLE_FORMATTING_ONLY: HtmlSanitization = HtmlSanitization::new(2);
+
+    /// Creates a new HtmlSanitization instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("HTML_SANITIZATION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("HTML_SANITIZATION_DISABLED"),
+            2 => std::borrow::Cow::Borrowed("SIMPLE_FORMATTING_ONLY"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "HTML_SANITIZATION_UNSPECIFIED" => {
+                std::option::Option::Some(Self::HTML_SANITIZATION_UNSPECIFIED)
+            }
+            "HTML_SANITIZATION_DISABLED" => {
+                std::option::Option::Some(Self::HTML_SANITIZATION_DISABLED)
+            }
+            "SIMPLE_FORMATTING_ONLY" => std::option::Option::Some(Self::SIMPLE_FORMATTING_ONLY),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for HtmlSanitization {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for HtmlSanitization {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for HtmlSanitization {
     fn default() -> Self {
-        html_sanitization::HTML_SANITIZATION_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Method for commute. Walking, biking and wheelchair accessible transit is
 /// still in the Preview stage.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct CommuteMethod(std::borrow::Cow<'static, str>);
+pub struct CommuteMethod(i32);
 
 impl CommuteMethod {
-    /// Creates a new CommuteMethod instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [CommuteMethod](CommuteMethod)
-pub mod commute_method {
-    use super::CommuteMethod;
-
     /// Commute method isn't specified.
-    pub const COMMUTE_METHOD_UNSPECIFIED: CommuteMethod =
-        CommuteMethod::new("COMMUTE_METHOD_UNSPECIFIED");
+    pub const COMMUTE_METHOD_UNSPECIFIED: CommuteMethod = CommuteMethod::new(0);
 
     /// Commute time is calculated based on driving time.
-    pub const DRIVING: CommuteMethod = CommuteMethod::new("DRIVING");
+    pub const DRIVING: CommuteMethod = CommuteMethod::new(1);
 
     /// Commute time is calculated based on public transit including bus, metro,
     /// subway, and so on.
-    pub const TRANSIT: CommuteMethod = CommuteMethod::new("TRANSIT");
+    pub const TRANSIT: CommuteMethod = CommuteMethod::new(2);
 
     /// Commute time is calculated based on walking time.
-    pub const WALKING: CommuteMethod = CommuteMethod::new("WALKING");
+    pub const WALKING: CommuteMethod = CommuteMethod::new(3);
 
     /// Commute time is calculated based on biking time.
-    pub const CYCLING: CommuteMethod = CommuteMethod::new("CYCLING");
+    pub const CYCLING: CommuteMethod = CommuteMethod::new(4);
 
     /// Commute time is calculated based on public transit that is wheelchair
     /// accessible.
-    pub const TRANSIT_ACCESSIBLE: CommuteMethod = CommuteMethod::new("TRANSIT_ACCESSIBLE");
+    pub const TRANSIT_ACCESSIBLE: CommuteMethod = CommuteMethod::new(5);
+
+    /// Creates a new CommuteMethod instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("COMMUTE_METHOD_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("DRIVING"),
+            2 => std::borrow::Cow::Borrowed("TRANSIT"),
+            3 => std::borrow::Cow::Borrowed("WALKING"),
+            4 => std::borrow::Cow::Borrowed("CYCLING"),
+            5 => std::borrow::Cow::Borrowed("TRANSIT_ACCESSIBLE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "COMMUTE_METHOD_UNSPECIFIED" => {
+                std::option::Option::Some(Self::COMMUTE_METHOD_UNSPECIFIED)
+            }
+            "DRIVING" => std::option::Option::Some(Self::DRIVING),
+            "TRANSIT" => std::option::Option::Some(Self::TRANSIT),
+            "WALKING" => std::option::Option::Some(Self::WALKING),
+            "CYCLING" => std::option::Option::Some(Self::CYCLING),
+            "TRANSIT_ACCESSIBLE" => std::option::Option::Some(Self::TRANSIT_ACCESSIBLE),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for CommuteMethod {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for CommuteMethod {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for CommuteMethod {
     fn default() -> Self {
-        commute_method::COMMUTE_METHOD_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -7576,26 +8249,11 @@ impl std::default::Default for CommuteMethod {
 /// [google.cloud.talent.v4.ListJobsResponse.jobs]: crate::model::ListJobsResponse::jobs
 /// [google.cloud.talent.v4.SearchJobsResponse.MatchingJob.job]: crate::model::search_jobs_response::MatchingJob::job
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct JobView(std::borrow::Cow<'static, str>);
+pub struct JobView(i32);
 
 impl JobView {
-    /// Creates a new JobView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [JobView](JobView)
-pub mod job_view {
-    use super::JobView;
-
     /// Default value.
-    pub const JOB_VIEW_UNSPECIFIED: JobView = JobView::new("JOB_VIEW_UNSPECIFIED");
+    pub const JOB_VIEW_UNSPECIFIED: JobView = JobView::new(0);
 
     /// A ID only view of job, with following attributes:
     /// [Job.name][google.cloud.talent.v4.Job.name],
@@ -7605,7 +8263,7 @@ pub mod job_view {
     /// [google.cloud.talent.v4.Job.language_code]: crate::model::Job::language_code
     /// [google.cloud.talent.v4.Job.name]: crate::model::Job::name
     /// [google.cloud.talent.v4.Job.requisition_id]: crate::model::Job::requisition_id
-    pub const JOB_VIEW_ID_ONLY: JobView = JobView::new("JOB_VIEW_ID_ONLY");
+    pub const JOB_VIEW_ID_ONLY: JobView = JobView::new(1);
 
     /// A minimal view of the job, with the following attributes:
     /// [Job.name][google.cloud.talent.v4.Job.name],
@@ -7621,7 +8279,7 @@ pub mod job_view {
     /// [google.cloud.talent.v4.Job.name]: crate::model::Job::name
     /// [google.cloud.talent.v4.Job.requisition_id]: crate::model::Job::requisition_id
     /// [google.cloud.talent.v4.Job.title]: crate::model::Job::title
-    pub const JOB_VIEW_MINIMAL: JobView = JobView::new("JOB_VIEW_MINIMAL");
+    pub const JOB_VIEW_MINIMAL: JobView = JobView::new(2);
 
     /// A small view of the job, with the following attributes in the search
     /// results: [Job.name][google.cloud.talent.v4.Job.name],
@@ -7641,20 +8299,54 @@ pub mod job_view {
     /// [google.cloud.talent.v4.Job.requisition_id]: crate::model::Job::requisition_id
     /// [google.cloud.talent.v4.Job.title]: crate::model::Job::title
     /// [google.cloud.talent.v4.Job.visibility]: crate::model::Job::visibility
-    pub const JOB_VIEW_SMALL: JobView = JobView::new("JOB_VIEW_SMALL");
+    pub const JOB_VIEW_SMALL: JobView = JobView::new(3);
 
     /// All available attributes are included in the search results.
-    pub const JOB_VIEW_FULL: JobView = JobView::new("JOB_VIEW_FULL");
+    pub const JOB_VIEW_FULL: JobView = JobView::new(4);
+
+    /// Creates a new JobView instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("JOB_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("JOB_VIEW_ID_ONLY"),
+            2 => std::borrow::Cow::Borrowed("JOB_VIEW_MINIMAL"),
+            3 => std::borrow::Cow::Borrowed("JOB_VIEW_SMALL"),
+            4 => std::borrow::Cow::Borrowed("JOB_VIEW_FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "JOB_VIEW_UNSPECIFIED" => std::option::Option::Some(Self::JOB_VIEW_UNSPECIFIED),
+            "JOB_VIEW_ID_ONLY" => std::option::Option::Some(Self::JOB_VIEW_ID_ONLY),
+            "JOB_VIEW_MINIMAL" => std::option::Option::Some(Self::JOB_VIEW_MINIMAL),
+            "JOB_VIEW_SMALL" => std::option::Option::Some(Self::JOB_VIEW_SMALL),
+            "JOB_VIEW_FULL" => std::option::Option::Some(Self::JOB_VIEW_FULL),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for JobView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for JobView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for JobView {
     fn default() -> Self {
-        job_view::JOB_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/talent/v4/src/transport.rs
+++ b/src/generated/cloud/talent/v4/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::CompanyService for CompanyService {
                 reqwest::Method::POST,
                 format!("/v4/{}/companies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -71,7 +71,7 @@ impl crate::stubs::CompanyService for CompanyService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v4/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -99,7 +99,7 @@ impl crate::stubs::CompanyService for CompanyService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -128,7 +128,7 @@ impl crate::stubs::CompanyService for CompanyService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v4/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -150,7 +150,7 @@ impl crate::stubs::CompanyService for CompanyService {
                 reqwest::Method::GET,
                 format!("/v4/{}/companies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -172,7 +172,7 @@ impl crate::stubs::CompanyService for CompanyService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v4/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -217,7 +217,7 @@ impl crate::stubs::Completion for Completion {
                 reqwest::Method::GET,
                 format!("/v4/{}:completeQuery", req.tenant),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -245,7 +245,7 @@ impl crate::stubs::Completion for Completion {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v4/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -290,7 +290,7 @@ impl crate::stubs::EventService for EventService {
                 reqwest::Method::POST,
                 format!("/v4/{}/clientEvents", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -309,7 +309,7 @@ impl crate::stubs::EventService for EventService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v4/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -351,7 +351,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v4/{}/jobs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -371,7 +371,7 @@ impl crate::stubs::JobService for JobService {
                 reqwest::Method::POST,
                 format!("/v4/{}/jobs:batchCreate", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -388,7 +388,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v4/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -416,7 +416,7 @@ impl crate::stubs::JobService for JobService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -446,7 +446,7 @@ impl crate::stubs::JobService for JobService {
                 reqwest::Method::POST,
                 format!("/v4/{}/jobs:batchUpdate", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -463,7 +463,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v4/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -485,7 +485,7 @@ impl crate::stubs::JobService for JobService {
                 reqwest::Method::POST,
                 format!("/v4/{}/jobs:batchDelete", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -502,7 +502,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v4/{}/jobs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -528,7 +528,7 @@ impl crate::stubs::JobService for JobService {
                 reqwest::Method::POST,
                 format!("/v4/{}/jobs:search", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -548,7 +548,7 @@ impl crate::stubs::JobService for JobService {
                 reqwest::Method::POST,
                 format!("/v4/{}/jobs:searchForAlert", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -565,7 +565,7 @@ impl crate::stubs::JobService for JobService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v4/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -621,7 +621,7 @@ impl crate::stubs::TenantService for TenantService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v4/{}/tenants", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -638,7 +638,7 @@ impl crate::stubs::TenantService for TenantService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v4/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -666,7 +666,7 @@ impl crate::stubs::TenantService for TenantService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -693,7 +693,7 @@ impl crate::stubs::TenantService for TenantService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v4/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -712,7 +712,7 @@ impl crate::stubs::TenantService for TenantService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v4/{}/tenants", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -733,7 +733,7 @@ impl crate::stubs::TenantService for TenantService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v4/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/tasks/v2/src/model.rs
+++ b/src/generated/cloud/tasks/v2/src/model.rs
@@ -1126,26 +1126,11 @@ pub mod queue {
 
     /// State of the queue.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The queue is running. Tasks can be dispatched.
         ///
@@ -1155,12 +1140,12 @@ pub mod queue {
         /// calls may return [NOT_FOUND][google.rpc.Code.NOT_FOUND] and
         /// tasks may not be dispatched for a few minutes until the queue
         /// has been re-activated.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(1);
 
         /// Tasks are paused by the user. If the queue is paused then Cloud
         /// Tasks will stop delivering tasks from it, but more tasks can
         /// still be added to it by the user.
-        pub const PAUSED: State = State::new("PAUSED");
+        pub const PAUSED: State = State::new(2);
 
         /// The queue is disabled.
         ///
@@ -1178,18 +1163,50 @@ pub mod queue {
         /// [DeleteQueue][google.cloud.tasks.v2.CloudTasks.DeleteQueue].
         ///
         /// [google.cloud.tasks.v2.CloudTasks.DeleteQueue]: crate::client::CloudTasks::delete_queue
-        pub const DISABLED: State = State::new("DISABLED");
+        pub const DISABLED: State = State::new(3);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RUNNING"),
+                2 => std::borrow::Cow::Borrowed("PAUSED"),
+                3 => std::borrow::Cow::Borrowed("DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "PAUSED" => std::option::Option::Some(Self::PAUSED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2543,26 +2560,11 @@ pub mod task {
     ///
     /// [google.cloud.tasks.v2.Task]: crate::model::Task
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct View(std::borrow::Cow<'static, str>);
+    pub struct View(i32);
 
     impl View {
-        /// Creates a new View instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [View](View)
-    pub mod view {
-        use super::View;
-
         /// Unspecified. Defaults to BASIC.
-        pub const VIEW_UNSPECIFIED: View = View::new("VIEW_UNSPECIFIED");
+        pub const VIEW_UNSPECIFIED: View = View::new(0);
 
         /// The basic view omits fields which can be large or can contain
         /// sensitive data.
@@ -2575,7 +2577,7 @@ pub mod task {
         /// choose to store in it.
         ///
         /// [google.cloud.tasks.v2.AppEngineHttpRequest.body]: crate::model::AppEngineHttpRequest::body
-        pub const BASIC: View = View::new("BASIC");
+        pub const BASIC: View = View::new(1);
 
         /// All information is returned.
         ///
@@ -2585,18 +2587,48 @@ pub mod task {
         ///
         /// [google.cloud.tasks.v2.Queue]: crate::model::Queue
         /// [google.cloud.tasks.v2.Task.View.FULL]: crate::model::task::view::FULL
-        pub const FULL: View = View::new("FULL");
+        pub const FULL: View = View::new(2);
+
+        /// Creates a new View instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VIEW_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BASIC"),
+                2 => std::borrow::Cow::Borrowed("FULL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VIEW_UNSPECIFIED" => std::option::Option::Some(Self::VIEW_UNSPECIFIED),
+                "BASIC" => std::option::Option::Some(Self::BASIC),
+                "FULL" => std::option::Option::Some(Self::FULL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for View {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for View {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for View {
         fn default() -> Self {
-            view::VIEW_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -2704,57 +2736,82 @@ impl wkt::message::Message for Attempt {
 
 /// The HTTP method used to deliver the task.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct HttpMethod(std::borrow::Cow<'static, str>);
+pub struct HttpMethod(i32);
 
 impl HttpMethod {
+    /// HTTP method unspecified
+    pub const HTTP_METHOD_UNSPECIFIED: HttpMethod = HttpMethod::new(0);
+
+    /// HTTP POST
+    pub const POST: HttpMethod = HttpMethod::new(1);
+
+    /// HTTP GET
+    pub const GET: HttpMethod = HttpMethod::new(2);
+
+    /// HTTP HEAD
+    pub const HEAD: HttpMethod = HttpMethod::new(3);
+
+    /// HTTP PUT
+    pub const PUT: HttpMethod = HttpMethod::new(4);
+
+    /// HTTP DELETE
+    pub const DELETE: HttpMethod = HttpMethod::new(5);
+
+    /// HTTP PATCH
+    pub const PATCH: HttpMethod = HttpMethod::new(6);
+
+    /// HTTP OPTIONS
+    pub const OPTIONS: HttpMethod = HttpMethod::new(7);
+
     /// Creates a new HttpMethod instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("HTTP_METHOD_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("POST"),
+            2 => std::borrow::Cow::Borrowed("GET"),
+            3 => std::borrow::Cow::Borrowed("HEAD"),
+            4 => std::borrow::Cow::Borrowed("PUT"),
+            5 => std::borrow::Cow::Borrowed("DELETE"),
+            6 => std::borrow::Cow::Borrowed("PATCH"),
+            7 => std::borrow::Cow::Borrowed("OPTIONS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "HTTP_METHOD_UNSPECIFIED" => std::option::Option::Some(Self::HTTP_METHOD_UNSPECIFIED),
+            "POST" => std::option::Option::Some(Self::POST),
+            "GET" => std::option::Option::Some(Self::GET),
+            "HEAD" => std::option::Option::Some(Self::HEAD),
+            "PUT" => std::option::Option::Some(Self::PUT),
+            "DELETE" => std::option::Option::Some(Self::DELETE),
+            "PATCH" => std::option::Option::Some(Self::PATCH),
+            "OPTIONS" => std::option::Option::Some(Self::OPTIONS),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [HttpMethod](HttpMethod)
-pub mod http_method {
-    use super::HttpMethod;
-
-    /// HTTP method unspecified
-    pub const HTTP_METHOD_UNSPECIFIED: HttpMethod = HttpMethod::new("HTTP_METHOD_UNSPECIFIED");
-
-    /// HTTP POST
-    pub const POST: HttpMethod = HttpMethod::new("POST");
-
-    /// HTTP GET
-    pub const GET: HttpMethod = HttpMethod::new("GET");
-
-    /// HTTP HEAD
-    pub const HEAD: HttpMethod = HttpMethod::new("HEAD");
-
-    /// HTTP PUT
-    pub const PUT: HttpMethod = HttpMethod::new("PUT");
-
-    /// HTTP DELETE
-    pub const DELETE: HttpMethod = HttpMethod::new("DELETE");
-
-    /// HTTP PATCH
-    pub const PATCH: HttpMethod = HttpMethod::new("PATCH");
-
-    /// HTTP OPTIONS
-    pub const OPTIONS: HttpMethod = HttpMethod::new("OPTIONS");
-}
-
-impl std::convert::From<std::string::String> for HttpMethod {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for HttpMethod {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for HttpMethod {
     fn default() -> Self {
-        http_method::HTTP_METHOD_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/tasks/v2/src/transport.rs
+++ b/src/generated/cloud/tasks/v2/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::CloudTasks for CloudTasks {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/queues", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -71,7 +71,7 @@ impl crate::stubs::CloudTasks for CloudTasks {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -90,7 +90,7 @@ impl crate::stubs::CloudTasks for CloudTasks {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}/queues", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -116,7 +116,7 @@ impl crate::stubs::CloudTasks for CloudTasks {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -143,7 +143,7 @@ impl crate::stubs::CloudTasks for CloudTasks {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -162,7 +162,7 @@ impl crate::stubs::CloudTasks for CloudTasks {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:purge", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -179,7 +179,7 @@ impl crate::stubs::CloudTasks for CloudTasks {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:pause", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -196,7 +196,7 @@ impl crate::stubs::CloudTasks for CloudTasks {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:resume", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -216,7 +216,7 @@ impl crate::stubs::CloudTasks for CloudTasks {
                 reqwest::Method::POST,
                 format!("/v2/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -236,7 +236,7 @@ impl crate::stubs::CloudTasks for CloudTasks {
                 reqwest::Method::POST,
                 format!("/v2/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -256,7 +256,7 @@ impl crate::stubs::CloudTasks for CloudTasks {
                 reqwest::Method::POST,
                 format!("/v2/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -273,7 +273,7 @@ impl crate::stubs::CloudTasks for CloudTasks {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/tasks", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -295,7 +295,7 @@ impl crate::stubs::CloudTasks for CloudTasks {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -315,7 +315,7 @@ impl crate::stubs::CloudTasks for CloudTasks {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}/tasks", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -332,7 +332,7 @@ impl crate::stubs::CloudTasks for CloudTasks {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -351,7 +351,7 @@ impl crate::stubs::CloudTasks for CloudTasks {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:run", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -368,7 +368,7 @@ impl crate::stubs::CloudTasks for CloudTasks {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -390,7 +390,7 @@ impl crate::stubs::CloudTasks for CloudTasks {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/telcoautomation/v1/src/model.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/model.rs
@@ -149,50 +149,69 @@ pub mod orchestration_cluster {
 
     /// Possible states that the Orchestration Cluster can be in.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// OrchestrationCluster is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// OrchestrationCluster has been created and is ready for use.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(2);
 
         /// OrchestrationCluster is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(3);
 
         /// OrchestrationCluster encountered an error and is in an indeterministic
         /// state. User can still initiate a delete operation on this state.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(4);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -327,94 +346,130 @@ pub mod edge_slm {
 
     /// Possible states of the resource.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// EdgeSlm is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// EdgeSlm has been created and is ready for use.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(2);
 
         /// EdgeSlm is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(3);
 
         /// EdgeSlm encountered an error and is in an indeterministic
         /// state. User can still initiate a delete operation on this state.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(4);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Workload clusters supported by TNA. New values will be added to the enum
     /// list as TNA adds supports for new workload clusters in future.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct WorkloadClusterType(std::borrow::Cow<'static, str>);
+    pub struct WorkloadClusterType(i32);
 
     impl WorkloadClusterType {
+        /// Unspecified workload cluster.
+        pub const WORKLOAD_CLUSTER_TYPE_UNSPECIFIED: WorkloadClusterType =
+            WorkloadClusterType::new(0);
+
+        /// Workload cluster is a GDCE cluster.
+        pub const GDCE: WorkloadClusterType = WorkloadClusterType::new(1);
+
+        /// Workload cluster is a GKE cluster.
+        pub const GKE: WorkloadClusterType = WorkloadClusterType::new(2);
+
         /// Creates a new WorkloadClusterType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("WORKLOAD_CLUSTER_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GDCE"),
+                2 => std::borrow::Cow::Borrowed("GKE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "WORKLOAD_CLUSTER_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::WORKLOAD_CLUSTER_TYPE_UNSPECIFIED)
+                }
+                "GDCE" => std::option::Option::Some(Self::GDCE),
+                "GKE" => std::option::Option::Some(Self::GKE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [WorkloadClusterType](WorkloadClusterType)
-    pub mod workload_cluster_type {
-        use super::WorkloadClusterType;
-
-        /// Unspecified workload cluster.
-        pub const WORKLOAD_CLUSTER_TYPE_UNSPECIFIED: WorkloadClusterType =
-            WorkloadClusterType::new("WORKLOAD_CLUSTER_TYPE_UNSPECIFIED");
-
-        /// Workload cluster is a GDCE cluster.
-        pub const GDCE: WorkloadClusterType = WorkloadClusterType::new("GDCE");
-
-        /// Workload cluster is a GKE cluster.
-        pub const GKE: WorkloadClusterType = WorkloadClusterType::new("GKE");
-    }
-
-    impl std::convert::From<std::string::String> for WorkloadClusterType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for WorkloadClusterType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for WorkloadClusterType {
         fn default() -> Self {
-            workload_cluster_type::WORKLOAD_CLUSTER_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -629,53 +684,71 @@ pub mod blueprint {
     /// Approval state indicates the state of a Blueprint in its approval
     /// lifecycle.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ApprovalState(std::borrow::Cow<'static, str>);
+    pub struct ApprovalState(i32);
 
     impl ApprovalState {
-        /// Creates a new ApprovalState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ApprovalState](ApprovalState)
-    pub mod approval_state {
-        use super::ApprovalState;
-
         /// Unspecified state.
-        pub const APPROVAL_STATE_UNSPECIFIED: ApprovalState =
-            ApprovalState::new("APPROVAL_STATE_UNSPECIFIED");
+        pub const APPROVAL_STATE_UNSPECIFIED: ApprovalState = ApprovalState::new(0);
 
         /// A blueprint starts in DRAFT state once it is created. All edits are made
         /// to the blueprint in DRAFT state.
-        pub const DRAFT: ApprovalState = ApprovalState::new("DRAFT");
+        pub const DRAFT: ApprovalState = ApprovalState::new(1);
 
         /// When the edits are ready for review, blueprint can be proposed and moves
         /// to PROPOSED state. Edits cannot be made to a blueprint in PROPOSED state.
-        pub const PROPOSED: ApprovalState = ApprovalState::new("PROPOSED");
+        pub const PROPOSED: ApprovalState = ApprovalState::new(2);
 
         /// When a proposed blueprint is approved, it moves to APPROVED state. A new
         /// revision is committed. The latest committed revision can be used to
         /// create a deployment on Orchestration or Workload Cluster. Edits to an
         /// APPROVED blueprint changes its state back to DRAFT. The last committed
         /// revision of a blueprint represents its latest APPROVED state.
-        pub const APPROVED: ApprovalState = ApprovalState::new("APPROVED");
+        pub const APPROVED: ApprovalState = ApprovalState::new(3);
+
+        /// Creates a new ApprovalState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("APPROVAL_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DRAFT"),
+                2 => std::borrow::Cow::Borrowed("PROPOSED"),
+                3 => std::borrow::Cow::Borrowed("APPROVED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "APPROVAL_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::APPROVAL_STATE_UNSPECIFIED)
+                }
+                "DRAFT" => std::option::Option::Some(Self::DRAFT),
+                "PROPOSED" => std::option::Option::Some(Self::PROPOSED),
+                "APPROVED" => std::option::Option::Some(Self::APPROVED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ApprovalState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ApprovalState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ApprovalState {
         fn default() -> Self {
-            approval_state::APPROVAL_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -986,31 +1059,16 @@ pub mod deployment {
 
     /// State defines which state the current deployment is in.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// A deployment starts in DRAFT state. All edits are made in DRAFT state. A
         /// deployment opened for editing after applying will be in draft state,
         /// while its prevision revision will be its current applied version.
-        pub const DRAFT: State = State::new("DRAFT");
+        pub const DRAFT: State = State::new(1);
 
         /// This state means that the contents (YAML files containing kubernetes
         /// resources) of the deployment have been applied to an Orchestration or
@@ -1018,23 +1076,55 @@ pub mod deployment {
         /// This revision will represent the latest view of what is applied on the
         /// cluster until the deployment is modified and applied again, which will
         /// create a new revision.
-        pub const APPLIED: State = State::new("APPLIED");
+        pub const APPLIED: State = State::new(2);
 
         /// A deployment in DELETING state has been marked for deletion. Its
         /// deletion status can be queried using `ComputeDeploymentStatus` API. No
         /// updates are allowed to a deployment in DELETING state.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(3);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DRAFT"),
+                2 => std::borrow::Cow::Borrowed("APPLIED"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "DRAFT" => std::option::Option::Some(Self::DRAFT),
+                "APPLIED" => std::option::Option::Some(Self::APPLIED),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1120,45 +1210,60 @@ pub mod hydrated_deployment {
 
     /// State defines which state the current hydrated deployment is in.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// A hydrated deployment starts in DRAFT state. All edits are made in DRAFT
         /// state.
-        pub const DRAFT: State = State::new("DRAFT");
+        pub const DRAFT: State = State::new(1);
 
         /// When the edit is applied, the hydrated deployment moves to APPLIED
         /// state. No changes can be made once a hydrated deployment is applied.
-        pub const APPLIED: State = State::new("APPLIED");
+        pub const APPLIED: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DRAFT"),
+                2 => std::borrow::Cow::Borrowed("APPLIED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "DRAFT" => std::option::Option::Some(Self::DRAFT),
+                "APPLIED" => std::option::Option::Some(Self::APPLIED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4521,251 +4626,345 @@ impl wkt::message::Message for WorkloadStatus {
 
 /// BlueprintView defines the type of view of the blueprint.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct BlueprintView(std::borrow::Cow<'static, str>);
+pub struct BlueprintView(i32);
 
 impl BlueprintView {
+    /// Unspecified enum value.
+    pub const BLUEPRINT_VIEW_UNSPECIFIED: BlueprintView = BlueprintView::new(0);
+
+    /// View which only contains metadata.
+    pub const BLUEPRINT_VIEW_BASIC: BlueprintView = BlueprintView::new(1);
+
+    /// View which contains metadata and files it encapsulates.
+    pub const BLUEPRINT_VIEW_FULL: BlueprintView = BlueprintView::new(2);
+
     /// Creates a new BlueprintView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("BLUEPRINT_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("BLUEPRINT_VIEW_BASIC"),
+            2 => std::borrow::Cow::Borrowed("BLUEPRINT_VIEW_FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "BLUEPRINT_VIEW_UNSPECIFIED" => {
+                std::option::Option::Some(Self::BLUEPRINT_VIEW_UNSPECIFIED)
+            }
+            "BLUEPRINT_VIEW_BASIC" => std::option::Option::Some(Self::BLUEPRINT_VIEW_BASIC),
+            "BLUEPRINT_VIEW_FULL" => std::option::Option::Some(Self::BLUEPRINT_VIEW_FULL),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [BlueprintView](BlueprintView)
-pub mod blueprint_view {
-    use super::BlueprintView;
-
-    /// Unspecified enum value.
-    pub const BLUEPRINT_VIEW_UNSPECIFIED: BlueprintView =
-        BlueprintView::new("BLUEPRINT_VIEW_UNSPECIFIED");
-
-    /// View which only contains metadata.
-    pub const BLUEPRINT_VIEW_BASIC: BlueprintView = BlueprintView::new("BLUEPRINT_VIEW_BASIC");
-
-    /// View which contains metadata and files it encapsulates.
-    pub const BLUEPRINT_VIEW_FULL: BlueprintView = BlueprintView::new("BLUEPRINT_VIEW_FULL");
-}
-
-impl std::convert::From<std::string::String> for BlueprintView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for BlueprintView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for BlueprintView {
     fn default() -> Self {
-        blueprint_view::BLUEPRINT_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// DeploymentView defines the type of view of the deployment.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DeploymentView(std::borrow::Cow<'static, str>);
+pub struct DeploymentView(i32);
 
 impl DeploymentView {
+    /// Unspecified enum value.
+    pub const DEPLOYMENT_VIEW_UNSPECIFIED: DeploymentView = DeploymentView::new(0);
+
+    /// View which only contains metadata.
+    pub const DEPLOYMENT_VIEW_BASIC: DeploymentView = DeploymentView::new(1);
+
+    /// View which contains metadata and files it encapsulates.
+    pub const DEPLOYMENT_VIEW_FULL: DeploymentView = DeploymentView::new(2);
+
     /// Creates a new DeploymentView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DEPLOYMENT_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("DEPLOYMENT_VIEW_BASIC"),
+            2 => std::borrow::Cow::Borrowed("DEPLOYMENT_VIEW_FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DEPLOYMENT_VIEW_UNSPECIFIED" => {
+                std::option::Option::Some(Self::DEPLOYMENT_VIEW_UNSPECIFIED)
+            }
+            "DEPLOYMENT_VIEW_BASIC" => std::option::Option::Some(Self::DEPLOYMENT_VIEW_BASIC),
+            "DEPLOYMENT_VIEW_FULL" => std::option::Option::Some(Self::DEPLOYMENT_VIEW_FULL),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [DeploymentView](DeploymentView)
-pub mod deployment_view {
-    use super::DeploymentView;
-
-    /// Unspecified enum value.
-    pub const DEPLOYMENT_VIEW_UNSPECIFIED: DeploymentView =
-        DeploymentView::new("DEPLOYMENT_VIEW_UNSPECIFIED");
-
-    /// View which only contains metadata.
-    pub const DEPLOYMENT_VIEW_BASIC: DeploymentView = DeploymentView::new("DEPLOYMENT_VIEW_BASIC");
-
-    /// View which contains metadata and files it encapsulates.
-    pub const DEPLOYMENT_VIEW_FULL: DeploymentView = DeploymentView::new("DEPLOYMENT_VIEW_FULL");
-}
-
-impl std::convert::From<std::string::String> for DeploymentView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DeploymentView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DeploymentView {
     fn default() -> Self {
-        deployment_view::DEPLOYMENT_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Represent type of CR.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ResourceType(std::borrow::Cow<'static, str>);
+pub struct ResourceType(i32);
 
 impl ResourceType {
+    /// Unspecified resource type.
+    pub const RESOURCE_TYPE_UNSPECIFIED: ResourceType = ResourceType::new(0);
+
+    /// User specified NF Deploy CR.
+    pub const NF_DEPLOY_RESOURCE: ResourceType = ResourceType::new(1);
+
+    /// CRs that are part of a blueprint.
+    pub const DEPLOYMENT_RESOURCE: ResourceType = ResourceType::new(2);
+
     /// Creates a new ResourceType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("RESOURCE_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("NF_DEPLOY_RESOURCE"),
+            2 => std::borrow::Cow::Borrowed("DEPLOYMENT_RESOURCE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "RESOURCE_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::RESOURCE_TYPE_UNSPECIFIED)
+            }
+            "NF_DEPLOY_RESOURCE" => std::option::Option::Some(Self::NF_DEPLOY_RESOURCE),
+            "DEPLOYMENT_RESOURCE" => std::option::Option::Some(Self::DEPLOYMENT_RESOURCE),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [ResourceType](ResourceType)
-pub mod resource_type {
-    use super::ResourceType;
-
-    /// Unspecified resource type.
-    pub const RESOURCE_TYPE_UNSPECIFIED: ResourceType =
-        ResourceType::new("RESOURCE_TYPE_UNSPECIFIED");
-
-    /// User specified NF Deploy CR.
-    pub const NF_DEPLOY_RESOURCE: ResourceType = ResourceType::new("NF_DEPLOY_RESOURCE");
-
-    /// CRs that are part of a blueprint.
-    pub const DEPLOYMENT_RESOURCE: ResourceType = ResourceType::new("DEPLOYMENT_RESOURCE");
-}
-
-impl std::convert::From<std::string::String> for ResourceType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ResourceType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ResourceType {
     fn default() -> Self {
-        resource_type::RESOURCE_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Status of an entity (resource, deployment).
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Status(std::borrow::Cow<'static, str>);
+pub struct Status(i32);
 
 impl Status {
-    /// Creates a new Status instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [Status](Status)
-pub mod status {
-    use super::Status;
-
     /// Unknown state.
-    pub const STATUS_UNSPECIFIED: Status = Status::new("STATUS_UNSPECIFIED");
+    pub const STATUS_UNSPECIFIED: Status = Status::new(0);
 
     /// Under progress.
-    pub const STATUS_IN_PROGRESS: Status = Status::new("STATUS_IN_PROGRESS");
+    pub const STATUS_IN_PROGRESS: Status = Status::new(1);
 
     /// Running and ready to serve traffic.
-    pub const STATUS_ACTIVE: Status = Status::new("STATUS_ACTIVE");
+    pub const STATUS_ACTIVE: Status = Status::new(2);
 
     /// Failed or stalled.
-    pub const STATUS_FAILED: Status = Status::new("STATUS_FAILED");
+    pub const STATUS_FAILED: Status = Status::new(3);
 
     /// Delete in progress.
-    pub const STATUS_DELETING: Status = Status::new("STATUS_DELETING");
+    pub const STATUS_DELETING: Status = Status::new(4);
 
     /// Deleted deployment.
-    pub const STATUS_DELETED: Status = Status::new("STATUS_DELETED");
+    pub const STATUS_DELETED: Status = Status::new(5);
 
     /// NFDeploy specific status. Peering in progress.
-    pub const STATUS_PEERING: Status = Status::new("STATUS_PEERING");
+    pub const STATUS_PEERING: Status = Status::new(10);
 
     /// K8s objects such as NetworkAttachmentDefinition don't have a defined
     /// status.
-    pub const STATUS_NOT_APPLICABLE: Status = Status::new("STATUS_NOT_APPLICABLE");
+    pub const STATUS_NOT_APPLICABLE: Status = Status::new(11);
+
+    /// Creates a new Status instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("STATUS_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("STATUS_IN_PROGRESS"),
+            2 => std::borrow::Cow::Borrowed("STATUS_ACTIVE"),
+            3 => std::borrow::Cow::Borrowed("STATUS_FAILED"),
+            4 => std::borrow::Cow::Borrowed("STATUS_DELETING"),
+            5 => std::borrow::Cow::Borrowed("STATUS_DELETED"),
+            10 => std::borrow::Cow::Borrowed("STATUS_PEERING"),
+            11 => std::borrow::Cow::Borrowed("STATUS_NOT_APPLICABLE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "STATUS_UNSPECIFIED" => std::option::Option::Some(Self::STATUS_UNSPECIFIED),
+            "STATUS_IN_PROGRESS" => std::option::Option::Some(Self::STATUS_IN_PROGRESS),
+            "STATUS_ACTIVE" => std::option::Option::Some(Self::STATUS_ACTIVE),
+            "STATUS_FAILED" => std::option::Option::Some(Self::STATUS_FAILED),
+            "STATUS_DELETING" => std::option::Option::Some(Self::STATUS_DELETING),
+            "STATUS_DELETED" => std::option::Option::Some(Self::STATUS_DELETED),
+            "STATUS_PEERING" => std::option::Option::Some(Self::STATUS_PEERING),
+            "STATUS_NOT_APPLICABLE" => std::option::Option::Some(Self::STATUS_NOT_APPLICABLE),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for Status {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Status {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Status {
     fn default() -> Self {
-        status::STATUS_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// DeploymentLevel of a blueprint signifies where the blueprint will be
 /// applied.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DeploymentLevel(std::borrow::Cow<'static, str>);
+pub struct DeploymentLevel(i32);
 
 impl DeploymentLevel {
-    /// Creates a new DeploymentLevel instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [DeploymentLevel](DeploymentLevel)
-pub mod deployment_level {
-    use super::DeploymentLevel;
-
     /// Default unspecified deployment level.
-    pub const DEPLOYMENT_LEVEL_UNSPECIFIED: DeploymentLevel =
-        DeploymentLevel::new("DEPLOYMENT_LEVEL_UNSPECIFIED");
+    pub const DEPLOYMENT_LEVEL_UNSPECIFIED: DeploymentLevel = DeploymentLevel::new(0);
 
     /// Blueprints at HYDRATION level cannot be used to create a Deployment
     /// (A user cannot manually initate deployment of these blueprints on
     /// orchestration or workload cluster).
     /// These blueprints stay in a user's private catalog and are configured and
     /// deployed by TNA automation.
-    pub const HYDRATION: DeploymentLevel = DeploymentLevel::new("HYDRATION");
+    pub const HYDRATION: DeploymentLevel = DeploymentLevel::new(1);
 
     /// Blueprints at SINGLE_DEPLOYMENT level can be
     /// a) Modified in private catalog.
     /// b) Used to create a deployment on orchestration cluster by the user, once
     /// approved.
-    pub const SINGLE_DEPLOYMENT: DeploymentLevel = DeploymentLevel::new("SINGLE_DEPLOYMENT");
+    pub const SINGLE_DEPLOYMENT: DeploymentLevel = DeploymentLevel::new(2);
 
     /// Blueprints at MULTI_DEPLOYMENT level can be
     /// a) Modified in private catalog.
     /// b) Used to create a deployment on orchestration cluster which will create
     /// further hydrated deployments.
-    pub const MULTI_DEPLOYMENT: DeploymentLevel = DeploymentLevel::new("MULTI_DEPLOYMENT");
+    pub const MULTI_DEPLOYMENT: DeploymentLevel = DeploymentLevel::new(3);
 
     /// Blueprints at WORKLOAD_CLUSTER_DEPLOYMENT level can be
     /// a) Modified in private catalog.
     /// b) Used to create a deployment on workload cluster by the user, once
     /// approved.
-    pub const WORKLOAD_CLUSTER_DEPLOYMENT: DeploymentLevel =
-        DeploymentLevel::new("WORKLOAD_CLUSTER_DEPLOYMENT");
+    pub const WORKLOAD_CLUSTER_DEPLOYMENT: DeploymentLevel = DeploymentLevel::new(4);
+
+    /// Creates a new DeploymentLevel instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DEPLOYMENT_LEVEL_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("HYDRATION"),
+            2 => std::borrow::Cow::Borrowed("SINGLE_DEPLOYMENT"),
+            3 => std::borrow::Cow::Borrowed("MULTI_DEPLOYMENT"),
+            4 => std::borrow::Cow::Borrowed("WORKLOAD_CLUSTER_DEPLOYMENT"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DEPLOYMENT_LEVEL_UNSPECIFIED" => {
+                std::option::Option::Some(Self::DEPLOYMENT_LEVEL_UNSPECIFIED)
+            }
+            "HYDRATION" => std::option::Option::Some(Self::HYDRATION),
+            "SINGLE_DEPLOYMENT" => std::option::Option::Some(Self::SINGLE_DEPLOYMENT),
+            "MULTI_DEPLOYMENT" => std::option::Option::Some(Self::MULTI_DEPLOYMENT),
+            "WORKLOAD_CLUSTER_DEPLOYMENT" => {
+                std::option::Option::Some(Self::WORKLOAD_CLUSTER_DEPLOYMENT)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for DeploymentLevel {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DeploymentLevel {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DeploymentLevel {
     fn default() -> Self {
-        deployment_level::DEPLOYMENT_LEVEL_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/telcoautomation/v1/src/transport.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
                 reqwest::Method::GET,
                 format!("/v1/{}/orchestrationClusters", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
                 reqwest::Method::POST,
                 format!("/v1/{}/orchestrationClusters", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -118,7 +118,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -138,7 +138,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/edgeSlms", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -161,7 +161,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -183,7 +183,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
                 reqwest::Method::POST,
                 format!("/v1/{}/edgeSlms", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -204,7 +204,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -227,7 +227,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
                 reqwest::Method::POST,
                 format!("/v1/{}/blueprints", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -256,7 +256,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -285,7 +285,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -305,7 +305,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -327,7 +327,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
                 reqwest::Method::GET,
                 format!("/v1/{}/blueprints", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -349,7 +349,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:approve", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -366,7 +366,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:propose", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -383,7 +383,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:reject", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -403,7 +403,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
                 reqwest::Method::GET,
                 format!("/v1/{}:listRevisions", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -427,7 +427,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
                 reqwest::Method::GET,
                 format!("/v1/{}/blueprints:searchRevisions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -452,7 +452,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
                 reqwest::Method::GET,
                 format!("/v1/{}/deployments:searchRevisions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -474,7 +474,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:discard", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -494,7 +494,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
                 reqwest::Method::GET,
                 format!("/v1/{}/publicBlueprints", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -515,7 +515,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -537,7 +537,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
                 reqwest::Method::POST,
                 format!("/v1/{}/deployments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -566,7 +566,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -595,7 +595,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -615,7 +615,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:remove", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -635,7 +635,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
                 reqwest::Method::GET,
                 format!("/v1/{}/deployments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -660,7 +660,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
                 reqwest::Method::GET,
                 format!("/v1/{}:listRevisions", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -681,7 +681,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:discard", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -698,7 +698,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:apply", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -718,7 +718,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
                 reqwest::Method::GET,
                 format!("/v1/{}:computeDeploymentStatus", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -737,7 +737,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:rollback", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -754,7 +754,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -776,7 +776,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
                 reqwest::Method::GET,
                 format!("/v1/{}/hydratedDeployments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -806,7 +806,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -835,7 +835,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:apply", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -852,7 +852,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -874,7 +874,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -893,7 +893,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -915,7 +915,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -934,7 +934,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -953,7 +953,7 @@ impl crate::stubs::TelcoAutomation for TelcoAutomation {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/texttospeech/v1/src/model.rs
+++ b/src/generated/cloud/texttospeech/v1/src/model.rs
@@ -351,48 +351,64 @@ pub mod custom_pronunciation_params {
 
     /// The phonetic encoding of the phrase.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PhoneticEncoding(std::borrow::Cow<'static, str>);
+    pub struct PhoneticEncoding(i32);
 
     impl PhoneticEncoding {
-        /// Creates a new PhoneticEncoding instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PhoneticEncoding](PhoneticEncoding)
-    pub mod phonetic_encoding {
-        use super::PhoneticEncoding;
-
         /// Not specified.
-        pub const PHONETIC_ENCODING_UNSPECIFIED: PhoneticEncoding =
-            PhoneticEncoding::new("PHONETIC_ENCODING_UNSPECIFIED");
+        pub const PHONETIC_ENCODING_UNSPECIFIED: PhoneticEncoding = PhoneticEncoding::new(0);
 
         /// IPA. (e.g. apple -> ˈæpəl )
         /// <https://en.wikipedia.org/wiki/International_Phonetic_Alphabet>
-        pub const PHONETIC_ENCODING_IPA: PhoneticEncoding =
-            PhoneticEncoding::new("PHONETIC_ENCODING_IPA");
+        pub const PHONETIC_ENCODING_IPA: PhoneticEncoding = PhoneticEncoding::new(1);
 
         /// X-SAMPA (e.g. apple -> "{p@l" )
         /// <https://en.wikipedia.org/wiki/X-SAMPA>
-        pub const PHONETIC_ENCODING_X_SAMPA: PhoneticEncoding =
-            PhoneticEncoding::new("PHONETIC_ENCODING_X_SAMPA");
+        pub const PHONETIC_ENCODING_X_SAMPA: PhoneticEncoding = PhoneticEncoding::new(2);
+
+        /// Creates a new PhoneticEncoding instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PHONETIC_ENCODING_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PHONETIC_ENCODING_IPA"),
+                2 => std::borrow::Cow::Borrowed("PHONETIC_ENCODING_X_SAMPA"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PHONETIC_ENCODING_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PHONETIC_ENCODING_UNSPECIFIED)
+                }
+                "PHONETIC_ENCODING_IPA" => std::option::Option::Some(Self::PHONETIC_ENCODING_IPA),
+                "PHONETIC_ENCODING_X_SAMPA" => {
+                    std::option::Option::Some(Self::PHONETIC_ENCODING_X_SAMPA)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PhoneticEncoding {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PhoneticEncoding {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PhoneticEncoding {
         fn default() -> Self {
-            phonetic_encoding::PHONETIC_ENCODING_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -931,47 +947,63 @@ pub mod custom_voice_params {
     /// Deprecated. The usage of the synthesized audio. Usage does not affect
     /// billing.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ReportedUsage(std::borrow::Cow<'static, str>);
+    pub struct ReportedUsage(i32);
 
     impl ReportedUsage {
-        /// Creates a new ReportedUsage instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ReportedUsage](ReportedUsage)
-    pub mod reported_usage {
-        use super::ReportedUsage;
-
         /// Request with reported usage unspecified will be rejected.
-        pub const REPORTED_USAGE_UNSPECIFIED: ReportedUsage =
-            ReportedUsage::new("REPORTED_USAGE_UNSPECIFIED");
+        pub const REPORTED_USAGE_UNSPECIFIED: ReportedUsage = ReportedUsage::new(0);
 
         /// For scenarios where the synthesized audio is not downloadable and can
         /// only be used once. For example, real-time request in IVR system.
-        pub const REALTIME: ReportedUsage = ReportedUsage::new("REALTIME");
+        pub const REALTIME: ReportedUsage = ReportedUsage::new(1);
 
         /// For scenarios where the synthesized audio is downloadable and can be
         /// reused. For example, the synthesized audio is downloaded, stored in
         /// customer service system and played repeatedly.
-        pub const OFFLINE: ReportedUsage = ReportedUsage::new("OFFLINE");
+        pub const OFFLINE: ReportedUsage = ReportedUsage::new(2);
+
+        /// Creates a new ReportedUsage instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("REPORTED_USAGE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REALTIME"),
+                2 => std::borrow::Cow::Borrowed("OFFLINE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "REPORTED_USAGE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::REPORTED_USAGE_UNSPECIFIED)
+                }
+                "REALTIME" => std::option::Option::Some(Self::REALTIME),
+                "OFFLINE" => std::option::Option::Some(Self::OFFLINE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ReportedUsage {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ReportedUsage {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ReportedUsage {
         fn default() -> Self {
-            reported_usage::REPORTED_USAGE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1531,115 +1563,157 @@ impl wkt::message::Message for SynthesizeLongAudioMetadata {
 /// Gender of the voice as described in
 /// [SSML voice element](https://www.w3.org/TR/speech-synthesis11/#edef_voice).
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SsmlVoiceGender(std::borrow::Cow<'static, str>);
+pub struct SsmlVoiceGender(i32);
 
 impl SsmlVoiceGender {
-    /// Creates a new SsmlVoiceGender instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [SsmlVoiceGender](SsmlVoiceGender)
-pub mod ssml_voice_gender {
-    use super::SsmlVoiceGender;
-
     /// An unspecified gender.
     /// In VoiceSelectionParams, this means that the client doesn't care which
     /// gender the selected voice will have. In the Voice field of
     /// ListVoicesResponse, this may mean that the voice doesn't fit any of the
     /// other categories in this enum, or that the gender of the voice isn't known.
-    pub const SSML_VOICE_GENDER_UNSPECIFIED: SsmlVoiceGender =
-        SsmlVoiceGender::new("SSML_VOICE_GENDER_UNSPECIFIED");
+    pub const SSML_VOICE_GENDER_UNSPECIFIED: SsmlVoiceGender = SsmlVoiceGender::new(0);
 
     /// A male voice.
-    pub const MALE: SsmlVoiceGender = SsmlVoiceGender::new("MALE");
+    pub const MALE: SsmlVoiceGender = SsmlVoiceGender::new(1);
 
     /// A female voice.
-    pub const FEMALE: SsmlVoiceGender = SsmlVoiceGender::new("FEMALE");
+    pub const FEMALE: SsmlVoiceGender = SsmlVoiceGender::new(2);
 
     /// A gender-neutral voice. This voice is not yet supported.
-    pub const NEUTRAL: SsmlVoiceGender = SsmlVoiceGender::new("NEUTRAL");
+    pub const NEUTRAL: SsmlVoiceGender = SsmlVoiceGender::new(3);
+
+    /// Creates a new SsmlVoiceGender instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SSML_VOICE_GENDER_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("MALE"),
+            2 => std::borrow::Cow::Borrowed("FEMALE"),
+            3 => std::borrow::Cow::Borrowed("NEUTRAL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SSML_VOICE_GENDER_UNSPECIFIED" => {
+                std::option::Option::Some(Self::SSML_VOICE_GENDER_UNSPECIFIED)
+            }
+            "MALE" => std::option::Option::Some(Self::MALE),
+            "FEMALE" => std::option::Option::Some(Self::FEMALE),
+            "NEUTRAL" => std::option::Option::Some(Self::NEUTRAL),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for SsmlVoiceGender {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SsmlVoiceGender {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SsmlVoiceGender {
     fn default() -> Self {
-        ssml_voice_gender::SSML_VOICE_GENDER_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Configuration to set up audio encoder. The encoding determines the output
 /// audio format that we'd like.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AudioEncoding(std::borrow::Cow<'static, str>);
+pub struct AudioEncoding(i32);
 
 impl AudioEncoding {
-    /// Creates a new AudioEncoding instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [AudioEncoding](AudioEncoding)
-pub mod audio_encoding {
-    use super::AudioEncoding;
-
     /// Not specified. Will return result
     /// [google.rpc.Code.INVALID_ARGUMENT][google.rpc.Code.INVALID_ARGUMENT].
-    pub const AUDIO_ENCODING_UNSPECIFIED: AudioEncoding =
-        AudioEncoding::new("AUDIO_ENCODING_UNSPECIFIED");
+    pub const AUDIO_ENCODING_UNSPECIFIED: AudioEncoding = AudioEncoding::new(0);
 
     /// Uncompressed 16-bit signed little-endian samples (Linear PCM).
     /// Audio content returned as LINEAR16 also contains a WAV header.
-    pub const LINEAR16: AudioEncoding = AudioEncoding::new("LINEAR16");
+    pub const LINEAR16: AudioEncoding = AudioEncoding::new(1);
 
     /// MP3 audio at 32kbps.
-    pub const MP3: AudioEncoding = AudioEncoding::new("MP3");
+    pub const MP3: AudioEncoding = AudioEncoding::new(2);
 
     /// Opus encoded audio wrapped in an ogg container. The result will be a
     /// file which can be played natively on Android, and in browsers (at least
     /// Chrome and Firefox). The quality of the encoding is considerably higher
     /// than MP3 while using approximately the same bitrate.
-    pub const OGG_OPUS: AudioEncoding = AudioEncoding::new("OGG_OPUS");
+    pub const OGG_OPUS: AudioEncoding = AudioEncoding::new(3);
 
     /// 8-bit samples that compand 14-bit audio samples using G.711 PCMU/mu-law.
     /// Audio content returned as MULAW also contains a WAV header.
-    pub const MULAW: AudioEncoding = AudioEncoding::new("MULAW");
+    pub const MULAW: AudioEncoding = AudioEncoding::new(5);
 
     /// 8-bit samples that compand 14-bit audio samples using G.711 PCMU/A-law.
     /// Audio content returned as ALAW also contains a WAV header.
-    pub const ALAW: AudioEncoding = AudioEncoding::new("ALAW");
+    pub const ALAW: AudioEncoding = AudioEncoding::new(6);
 
     /// Uncompressed 16-bit signed little-endian samples (Linear PCM).
     /// Note that as opposed to LINEAR16, audio will not be wrapped in a WAV (or
     /// any other) header.
-    pub const PCM: AudioEncoding = AudioEncoding::new("PCM");
+    pub const PCM: AudioEncoding = AudioEncoding::new(7);
+
+    /// Creates a new AudioEncoding instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("LINEAR16"),
+            2 => std::borrow::Cow::Borrowed("MP3"),
+            3 => std::borrow::Cow::Borrowed("OGG_OPUS"),
+            5 => std::borrow::Cow::Borrowed("MULAW"),
+            6 => std::borrow::Cow::Borrowed("ALAW"),
+            7 => std::borrow::Cow::Borrowed("PCM"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "AUDIO_ENCODING_UNSPECIFIED" => {
+                std::option::Option::Some(Self::AUDIO_ENCODING_UNSPECIFIED)
+            }
+            "LINEAR16" => std::option::Option::Some(Self::LINEAR16),
+            "MP3" => std::option::Option::Some(Self::MP3),
+            "OGG_OPUS" => std::option::Option::Some(Self::OGG_OPUS),
+            "MULAW" => std::option::Option::Some(Self::MULAW),
+            "ALAW" => std::option::Option::Some(Self::ALAW),
+            "PCM" => std::option::Option::Some(Self::PCM),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for AudioEncoding {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for AudioEncoding {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for AudioEncoding {
     fn default() -> Self {
-        audio_encoding::AUDIO_ENCODING_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/texttospeech/v1/src/transport.rs
+++ b/src/generated/cloud/texttospeech/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::TextToSpeech for TextToSpeech {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v1/voices".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -69,7 +69,7 @@ impl crate::stubs::TextToSpeech for TextToSpeech {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, "/v1/text:synthesize".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -86,7 +86,7 @@ impl crate::stubs::TextToSpeech for TextToSpeech {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -108,7 +108,7 @@ impl crate::stubs::TextToSpeech for TextToSpeech {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -153,7 +153,7 @@ impl crate::stubs::TextToSpeechLongAudioSynthesize for TextToSpeechLongAudioSynt
                 reqwest::Method::POST,
                 format!("/v1/{}:synthesizeLongAudio", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -170,7 +170,7 @@ impl crate::stubs::TextToSpeechLongAudioSynthesize for TextToSpeechLongAudioSynt
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -192,7 +192,7 @@ impl crate::stubs::TextToSpeechLongAudioSynthesize for TextToSpeechLongAudioSynt
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/timeseriesinsights/v1/src/model.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/model.rs
@@ -259,59 +259,84 @@ pub mod data_set {
 
     /// DataSet state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified / undefined state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Dataset is unknown to the system; we have never seen this dataset before
         /// or we have seen this dataset but have fully GC-ed it.
-        pub const UNKNOWN: State = State::new("UNKNOWN");
+        pub const UNKNOWN: State = State::new(1);
 
         /// Dataset processing is pending.
-        pub const PENDING: State = State::new("PENDING");
+        pub const PENDING: State = State::new(2);
 
         /// Dataset is loading.
-        pub const LOADING: State = State::new("LOADING");
+        pub const LOADING: State = State::new(3);
 
         /// Dataset is loaded and can be queried.
-        pub const LOADED: State = State::new("LOADED");
+        pub const LOADED: State = State::new(4);
 
         /// Dataset is unloading.
-        pub const UNLOADING: State = State::new("UNLOADING");
+        pub const UNLOADING: State = State::new(5);
 
         /// Dataset is unloaded and is removed from the system.
-        pub const UNLOADED: State = State::new("UNLOADED");
+        pub const UNLOADED: State = State::new(6);
 
         /// Dataset processing failed.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(7);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                2 => std::borrow::Cow::Borrowed("PENDING"),
+                3 => std::borrow::Cow::Borrowed("LOADING"),
+                4 => std::borrow::Cow::Borrowed("LOADED"),
+                5 => std::borrow::Cow::Borrowed("UNLOADING"),
+                6 => std::borrow::Cow::Borrowed("UNLOADED"),
+                7 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "LOADING" => std::option::Option::Some(Self::LOADING),
+                "LOADED" => std::option::Option::Some(Self::LOADED),
+                "UNLOADING" => std::option::Option::Some(Self::UNLOADING),
+                "UNLOADED" => std::option::Option::Some(Self::UNLOADED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1064,52 +1089,73 @@ pub mod forecast_params {
 
     /// A time period of a fixed interval.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Period(std::borrow::Cow<'static, str>);
+    pub struct Period(i32);
 
     impl Period {
+        /// Unknown or simply not given.
+        pub const PERIOD_UNSPECIFIED: Period = Period::new(0);
+
+        /// 1 hour
+        pub const HOURLY: Period = Period::new(5);
+
+        /// 24 hours
+        pub const DAILY: Period = Period::new(1);
+
+        /// 7 days
+        pub const WEEKLY: Period = Period::new(2);
+
+        /// 30 days
+        pub const MONTHLY: Period = Period::new(3);
+
+        /// 365 days
+        pub const YEARLY: Period = Period::new(4);
+
         /// Creates a new Period instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PERIOD_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DAILY"),
+                2 => std::borrow::Cow::Borrowed("WEEKLY"),
+                3 => std::borrow::Cow::Borrowed("MONTHLY"),
+                4 => std::borrow::Cow::Borrowed("YEARLY"),
+                5 => std::borrow::Cow::Borrowed("HOURLY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PERIOD_UNSPECIFIED" => std::option::Option::Some(Self::PERIOD_UNSPECIFIED),
+                "HOURLY" => std::option::Option::Some(Self::HOURLY),
+                "DAILY" => std::option::Option::Some(Self::DAILY),
+                "WEEKLY" => std::option::Option::Some(Self::WEEKLY),
+                "MONTHLY" => std::option::Option::Some(Self::MONTHLY),
+                "YEARLY" => std::option::Option::Some(Self::YEARLY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Period](Period)
-    pub mod period {
-        use super::Period;
-
-        /// Unknown or simply not given.
-        pub const PERIOD_UNSPECIFIED: Period = Period::new("PERIOD_UNSPECIFIED");
-
-        /// 1 hour
-        pub const HOURLY: Period = Period::new("HOURLY");
-
-        /// 24 hours
-        pub const DAILY: Period = Period::new("DAILY");
-
-        /// 7 days
-        pub const WEEKLY: Period = Period::new("WEEKLY");
-
-        /// 30 days
-        pub const MONTHLY: Period = Period::new("MONTHLY");
-
-        /// 365 days
-        pub const YEARLY: Period = Period::new("YEARLY");
-    }
-
-    impl std::convert::From<std::string::String> for Period {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Period {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Period {
         fn default() -> Self {
-            period::PERIOD_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1704,50 +1750,66 @@ pub mod timeseries_params {
     ///
     /// [google.cloud.timeseriesinsights.v1.TimeseriesParams.metric]: crate::model::TimeseriesParams::metric
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AggregationMethod(std::borrow::Cow<'static, str>);
+    pub struct AggregationMethod(i32);
 
     impl AggregationMethod {
-        /// Creates a new AggregationMethod instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [AggregationMethod](AggregationMethod)
-    pub mod aggregation_method {
-        use super::AggregationMethod;
-
         /// Unspecified.
-        pub const AGGREGATION_METHOD_UNSPECIFIED: AggregationMethod =
-            AggregationMethod::new("AGGREGATION_METHOD_UNSPECIFIED");
+        pub const AGGREGATION_METHOD_UNSPECIFIED: AggregationMethod = AggregationMethod::new(0);
 
         /// Aggregate multiple events by summing up the values found in the
         /// [metric][google.cloud.timeseriesinsights.v1.TimeseriesParams.metric] dimension.
         ///
         /// [google.cloud.timeseriesinsights.v1.TimeseriesParams.metric]: crate::model::TimeseriesParams::metric
-        pub const SUM: AggregationMethod = AggregationMethod::new("SUM");
+        pub const SUM: AggregationMethod = AggregationMethod::new(1);
 
         /// Aggregate multiple events by averaging out the values found in the
         /// [metric][google.cloud.timeseriesinsights.v1.TimeseriesParams.metric] dimension.
         ///
         /// [google.cloud.timeseriesinsights.v1.TimeseriesParams.metric]: crate::model::TimeseriesParams::metric
-        pub const AVERAGE: AggregationMethod = AggregationMethod::new("AVERAGE");
+        pub const AVERAGE: AggregationMethod = AggregationMethod::new(2);
+
+        /// Creates a new AggregationMethod instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("AGGREGATION_METHOD_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SUM"),
+                2 => std::borrow::Cow::Borrowed("AVERAGE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "AGGREGATION_METHOD_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::AGGREGATION_METHOD_UNSPECIFIED)
+                }
+                "SUM" => std::option::Option::Some(Self::SUM),
+                "AVERAGE" => std::option::Option::Some(Self::AVERAGE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for AggregationMethod {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AggregationMethod {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AggregationMethod {
         fn default() -> Self {
-            aggregation_method::AGGREGATION_METHOD_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/timeseriesinsights/v1/src/transport.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::TimeseriesInsightsController for TimeseriesInsightsController
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/datasets", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -73,7 +73,7 @@ impl crate::stubs::TimeseriesInsightsController for TimeseriesInsightsController
                 reqwest::Method::POST,
                 format!("/v1/{}/datasets", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -92,7 +92,7 @@ impl crate::stubs::TimeseriesInsightsController for TimeseriesInsightsController
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -114,7 +114,7 @@ impl crate::stubs::TimeseriesInsightsController for TimeseriesInsightsController
                 reqwest::Method::POST,
                 format!("/v1/{}:appendEvents", req.dataset),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -131,7 +131,7 @@ impl crate::stubs::TimeseriesInsightsController for TimeseriesInsightsController
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:query", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -151,7 +151,7 @@ impl crate::stubs::TimeseriesInsightsController for TimeseriesInsightsController
                 reqwest::Method::POST,
                 format!("/v1/{}:evaluateSlice", req.dataset),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -171,7 +171,7 @@ impl crate::stubs::TimeseriesInsightsController for TimeseriesInsightsController
                 reqwest::Method::POST,
                 format!("/v1/{}/datasets:evaluateTimeseries", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/tpu/v2/src/model.rs
+++ b/src/generated/cloud/tpu/v2/src/model.rs
@@ -215,45 +215,60 @@ pub mod attached_disk {
 
     /// The different mode of the attached disk.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DiskMode(std::borrow::Cow<'static, str>);
+    pub struct DiskMode(i32);
 
     impl DiskMode {
-        /// Creates a new DiskMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DiskMode](DiskMode)
-    pub mod disk_mode {
-        use super::DiskMode;
-
         /// The disk mode is not known/set.
-        pub const DISK_MODE_UNSPECIFIED: DiskMode = DiskMode::new("DISK_MODE_UNSPECIFIED");
+        pub const DISK_MODE_UNSPECIFIED: DiskMode = DiskMode::new(0);
 
         /// Attaches the disk in read-write mode. Only one TPU node can attach a disk
         /// in read-write mode at a time.
-        pub const READ_WRITE: DiskMode = DiskMode::new("READ_WRITE");
+        pub const READ_WRITE: DiskMode = DiskMode::new(1);
 
         /// Attaches the disk in read-only mode. Multiple TPU nodes can attach
         /// a disk in read-only mode at a time.
-        pub const READ_ONLY: DiskMode = DiskMode::new("READ_ONLY");
+        pub const READ_ONLY: DiskMode = DiskMode::new(2);
+
+        /// Creates a new DiskMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DISK_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("READ_WRITE"),
+                2 => std::borrow::Cow::Borrowed("READ_ONLY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DISK_MODE_UNSPECIFIED" => std::option::Option::Some(Self::DISK_MODE_UNSPECIFIED),
+                "READ_WRITE" => std::option::Option::Some(Self::READ_WRITE),
+                "READ_ONLY" => std::option::Option::Some(Self::READ_ONLY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DiskMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DiskMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DiskMode {
         fn default() -> Self {
-            disk_mode::DISK_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -871,182 +886,263 @@ pub mod node {
 
     /// Represents the different states of a TPU node during its lifecycle.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// TPU node state is not known/set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// TPU node is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// TPU node has been created.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(2);
 
         /// TPU node is restarting.
-        pub const RESTARTING: State = State::new("RESTARTING");
+        pub const RESTARTING: State = State::new(3);
 
         /// TPU node is undergoing reimaging.
-        pub const REIMAGING: State = State::new("REIMAGING");
+        pub const REIMAGING: State = State::new(4);
 
         /// TPU node is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(5);
 
         /// TPU node is being repaired and may be unusable. Details can be
         /// found in the 'help_description' field.
-        pub const REPAIRING: State = State::new("REPAIRING");
+        pub const REPAIRING: State = State::new(6);
 
         /// TPU node is stopped.
-        pub const STOPPED: State = State::new("STOPPED");
+        pub const STOPPED: State = State::new(8);
 
         /// TPU node is currently stopping.
-        pub const STOPPING: State = State::new("STOPPING");
+        pub const STOPPING: State = State::new(9);
 
         /// TPU node is currently starting.
-        pub const STARTING: State = State::new("STARTING");
+        pub const STARTING: State = State::new(10);
 
         /// TPU node has been preempted. Only applies to Preemptible TPU Nodes.
-        pub const PREEMPTED: State = State::new("PREEMPTED");
+        pub const PREEMPTED: State = State::new(11);
 
         /// TPU node has been terminated due to maintenance or has reached the end of
         /// its life cycle (for preemptible nodes).
-        pub const TERMINATED: State = State::new("TERMINATED");
+        pub const TERMINATED: State = State::new(12);
 
         /// TPU node is currently hiding.
-        pub const HIDING: State = State::new("HIDING");
+        pub const HIDING: State = State::new(13);
 
         /// TPU node has been hidden.
-        pub const HIDDEN: State = State::new("HIDDEN");
+        pub const HIDDEN: State = State::new(14);
 
         /// TPU node is currently unhiding.
-        pub const UNHIDING: State = State::new("UNHIDING");
+        pub const UNHIDING: State = State::new(15);
 
         /// TPU node has unknown state after a failed repair.
-        pub const UNKNOWN: State = State::new("UNKNOWN");
+        pub const UNKNOWN: State = State::new(16);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                3 => std::borrow::Cow::Borrowed("RESTARTING"),
+                4 => std::borrow::Cow::Borrowed("REIMAGING"),
+                5 => std::borrow::Cow::Borrowed("DELETING"),
+                6 => std::borrow::Cow::Borrowed("REPAIRING"),
+                8 => std::borrow::Cow::Borrowed("STOPPED"),
+                9 => std::borrow::Cow::Borrowed("STOPPING"),
+                10 => std::borrow::Cow::Borrowed("STARTING"),
+                11 => std::borrow::Cow::Borrowed("PREEMPTED"),
+                12 => std::borrow::Cow::Borrowed("TERMINATED"),
+                13 => std::borrow::Cow::Borrowed("HIDING"),
+                14 => std::borrow::Cow::Borrowed("HIDDEN"),
+                15 => std::borrow::Cow::Borrowed("UNHIDING"),
+                16 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "RESTARTING" => std::option::Option::Some(Self::RESTARTING),
+                "REIMAGING" => std::option::Option::Some(Self::REIMAGING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "REPAIRING" => std::option::Option::Some(Self::REPAIRING),
+                "STOPPED" => std::option::Option::Some(Self::STOPPED),
+                "STOPPING" => std::option::Option::Some(Self::STOPPING),
+                "STARTING" => std::option::Option::Some(Self::STARTING),
+                "PREEMPTED" => std::option::Option::Some(Self::PREEMPTED),
+                "TERMINATED" => std::option::Option::Some(Self::TERMINATED),
+                "HIDING" => std::option::Option::Some(Self::HIDING),
+                "HIDDEN" => std::option::Option::Some(Self::HIDDEN),
+                "UNHIDING" => std::option::Option::Some(Self::UNHIDING),
+                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Health defines the status of a TPU node as reported by
     /// Health Monitor.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Health(std::borrow::Cow<'static, str>);
+    pub struct Health(i32);
 
     impl Health {
-        /// Creates a new Health instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Health](Health)
-    pub mod health {
-        use super::Health;
-
         /// Health status is unknown: not initialized or failed to retrieve.
-        pub const HEALTH_UNSPECIFIED: Health = Health::new("HEALTH_UNSPECIFIED");
+        pub const HEALTH_UNSPECIFIED: Health = Health::new(0);
 
         /// The resource is healthy.
-        pub const HEALTHY: Health = Health::new("HEALTHY");
+        pub const HEALTHY: Health = Health::new(1);
 
         /// The resource is unresponsive.
-        pub const TIMEOUT: Health = Health::new("TIMEOUT");
+        pub const TIMEOUT: Health = Health::new(3);
 
         /// The in-guest ML stack is unhealthy.
-        pub const UNHEALTHY_TENSORFLOW: Health = Health::new("UNHEALTHY_TENSORFLOW");
+        pub const UNHEALTHY_TENSORFLOW: Health = Health::new(4);
 
         /// The node is under maintenance/priority boost caused rescheduling and
         /// will resume running once rescheduled.
-        pub const UNHEALTHY_MAINTENANCE: Health = Health::new("UNHEALTHY_MAINTENANCE");
+        pub const UNHEALTHY_MAINTENANCE: Health = Health::new(5);
+
+        /// Creates a new Health instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("HEALTH_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("HEALTHY"),
+                3 => std::borrow::Cow::Borrowed("TIMEOUT"),
+                4 => std::borrow::Cow::Borrowed("UNHEALTHY_TENSORFLOW"),
+                5 => std::borrow::Cow::Borrowed("UNHEALTHY_MAINTENANCE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "HEALTH_UNSPECIFIED" => std::option::Option::Some(Self::HEALTH_UNSPECIFIED),
+                "HEALTHY" => std::option::Option::Some(Self::HEALTHY),
+                "TIMEOUT" => std::option::Option::Some(Self::TIMEOUT),
+                "UNHEALTHY_TENSORFLOW" => std::option::Option::Some(Self::UNHEALTHY_TENSORFLOW),
+                "UNHEALTHY_MAINTENANCE" => std::option::Option::Some(Self::UNHEALTHY_MAINTENANCE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Health {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Health {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Health {
         fn default() -> Self {
-            health::HEALTH_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// TPU API Version.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ApiVersion(std::borrow::Cow<'static, str>);
+    pub struct ApiVersion(i32);
 
     impl ApiVersion {
+        /// API version is unknown.
+        pub const API_VERSION_UNSPECIFIED: ApiVersion = ApiVersion::new(0);
+
+        /// TPU API V1Alpha1 version.
+        pub const V1_ALPHA1: ApiVersion = ApiVersion::new(1);
+
+        /// TPU API V1 version.
+        pub const V1: ApiVersion = ApiVersion::new(2);
+
+        /// TPU API V2Alpha1 version.
+        pub const V2_ALPHA1: ApiVersion = ApiVersion::new(3);
+
+        /// TPU API V2 version.
+        pub const V2: ApiVersion = ApiVersion::new(4);
+
         /// Creates a new ApiVersion instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("API_VERSION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("V1_ALPHA1"),
+                2 => std::borrow::Cow::Borrowed("V1"),
+                3 => std::borrow::Cow::Borrowed("V2_ALPHA1"),
+                4 => std::borrow::Cow::Borrowed("V2"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "API_VERSION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::API_VERSION_UNSPECIFIED)
+                }
+                "V1_ALPHA1" => std::option::Option::Some(Self::V1_ALPHA1),
+                "V1" => std::option::Option::Some(Self::V1),
+                "V2_ALPHA1" => std::option::Option::Some(Self::V2_ALPHA1),
+                "V2" => std::option::Option::Some(Self::V2),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ApiVersion](ApiVersion)
-    pub mod api_version {
-        use super::ApiVersion;
-
-        /// API version is unknown.
-        pub const API_VERSION_UNSPECIFIED: ApiVersion = ApiVersion::new("API_VERSION_UNSPECIFIED");
-
-        /// TPU API V1Alpha1 version.
-        pub const V1_ALPHA1: ApiVersion = ApiVersion::new("V1_ALPHA1");
-
-        /// TPU API V1 version.
-        pub const V1: ApiVersion = ApiVersion::new("V1");
-
-        /// TPU API V2Alpha1 version.
-        pub const V2_ALPHA1: ApiVersion = ApiVersion::new("V2_ALPHA1");
-
-        /// TPU API V2 version.
-        pub const V2: ApiVersion = ApiVersion::new("V2");
-    }
-
-    impl std::convert::From<std::string::String> for ApiVersion {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ApiVersion {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ApiVersion {
         fn default() -> Self {
-            api_version::API_VERSION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2289,61 +2385,46 @@ pub mod queued_resource_state {
 
     /// Output only state of the request
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// State of the QueuedResource request is not known/set.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The QueuedResource request has been received. We're still working on
         /// determining if we will be able to honor this request.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The QueuedResource request has passed initial validation/admission
         /// control and has been persisted in the queue.
-        pub const ACCEPTED: State = State::new("ACCEPTED");
+        pub const ACCEPTED: State = State::new(2);
 
         /// The QueuedResource request has been selected. The
         /// associated resources are currently being provisioned (or very soon
         /// will begin provisioning).
-        pub const PROVISIONING: State = State::new("PROVISIONING");
+        pub const PROVISIONING: State = State::new(3);
 
         /// The request could not be completed. This may be due to some
         /// late-discovered problem with the request itself, or due to
         /// unavailability of resources within the constraints of the request
         /// (e.g., the 'valid until' start timing constraint expired).
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(4);
 
         /// The QueuedResource is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(5);
 
         /// The resources specified in the QueuedResource request have been
         /// provisioned and are ready for use by the end-user/consumer.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(6);
 
         /// The resources specified in the QueuedResource request are being
         /// deleted. This may have been initiated by the user, or
         /// the Cloud TPU service. Inspect the state data for more details.
-        pub const SUSPENDING: State = State::new("SUSPENDING");
+        pub const SUSPENDING: State = State::new(7);
 
         /// The resources specified in the QueuedResource request have been
         /// deleted.
-        pub const SUSPENDED: State = State::new("SUSPENDED");
+        pub const SUSPENDED: State = State::new(8);
 
         /// The QueuedResource request has passed initial validation and has been
         /// persisted in the queue. It will remain in this state until there are
@@ -2354,61 +2435,121 @@ pub mod queued_resource_state {
         /// reservation. To put a limit on how long you are willing to wait, use
         /// [timing
         /// constraints](https://cloud.google.com/tpu/docs/queued-resources#request_a_queued_resource_before_a_specified_time).
-        pub const WAITING_FOR_RESOURCES: State = State::new("WAITING_FOR_RESOURCES");
+        pub const WAITING_FOR_RESOURCES: State = State::new(9);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACCEPTED"),
+                3 => std::borrow::Cow::Borrowed("PROVISIONING"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                5 => std::borrow::Cow::Borrowed("DELETING"),
+                6 => std::borrow::Cow::Borrowed("ACTIVE"),
+                7 => std::borrow::Cow::Borrowed("SUSPENDING"),
+                8 => std::borrow::Cow::Borrowed("SUSPENDED"),
+                9 => std::borrow::Cow::Borrowed("WAITING_FOR_RESOURCES"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACCEPTED" => std::option::Option::Some(Self::ACCEPTED),
+                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "SUSPENDING" => std::option::Option::Some(Self::SUSPENDING),
+                "SUSPENDED" => std::option::Option::Some(Self::SUSPENDED),
+                "WAITING_FOR_RESOURCES" => std::option::Option::Some(Self::WAITING_FOR_RESOURCES),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The initiator of the QueuedResource's SUSPENDING/SUSPENDED state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StateInitiator(std::borrow::Cow<'static, str>);
+    pub struct StateInitiator(i32);
 
     impl StateInitiator {
+        /// The state initiator is unspecified.
+        pub const STATE_INITIATOR_UNSPECIFIED: StateInitiator = StateInitiator::new(0);
+
+        /// The current QueuedResource state was initiated by the user.
+        pub const USER: StateInitiator = StateInitiator::new(1);
+
+        /// The current QueuedResource state was initiated by the service.
+        pub const SERVICE: StateInitiator = StateInitiator::new(2);
+
         /// Creates a new StateInitiator instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_INITIATOR_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("USER"),
+                2 => std::borrow::Cow::Borrowed("SERVICE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_INITIATOR_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::STATE_INITIATOR_UNSPECIFIED)
+                }
+                "USER" => std::option::Option::Some(Self::USER),
+                "SERVICE" => std::option::Option::Some(Self::SERVICE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [StateInitiator](StateInitiator)
-    pub mod state_initiator {
-        use super::StateInitiator;
-
-        /// The state initiator is unspecified.
-        pub const STATE_INITIATOR_UNSPECIFIED: StateInitiator =
-            StateInitiator::new("STATE_INITIATOR_UNSPECIFIED");
-
-        /// The current QueuedResource state was initiated by the user.
-        pub const USER: StateInitiator = StateInitiator::new("USER");
-
-        /// The current QueuedResource state was initiated by the service.
-        pub const SERVICE: StateInitiator = StateInitiator::new("SERVICE");
-    }
-
-    impl std::convert::From<std::string::String> for StateInitiator {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for StateInitiator {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for StateInitiator {
         fn default() -> Self {
-            state_initiator::STATE_INITIATOR_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -3818,57 +3959,81 @@ pub mod symptom {
     /// SymptomType represents the different types of Symptoms that a TPU can be
     /// at.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SymptomType(std::borrow::Cow<'static, str>);
+    pub struct SymptomType(i32);
 
     impl SymptomType {
-        /// Creates a new SymptomType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [SymptomType](SymptomType)
-    pub mod symptom_type {
-        use super::SymptomType;
-
         /// Unspecified symptom.
-        pub const SYMPTOM_TYPE_UNSPECIFIED: SymptomType =
-            SymptomType::new("SYMPTOM_TYPE_UNSPECIFIED");
+        pub const SYMPTOM_TYPE_UNSPECIFIED: SymptomType = SymptomType::new(0);
 
         /// TPU VM memory is low.
-        pub const LOW_MEMORY: SymptomType = SymptomType::new("LOW_MEMORY");
+        pub const LOW_MEMORY: SymptomType = SymptomType::new(1);
 
         /// TPU runtime is out of memory.
-        pub const OUT_OF_MEMORY: SymptomType = SymptomType::new("OUT_OF_MEMORY");
+        pub const OUT_OF_MEMORY: SymptomType = SymptomType::new(2);
 
         /// TPU runtime execution has timed out.
-        pub const EXECUTE_TIMED_OUT: SymptomType = SymptomType::new("EXECUTE_TIMED_OUT");
+        pub const EXECUTE_TIMED_OUT: SymptomType = SymptomType::new(3);
 
         /// TPU runtime fails to construct a mesh that recognizes each TPU device's
         /// neighbors.
-        pub const MESH_BUILD_FAIL: SymptomType = SymptomType::new("MESH_BUILD_FAIL");
+        pub const MESH_BUILD_FAIL: SymptomType = SymptomType::new(4);
 
         /// TPU HBM is out of memory.
-        pub const HBM_OUT_OF_MEMORY: SymptomType = SymptomType::new("HBM_OUT_OF_MEMORY");
+        pub const HBM_OUT_OF_MEMORY: SymptomType = SymptomType::new(5);
 
         /// Abusive behaviors have been identified on the current project.
-        pub const PROJECT_ABUSE: SymptomType = SymptomType::new("PROJECT_ABUSE");
+        pub const PROJECT_ABUSE: SymptomType = SymptomType::new(6);
+
+        /// Creates a new SymptomType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SYMPTOM_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LOW_MEMORY"),
+                2 => std::borrow::Cow::Borrowed("OUT_OF_MEMORY"),
+                3 => std::borrow::Cow::Borrowed("EXECUTE_TIMED_OUT"),
+                4 => std::borrow::Cow::Borrowed("MESH_BUILD_FAIL"),
+                5 => std::borrow::Cow::Borrowed("HBM_OUT_OF_MEMORY"),
+                6 => std::borrow::Cow::Borrowed("PROJECT_ABUSE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SYMPTOM_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SYMPTOM_TYPE_UNSPECIFIED)
+                }
+                "LOW_MEMORY" => std::option::Option::Some(Self::LOW_MEMORY),
+                "OUT_OF_MEMORY" => std::option::Option::Some(Self::OUT_OF_MEMORY),
+                "EXECUTE_TIMED_OUT" => std::option::Option::Some(Self::EXECUTE_TIMED_OUT),
+                "MESH_BUILD_FAIL" => std::option::Option::Some(Self::MESH_BUILD_FAIL),
+                "HBM_OUT_OF_MEMORY" => std::option::Option::Some(Self::HBM_OUT_OF_MEMORY),
+                "PROJECT_ABUSE" => std::option::Option::Some(Self::PROJECT_ABUSE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for SymptomType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SymptomType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SymptomType {
         fn default() -> Self {
-            symptom_type::SYMPTOM_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4016,55 +4181,78 @@ pub mod accelerator_config {
 
     /// TPU type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Unspecified version.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// TPU v2.
+        pub const V2: Type = Type::new(2);
+
+        /// TPU v3.
+        pub const V3: Type = Type::new(4);
+
+        /// TPU v4.
+        pub const V4: Type = Type::new(7);
+
+        /// TPU v5lite pod.
+        pub const V5LITE_POD: Type = Type::new(9);
+
+        /// TPU v5p.
+        pub const V5P: Type = Type::new(10);
+
+        /// TPU v6e.
+        pub const V6E: Type = Type::new(11);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                2 => std::borrow::Cow::Borrowed("V2"),
+                4 => std::borrow::Cow::Borrowed("V3"),
+                7 => std::borrow::Cow::Borrowed("V4"),
+                9 => std::borrow::Cow::Borrowed("V5LITE_POD"),
+                10 => std::borrow::Cow::Borrowed("V5P"),
+                11 => std::borrow::Cow::Borrowed("V6E"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "V2" => std::option::Option::Some(Self::V2),
+                "V3" => std::option::Option::Some(Self::V3),
+                "V4" => std::option::Option::Some(Self::V4),
+                "V5LITE_POD" => std::option::Option::Some(Self::V5LITE_POD),
+                "V5P" => std::option::Option::Some(Self::V5P),
+                "V6E" => std::option::Option::Some(Self::V6E),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Unspecified version.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// TPU v2.
-        pub const V2: Type = Type::new("V2");
-
-        /// TPU v3.
-        pub const V3: Type = Type::new("V3");
-
-        /// TPU v4.
-        pub const V4: Type = Type::new("V4");
-
-        /// TPU v5lite pod.
-        pub const V5LITE_POD: Type = Type::new("V5LITE_POD");
-
-        /// TPU v5p.
-        pub const V5P: Type = Type::new("V5P");
-
-        /// TPU v6e.
-        pub const V6E: Type = Type::new("V6E");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/tpu/v2/src/transport.rs
+++ b/src/generated/cloud/tpu/v2/src/transport.rs
@@ -47,7 +47,7 @@ impl crate::stubs::Tpu for Tpu {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/nodes", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -68,7 +68,7 @@ impl crate::stubs::Tpu for Tpu {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -87,7 +87,7 @@ impl crate::stubs::Tpu for Tpu {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}/nodes", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -105,7 +105,7 @@ impl crate::stubs::Tpu for Tpu {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -124,7 +124,7 @@ impl crate::stubs::Tpu for Tpu {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:stop", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -141,7 +141,7 @@ impl crate::stubs::Tpu for Tpu {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:start", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -167,7 +167,7 @@ impl crate::stubs::Tpu for Tpu {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -197,7 +197,7 @@ impl crate::stubs::Tpu for Tpu {
                 reqwest::Method::GET,
                 format!("/v2/{}/queuedResources", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -218,7 +218,7 @@ impl crate::stubs::Tpu for Tpu {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -240,7 +240,7 @@ impl crate::stubs::Tpu for Tpu {
                 reqwest::Method::POST,
                 format!("/v2/{}/queuedResources", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -261,7 +261,7 @@ impl crate::stubs::Tpu for Tpu {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -282,7 +282,7 @@ impl crate::stubs::Tpu for Tpu {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:reset", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -302,7 +302,7 @@ impl crate::stubs::Tpu for Tpu {
                 reqwest::Method::POST,
                 format!("/v2/{}:generateServiceIdentity", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -322,7 +322,7 @@ impl crate::stubs::Tpu for Tpu {
                 reqwest::Method::GET,
                 format!("/v2/{}/acceleratorTypes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -345,7 +345,7 @@ impl crate::stubs::Tpu for Tpu {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -367,7 +367,7 @@ impl crate::stubs::Tpu for Tpu {
                 reqwest::Method::GET,
                 format!("/v2/{}/runtimeVersions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -390,7 +390,7 @@ impl crate::stubs::Tpu for Tpu {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -412,7 +412,7 @@ impl crate::stubs::Tpu for Tpu {
                 reqwest::Method::POST,
                 format!("/v2/{}:getGuestAttributes", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -429,7 +429,7 @@ impl crate::stubs::Tpu for Tpu {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -451,7 +451,7 @@ impl crate::stubs::Tpu for Tpu {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -470,7 +470,7 @@ impl crate::stubs::Tpu for Tpu {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -492,7 +492,7 @@ impl crate::stubs::Tpu for Tpu {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -511,7 +511,7 @@ impl crate::stubs::Tpu for Tpu {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -530,7 +530,7 @@ impl crate::stubs::Tpu for Tpu {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/translate/v3/src/model.rs
+++ b/src/generated/cloud/translate/v3/src/model.rs
@@ -5559,56 +5559,77 @@ pub mod batch_translate_metadata {
 
     /// State of the job.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Invalid.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Request is being processed.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(1);
 
         /// The batch is processed, and at least one item was successfully
         /// processed.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
+        pub const SUCCEEDED: State = State::new(2);
 
         /// The batch is done and no item was successfully processed.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(3);
 
         /// Request is in the process of being canceled after caller invoked
         /// longrunning.Operations.CancelOperation on the request id.
-        pub const CANCELLING: State = State::new("CANCELLING");
+        pub const CANCELLING: State = State::new(4);
 
         /// The batch is done after the user has called the
         /// longrunning.Operations.CancelOperation. Any records processed before the
         /// cancel command are output as specified in the request.
-        pub const CANCELLED: State = State::new("CANCELLED");
+        pub const CANCELLED: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RUNNING"),
+                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                4 => std::borrow::Cow::Borrowed("CANCELLING"),
+                5 => std::borrow::Cow::Borrowed("CANCELLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6654,53 +6675,74 @@ pub mod create_glossary_metadata {
 
     /// Enumerates the possible states that the creation request can be in.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Invalid.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Request is being processed.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(1);
 
         /// The glossary was successfully created.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
+        pub const SUCCEEDED: State = State::new(2);
 
         /// Failed to create the glossary.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(3);
 
         /// Request is in the process of being canceled after caller invoked
         /// longrunning.Operations.CancelOperation on the request id.
-        pub const CANCELLING: State = State::new("CANCELLING");
+        pub const CANCELLING: State = State::new(4);
 
         /// The glossary creation request was successfully canceled.
-        pub const CANCELLED: State = State::new("CANCELLED");
+        pub const CANCELLED: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RUNNING"),
+                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                4 => std::borrow::Cow::Borrowed("CANCELLING"),
+                5 => std::borrow::Cow::Borrowed("CANCELLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6774,53 +6816,74 @@ pub mod update_glossary_metadata {
 
     /// Enumerates the possible states that the update request can be in.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Invalid.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Request is being processed.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(1);
 
         /// The glossary was successfully updated.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
+        pub const SUCCEEDED: State = State::new(2);
 
         /// Failed to update the glossary.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(3);
 
         /// Request is in the process of being canceled after caller invoked
         /// longrunning.Operations.CancelOperation on the request id.
-        pub const CANCELLING: State = State::new("CANCELLING");
+        pub const CANCELLING: State = State::new(4);
 
         /// The glossary update request was successfully canceled.
-        pub const CANCELLED: State = State::new("CANCELLED");
+        pub const CANCELLED: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RUNNING"),
+                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                4 => std::borrow::Cow::Borrowed("CANCELLING"),
+                5 => std::borrow::Cow::Borrowed("CANCELLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6890,53 +6953,74 @@ pub mod delete_glossary_metadata {
 
     /// Enumerates the possible states that the creation request can be in.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Invalid.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Request is being processed.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(1);
 
         /// The glossary was successfully deleted.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
+        pub const SUCCEEDED: State = State::new(2);
 
         /// Failed to delete the glossary.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(3);
 
         /// Request is in the process of being canceled after caller invoked
         /// longrunning.Operations.CancelOperation on the request id.
-        pub const CANCELLING: State = State::new("CANCELLING");
+        pub const CANCELLING: State = State::new(4);
 
         /// The glossary deletion request was successfully canceled.
-        pub const CANCELLED: State = State::new("CANCELLED");
+        pub const CANCELLED: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RUNNING"),
+                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                4 => std::borrow::Cow::Borrowed("CANCELLING"),
+                5 => std::borrow::Cow::Borrowed("CANCELLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7726,55 +7810,76 @@ pub mod batch_translate_document_metadata {
 
     /// State of the job.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Invalid.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Request is being processed.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(1);
 
         /// The batch is processed, and at least one item was successfully processed.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
+        pub const SUCCEEDED: State = State::new(2);
 
         /// The batch is done and no item was successfully processed.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(3);
 
         /// Request is in the process of being canceled after caller invoked
         /// longrunning.Operations.CancelOperation on the request id.
-        pub const CANCELLING: State = State::new("CANCELLING");
+        pub const CANCELLING: State = State::new(4);
 
         /// The batch is done after the user has called the
         /// longrunning.Operations.CancelOperation. Any records processed before the
         /// cancel command are output as specified in the request.
-        pub const CANCELLED: State = State::new("CANCELLED");
+        pub const CANCELLED: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RUNNING"),
+                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                4 => std::borrow::Cow::Borrowed("CANCELLING"),
+                5 => std::borrow::Cow::Borrowed("CANCELLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7836,58 +7941,81 @@ impl wkt::message::Message for TranslateTextGlossaryConfig {
 
 /// Possible states of long running operations.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OperationState(std::borrow::Cow<'static, str>);
+pub struct OperationState(i32);
 
 impl OperationState {
-    /// Creates a new OperationState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [OperationState](OperationState)
-pub mod operation_state {
-    use super::OperationState;
-
     /// Invalid.
-    pub const OPERATION_STATE_UNSPECIFIED: OperationState =
-        OperationState::new("OPERATION_STATE_UNSPECIFIED");
+    pub const OPERATION_STATE_UNSPECIFIED: OperationState = OperationState::new(0);
 
     /// Request is being processed.
-    pub const OPERATION_STATE_RUNNING: OperationState =
-        OperationState::new("OPERATION_STATE_RUNNING");
+    pub const OPERATION_STATE_RUNNING: OperationState = OperationState::new(1);
 
     /// The operation was successful.
-    pub const OPERATION_STATE_SUCCEEDED: OperationState =
-        OperationState::new("OPERATION_STATE_SUCCEEDED");
+    pub const OPERATION_STATE_SUCCEEDED: OperationState = OperationState::new(2);
 
     /// Failed to process operation.
-    pub const OPERATION_STATE_FAILED: OperationState =
-        OperationState::new("OPERATION_STATE_FAILED");
+    pub const OPERATION_STATE_FAILED: OperationState = OperationState::new(3);
 
     /// Request is in the process of being canceled after caller invoked
     /// longrunning.Operations.CancelOperation on the request id.
-    pub const OPERATION_STATE_CANCELLING: OperationState =
-        OperationState::new("OPERATION_STATE_CANCELLING");
+    pub const OPERATION_STATE_CANCELLING: OperationState = OperationState::new(4);
 
     /// The operation request was successfully canceled.
-    pub const OPERATION_STATE_CANCELLED: OperationState =
-        OperationState::new("OPERATION_STATE_CANCELLED");
+    pub const OPERATION_STATE_CANCELLED: OperationState = OperationState::new(5);
+
+    /// Creates a new OperationState instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("OPERATION_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("OPERATION_STATE_RUNNING"),
+            2 => std::borrow::Cow::Borrowed("OPERATION_STATE_SUCCEEDED"),
+            3 => std::borrow::Cow::Borrowed("OPERATION_STATE_FAILED"),
+            4 => std::borrow::Cow::Borrowed("OPERATION_STATE_CANCELLING"),
+            5 => std::borrow::Cow::Borrowed("OPERATION_STATE_CANCELLED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "OPERATION_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::OPERATION_STATE_UNSPECIFIED)
+            }
+            "OPERATION_STATE_RUNNING" => std::option::Option::Some(Self::OPERATION_STATE_RUNNING),
+            "OPERATION_STATE_SUCCEEDED" => {
+                std::option::Option::Some(Self::OPERATION_STATE_SUCCEEDED)
+            }
+            "OPERATION_STATE_FAILED" => std::option::Option::Some(Self::OPERATION_STATE_FAILED),
+            "OPERATION_STATE_CANCELLING" => {
+                std::option::Option::Some(Self::OPERATION_STATE_CANCELLING)
+            }
+            "OPERATION_STATE_CANCELLED" => {
+                std::option::Option::Some(Self::OPERATION_STATE_CANCELLED)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for OperationState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for OperationState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for OperationState {
     fn default() -> Self {
-        operation_state::OPERATION_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/translate/v3/src/transport.rs
+++ b/src/generated/cloud/translate/v3/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::TranslationService for TranslationService {
                 reqwest::Method::POST,
                 format!("/v3/{}:translateText", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::TranslationService for TranslationService {
                 reqwest::Method::POST,
                 format!("/v3/{}:romanizeText", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -92,7 +92,7 @@ impl crate::stubs::TranslationService for TranslationService {
                 reqwest::Method::POST,
                 format!("/v3/{}:detectLanguage", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -112,7 +112,7 @@ impl crate::stubs::TranslationService for TranslationService {
                 reqwest::Method::GET,
                 format!("/v3/{}/supportedLanguages", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -136,7 +136,7 @@ impl crate::stubs::TranslationService for TranslationService {
                 reqwest::Method::POST,
                 format!("/v3/{}:translateDocument", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -156,7 +156,7 @@ impl crate::stubs::TranslationService for TranslationService {
                 reqwest::Method::POST,
                 format!("/v3/{}:batchTranslateText", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -176,7 +176,7 @@ impl crate::stubs::TranslationService for TranslationService {
                 reqwest::Method::POST,
                 format!("/v3/{}:batchTranslateDocument", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -196,7 +196,7 @@ impl crate::stubs::TranslationService for TranslationService {
                 reqwest::Method::POST,
                 format!("/v3/{}/glossaries", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -224,7 +224,7 @@ impl crate::stubs::TranslationService for TranslationService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -256,7 +256,7 @@ impl crate::stubs::TranslationService for TranslationService {
                 reqwest::Method::GET,
                 format!("/v3/{}/glossaries", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -278,7 +278,7 @@ impl crate::stubs::TranslationService for TranslationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -297,7 +297,7 @@ impl crate::stubs::TranslationService for TranslationService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -316,7 +316,7 @@ impl crate::stubs::TranslationService for TranslationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -338,7 +338,7 @@ impl crate::stubs::TranslationService for TranslationService {
                 reqwest::Method::GET,
                 format!("/v3/{}/glossaryEntries", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -362,7 +362,7 @@ impl crate::stubs::TranslationService for TranslationService {
                 reqwest::Method::POST,
                 format!("/v3/{}/glossaryEntries", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -390,7 +390,7 @@ impl crate::stubs::TranslationService for TranslationService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -409,7 +409,7 @@ impl crate::stubs::TranslationService for TranslationService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -431,7 +431,7 @@ impl crate::stubs::TranslationService for TranslationService {
                 reqwest::Method::POST,
                 format!("/v3/{}/datasets", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -450,7 +450,7 @@ impl crate::stubs::TranslationService for TranslationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -469,7 +469,7 @@ impl crate::stubs::TranslationService for TranslationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/datasets", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -490,7 +490,7 @@ impl crate::stubs::TranslationService for TranslationService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -512,7 +512,7 @@ impl crate::stubs::TranslationService for TranslationService {
                 reqwest::Method::POST,
                 format!("/v3/{}/adaptiveMtDatasets", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -531,7 +531,7 @@ impl crate::stubs::TranslationService for TranslationService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -550,7 +550,7 @@ impl crate::stubs::TranslationService for TranslationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -572,7 +572,7 @@ impl crate::stubs::TranslationService for TranslationService {
                 reqwest::Method::GET,
                 format!("/v3/{}/adaptiveMtDatasets", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -597,7 +597,7 @@ impl crate::stubs::TranslationService for TranslationService {
                 reqwest::Method::POST,
                 format!("/v3/{}:adaptiveMtTranslate", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -614,7 +614,7 @@ impl crate::stubs::TranslationService for TranslationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -633,7 +633,7 @@ impl crate::stubs::TranslationService for TranslationService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -655,7 +655,7 @@ impl crate::stubs::TranslationService for TranslationService {
                 reqwest::Method::POST,
                 format!("/v3/{}:importAdaptiveMtFile", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -675,7 +675,7 @@ impl crate::stubs::TranslationService for TranslationService {
                 reqwest::Method::GET,
                 format!("/v3/{}/adaptiveMtFiles", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -699,7 +699,7 @@ impl crate::stubs::TranslationService for TranslationService {
                 reqwest::Method::GET,
                 format!("/v3/{}/adaptiveMtSentences", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -723,7 +723,7 @@ impl crate::stubs::TranslationService for TranslationService {
                 reqwest::Method::POST,
                 format!("/v3/{}:importData", req.dataset),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -743,7 +743,7 @@ impl crate::stubs::TranslationService for TranslationService {
                 reqwest::Method::POST,
                 format!("/v3/{}:exportData", req.dataset),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -760,7 +760,7 @@ impl crate::stubs::TranslationService for TranslationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/examples", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -782,7 +782,7 @@ impl crate::stubs::TranslationService for TranslationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}/models", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -799,7 +799,7 @@ impl crate::stubs::TranslationService for TranslationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/models", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -821,7 +821,7 @@ impl crate::stubs::TranslationService for TranslationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -840,7 +840,7 @@ impl crate::stubs::TranslationService for TranslationService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -859,7 +859,7 @@ impl crate::stubs::TranslationService for TranslationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -881,7 +881,7 @@ impl crate::stubs::TranslationService for TranslationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -900,7 +900,7 @@ impl crate::stubs::TranslationService for TranslationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -922,7 +922,7 @@ impl crate::stubs::TranslationService for TranslationService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -941,7 +941,7 @@ impl crate::stubs::TranslationService for TranslationService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -960,7 +960,7 @@ impl crate::stubs::TranslationService for TranslationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -977,7 +977,7 @@ impl crate::stubs::TranslationService for TranslationService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:wait", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/video/livestream/v1/src/model.rs
+++ b/src/generated/cloud/video/livestream/v1/src/model.rs
@@ -426,44 +426,60 @@ pub mod manifest {
 
     /// The manifest type can be either `HLS` or `DASH`.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ManifestType(std::borrow::Cow<'static, str>);
+    pub struct ManifestType(i32);
 
     impl ManifestType {
+        /// The manifest type is not specified.
+        pub const MANIFEST_TYPE_UNSPECIFIED: ManifestType = ManifestType::new(0);
+
+        /// Create an `HLS` manifest. The corresponding file extension is `.m3u8`.
+        pub const HLS: ManifestType = ManifestType::new(1);
+
+        /// Create a `DASH` manifest. The corresponding file extension is `.mpd`.
+        pub const DASH: ManifestType = ManifestType::new(2);
+
         /// Creates a new ManifestType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MANIFEST_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("HLS"),
+                2 => std::borrow::Cow::Borrowed("DASH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MANIFEST_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MANIFEST_TYPE_UNSPECIFIED)
+                }
+                "HLS" => std::option::Option::Some(Self::HLS),
+                "DASH" => std::option::Option::Some(Self::DASH),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ManifestType](ManifestType)
-    pub mod manifest_type {
-        use super::ManifestType;
-
-        /// The manifest type is not specified.
-        pub const MANIFEST_TYPE_UNSPECIFIED: ManifestType =
-            ManifestType::new("MANIFEST_TYPE_UNSPECIFIED");
-
-        /// Create an `HLS` manifest. The corresponding file extension is `.m3u8`.
-        pub const HLS: ManifestType = ManifestType::new("HLS");
-
-        /// Create a `DASH` manifest. The corresponding file extension is `.mpd`.
-        pub const DASH: ManifestType = ManifestType::new("DASH");
-    }
-
-    impl std::convert::From<std::string::String> for ManifestType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ManifestType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ManifestType {
         fn default() -> Self {
-            manifest_type::MANIFEST_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1563,44 +1579,60 @@ pub mod timecode_config {
 
     /// The source of timecode.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TimecodeSource(std::borrow::Cow<'static, str>);
+    pub struct TimecodeSource(i32);
 
     impl TimecodeSource {
+        /// The timecode source is not specified.
+        pub const TIMECODE_SOURCE_UNSPECIFIED: TimecodeSource = TimecodeSource::new(0);
+
+        /// Use input media timestamp.
+        pub const MEDIA_TIMESTAMP: TimecodeSource = TimecodeSource::new(1);
+
+        /// Use input embedded timecode e.g. picture timing SEI message.
+        pub const EMBEDDED_TIMECODE: TimecodeSource = TimecodeSource::new(2);
+
         /// Creates a new TimecodeSource instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TIMECODE_SOURCE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MEDIA_TIMESTAMP"),
+                2 => std::borrow::Cow::Borrowed("EMBEDDED_TIMECODE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TIMECODE_SOURCE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::TIMECODE_SOURCE_UNSPECIFIED)
+                }
+                "MEDIA_TIMESTAMP" => std::option::Option::Some(Self::MEDIA_TIMESTAMP),
+                "EMBEDDED_TIMECODE" => std::option::Option::Some(Self::EMBEDDED_TIMECODE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [TimecodeSource](TimecodeSource)
-    pub mod timecode_source {
-        use super::TimecodeSource;
-
-        /// The timecode source is not specified.
-        pub const TIMECODE_SOURCE_UNSPECIFIED: TimecodeSource =
-            TimecodeSource::new("TIMECODE_SOURCE_UNSPECIFIED");
-
-        /// Use input media timestamp.
-        pub const MEDIA_TIMESTAMP: TimecodeSource = TimecodeSource::new("MEDIA_TIMESTAMP");
-
-        /// Use input embedded timecode e.g. picture timing SEI message.
-        pub const EMBEDDED_TIMECODE: TimecodeSource = TimecodeSource::new("EMBEDDED_TIMECODE");
-    }
-
-    impl std::convert::From<std::string::String> for TimecodeSource {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TimecodeSource {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TimecodeSource {
         fn default() -> Self {
-            timecode_source::TIMECODE_SOURCE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1821,88 +1853,120 @@ pub mod input {
 
     /// The type of the input.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Input type is not specified.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// Input will take an rtmp input stream.
+        pub const RTMP_PUSH: Type = Type::new(1);
+
+        /// Input will take an srt (Secure Reliable Transport) input stream.
+        pub const SRT_PUSH: Type = Type::new(2);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RTMP_PUSH"),
+                2 => std::borrow::Cow::Borrowed("SRT_PUSH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "RTMP_PUSH" => std::option::Option::Some(Self::RTMP_PUSH),
+                "SRT_PUSH" => std::option::Option::Some(Self::SRT_PUSH),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Input type is not specified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// Input will take an rtmp input stream.
-        pub const RTMP_PUSH: Type = Type::new("RTMP_PUSH");
-
-        /// Input will take an srt (Secure Reliable Transport) input stream.
-        pub const SRT_PUSH: Type = Type::new("SRT_PUSH");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Tier of the input specification.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Tier(std::borrow::Cow<'static, str>);
+    pub struct Tier(i32);
 
     impl Tier {
+        /// Tier is not specified.
+        pub const TIER_UNSPECIFIED: Tier = Tier::new(0);
+
+        /// Resolution < 1280x720. Bitrate <= 6 Mbps. FPS <= 60.
+        pub const SD: Tier = Tier::new(1);
+
+        /// Resolution <= 1920x1080. Bitrate <= 25 Mbps. FPS <= 60.
+        pub const HD: Tier = Tier::new(2);
+
+        /// Resolution <= 4096x2160. Not supported yet.
+        pub const UHD: Tier = Tier::new(3);
+
         /// Creates a new Tier instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TIER_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SD"),
+                2 => std::borrow::Cow::Borrowed("HD"),
+                3 => std::borrow::Cow::Borrowed("UHD"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TIER_UNSPECIFIED" => std::option::Option::Some(Self::TIER_UNSPECIFIED),
+                "SD" => std::option::Option::Some(Self::SD),
+                "HD" => std::option::Option::Some(Self::HD),
+                "UHD" => std::option::Option::Some(Self::UHD),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Tier](Tier)
-    pub mod tier {
-        use super::Tier;
-
-        /// Tier is not specified.
-        pub const TIER_UNSPECIFIED: Tier = Tier::new("TIER_UNSPECIFIED");
-
-        /// Resolution < 1280x720. Bitrate <= 6 Mbps. FPS <= 60.
-        pub const SD: Tier = Tier::new("SD");
-
-        /// Resolution <= 1920x1080. Bitrate <= 25 Mbps. FPS <= 60.
-        pub const HD: Tier = Tier::new("HD");
-
-        /// Resolution <= 4096x2160. Not supported yet.
-        pub const UHD: Tier = Tier::new("UHD");
-    }
-
-    impl std::convert::From<std::string::String> for Tier {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Tier {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Tier {
         fn default() -> Self {
-            tier::TIER_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2253,64 +2317,90 @@ pub mod channel {
 
     /// State of streaming operation that the channel is running.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StreamingState(std::borrow::Cow<'static, str>);
+    pub struct StreamingState(i32);
 
     impl StreamingState {
-        /// Creates a new StreamingState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [StreamingState](StreamingState)
-    pub mod streaming_state {
-        use super::StreamingState;
-
         /// Streaming state is not specified.
-        pub const STREAMING_STATE_UNSPECIFIED: StreamingState =
-            StreamingState::new("STREAMING_STATE_UNSPECIFIED");
+        pub const STREAMING_STATE_UNSPECIFIED: StreamingState = StreamingState::new(0);
 
         /// Channel is getting the input stream, generating the live streams to the
         /// specified output location.
-        pub const STREAMING: StreamingState = StreamingState::new("STREAMING");
+        pub const STREAMING: StreamingState = StreamingState::new(1);
 
         /// Channel is waiting for the input stream through the input.
-        pub const AWAITING_INPUT: StreamingState = StreamingState::new("AWAITING_INPUT");
+        pub const AWAITING_INPUT: StreamingState = StreamingState::new(2);
 
         /// Channel is running, but has trouble publishing the live streams onto the
         /// specified output location (for example, the specified Cloud Storage
         /// bucket is not writable).
-        pub const STREAMING_ERROR: StreamingState = StreamingState::new("STREAMING_ERROR");
+        pub const STREAMING_ERROR: StreamingState = StreamingState::new(4);
 
         /// Channel is generating live streams with no input stream. Live streams are
         /// filled out with black screen, while input stream is missing.
         /// Not supported yet.
-        pub const STREAMING_NO_INPUT: StreamingState = StreamingState::new("STREAMING_NO_INPUT");
+        pub const STREAMING_NO_INPUT: StreamingState = StreamingState::new(5);
 
         /// Channel is stopped, finishing live streams.
-        pub const STOPPED: StreamingState = StreamingState::new("STOPPED");
+        pub const STOPPED: StreamingState = StreamingState::new(6);
 
         /// Channel is starting.
-        pub const STARTING: StreamingState = StreamingState::new("STARTING");
+        pub const STARTING: StreamingState = StreamingState::new(7);
 
         /// Channel is stopping.
-        pub const STOPPING: StreamingState = StreamingState::new("STOPPING");
+        pub const STOPPING: StreamingState = StreamingState::new(8);
+
+        /// Creates a new StreamingState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STREAMING_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STREAMING"),
+                2 => std::borrow::Cow::Borrowed("AWAITING_INPUT"),
+                4 => std::borrow::Cow::Borrowed("STREAMING_ERROR"),
+                5 => std::borrow::Cow::Borrowed("STREAMING_NO_INPUT"),
+                6 => std::borrow::Cow::Borrowed("STOPPED"),
+                7 => std::borrow::Cow::Borrowed("STARTING"),
+                8 => std::borrow::Cow::Borrowed("STOPPING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STREAMING_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::STREAMING_STATE_UNSPECIFIED)
+                }
+                "STREAMING" => std::option::Option::Some(Self::STREAMING),
+                "AWAITING_INPUT" => std::option::Option::Some(Self::AWAITING_INPUT),
+                "STREAMING_ERROR" => std::option::Option::Some(Self::STREAMING_ERROR),
+                "STREAMING_NO_INPUT" => std::option::Option::Some(Self::STREAMING_NO_INPUT),
+                "STOPPED" => std::option::Option::Some(Self::STOPPED),
+                "STARTING" => std::option::Option::Some(Self::STARTING),
+                "STOPPING" => std::option::Option::Some(Self::STOPPING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for StreamingState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for StreamingState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for StreamingState {
         fn default() -> Self {
-            streaming_state::STREAMING_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2508,27 +2598,11 @@ pub mod input_config {
 
     /// Input switch mode.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct InputSwitchMode(std::borrow::Cow<'static, str>);
+    pub struct InputSwitchMode(i32);
 
     impl InputSwitchMode {
-        /// Creates a new InputSwitchMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [InputSwitchMode](InputSwitchMode)
-    pub mod input_switch_mode {
-        use super::InputSwitchMode;
-
         /// The input switch mode is not specified.
-        pub const INPUT_SWITCH_MODE_UNSPECIFIED: InputSwitchMode =
-            InputSwitchMode::new("INPUT_SWITCH_MODE_UNSPECIFIED");
+        pub const INPUT_SWITCH_MODE_UNSPECIFIED: InputSwitchMode = InputSwitchMode::new(0);
 
         /// Automatic failover is enabled. The primary input stream is always
         /// preferred over its backup input streams configured using the
@@ -2536,8 +2610,7 @@ pub mod input_config {
         /// field.
         ///
         /// [google.cloud.video.livestream.v1.InputAttachment.AutomaticFailover]: crate::model::input_attachment::AutomaticFailover
-        pub const FAILOVER_PREFER_PRIMARY: InputSwitchMode =
-            InputSwitchMode::new("FAILOVER_PREFER_PRIMARY");
+        pub const FAILOVER_PREFER_PRIMARY: InputSwitchMode = InputSwitchMode::new(1);
 
         /// Automatic failover is disabled. You must use the
         /// [inputSwitch][google.cloud.video.livestream.v1.Event.input_switch] event
@@ -2548,18 +2621,52 @@ pub mod input_config {
         ///
         /// [google.cloud.video.livestream.v1.Event.input_switch]: crate::model::Event::task
         /// [google.cloud.video.livestream.v1.InputAttachment.AutomaticFailover]: crate::model::input_attachment::AutomaticFailover
-        pub const MANUAL: InputSwitchMode = InputSwitchMode::new("MANUAL");
+        pub const MANUAL: InputSwitchMode = InputSwitchMode::new(3);
+
+        /// Creates a new InputSwitchMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("INPUT_SWITCH_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FAILOVER_PREFER_PRIMARY"),
+                3 => std::borrow::Cow::Borrowed("MANUAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "INPUT_SWITCH_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::INPUT_SWITCH_MODE_UNSPECIFIED)
+                }
+                "FAILOVER_PREFER_PRIMARY" => {
+                    std::option::Option::Some(Self::FAILOVER_PREFER_PRIMARY)
+                }
+                "MANUAL" => std::option::Option::Some(Self::MANUAL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for InputSwitchMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for InputSwitchMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for InputSwitchMode {
         fn default() -> Self {
-            input_switch_mode::INPUT_SWITCH_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2612,53 +2719,75 @@ pub mod log_config {
     /// [LogSeverity](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logseverity)
     /// for more information.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LogSeverity(std::borrow::Cow<'static, str>);
+    pub struct LogSeverity(i32);
 
     impl LogSeverity {
+        /// Log severity is not specified. This is the same as log severity is OFF.
+        pub const LOG_SEVERITY_UNSPECIFIED: LogSeverity = LogSeverity::new(0);
+
+        /// Log is turned off.
+        pub const OFF: LogSeverity = LogSeverity::new(1);
+
+        /// Log with severity higher than or equal to DEBUG are logged.
+        pub const DEBUG: LogSeverity = LogSeverity::new(100);
+
+        /// Logs with severity higher than or equal to INFO are logged.
+        pub const INFO: LogSeverity = LogSeverity::new(200);
+
+        /// Logs with severity higher than or equal to WARNING are logged.
+        pub const WARNING: LogSeverity = LogSeverity::new(400);
+
+        /// Logs with severity higher than or equal to ERROR are logged.
+        pub const ERROR: LogSeverity = LogSeverity::new(500);
+
         /// Creates a new LogSeverity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LOG_SEVERITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("OFF"),
+                100 => std::borrow::Cow::Borrowed("DEBUG"),
+                200 => std::borrow::Cow::Borrowed("INFO"),
+                400 => std::borrow::Cow::Borrowed("WARNING"),
+                500 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LOG_SEVERITY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::LOG_SEVERITY_UNSPECIFIED)
+                }
+                "OFF" => std::option::Option::Some(Self::OFF),
+                "DEBUG" => std::option::Option::Some(Self::DEBUG),
+                "INFO" => std::option::Option::Some(Self::INFO),
+                "WARNING" => std::option::Option::Some(Self::WARNING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [LogSeverity](LogSeverity)
-    pub mod log_severity {
-        use super::LogSeverity;
-
-        /// Log severity is not specified. This is the same as log severity is OFF.
-        pub const LOG_SEVERITY_UNSPECIFIED: LogSeverity =
-            LogSeverity::new("LOG_SEVERITY_UNSPECIFIED");
-
-        /// Log is turned off.
-        pub const OFF: LogSeverity = LogSeverity::new("OFF");
-
-        /// Log with severity higher than or equal to DEBUG are logged.
-        pub const DEBUG: LogSeverity = LogSeverity::new("DEBUG");
-
-        /// Logs with severity higher than or equal to INFO are logged.
-        pub const INFO: LogSeverity = LogSeverity::new("INFO");
-
-        /// Logs with severity higher than or equal to WARNING are logged.
-        pub const WARNING: LogSeverity = LogSeverity::new("WARNING");
-
-        /// Logs with severity higher than or equal to ERROR are logged.
-        pub const ERROR: LogSeverity = LogSeverity::new("ERROR");
-    }
-
-    impl std::convert::From<std::string::String> for LogSeverity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LogSeverity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LogSeverity {
         fn default() -> Self {
-            log_severity::LOG_SEVERITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3570,55 +3699,78 @@ pub mod event {
 
     /// State of the event
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Event state is not specified.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Event is scheduled but not executed yet.
+        pub const SCHEDULED: State = State::new(1);
+
+        /// Event is being executed.
+        pub const RUNNING: State = State::new(2);
+
+        /// Event has been successfully executed.
+        pub const SUCCEEDED: State = State::new(3);
+
+        /// Event fails to be executed.
+        pub const FAILED: State = State::new(4);
+
+        /// Event has been created but not scheduled yet.
+        pub const PENDING: State = State::new(5);
+
+        /// Event was stopped before running for its full duration.
+        pub const STOPPED: State = State::new(6);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SCHEDULED"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                5 => std::borrow::Cow::Borrowed("PENDING"),
+                6 => std::borrow::Cow::Borrowed("STOPPED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "SCHEDULED" => std::option::Option::Some(Self::SCHEDULED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "STOPPED" => std::option::Option::Some(Self::STOPPED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Event state is not specified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Event is scheduled but not executed yet.
-        pub const SCHEDULED: State = State::new("SCHEDULED");
-
-        /// Event is being executed.
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// Event has been successfully executed.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-        /// Event fails to be executed.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// Event has been created but not scheduled yet.
-        pub const PENDING: State = State::new("PENDING");
-
-        /// Event was stopped before running for its full duration.
-        pub const STOPPED: State = State::new("STOPPED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -3985,52 +4137,71 @@ pub mod clip {
 
     /// State of clipping operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// State is not specified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The operation is pending to be picked up by the server.
-        pub const PENDING: State = State::new("PENDING");
+        pub const PENDING: State = State::new(1);
 
         /// The server admitted this create clip request, and
         /// outputs are under processing.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(2);
 
         /// Outputs are available in the specified Cloud Storage bucket. For
         /// additional information, see the `outputs` field.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
+        pub const SUCCEEDED: State = State::new(3);
 
         /// The operation has failed. For additional information, see the `error`
         /// field.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(4);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("CREATING"),
+                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4289,49 +4460,68 @@ pub mod asset {
 
     /// State of the asset resource.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State is not specified.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The asset is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// The asset is ready for use.
+        pub const ACTIVE: State = State::new(2);
+
+        /// The asset is being deleted.
+        pub const DELETING: State = State::new(3);
+
+        /// The asset has an error.
+        pub const ERROR: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State is not specified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The asset is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The asset is ready for use.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The asset is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// The asset has an error.
-        pub const ERROR: State = State::new("ERROR");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 

--- a/src/generated/cloud/video/livestream/v1/src/transport.rs
+++ b/src/generated/cloud/video/livestream/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
                 reqwest::Method::POST,
                 format!("/v1/{}/channels", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -73,7 +73,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/channels", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -96,7 +96,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -115,7 +115,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -145,7 +145,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -175,7 +175,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:start", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -192,7 +192,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:stop", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -209,7 +209,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/inputs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -228,7 +228,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/inputs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -251,7 +251,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -270,7 +270,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -299,7 +299,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -327,7 +327,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/events", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -346,7 +346,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/events", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -369,7 +369,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -388,7 +388,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -408,7 +408,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/clips", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -431,7 +431,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -450,7 +450,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/clips", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -469,7 +469,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -489,7 +489,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/assets", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -508,7 +508,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -528,7 +528,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -547,7 +547,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/assets", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -570,7 +570,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -598,7 +598,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -626,7 +626,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -648,7 +648,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -667,7 +667,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -689,7 +689,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -708,7 +708,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -727,7 +727,7 @@ impl crate::stubs::LivestreamService for LivestreamService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/video/stitcher/v1/src/model.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/model.rs
@@ -688,47 +688,65 @@ pub mod companion_ads {
 
     /// Indicates how many of the companions should be displayed with the ad.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DisplayRequirement(std::borrow::Cow<'static, str>);
+    pub struct DisplayRequirement(i32);
 
     impl DisplayRequirement {
+        /// Required companions are not specified. The default is ALL.
+        pub const DISPLAY_REQUIREMENT_UNSPECIFIED: DisplayRequirement = DisplayRequirement::new(0);
+
+        /// All companions are required to be displayed.
+        pub const ALL: DisplayRequirement = DisplayRequirement::new(1);
+
+        /// At least one of companions needs to be displayed.
+        pub const ANY: DisplayRequirement = DisplayRequirement::new(2);
+
+        /// All companions are optional for display.
+        pub const NONE: DisplayRequirement = DisplayRequirement::new(3);
+
         /// Creates a new DisplayRequirement instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DISPLAY_REQUIREMENT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALL"),
+                2 => std::borrow::Cow::Borrowed("ANY"),
+                3 => std::borrow::Cow::Borrowed("NONE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DISPLAY_REQUIREMENT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DISPLAY_REQUIREMENT_UNSPECIFIED)
+                }
+                "ALL" => std::option::Option::Some(Self::ALL),
+                "ANY" => std::option::Option::Some(Self::ANY),
+                "NONE" => std::option::Option::Some(Self::NONE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DisplayRequirement](DisplayRequirement)
-    pub mod display_requirement {
-        use super::DisplayRequirement;
-
-        /// Required companions are not specified. The default is ALL.
-        pub const DISPLAY_REQUIREMENT_UNSPECIFIED: DisplayRequirement =
-            DisplayRequirement::new("DISPLAY_REQUIREMENT_UNSPECIFIED");
-
-        /// All companions are required to be displayed.
-        pub const ALL: DisplayRequirement = DisplayRequirement::new("ALL");
-
-        /// At least one of companions needs to be displayed.
-        pub const ANY: DisplayRequirement = DisplayRequirement::new("ANY");
-
-        /// All companions are optional for display.
-        pub const NONE: DisplayRequirement = DisplayRequirement::new("NONE");
-    }
-
-    impl std::convert::From<std::string::String> for DisplayRequirement {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DisplayRequirement {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DisplayRequirement {
         fn default() -> Self {
-            display_requirement::DISPLAY_REQUIREMENT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1137,109 +1155,168 @@ pub mod event {
 
     /// Describes the event that occurred.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EventType(std::borrow::Cow<'static, str>);
+    pub struct EventType(i32);
 
     impl EventType {
+        /// The event type is unspecified.
+        pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new(0);
+
+        /// First frame of creative ad viewed.
+        pub const CREATIVE_VIEW: EventType = EventType::new(1);
+
+        /// Creative ad started.
+        pub const START: EventType = EventType::new(2);
+
+        /// Start of an ad break.
+        pub const BREAK_START: EventType = EventType::new(3);
+
+        /// End of an ad break.
+        pub const BREAK_END: EventType = EventType::new(4);
+
+        /// Impression.
+        pub const IMPRESSION: EventType = EventType::new(5);
+
+        /// First quartile progress.
+        pub const FIRST_QUARTILE: EventType = EventType::new(6);
+
+        /// Midpoint progress.
+        pub const MIDPOINT: EventType = EventType::new(7);
+
+        /// Third quartile progress.
+        pub const THIRD_QUARTILE: EventType = EventType::new(8);
+
+        /// Ad progress completed.
+        pub const COMPLETE: EventType = EventType::new(9);
+
+        /// Specific progress event with an offset.
+        pub const PROGRESS: EventType = EventType::new(10);
+
+        /// Player muted.
+        pub const MUTE: EventType = EventType::new(11);
+
+        /// Player unmuted.
+        pub const UNMUTE: EventType = EventType::new(12);
+
+        /// Player paused.
+        pub const PAUSE: EventType = EventType::new(13);
+
+        /// Click event.
+        pub const CLICK: EventType = EventType::new(14);
+
+        /// Click-through event.
+        pub const CLICK_THROUGH: EventType = EventType::new(15);
+
+        /// Player rewinding.
+        pub const REWIND: EventType = EventType::new(16);
+
+        /// Player resumed.
+        pub const RESUME: EventType = EventType::new(17);
+
+        /// Error event.
+        pub const ERROR: EventType = EventType::new(18);
+
+        /// Ad expanded to a larger size.
+        pub const EXPAND: EventType = EventType::new(21);
+
+        /// Ad collapsed to a smaller size.
+        pub const COLLAPSE: EventType = EventType::new(22);
+
+        /// Non-linear ad closed.
+        pub const CLOSE: EventType = EventType::new(24);
+
+        /// Linear ad closed.
+        pub const CLOSE_LINEAR: EventType = EventType::new(25);
+
+        /// Ad skipped.
+        pub const SKIP: EventType = EventType::new(26);
+
+        /// Accept invitation event.
+        pub const ACCEPT_INVITATION: EventType = EventType::new(27);
+
         /// Creates a new EventType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EVENT_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATIVE_VIEW"),
+                2 => std::borrow::Cow::Borrowed("START"),
+                3 => std::borrow::Cow::Borrowed("BREAK_START"),
+                4 => std::borrow::Cow::Borrowed("BREAK_END"),
+                5 => std::borrow::Cow::Borrowed("IMPRESSION"),
+                6 => std::borrow::Cow::Borrowed("FIRST_QUARTILE"),
+                7 => std::borrow::Cow::Borrowed("MIDPOINT"),
+                8 => std::borrow::Cow::Borrowed("THIRD_QUARTILE"),
+                9 => std::borrow::Cow::Borrowed("COMPLETE"),
+                10 => std::borrow::Cow::Borrowed("PROGRESS"),
+                11 => std::borrow::Cow::Borrowed("MUTE"),
+                12 => std::borrow::Cow::Borrowed("UNMUTE"),
+                13 => std::borrow::Cow::Borrowed("PAUSE"),
+                14 => std::borrow::Cow::Borrowed("CLICK"),
+                15 => std::borrow::Cow::Borrowed("CLICK_THROUGH"),
+                16 => std::borrow::Cow::Borrowed("REWIND"),
+                17 => std::borrow::Cow::Borrowed("RESUME"),
+                18 => std::borrow::Cow::Borrowed("ERROR"),
+                21 => std::borrow::Cow::Borrowed("EXPAND"),
+                22 => std::borrow::Cow::Borrowed("COLLAPSE"),
+                24 => std::borrow::Cow::Borrowed("CLOSE"),
+                25 => std::borrow::Cow::Borrowed("CLOSE_LINEAR"),
+                26 => std::borrow::Cow::Borrowed("SKIP"),
+                27 => std::borrow::Cow::Borrowed("ACCEPT_INVITATION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EVENT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::EVENT_TYPE_UNSPECIFIED),
+                "CREATIVE_VIEW" => std::option::Option::Some(Self::CREATIVE_VIEW),
+                "START" => std::option::Option::Some(Self::START),
+                "BREAK_START" => std::option::Option::Some(Self::BREAK_START),
+                "BREAK_END" => std::option::Option::Some(Self::BREAK_END),
+                "IMPRESSION" => std::option::Option::Some(Self::IMPRESSION),
+                "FIRST_QUARTILE" => std::option::Option::Some(Self::FIRST_QUARTILE),
+                "MIDPOINT" => std::option::Option::Some(Self::MIDPOINT),
+                "THIRD_QUARTILE" => std::option::Option::Some(Self::THIRD_QUARTILE),
+                "COMPLETE" => std::option::Option::Some(Self::COMPLETE),
+                "PROGRESS" => std::option::Option::Some(Self::PROGRESS),
+                "MUTE" => std::option::Option::Some(Self::MUTE),
+                "UNMUTE" => std::option::Option::Some(Self::UNMUTE),
+                "PAUSE" => std::option::Option::Some(Self::PAUSE),
+                "CLICK" => std::option::Option::Some(Self::CLICK),
+                "CLICK_THROUGH" => std::option::Option::Some(Self::CLICK_THROUGH),
+                "REWIND" => std::option::Option::Some(Self::REWIND),
+                "RESUME" => std::option::Option::Some(Self::RESUME),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "EXPAND" => std::option::Option::Some(Self::EXPAND),
+                "COLLAPSE" => std::option::Option::Some(Self::COLLAPSE),
+                "CLOSE" => std::option::Option::Some(Self::CLOSE),
+                "CLOSE_LINEAR" => std::option::Option::Some(Self::CLOSE_LINEAR),
+                "SKIP" => std::option::Option::Some(Self::SKIP),
+                "ACCEPT_INVITATION" => std::option::Option::Some(Self::ACCEPT_INVITATION),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [EventType](EventType)
-    pub mod event_type {
-        use super::EventType;
-
-        /// The event type is unspecified.
-        pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new("EVENT_TYPE_UNSPECIFIED");
-
-        /// First frame of creative ad viewed.
-        pub const CREATIVE_VIEW: EventType = EventType::new("CREATIVE_VIEW");
-
-        /// Creative ad started.
-        pub const START: EventType = EventType::new("START");
-
-        /// Start of an ad break.
-        pub const BREAK_START: EventType = EventType::new("BREAK_START");
-
-        /// End of an ad break.
-        pub const BREAK_END: EventType = EventType::new("BREAK_END");
-
-        /// Impression.
-        pub const IMPRESSION: EventType = EventType::new("IMPRESSION");
-
-        /// First quartile progress.
-        pub const FIRST_QUARTILE: EventType = EventType::new("FIRST_QUARTILE");
-
-        /// Midpoint progress.
-        pub const MIDPOINT: EventType = EventType::new("MIDPOINT");
-
-        /// Third quartile progress.
-        pub const THIRD_QUARTILE: EventType = EventType::new("THIRD_QUARTILE");
-
-        /// Ad progress completed.
-        pub const COMPLETE: EventType = EventType::new("COMPLETE");
-
-        /// Specific progress event with an offset.
-        pub const PROGRESS: EventType = EventType::new("PROGRESS");
-
-        /// Player muted.
-        pub const MUTE: EventType = EventType::new("MUTE");
-
-        /// Player unmuted.
-        pub const UNMUTE: EventType = EventType::new("UNMUTE");
-
-        /// Player paused.
-        pub const PAUSE: EventType = EventType::new("PAUSE");
-
-        /// Click event.
-        pub const CLICK: EventType = EventType::new("CLICK");
-
-        /// Click-through event.
-        pub const CLICK_THROUGH: EventType = EventType::new("CLICK_THROUGH");
-
-        /// Player rewinding.
-        pub const REWIND: EventType = EventType::new("REWIND");
-
-        /// Player resumed.
-        pub const RESUME: EventType = EventType::new("RESUME");
-
-        /// Error event.
-        pub const ERROR: EventType = EventType::new("ERROR");
-
-        /// Ad expanded to a larger size.
-        pub const EXPAND: EventType = EventType::new("EXPAND");
-
-        /// Ad collapsed to a smaller size.
-        pub const COLLAPSE: EventType = EventType::new("COLLAPSE");
-
-        /// Non-linear ad closed.
-        pub const CLOSE: EventType = EventType::new("CLOSE");
-
-        /// Linear ad closed.
-        pub const CLOSE_LINEAR: EventType = EventType::new("CLOSE_LINEAR");
-
-        /// Ad skipped.
-        pub const SKIP: EventType = EventType::new("SKIP");
-
-        /// Accept invitation event.
-        pub const ACCEPT_INVITATION: EventType = EventType::new("ACCEPT_INVITATION");
-    }
-
-    impl std::convert::From<std::string::String> for EventType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EventType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EventType {
         fn default() -> Self {
-            event_type::EVENT_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1489,46 +1566,63 @@ pub mod live_config {
 
     /// State of the live config.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State is not specified.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Live config is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// Live config is ready for use.
+        pub const READY: State = State::new(2);
+
+        /// Live config is queued up for deletion.
+        pub const DELETING: State = State::new(3);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State is not specified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Live config is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// Live config is ready for use.
-        pub const READY: State = State::new("READY");
-
-        /// Live config is queued up for deletion.
-        pub const DELETING: State = State::new("DELETING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1536,44 +1630,60 @@ pub mod live_config {
     /// exactly with the ad break boundaries. If not specified, the default is
     /// `CUT_CURRENT`.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StitchingPolicy(std::borrow::Cow<'static, str>);
+    pub struct StitchingPolicy(i32);
 
     impl StitchingPolicy {
+        /// Stitching policy is not specified.
+        pub const STITCHING_POLICY_UNSPECIFIED: StitchingPolicy = StitchingPolicy::new(0);
+
+        /// Cuts an ad short and returns to content in the middle of the ad.
+        pub const CUT_CURRENT: StitchingPolicy = StitchingPolicy::new(1);
+
+        /// Finishes stitching the current ad before returning to content.
+        pub const COMPLETE_AD: StitchingPolicy = StitchingPolicy::new(2);
+
         /// Creates a new StitchingPolicy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STITCHING_POLICY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CUT_CURRENT"),
+                2 => std::borrow::Cow::Borrowed("COMPLETE_AD"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STITCHING_POLICY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::STITCHING_POLICY_UNSPECIFIED)
+                }
+                "CUT_CURRENT" => std::option::Option::Some(Self::CUT_CURRENT),
+                "COMPLETE_AD" => std::option::Option::Some(Self::COMPLETE_AD),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [StitchingPolicy](StitchingPolicy)
-    pub mod stitching_policy {
-        use super::StitchingPolicy;
-
-        /// Stitching policy is not specified.
-        pub const STITCHING_POLICY_UNSPECIFIED: StitchingPolicy =
-            StitchingPolicy::new("STITCHING_POLICY_UNSPECIFIED");
-
-        /// Cuts an ad short and returns to content in the middle of the ad.
-        pub const CUT_CURRENT: StitchingPolicy = StitchingPolicy::new("CUT_CURRENT");
-
-        /// Finishes stitching the current ad before returning to content.
-        pub const COMPLETE_AD: StitchingPolicy = StitchingPolicy::new("COMPLETE_AD");
-    }
-
-    impl std::convert::From<std::string::String> for StitchingPolicy {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for StitchingPolicy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for StitchingPolicy {
         fn default() -> Self {
-            stitching_policy::STITCHING_POLICY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2360,44 +2470,60 @@ pub mod manifest_options {
 
     /// Defines the ordering policy during manifest generation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OrderPolicy(std::borrow::Cow<'static, str>);
+    pub struct OrderPolicy(i32);
 
     impl OrderPolicy {
+        /// Ordering policy is not specified.
+        pub const ORDER_POLICY_UNSPECIFIED: OrderPolicy = OrderPolicy::new(0);
+
+        /// Order by ascending.
+        pub const ASCENDING: OrderPolicy = OrderPolicy::new(1);
+
+        /// Order by descending.
+        pub const DESCENDING: OrderPolicy = OrderPolicy::new(2);
+
         /// Creates a new OrderPolicy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ORDER_POLICY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ASCENDING"),
+                2 => std::borrow::Cow::Borrowed("DESCENDING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ORDER_POLICY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ORDER_POLICY_UNSPECIFIED)
+                }
+                "ASCENDING" => std::option::Option::Some(Self::ASCENDING),
+                "DESCENDING" => std::option::Option::Some(Self::DESCENDING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [OrderPolicy](OrderPolicy)
-    pub mod order_policy {
-        use super::OrderPolicy;
-
-        /// Ordering policy is not specified.
-        pub const ORDER_POLICY_UNSPECIFIED: OrderPolicy =
-            OrderPolicy::new("ORDER_POLICY_UNSPECIFIED");
-
-        /// Order by ascending.
-        pub const ASCENDING: OrderPolicy = OrderPolicy::new("ASCENDING");
-
-        /// Order by descending.
-        pub const DESCENDING: OrderPolicy = OrderPolicy::new("DESCENDING");
-    }
-
-    impl std::convert::From<std::string::String> for OrderPolicy {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for OrderPolicy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for OrderPolicy {
         fn default() -> Self {
-            order_policy::ORDER_POLICY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4682,46 +4808,63 @@ pub mod vod_config {
 
     /// State of the VOD config.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State is not specified.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// VOD config is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// VOD config is ready for use.
+        pub const READY: State = State::new(2);
+
+        /// VOD config is queued up for deletion.
+        pub const DELETING: State = State::new(3);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State is not specified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// VOD config is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// VOD config is ready for use.
-        pub const READY: State = State::new("READY");
-
-        /// VOD config is queued up for deletion.
-        pub const DELETING: State = State::new("DELETING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4757,44 +4900,59 @@ impl wkt::message::Message for GamVodConfig {
 
 /// Determines the ad tracking policy.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AdTracking(std::borrow::Cow<'static, str>);
+pub struct AdTracking(i32);
 
 impl AdTracking {
-    /// Creates a new AdTracking instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [AdTracking](AdTracking)
-pub mod ad_tracking {
-    use super::AdTracking;
-
     /// The ad tracking policy is not specified.
-    pub const AD_TRACKING_UNSPECIFIED: AdTracking = AdTracking::new("AD_TRACKING_UNSPECIFIED");
+    pub const AD_TRACKING_UNSPECIFIED: AdTracking = AdTracking::new(0);
 
     /// Client-side ad tracking is specified. The client player is expected to
     /// trigger playback and activity events itself.
-    pub const CLIENT: AdTracking = AdTracking::new("CLIENT");
+    pub const CLIENT: AdTracking = AdTracking::new(1);
 
     /// The Video Stitcher API will trigger playback events on behalf of
     /// the client player.
-    pub const SERVER: AdTracking = AdTracking::new("SERVER");
+    pub const SERVER: AdTracking = AdTracking::new(2);
+
+    /// Creates a new AdTracking instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("AD_TRACKING_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("CLIENT"),
+            2 => std::borrow::Cow::Borrowed("SERVER"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "AD_TRACKING_UNSPECIFIED" => std::option::Option::Some(Self::AD_TRACKING_UNSPECIFIED),
+            "CLIENT" => std::option::Option::Some(Self::CLIENT),
+            "SERVER" => std::option::Option::Some(Self::SERVER),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for AdTracking {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for AdTracking {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for AdTracking {
     fn default() -> Self {
-        ad_tracking::AD_TRACKING_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/video/stitcher/v1/src/transport.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/cdnKeys", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -69,7 +69,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/cdnKeys", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -92,7 +92,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -111,7 +111,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -139,7 +139,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -171,7 +171,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
                 reqwest::Method::POST,
                 format!("/v1/{}/vodSessions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -190,7 +190,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -212,7 +212,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
                 reqwest::Method::GET,
                 format!("/v1/{}/vodStitchDetails", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -233,7 +233,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -255,7 +255,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
                 reqwest::Method::GET,
                 format!("/v1/{}/vodAdTagDetails", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -276,7 +276,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -298,7 +298,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
                 reqwest::Method::GET,
                 format!("/v1/{}/liveAdTagDetails", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -319,7 +319,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -338,7 +338,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/slates", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -357,7 +357,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/slates", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -380,7 +380,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -408,7 +408,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -435,7 +435,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -457,7 +457,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
                 reqwest::Method::POST,
                 format!("/v1/{}/liveSessions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -476,7 +476,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -498,7 +498,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
                 reqwest::Method::POST,
                 format!("/v1/{}/liveConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -522,7 +522,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
                 reqwest::Method::GET,
                 format!("/v1/{}/liveConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -545,7 +545,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -564,7 +564,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -592,7 +592,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -624,7 +624,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
                 reqwest::Method::POST,
                 format!("/v1/{}/vodConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -648,7 +648,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
                 reqwest::Method::GET,
                 format!("/v1/{}/vodConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -671,7 +671,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -690,7 +690,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -718,7 +718,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -747,7 +747,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -769,7 +769,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -788,7 +788,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -807,7 +807,7 @@ impl crate::stubs::VideoStitcherService for VideoStitcherService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/video/transcoder/v1/src/model.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/model.rs
@@ -291,142 +291,195 @@ pub mod job {
 
     /// The current state of the job.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ProcessingState(std::borrow::Cow<'static, str>);
+    pub struct ProcessingState(i32);
 
     impl ProcessingState {
-        /// Creates a new ProcessingState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ProcessingState](ProcessingState)
-    pub mod processing_state {
-        use super::ProcessingState;
-
         /// The processing state is not specified.
-        pub const PROCESSING_STATE_UNSPECIFIED: ProcessingState =
-            ProcessingState::new("PROCESSING_STATE_UNSPECIFIED");
+        pub const PROCESSING_STATE_UNSPECIFIED: ProcessingState = ProcessingState::new(0);
 
         /// The job is enqueued and will be picked up for processing soon.
-        pub const PENDING: ProcessingState = ProcessingState::new("PENDING");
+        pub const PENDING: ProcessingState = ProcessingState::new(1);
 
         /// The job is being processed.
-        pub const RUNNING: ProcessingState = ProcessingState::new("RUNNING");
+        pub const RUNNING: ProcessingState = ProcessingState::new(2);
 
         /// The job has been completed successfully.
-        pub const SUCCEEDED: ProcessingState = ProcessingState::new("SUCCEEDED");
+        pub const SUCCEEDED: ProcessingState = ProcessingState::new(3);
 
         /// The job has failed. For additional information, see `failure_reason` and
         /// `failure_details`
-        pub const FAILED: ProcessingState = ProcessingState::new("FAILED");
+        pub const FAILED: ProcessingState = ProcessingState::new(4);
+
+        /// Creates a new ProcessingState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PROCESSING_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PROCESSING_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PROCESSING_STATE_UNSPECIFIED)
+                }
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ProcessingState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ProcessingState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ProcessingState {
         fn default() -> Self {
-            processing_state::PROCESSING_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The processing mode of the job.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ProcessingMode(std::borrow::Cow<'static, str>);
+    pub struct ProcessingMode(i32);
 
     impl ProcessingMode {
-        /// Creates a new ProcessingMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ProcessingMode](ProcessingMode)
-    pub mod processing_mode {
-        use super::ProcessingMode;
-
         /// The job processing mode is not specified.
-        pub const PROCESSING_MODE_UNSPECIFIED: ProcessingMode =
-            ProcessingMode::new("PROCESSING_MODE_UNSPECIFIED");
+        pub const PROCESSING_MODE_UNSPECIFIED: ProcessingMode = ProcessingMode::new(0);
 
         /// The job processing mode is interactive mode.
         /// Interactive job will either be ran or rejected if quota does not allow
         /// for it.
-        pub const PROCESSING_MODE_INTERACTIVE: ProcessingMode =
-            ProcessingMode::new("PROCESSING_MODE_INTERACTIVE");
+        pub const PROCESSING_MODE_INTERACTIVE: ProcessingMode = ProcessingMode::new(1);
 
         /// The job processing mode is batch mode.
         /// Batch mode allows queuing of jobs.
-        pub const PROCESSING_MODE_BATCH: ProcessingMode =
-            ProcessingMode::new("PROCESSING_MODE_BATCH");
+        pub const PROCESSING_MODE_BATCH: ProcessingMode = ProcessingMode::new(2);
+
+        /// Creates a new ProcessingMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PROCESSING_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROCESSING_MODE_INTERACTIVE"),
+                2 => std::borrow::Cow::Borrowed("PROCESSING_MODE_BATCH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PROCESSING_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PROCESSING_MODE_UNSPECIFIED)
+                }
+                "PROCESSING_MODE_INTERACTIVE" => {
+                    std::option::Option::Some(Self::PROCESSING_MODE_INTERACTIVE)
+                }
+                "PROCESSING_MODE_BATCH" => std::option::Option::Some(Self::PROCESSING_MODE_BATCH),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ProcessingMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ProcessingMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ProcessingMode {
         fn default() -> Self {
-            processing_mode::PROCESSING_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The optimization strategy of the job. The default is `AUTODETECT`.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OptimizationStrategy(std::borrow::Cow<'static, str>);
+    pub struct OptimizationStrategy(i32);
 
     impl OptimizationStrategy {
+        /// The optimization strategy is not specified.
+        pub const OPTIMIZATION_STRATEGY_UNSPECIFIED: OptimizationStrategy =
+            OptimizationStrategy::new(0);
+
+        /// Prioritize job processing speed.
+        pub const AUTODETECT: OptimizationStrategy = OptimizationStrategy::new(1);
+
+        /// Disable all optimizations.
+        pub const DISABLED: OptimizationStrategy = OptimizationStrategy::new(2);
+
         /// Creates a new OptimizationStrategy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("OPTIMIZATION_STRATEGY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AUTODETECT"),
+                2 => std::borrow::Cow::Borrowed("DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "OPTIMIZATION_STRATEGY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::OPTIMIZATION_STRATEGY_UNSPECIFIED)
+                }
+                "AUTODETECT" => std::option::Option::Some(Self::AUTODETECT),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [OptimizationStrategy](OptimizationStrategy)
-    pub mod optimization_strategy {
-        use super::OptimizationStrategy;
-
-        /// The optimization strategy is not specified.
-        pub const OPTIMIZATION_STRATEGY_UNSPECIFIED: OptimizationStrategy =
-            OptimizationStrategy::new("OPTIMIZATION_STRATEGY_UNSPECIFIED");
-
-        /// Prioritize job processing speed.
-        pub const AUTODETECT: OptimizationStrategy = OptimizationStrategy::new("AUTODETECT");
-
-        /// Disable all optimizations.
-        pub const DISABLED: OptimizationStrategy = OptimizationStrategy::new("DISABLED");
-    }
-
-    impl std::convert::From<std::string::String> for OptimizationStrategy {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for OptimizationStrategy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for OptimizationStrategy {
         fn default() -> Self {
-            optimization_strategy::OPTIMIZATION_STRATEGY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1310,90 +1363,124 @@ pub mod manifest {
 
         /// The segment reference scheme for a `DASH` manifest.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SegmentReferenceScheme(std::borrow::Cow<'static, str>);
+        pub struct SegmentReferenceScheme(i32);
 
         impl SegmentReferenceScheme {
-            /// Creates a new SegmentReferenceScheme instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [SegmentReferenceScheme](SegmentReferenceScheme)
-        pub mod segment_reference_scheme {
-            use super::SegmentReferenceScheme;
-
             /// The segment reference scheme is not specified.
             pub const SEGMENT_REFERENCE_SCHEME_UNSPECIFIED: SegmentReferenceScheme =
-                SegmentReferenceScheme::new("SEGMENT_REFERENCE_SCHEME_UNSPECIFIED");
+                SegmentReferenceScheme::new(0);
 
             /// Lists the URLs of media files for each segment.
-            pub const SEGMENT_LIST: SegmentReferenceScheme =
-                SegmentReferenceScheme::new("SEGMENT_LIST");
+            pub const SEGMENT_LIST: SegmentReferenceScheme = SegmentReferenceScheme::new(1);
 
             /// Lists each segment from a template with $Number$ variable.
             pub const SEGMENT_TEMPLATE_NUMBER: SegmentReferenceScheme =
-                SegmentReferenceScheme::new("SEGMENT_TEMPLATE_NUMBER");
+                SegmentReferenceScheme::new(2);
+
+            /// Creates a new SegmentReferenceScheme instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("SEGMENT_REFERENCE_SCHEME_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("SEGMENT_LIST"),
+                    2 => std::borrow::Cow::Borrowed("SEGMENT_TEMPLATE_NUMBER"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "SEGMENT_REFERENCE_SCHEME_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::SEGMENT_REFERENCE_SCHEME_UNSPECIFIED)
+                    }
+                    "SEGMENT_LIST" => std::option::Option::Some(Self::SEGMENT_LIST),
+                    "SEGMENT_TEMPLATE_NUMBER" => {
+                        std::option::Option::Some(Self::SEGMENT_TEMPLATE_NUMBER)
+                    }
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for SegmentReferenceScheme {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for SegmentReferenceScheme {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for SegmentReferenceScheme {
             fn default() -> Self {
-                segment_reference_scheme::SEGMENT_REFERENCE_SCHEME_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// The manifest type, which corresponds to the adaptive streaming format used.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ManifestType(std::borrow::Cow<'static, str>);
+    pub struct ManifestType(i32);
 
     impl ManifestType {
+        /// The manifest type is not specified.
+        pub const MANIFEST_TYPE_UNSPECIFIED: ManifestType = ManifestType::new(0);
+
+        /// Create an HLS manifest. The corresponding file extension is `.m3u8`.
+        pub const HLS: ManifestType = ManifestType::new(1);
+
+        /// Create an MPEG-DASH manifest. The corresponding file extension is `.mpd`.
+        pub const DASH: ManifestType = ManifestType::new(2);
+
         /// Creates a new ManifestType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MANIFEST_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("HLS"),
+                2 => std::borrow::Cow::Borrowed("DASH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MANIFEST_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::MANIFEST_TYPE_UNSPECIFIED)
+                }
+                "HLS" => std::option::Option::Some(Self::HLS),
+                "DASH" => std::option::Option::Some(Self::DASH),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ManifestType](ManifestType)
-    pub mod manifest_type {
-        use super::ManifestType;
-
-        /// The manifest type is not specified.
-        pub const MANIFEST_TYPE_UNSPECIFIED: ManifestType =
-            ManifestType::new("MANIFEST_TYPE_UNSPECIFIED");
-
-        /// Create an HLS manifest. The corresponding file extension is `.m3u8`.
-        pub const HLS: ManifestType = ManifestType::new("HLS");
-
-        /// Create an MPEG-DASH manifest. The corresponding file extension is `.mpd`.
-        pub const DASH: ManifestType = ManifestType::new("DASH");
-    }
-
-    impl std::convert::From<std::string::String> for ManifestType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ManifestType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ManifestType {
         fn default() -> Self {
-            manifest_type::MANIFEST_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -2142,43 +2229,58 @@ pub mod overlay {
 
     /// Fade type for the overlay: `FADE_IN` or `FADE_OUT`.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FadeType(std::borrow::Cow<'static, str>);
+    pub struct FadeType(i32);
 
     impl FadeType {
+        /// The fade type is not specified.
+        pub const FADE_TYPE_UNSPECIFIED: FadeType = FadeType::new(0);
+
+        /// Fade the overlay object into view.
+        pub const FADE_IN: FadeType = FadeType::new(1);
+
+        /// Fade the overlay object out of view.
+        pub const FADE_OUT: FadeType = FadeType::new(2);
+
         /// Creates a new FadeType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FADE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FADE_IN"),
+                2 => std::borrow::Cow::Borrowed("FADE_OUT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FADE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::FADE_TYPE_UNSPECIFIED),
+                "FADE_IN" => std::option::Option::Some(Self::FADE_IN),
+                "FADE_OUT" => std::option::Option::Some(Self::FADE_OUT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [FadeType](FadeType)
-    pub mod fade_type {
-        use super::FadeType;
-
-        /// The fade type is not specified.
-        pub const FADE_TYPE_UNSPECIFIED: FadeType = FadeType::new("FADE_TYPE_UNSPECIFIED");
-
-        /// Fade the overlay object into view.
-        pub const FADE_IN: FadeType = FadeType::new("FADE_IN");
-
-        /// Fade the overlay object out of view.
-        pub const FADE_OUT: FadeType = FadeType::new("FADE_OUT");
-    }
-
-    impl std::convert::From<std::string::String> for FadeType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for FadeType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for FadeType {
         fn default() -> Self {
-            fade_type::FADE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/video/transcoder/v1/src/transport.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::TranscoderService for TranscoderService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/jobs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -66,7 +66,7 @@ impl crate::stubs::TranscoderService for TranscoderService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/jobs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -89,7 +89,7 @@ impl crate::stubs::TranscoderService for TranscoderService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -108,7 +108,7 @@ impl crate::stubs::TranscoderService for TranscoderService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -131,7 +131,7 @@ impl crate::stubs::TranscoderService for TranscoderService {
                 reqwest::Method::POST,
                 format!("/v1/{}/jobTemplates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -154,7 +154,7 @@ impl crate::stubs::TranscoderService for TranscoderService {
                 reqwest::Method::GET,
                 format!("/v1/{}/jobTemplates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -177,7 +177,7 @@ impl crate::stubs::TranscoderService for TranscoderService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -196,7 +196,7 @@ impl crate::stubs::TranscoderService for TranscoderService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/videointelligence/v1/src/model.rs
+++ b/src/generated/cloud/videointelligence/v1/src/model.rs
@@ -2893,161 +2893,230 @@ impl wkt::message::Message for LogoRecognitionAnnotation {
 
 /// Video annotation feature.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Feature(std::borrow::Cow<'static, str>);
+pub struct Feature(i32);
 
 impl Feature {
+    /// Unspecified.
+    pub const FEATURE_UNSPECIFIED: Feature = Feature::new(0);
+
+    /// Label detection. Detect objects, such as dog or flower.
+    pub const LABEL_DETECTION: Feature = Feature::new(1);
+
+    /// Shot change detection.
+    pub const SHOT_CHANGE_DETECTION: Feature = Feature::new(2);
+
+    /// Explicit content detection.
+    pub const EXPLICIT_CONTENT_DETECTION: Feature = Feature::new(3);
+
+    /// Human face detection.
+    pub const FACE_DETECTION: Feature = Feature::new(4);
+
+    /// Speech transcription.
+    pub const SPEECH_TRANSCRIPTION: Feature = Feature::new(6);
+
+    /// OCR text detection and tracking.
+    pub const TEXT_DETECTION: Feature = Feature::new(7);
+
+    /// Object detection and tracking.
+    pub const OBJECT_TRACKING: Feature = Feature::new(9);
+
+    /// Logo detection, tracking, and recognition.
+    pub const LOGO_RECOGNITION: Feature = Feature::new(12);
+
+    /// Person detection.
+    pub const PERSON_DETECTION: Feature = Feature::new(14);
+
     /// Creates a new Feature instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("FEATURE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("LABEL_DETECTION"),
+            2 => std::borrow::Cow::Borrowed("SHOT_CHANGE_DETECTION"),
+            3 => std::borrow::Cow::Borrowed("EXPLICIT_CONTENT_DETECTION"),
+            4 => std::borrow::Cow::Borrowed("FACE_DETECTION"),
+            6 => std::borrow::Cow::Borrowed("SPEECH_TRANSCRIPTION"),
+            7 => std::borrow::Cow::Borrowed("TEXT_DETECTION"),
+            9 => std::borrow::Cow::Borrowed("OBJECT_TRACKING"),
+            12 => std::borrow::Cow::Borrowed("LOGO_RECOGNITION"),
+            14 => std::borrow::Cow::Borrowed("PERSON_DETECTION"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "FEATURE_UNSPECIFIED" => std::option::Option::Some(Self::FEATURE_UNSPECIFIED),
+            "LABEL_DETECTION" => std::option::Option::Some(Self::LABEL_DETECTION),
+            "SHOT_CHANGE_DETECTION" => std::option::Option::Some(Self::SHOT_CHANGE_DETECTION),
+            "EXPLICIT_CONTENT_DETECTION" => {
+                std::option::Option::Some(Self::EXPLICIT_CONTENT_DETECTION)
+            }
+            "FACE_DETECTION" => std::option::Option::Some(Self::FACE_DETECTION),
+            "SPEECH_TRANSCRIPTION" => std::option::Option::Some(Self::SPEECH_TRANSCRIPTION),
+            "TEXT_DETECTION" => std::option::Option::Some(Self::TEXT_DETECTION),
+            "OBJECT_TRACKING" => std::option::Option::Some(Self::OBJECT_TRACKING),
+            "LOGO_RECOGNITION" => std::option::Option::Some(Self::LOGO_RECOGNITION),
+            "PERSON_DETECTION" => std::option::Option::Some(Self::PERSON_DETECTION),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [Feature](Feature)
-pub mod feature {
-    use super::Feature;
-
-    /// Unspecified.
-    pub const FEATURE_UNSPECIFIED: Feature = Feature::new("FEATURE_UNSPECIFIED");
-
-    /// Label detection. Detect objects, such as dog or flower.
-    pub const LABEL_DETECTION: Feature = Feature::new("LABEL_DETECTION");
-
-    /// Shot change detection.
-    pub const SHOT_CHANGE_DETECTION: Feature = Feature::new("SHOT_CHANGE_DETECTION");
-
-    /// Explicit content detection.
-    pub const EXPLICIT_CONTENT_DETECTION: Feature = Feature::new("EXPLICIT_CONTENT_DETECTION");
-
-    /// Human face detection.
-    pub const FACE_DETECTION: Feature = Feature::new("FACE_DETECTION");
-
-    /// Speech transcription.
-    pub const SPEECH_TRANSCRIPTION: Feature = Feature::new("SPEECH_TRANSCRIPTION");
-
-    /// OCR text detection and tracking.
-    pub const TEXT_DETECTION: Feature = Feature::new("TEXT_DETECTION");
-
-    /// Object detection and tracking.
-    pub const OBJECT_TRACKING: Feature = Feature::new("OBJECT_TRACKING");
-
-    /// Logo detection, tracking, and recognition.
-    pub const LOGO_RECOGNITION: Feature = Feature::new("LOGO_RECOGNITION");
-
-    /// Person detection.
-    pub const PERSON_DETECTION: Feature = Feature::new("PERSON_DETECTION");
-}
-
-impl std::convert::From<std::string::String> for Feature {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Feature {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Feature {
     fn default() -> Self {
-        feature::FEATURE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Label detection mode.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LabelDetectionMode(std::borrow::Cow<'static, str>);
+pub struct LabelDetectionMode(i32);
 
 impl LabelDetectionMode {
+    /// Unspecified.
+    pub const LABEL_DETECTION_MODE_UNSPECIFIED: LabelDetectionMode = LabelDetectionMode::new(0);
+
+    /// Detect shot-level labels.
+    pub const SHOT_MODE: LabelDetectionMode = LabelDetectionMode::new(1);
+
+    /// Detect frame-level labels.
+    pub const FRAME_MODE: LabelDetectionMode = LabelDetectionMode::new(2);
+
+    /// Detect both shot-level and frame-level labels.
+    pub const SHOT_AND_FRAME_MODE: LabelDetectionMode = LabelDetectionMode::new(3);
+
     /// Creates a new LabelDetectionMode instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("LABEL_DETECTION_MODE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SHOT_MODE"),
+            2 => std::borrow::Cow::Borrowed("FRAME_MODE"),
+            3 => std::borrow::Cow::Borrowed("SHOT_AND_FRAME_MODE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "LABEL_DETECTION_MODE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::LABEL_DETECTION_MODE_UNSPECIFIED)
+            }
+            "SHOT_MODE" => std::option::Option::Some(Self::SHOT_MODE),
+            "FRAME_MODE" => std::option::Option::Some(Self::FRAME_MODE),
+            "SHOT_AND_FRAME_MODE" => std::option::Option::Some(Self::SHOT_AND_FRAME_MODE),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [LabelDetectionMode](LabelDetectionMode)
-pub mod label_detection_mode {
-    use super::LabelDetectionMode;
-
-    /// Unspecified.
-    pub const LABEL_DETECTION_MODE_UNSPECIFIED: LabelDetectionMode =
-        LabelDetectionMode::new("LABEL_DETECTION_MODE_UNSPECIFIED");
-
-    /// Detect shot-level labels.
-    pub const SHOT_MODE: LabelDetectionMode = LabelDetectionMode::new("SHOT_MODE");
-
-    /// Detect frame-level labels.
-    pub const FRAME_MODE: LabelDetectionMode = LabelDetectionMode::new("FRAME_MODE");
-
-    /// Detect both shot-level and frame-level labels.
-    pub const SHOT_AND_FRAME_MODE: LabelDetectionMode =
-        LabelDetectionMode::new("SHOT_AND_FRAME_MODE");
-}
-
-impl std::convert::From<std::string::String> for LabelDetectionMode {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for LabelDetectionMode {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for LabelDetectionMode {
     fn default() -> Self {
-        label_detection_mode::LABEL_DETECTION_MODE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Bucketized representation of likelihood.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Likelihood(std::borrow::Cow<'static, str>);
+pub struct Likelihood(i32);
 
 impl Likelihood {
+    /// Unspecified likelihood.
+    pub const LIKELIHOOD_UNSPECIFIED: Likelihood = Likelihood::new(0);
+
+    /// Very unlikely.
+    pub const VERY_UNLIKELY: Likelihood = Likelihood::new(1);
+
+    /// Unlikely.
+    pub const UNLIKELY: Likelihood = Likelihood::new(2);
+
+    /// Possible.
+    pub const POSSIBLE: Likelihood = Likelihood::new(3);
+
+    /// Likely.
+    pub const LIKELY: Likelihood = Likelihood::new(4);
+
+    /// Very likely.
+    pub const VERY_LIKELY: Likelihood = Likelihood::new(5);
+
     /// Creates a new Likelihood instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("LIKELIHOOD_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("VERY_UNLIKELY"),
+            2 => std::borrow::Cow::Borrowed("UNLIKELY"),
+            3 => std::borrow::Cow::Borrowed("POSSIBLE"),
+            4 => std::borrow::Cow::Borrowed("LIKELY"),
+            5 => std::borrow::Cow::Borrowed("VERY_LIKELY"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "LIKELIHOOD_UNSPECIFIED" => std::option::Option::Some(Self::LIKELIHOOD_UNSPECIFIED),
+            "VERY_UNLIKELY" => std::option::Option::Some(Self::VERY_UNLIKELY),
+            "UNLIKELY" => std::option::Option::Some(Self::UNLIKELY),
+            "POSSIBLE" => std::option::Option::Some(Self::POSSIBLE),
+            "LIKELY" => std::option::Option::Some(Self::LIKELY),
+            "VERY_LIKELY" => std::option::Option::Some(Self::VERY_LIKELY),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [Likelihood](Likelihood)
-pub mod likelihood {
-    use super::Likelihood;
-
-    /// Unspecified likelihood.
-    pub const LIKELIHOOD_UNSPECIFIED: Likelihood = Likelihood::new("LIKELIHOOD_UNSPECIFIED");
-
-    /// Very unlikely.
-    pub const VERY_UNLIKELY: Likelihood = Likelihood::new("VERY_UNLIKELY");
-
-    /// Unlikely.
-    pub const UNLIKELY: Likelihood = Likelihood::new("UNLIKELY");
-
-    /// Possible.
-    pub const POSSIBLE: Likelihood = Likelihood::new("POSSIBLE");
-
-    /// Likely.
-    pub const LIKELY: Likelihood = Likelihood::new("LIKELY");
-
-    /// Very likely.
-    pub const VERY_LIKELY: Likelihood = Likelihood::new("VERY_LIKELY");
-}
-
-impl std::convert::From<std::string::String> for Likelihood {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Likelihood {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Likelihood {
     fn default() -> Self {
-        likelihood::LIKELIHOOD_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/videointelligence/v1/src/transport.rs
+++ b/src/generated/cloud/videointelligence/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::VideoIntelligenceService for VideoIntelligenceService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, "/v1/videos:annotate".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -66,7 +66,7 @@ impl crate::stubs::VideoIntelligenceService for VideoIntelligenceService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -88,7 +88,7 @@ impl crate::stubs::VideoIntelligenceService for VideoIntelligenceService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -107,7 +107,7 @@ impl crate::stubs::VideoIntelligenceService for VideoIntelligenceService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -126,7 +126,7 @@ impl crate::stubs::VideoIntelligenceService for VideoIntelligenceService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/vision/v1/src/model.rs
+++ b/src/generated/cloud/vision/v1/src/model.rs
@@ -268,78 +268,115 @@ pub mod feature {
 
     /// Type of Google Cloud Vision API feature to be extracted.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// Unspecified feature type.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// Run face detection.
-        pub const FACE_DETECTION: Type = Type::new("FACE_DETECTION");
+        pub const FACE_DETECTION: Type = Type::new(1);
 
         /// Run landmark detection.
-        pub const LANDMARK_DETECTION: Type = Type::new("LANDMARK_DETECTION");
+        pub const LANDMARK_DETECTION: Type = Type::new(2);
 
         /// Run logo detection.
-        pub const LOGO_DETECTION: Type = Type::new("LOGO_DETECTION");
+        pub const LOGO_DETECTION: Type = Type::new(3);
 
         /// Run label detection.
-        pub const LABEL_DETECTION: Type = Type::new("LABEL_DETECTION");
+        pub const LABEL_DETECTION: Type = Type::new(4);
 
         /// Run text detection / optical character recognition (OCR). Text detection
         /// is optimized for areas of text within a larger image; if the image is
         /// a document, use `DOCUMENT_TEXT_DETECTION` instead.
-        pub const TEXT_DETECTION: Type = Type::new("TEXT_DETECTION");
+        pub const TEXT_DETECTION: Type = Type::new(5);
 
         /// Run dense text document OCR. Takes precedence when both
         /// `DOCUMENT_TEXT_DETECTION` and `TEXT_DETECTION` are present.
-        pub const DOCUMENT_TEXT_DETECTION: Type = Type::new("DOCUMENT_TEXT_DETECTION");
+        pub const DOCUMENT_TEXT_DETECTION: Type = Type::new(11);
 
         /// Run Safe Search to detect potentially unsafe
         /// or undesirable content.
-        pub const SAFE_SEARCH_DETECTION: Type = Type::new("SAFE_SEARCH_DETECTION");
+        pub const SAFE_SEARCH_DETECTION: Type = Type::new(6);
 
         /// Compute a set of image properties, such as the
         /// image's dominant colors.
-        pub const IMAGE_PROPERTIES: Type = Type::new("IMAGE_PROPERTIES");
+        pub const IMAGE_PROPERTIES: Type = Type::new(7);
 
         /// Run crop hints.
-        pub const CROP_HINTS: Type = Type::new("CROP_HINTS");
+        pub const CROP_HINTS: Type = Type::new(9);
 
         /// Run web detection.
-        pub const WEB_DETECTION: Type = Type::new("WEB_DETECTION");
+        pub const WEB_DETECTION: Type = Type::new(10);
 
         /// Run Product Search.
-        pub const PRODUCT_SEARCH: Type = Type::new("PRODUCT_SEARCH");
+        pub const PRODUCT_SEARCH: Type = Type::new(12);
 
         /// Run localizer for object detection.
-        pub const OBJECT_LOCALIZATION: Type = Type::new("OBJECT_LOCALIZATION");
+        pub const OBJECT_LOCALIZATION: Type = Type::new(19);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FACE_DETECTION"),
+                2 => std::borrow::Cow::Borrowed("LANDMARK_DETECTION"),
+                3 => std::borrow::Cow::Borrowed("LOGO_DETECTION"),
+                4 => std::borrow::Cow::Borrowed("LABEL_DETECTION"),
+                5 => std::borrow::Cow::Borrowed("TEXT_DETECTION"),
+                6 => std::borrow::Cow::Borrowed("SAFE_SEARCH_DETECTION"),
+                7 => std::borrow::Cow::Borrowed("IMAGE_PROPERTIES"),
+                9 => std::borrow::Cow::Borrowed("CROP_HINTS"),
+                10 => std::borrow::Cow::Borrowed("WEB_DETECTION"),
+                11 => std::borrow::Cow::Borrowed("DOCUMENT_TEXT_DETECTION"),
+                12 => std::borrow::Cow::Borrowed("PRODUCT_SEARCH"),
+                19 => std::borrow::Cow::Borrowed("OBJECT_LOCALIZATION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "FACE_DETECTION" => std::option::Option::Some(Self::FACE_DETECTION),
+                "LANDMARK_DETECTION" => std::option::Option::Some(Self::LANDMARK_DETECTION),
+                "LOGO_DETECTION" => std::option::Option::Some(Self::LOGO_DETECTION),
+                "LABEL_DETECTION" => std::option::Option::Some(Self::LABEL_DETECTION),
+                "TEXT_DETECTION" => std::option::Option::Some(Self::TEXT_DETECTION),
+                "DOCUMENT_TEXT_DETECTION" => {
+                    std::option::Option::Some(Self::DOCUMENT_TEXT_DETECTION)
+                }
+                "SAFE_SEARCH_DETECTION" => std::option::Option::Some(Self::SAFE_SEARCH_DETECTION),
+                "IMAGE_PROPERTIES" => std::option::Option::Some(Self::IMAGE_PROPERTIES),
+                "CROP_HINTS" => std::option::Option::Some(Self::CROP_HINTS),
+                "WEB_DETECTION" => std::option::Option::Some(Self::WEB_DETECTION),
+                "PRODUCT_SEARCH" => std::option::Option::Some(Self::PRODUCT_SEARCH),
+                "OBJECT_LOCALIZATION" => std::option::Option::Some(Self::OBJECT_LOCALIZATION),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -724,146 +761,254 @@ pub mod face_annotation {
         /// without considering mirror projections typical of photos. So, `LEFT_EYE`,
         /// typically, is the person's right eye.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(std::borrow::Cow<'static, str>);
+        pub struct Type(i32);
 
         impl Type {
+            /// Unknown face landmark detected. Should not be filled.
+            pub const UNKNOWN_LANDMARK: Type = Type::new(0);
+
+            /// Left eye.
+            pub const LEFT_EYE: Type = Type::new(1);
+
+            /// Right eye.
+            pub const RIGHT_EYE: Type = Type::new(2);
+
+            /// Left of left eyebrow.
+            pub const LEFT_OF_LEFT_EYEBROW: Type = Type::new(3);
+
+            /// Right of left eyebrow.
+            pub const RIGHT_OF_LEFT_EYEBROW: Type = Type::new(4);
+
+            /// Left of right eyebrow.
+            pub const LEFT_OF_RIGHT_EYEBROW: Type = Type::new(5);
+
+            /// Right of right eyebrow.
+            pub const RIGHT_OF_RIGHT_EYEBROW: Type = Type::new(6);
+
+            /// Midpoint between eyes.
+            pub const MIDPOINT_BETWEEN_EYES: Type = Type::new(7);
+
+            /// Nose tip.
+            pub const NOSE_TIP: Type = Type::new(8);
+
+            /// Upper lip.
+            pub const UPPER_LIP: Type = Type::new(9);
+
+            /// Lower lip.
+            pub const LOWER_LIP: Type = Type::new(10);
+
+            /// Mouth left.
+            pub const MOUTH_LEFT: Type = Type::new(11);
+
+            /// Mouth right.
+            pub const MOUTH_RIGHT: Type = Type::new(12);
+
+            /// Mouth center.
+            pub const MOUTH_CENTER: Type = Type::new(13);
+
+            /// Nose, bottom right.
+            pub const NOSE_BOTTOM_RIGHT: Type = Type::new(14);
+
+            /// Nose, bottom left.
+            pub const NOSE_BOTTOM_LEFT: Type = Type::new(15);
+
+            /// Nose, bottom center.
+            pub const NOSE_BOTTOM_CENTER: Type = Type::new(16);
+
+            /// Left eye, top boundary.
+            pub const LEFT_EYE_TOP_BOUNDARY: Type = Type::new(17);
+
+            /// Left eye, right corner.
+            pub const LEFT_EYE_RIGHT_CORNER: Type = Type::new(18);
+
+            /// Left eye, bottom boundary.
+            pub const LEFT_EYE_BOTTOM_BOUNDARY: Type = Type::new(19);
+
+            /// Left eye, left corner.
+            pub const LEFT_EYE_LEFT_CORNER: Type = Type::new(20);
+
+            /// Right eye, top boundary.
+            pub const RIGHT_EYE_TOP_BOUNDARY: Type = Type::new(21);
+
+            /// Right eye, right corner.
+            pub const RIGHT_EYE_RIGHT_CORNER: Type = Type::new(22);
+
+            /// Right eye, bottom boundary.
+            pub const RIGHT_EYE_BOTTOM_BOUNDARY: Type = Type::new(23);
+
+            /// Right eye, left corner.
+            pub const RIGHT_EYE_LEFT_CORNER: Type = Type::new(24);
+
+            /// Left eyebrow, upper midpoint.
+            pub const LEFT_EYEBROW_UPPER_MIDPOINT: Type = Type::new(25);
+
+            /// Right eyebrow, upper midpoint.
+            pub const RIGHT_EYEBROW_UPPER_MIDPOINT: Type = Type::new(26);
+
+            /// Left ear tragion.
+            pub const LEFT_EAR_TRAGION: Type = Type::new(27);
+
+            /// Right ear tragion.
+            pub const RIGHT_EAR_TRAGION: Type = Type::new(28);
+
+            /// Left eye pupil.
+            pub const LEFT_EYE_PUPIL: Type = Type::new(29);
+
+            /// Right eye pupil.
+            pub const RIGHT_EYE_PUPIL: Type = Type::new(30);
+
+            /// Forehead glabella.
+            pub const FOREHEAD_GLABELLA: Type = Type::new(31);
+
+            /// Chin gnathion.
+            pub const CHIN_GNATHION: Type = Type::new(32);
+
+            /// Chin left gonion.
+            pub const CHIN_LEFT_GONION: Type = Type::new(33);
+
+            /// Chin right gonion.
+            pub const CHIN_RIGHT_GONION: Type = Type::new(34);
+
+            /// Left cheek center.
+            pub const LEFT_CHEEK_CENTER: Type = Type::new(35);
+
+            /// Right cheek center.
+            pub const RIGHT_CHEEK_CENTER: Type = Type::new(36);
+
             /// Creates a new Type instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("UNKNOWN_LANDMARK"),
+                    1 => std::borrow::Cow::Borrowed("LEFT_EYE"),
+                    2 => std::borrow::Cow::Borrowed("RIGHT_EYE"),
+                    3 => std::borrow::Cow::Borrowed("LEFT_OF_LEFT_EYEBROW"),
+                    4 => std::borrow::Cow::Borrowed("RIGHT_OF_LEFT_EYEBROW"),
+                    5 => std::borrow::Cow::Borrowed("LEFT_OF_RIGHT_EYEBROW"),
+                    6 => std::borrow::Cow::Borrowed("RIGHT_OF_RIGHT_EYEBROW"),
+                    7 => std::borrow::Cow::Borrowed("MIDPOINT_BETWEEN_EYES"),
+                    8 => std::borrow::Cow::Borrowed("NOSE_TIP"),
+                    9 => std::borrow::Cow::Borrowed("UPPER_LIP"),
+                    10 => std::borrow::Cow::Borrowed("LOWER_LIP"),
+                    11 => std::borrow::Cow::Borrowed("MOUTH_LEFT"),
+                    12 => std::borrow::Cow::Borrowed("MOUTH_RIGHT"),
+                    13 => std::borrow::Cow::Borrowed("MOUTH_CENTER"),
+                    14 => std::borrow::Cow::Borrowed("NOSE_BOTTOM_RIGHT"),
+                    15 => std::borrow::Cow::Borrowed("NOSE_BOTTOM_LEFT"),
+                    16 => std::borrow::Cow::Borrowed("NOSE_BOTTOM_CENTER"),
+                    17 => std::borrow::Cow::Borrowed("LEFT_EYE_TOP_BOUNDARY"),
+                    18 => std::borrow::Cow::Borrowed("LEFT_EYE_RIGHT_CORNER"),
+                    19 => std::borrow::Cow::Borrowed("LEFT_EYE_BOTTOM_BOUNDARY"),
+                    20 => std::borrow::Cow::Borrowed("LEFT_EYE_LEFT_CORNER"),
+                    21 => std::borrow::Cow::Borrowed("RIGHT_EYE_TOP_BOUNDARY"),
+                    22 => std::borrow::Cow::Borrowed("RIGHT_EYE_RIGHT_CORNER"),
+                    23 => std::borrow::Cow::Borrowed("RIGHT_EYE_BOTTOM_BOUNDARY"),
+                    24 => std::borrow::Cow::Borrowed("RIGHT_EYE_LEFT_CORNER"),
+                    25 => std::borrow::Cow::Borrowed("LEFT_EYEBROW_UPPER_MIDPOINT"),
+                    26 => std::borrow::Cow::Borrowed("RIGHT_EYEBROW_UPPER_MIDPOINT"),
+                    27 => std::borrow::Cow::Borrowed("LEFT_EAR_TRAGION"),
+                    28 => std::borrow::Cow::Borrowed("RIGHT_EAR_TRAGION"),
+                    29 => std::borrow::Cow::Borrowed("LEFT_EYE_PUPIL"),
+                    30 => std::borrow::Cow::Borrowed("RIGHT_EYE_PUPIL"),
+                    31 => std::borrow::Cow::Borrowed("FOREHEAD_GLABELLA"),
+                    32 => std::borrow::Cow::Borrowed("CHIN_GNATHION"),
+                    33 => std::borrow::Cow::Borrowed("CHIN_LEFT_GONION"),
+                    34 => std::borrow::Cow::Borrowed("CHIN_RIGHT_GONION"),
+                    35 => std::borrow::Cow::Borrowed("LEFT_CHEEK_CENTER"),
+                    36 => std::borrow::Cow::Borrowed("RIGHT_CHEEK_CENTER"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "UNKNOWN_LANDMARK" => std::option::Option::Some(Self::UNKNOWN_LANDMARK),
+                    "LEFT_EYE" => std::option::Option::Some(Self::LEFT_EYE),
+                    "RIGHT_EYE" => std::option::Option::Some(Self::RIGHT_EYE),
+                    "LEFT_OF_LEFT_EYEBROW" => std::option::Option::Some(Self::LEFT_OF_LEFT_EYEBROW),
+                    "RIGHT_OF_LEFT_EYEBROW" => {
+                        std::option::Option::Some(Self::RIGHT_OF_LEFT_EYEBROW)
+                    }
+                    "LEFT_OF_RIGHT_EYEBROW" => {
+                        std::option::Option::Some(Self::LEFT_OF_RIGHT_EYEBROW)
+                    }
+                    "RIGHT_OF_RIGHT_EYEBROW" => {
+                        std::option::Option::Some(Self::RIGHT_OF_RIGHT_EYEBROW)
+                    }
+                    "MIDPOINT_BETWEEN_EYES" => {
+                        std::option::Option::Some(Self::MIDPOINT_BETWEEN_EYES)
+                    }
+                    "NOSE_TIP" => std::option::Option::Some(Self::NOSE_TIP),
+                    "UPPER_LIP" => std::option::Option::Some(Self::UPPER_LIP),
+                    "LOWER_LIP" => std::option::Option::Some(Self::LOWER_LIP),
+                    "MOUTH_LEFT" => std::option::Option::Some(Self::MOUTH_LEFT),
+                    "MOUTH_RIGHT" => std::option::Option::Some(Self::MOUTH_RIGHT),
+                    "MOUTH_CENTER" => std::option::Option::Some(Self::MOUTH_CENTER),
+                    "NOSE_BOTTOM_RIGHT" => std::option::Option::Some(Self::NOSE_BOTTOM_RIGHT),
+                    "NOSE_BOTTOM_LEFT" => std::option::Option::Some(Self::NOSE_BOTTOM_LEFT),
+                    "NOSE_BOTTOM_CENTER" => std::option::Option::Some(Self::NOSE_BOTTOM_CENTER),
+                    "LEFT_EYE_TOP_BOUNDARY" => {
+                        std::option::Option::Some(Self::LEFT_EYE_TOP_BOUNDARY)
+                    }
+                    "LEFT_EYE_RIGHT_CORNER" => {
+                        std::option::Option::Some(Self::LEFT_EYE_RIGHT_CORNER)
+                    }
+                    "LEFT_EYE_BOTTOM_BOUNDARY" => {
+                        std::option::Option::Some(Self::LEFT_EYE_BOTTOM_BOUNDARY)
+                    }
+                    "LEFT_EYE_LEFT_CORNER" => std::option::Option::Some(Self::LEFT_EYE_LEFT_CORNER),
+                    "RIGHT_EYE_TOP_BOUNDARY" => {
+                        std::option::Option::Some(Self::RIGHT_EYE_TOP_BOUNDARY)
+                    }
+                    "RIGHT_EYE_RIGHT_CORNER" => {
+                        std::option::Option::Some(Self::RIGHT_EYE_RIGHT_CORNER)
+                    }
+                    "RIGHT_EYE_BOTTOM_BOUNDARY" => {
+                        std::option::Option::Some(Self::RIGHT_EYE_BOTTOM_BOUNDARY)
+                    }
+                    "RIGHT_EYE_LEFT_CORNER" => {
+                        std::option::Option::Some(Self::RIGHT_EYE_LEFT_CORNER)
+                    }
+                    "LEFT_EYEBROW_UPPER_MIDPOINT" => {
+                        std::option::Option::Some(Self::LEFT_EYEBROW_UPPER_MIDPOINT)
+                    }
+                    "RIGHT_EYEBROW_UPPER_MIDPOINT" => {
+                        std::option::Option::Some(Self::RIGHT_EYEBROW_UPPER_MIDPOINT)
+                    }
+                    "LEFT_EAR_TRAGION" => std::option::Option::Some(Self::LEFT_EAR_TRAGION),
+                    "RIGHT_EAR_TRAGION" => std::option::Option::Some(Self::RIGHT_EAR_TRAGION),
+                    "LEFT_EYE_PUPIL" => std::option::Option::Some(Self::LEFT_EYE_PUPIL),
+                    "RIGHT_EYE_PUPIL" => std::option::Option::Some(Self::RIGHT_EYE_PUPIL),
+                    "FOREHEAD_GLABELLA" => std::option::Option::Some(Self::FOREHEAD_GLABELLA),
+                    "CHIN_GNATHION" => std::option::Option::Some(Self::CHIN_GNATHION),
+                    "CHIN_LEFT_GONION" => std::option::Option::Some(Self::CHIN_LEFT_GONION),
+                    "CHIN_RIGHT_GONION" => std::option::Option::Some(Self::CHIN_RIGHT_GONION),
+                    "LEFT_CHEEK_CENTER" => std::option::Option::Some(Self::LEFT_CHEEK_CENTER),
+                    "RIGHT_CHEEK_CENTER" => std::option::Option::Some(Self::RIGHT_CHEEK_CENTER),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Type](Type)
-        pub mod r#type {
-            use super::Type;
-
-            /// Unknown face landmark detected. Should not be filled.
-            pub const UNKNOWN_LANDMARK: Type = Type::new("UNKNOWN_LANDMARK");
-
-            /// Left eye.
-            pub const LEFT_EYE: Type = Type::new("LEFT_EYE");
-
-            /// Right eye.
-            pub const RIGHT_EYE: Type = Type::new("RIGHT_EYE");
-
-            /// Left of left eyebrow.
-            pub const LEFT_OF_LEFT_EYEBROW: Type = Type::new("LEFT_OF_LEFT_EYEBROW");
-
-            /// Right of left eyebrow.
-            pub const RIGHT_OF_LEFT_EYEBROW: Type = Type::new("RIGHT_OF_LEFT_EYEBROW");
-
-            /// Left of right eyebrow.
-            pub const LEFT_OF_RIGHT_EYEBROW: Type = Type::new("LEFT_OF_RIGHT_EYEBROW");
-
-            /// Right of right eyebrow.
-            pub const RIGHT_OF_RIGHT_EYEBROW: Type = Type::new("RIGHT_OF_RIGHT_EYEBROW");
-
-            /// Midpoint between eyes.
-            pub const MIDPOINT_BETWEEN_EYES: Type = Type::new("MIDPOINT_BETWEEN_EYES");
-
-            /// Nose tip.
-            pub const NOSE_TIP: Type = Type::new("NOSE_TIP");
-
-            /// Upper lip.
-            pub const UPPER_LIP: Type = Type::new("UPPER_LIP");
-
-            /// Lower lip.
-            pub const LOWER_LIP: Type = Type::new("LOWER_LIP");
-
-            /// Mouth left.
-            pub const MOUTH_LEFT: Type = Type::new("MOUTH_LEFT");
-
-            /// Mouth right.
-            pub const MOUTH_RIGHT: Type = Type::new("MOUTH_RIGHT");
-
-            /// Mouth center.
-            pub const MOUTH_CENTER: Type = Type::new("MOUTH_CENTER");
-
-            /// Nose, bottom right.
-            pub const NOSE_BOTTOM_RIGHT: Type = Type::new("NOSE_BOTTOM_RIGHT");
-
-            /// Nose, bottom left.
-            pub const NOSE_BOTTOM_LEFT: Type = Type::new("NOSE_BOTTOM_LEFT");
-
-            /// Nose, bottom center.
-            pub const NOSE_BOTTOM_CENTER: Type = Type::new("NOSE_BOTTOM_CENTER");
-
-            /// Left eye, top boundary.
-            pub const LEFT_EYE_TOP_BOUNDARY: Type = Type::new("LEFT_EYE_TOP_BOUNDARY");
-
-            /// Left eye, right corner.
-            pub const LEFT_EYE_RIGHT_CORNER: Type = Type::new("LEFT_EYE_RIGHT_CORNER");
-
-            /// Left eye, bottom boundary.
-            pub const LEFT_EYE_BOTTOM_BOUNDARY: Type = Type::new("LEFT_EYE_BOTTOM_BOUNDARY");
-
-            /// Left eye, left corner.
-            pub const LEFT_EYE_LEFT_CORNER: Type = Type::new("LEFT_EYE_LEFT_CORNER");
-
-            /// Right eye, top boundary.
-            pub const RIGHT_EYE_TOP_BOUNDARY: Type = Type::new("RIGHT_EYE_TOP_BOUNDARY");
-
-            /// Right eye, right corner.
-            pub const RIGHT_EYE_RIGHT_CORNER: Type = Type::new("RIGHT_EYE_RIGHT_CORNER");
-
-            /// Right eye, bottom boundary.
-            pub const RIGHT_EYE_BOTTOM_BOUNDARY: Type = Type::new("RIGHT_EYE_BOTTOM_BOUNDARY");
-
-            /// Right eye, left corner.
-            pub const RIGHT_EYE_LEFT_CORNER: Type = Type::new("RIGHT_EYE_LEFT_CORNER");
-
-            /// Left eyebrow, upper midpoint.
-            pub const LEFT_EYEBROW_UPPER_MIDPOINT: Type = Type::new("LEFT_EYEBROW_UPPER_MIDPOINT");
-
-            /// Right eyebrow, upper midpoint.
-            pub const RIGHT_EYEBROW_UPPER_MIDPOINT: Type =
-                Type::new("RIGHT_EYEBROW_UPPER_MIDPOINT");
-
-            /// Left ear tragion.
-            pub const LEFT_EAR_TRAGION: Type = Type::new("LEFT_EAR_TRAGION");
-
-            /// Right ear tragion.
-            pub const RIGHT_EAR_TRAGION: Type = Type::new("RIGHT_EAR_TRAGION");
-
-            /// Left eye pupil.
-            pub const LEFT_EYE_PUPIL: Type = Type::new("LEFT_EYE_PUPIL");
-
-            /// Right eye pupil.
-            pub const RIGHT_EYE_PUPIL: Type = Type::new("RIGHT_EYE_PUPIL");
-
-            /// Forehead glabella.
-            pub const FOREHEAD_GLABELLA: Type = Type::new("FOREHEAD_GLABELLA");
-
-            /// Chin gnathion.
-            pub const CHIN_GNATHION: Type = Type::new("CHIN_GNATHION");
-
-            /// Chin left gonion.
-            pub const CHIN_LEFT_GONION: Type = Type::new("CHIN_LEFT_GONION");
-
-            /// Chin right gonion.
-            pub const CHIN_RIGHT_GONION: Type = Type::new("CHIN_RIGHT_GONION");
-
-            /// Left cheek center.
-            pub const LEFT_CHEEK_CENTER: Type = Type::new("LEFT_CHEEK_CENTER");
-
-            /// Right cheek center.
-            pub const RIGHT_CHEEK_CENTER: Type = Type::new("RIGHT_CHEEK_CENTER");
-        }
-
-        impl std::convert::From<std::string::String> for Type {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                r#type::UNKNOWN_LANDMARK
+                Self::new(0)
             }
         }
     }
@@ -3061,49 +3206,68 @@ pub mod operation_metadata {
 
     /// Batch operation states.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Invalid.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Request is received.
+        pub const CREATED: State = State::new(1);
+
+        /// Request is actively being processed.
+        pub const RUNNING: State = State::new(2);
+
+        /// The batch processing is done.
+        pub const DONE: State = State::new(3);
+
+        /// The batch processing was cancelled.
+        pub const CANCELLED: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATED"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("DONE"),
+                4 => std::borrow::Cow::Borrowed("CANCELLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATED" => std::option::Option::Some(Self::CREATED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "DONE" => std::option::Option::Some(Self::DONE),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Invalid.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Request is received.
-        pub const CREATED: State = State::new("CREATED");
-
-        /// Request is actively being processed.
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// The batch processing is done.
-        pub const DONE: State = State::new("DONE");
-
-        /// The batch processing was cancelled.
-        pub const CANCELLED: State = State::new("CANCELLED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5121,52 +5285,71 @@ pub mod batch_operation_metadata {
 
     /// Enumerates the possible states that the batch request can be in.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Invalid.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Request is actively being processed.
-        pub const PROCESSING: State = State::new("PROCESSING");
+        pub const PROCESSING: State = State::new(1);
 
         /// The request is done and at least one item has been successfully
         /// processed.
-        pub const SUCCESSFUL: State = State::new("SUCCESSFUL");
+        pub const SUCCESSFUL: State = State::new(2);
 
         /// The request is done and no item has been successfully processed.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(3);
 
         /// The request is done after the longrunning.Operations.CancelOperation has
         /// been called by the user.  Any records that were processed before the
         /// cancel command are output as specified in the request.
-        pub const CANCELLED: State = State::new("CANCELLED");
+        pub const CANCELLED: State = State::new(4);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROCESSING"),
+                2 => std::borrow::Cow::Borrowed("SUCCESSFUL"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                4 => std::borrow::Cow::Borrowed("CANCELLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PROCESSING" => std::option::Option::Some(Self::PROCESSING),
+                "SUCCESSFUL" => std::option::Option::Some(Self::SUCCESSFUL),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5484,53 +5667,74 @@ pub mod text_annotation {
 
         /// Enum to denote the type of break found. New line, space etc.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct BreakType(std::borrow::Cow<'static, str>);
+        pub struct BreakType(i32);
 
         impl BreakType {
-            /// Creates a new BreakType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [BreakType](BreakType)
-        pub mod break_type {
-            use super::BreakType;
-
             /// Unknown break label type.
-            pub const UNKNOWN: BreakType = BreakType::new("UNKNOWN");
+            pub const UNKNOWN: BreakType = BreakType::new(0);
 
             /// Regular space.
-            pub const SPACE: BreakType = BreakType::new("SPACE");
+            pub const SPACE: BreakType = BreakType::new(1);
 
             /// Sure space (very wide).
-            pub const SURE_SPACE: BreakType = BreakType::new("SURE_SPACE");
+            pub const SURE_SPACE: BreakType = BreakType::new(2);
 
             /// Line-wrapping break.
-            pub const EOL_SURE_SPACE: BreakType = BreakType::new("EOL_SURE_SPACE");
+            pub const EOL_SURE_SPACE: BreakType = BreakType::new(3);
 
             /// End-line hyphen that is not present in text; does not co-occur with
             /// `SPACE`, `LEADER_SPACE`, or `LINE_BREAK`.
-            pub const HYPHEN: BreakType = BreakType::new("HYPHEN");
+            pub const HYPHEN: BreakType = BreakType::new(4);
 
             /// Line break that ends a paragraph.
-            pub const LINE_BREAK: BreakType = BreakType::new("LINE_BREAK");
+            pub const LINE_BREAK: BreakType = BreakType::new(5);
+
+            /// Creates a new BreakType instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                    1 => std::borrow::Cow::Borrowed("SPACE"),
+                    2 => std::borrow::Cow::Borrowed("SURE_SPACE"),
+                    3 => std::borrow::Cow::Borrowed("EOL_SURE_SPACE"),
+                    4 => std::borrow::Cow::Borrowed("HYPHEN"),
+                    5 => std::borrow::Cow::Borrowed("LINE_BREAK"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                    "SPACE" => std::option::Option::Some(Self::SPACE),
+                    "SURE_SPACE" => std::option::Option::Some(Self::SURE_SPACE),
+                    "EOL_SURE_SPACE" => std::option::Option::Some(Self::EOL_SURE_SPACE),
+                    "HYPHEN" => std::option::Option::Some(Self::HYPHEN),
+                    "LINE_BREAK" => std::option::Option::Some(Self::LINE_BREAK),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for BreakType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for BreakType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for BreakType {
             fn default() -> Self {
-                break_type::UNKNOWN
+                Self::new(0)
             }
         }
     }
@@ -5779,52 +5983,73 @@ pub mod block {
 
     /// Type of a block (text, image etc) as identified by OCR.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BlockType(std::borrow::Cow<'static, str>);
+    pub struct BlockType(i32);
 
     impl BlockType {
+        /// Unknown block type.
+        pub const UNKNOWN: BlockType = BlockType::new(0);
+
+        /// Regular text block.
+        pub const TEXT: BlockType = BlockType::new(1);
+
+        /// Table block.
+        pub const TABLE: BlockType = BlockType::new(2);
+
+        /// Image block.
+        pub const PICTURE: BlockType = BlockType::new(3);
+
+        /// Horizontal/vertical line box.
+        pub const RULER: BlockType = BlockType::new(4);
+
+        /// Barcode block.
+        pub const BARCODE: BlockType = BlockType::new(5);
+
         /// Creates a new BlockType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("TEXT"),
+                2 => std::borrow::Cow::Borrowed("TABLE"),
+                3 => std::borrow::Cow::Borrowed("PICTURE"),
+                4 => std::borrow::Cow::Borrowed("RULER"),
+                5 => std::borrow::Cow::Borrowed("BARCODE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                "TEXT" => std::option::Option::Some(Self::TEXT),
+                "TABLE" => std::option::Option::Some(Self::TABLE),
+                "PICTURE" => std::option::Option::Some(Self::PICTURE),
+                "RULER" => std::option::Option::Some(Self::RULER),
+                "BARCODE" => std::option::Option::Some(Self::BARCODE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [BlockType](BlockType)
-    pub mod block_type {
-        use super::BlockType;
-
-        /// Unknown block type.
-        pub const UNKNOWN: BlockType = BlockType::new("UNKNOWN");
-
-        /// Regular text block.
-        pub const TEXT: BlockType = BlockType::new("TEXT");
-
-        /// Table block.
-        pub const TABLE: BlockType = BlockType::new("TABLE");
-
-        /// Image block.
-        pub const PICTURE: BlockType = BlockType::new("PICTURE");
-
-        /// Horizontal/vertical line box.
-        pub const RULER: BlockType = BlockType::new("RULER");
-
-        /// Barcode block.
-        pub const BARCODE: BlockType = BlockType::new("BARCODE");
-    }
-
-    impl std::convert::From<std::string::String> for BlockType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for BlockType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for BlockType {
         fn default() -> Self {
-            block_type::UNKNOWN
+            Self::new(0)
         }
     }
 }
@@ -6424,51 +6649,72 @@ pub mod web_detection {
 /// A bucketized representation of likelihood, which is intended to give clients
 /// highly stable results across model upgrades.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Likelihood(std::borrow::Cow<'static, str>);
+pub struct Likelihood(i32);
 
 impl Likelihood {
+    /// Unknown likelihood.
+    pub const UNKNOWN: Likelihood = Likelihood::new(0);
+
+    /// It is very unlikely.
+    pub const VERY_UNLIKELY: Likelihood = Likelihood::new(1);
+
+    /// It is unlikely.
+    pub const UNLIKELY: Likelihood = Likelihood::new(2);
+
+    /// It is possible.
+    pub const POSSIBLE: Likelihood = Likelihood::new(3);
+
+    /// It is likely.
+    pub const LIKELY: Likelihood = Likelihood::new(4);
+
+    /// It is very likely.
+    pub const VERY_LIKELY: Likelihood = Likelihood::new(5);
+
     /// Creates a new Likelihood instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("UNKNOWN"),
+            1 => std::borrow::Cow::Borrowed("VERY_UNLIKELY"),
+            2 => std::borrow::Cow::Borrowed("UNLIKELY"),
+            3 => std::borrow::Cow::Borrowed("POSSIBLE"),
+            4 => std::borrow::Cow::Borrowed("LIKELY"),
+            5 => std::borrow::Cow::Borrowed("VERY_LIKELY"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+            "VERY_UNLIKELY" => std::option::Option::Some(Self::VERY_UNLIKELY),
+            "UNLIKELY" => std::option::Option::Some(Self::UNLIKELY),
+            "POSSIBLE" => std::option::Option::Some(Self::POSSIBLE),
+            "LIKELY" => std::option::Option::Some(Self::LIKELY),
+            "VERY_LIKELY" => std::option::Option::Some(Self::VERY_LIKELY),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [Likelihood](Likelihood)
-pub mod likelihood {
-    use super::Likelihood;
-
-    /// Unknown likelihood.
-    pub const UNKNOWN: Likelihood = Likelihood::new("UNKNOWN");
-
-    /// It is very unlikely.
-    pub const VERY_UNLIKELY: Likelihood = Likelihood::new("VERY_UNLIKELY");
-
-    /// It is unlikely.
-    pub const UNLIKELY: Likelihood = Likelihood::new("UNLIKELY");
-
-    /// It is possible.
-    pub const POSSIBLE: Likelihood = Likelihood::new("POSSIBLE");
-
-    /// It is likely.
-    pub const LIKELY: Likelihood = Likelihood::new("LIKELY");
-
-    /// It is very likely.
-    pub const VERY_LIKELY: Likelihood = Likelihood::new("VERY_LIKELY");
-}
-
-impl std::convert::From<std::string::String> for Likelihood {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Likelihood {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Likelihood {
     fn default() -> Self {
-        likelihood::UNKNOWN
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/vision/v1/src/transport.rs
+++ b/src/generated/cloud/vision/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::ImageAnnotator for ImageAnnotator {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, "/v1/images:annotate".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -66,7 +66,7 @@ impl crate::stubs::ImageAnnotator for ImageAnnotator {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, "/v1/files:annotate".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -86,7 +86,7 @@ impl crate::stubs::ImageAnnotator for ImageAnnotator {
                 reqwest::Method::POST,
                 "/v1/images:asyncBatchAnnotate".to_string(),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -106,7 +106,7 @@ impl crate::stubs::ImageAnnotator for ImageAnnotator {
                 reqwest::Method::POST,
                 "/v1/files:asyncBatchAnnotate".to_string(),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -123,7 +123,7 @@ impl crate::stubs::ImageAnnotator for ImageAnnotator {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -182,7 +182,7 @@ impl crate::stubs::ProductSearch for ProductSearch {
                 reqwest::Method::POST,
                 format!("/v1/{}/productSets", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -205,7 +205,7 @@ impl crate::stubs::ProductSearch for ProductSearch {
                 reqwest::Method::GET,
                 format!("/v1/{}/productSets", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -226,7 +226,7 @@ impl crate::stubs::ProductSearch for ProductSearch {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -254,7 +254,7 @@ impl crate::stubs::ProductSearch for ProductSearch {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -283,7 +283,7 @@ impl crate::stubs::ProductSearch for ProductSearch {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -305,7 +305,7 @@ impl crate::stubs::ProductSearch for ProductSearch {
                 reqwest::Method::POST,
                 format!("/v1/{}/products", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -325,7 +325,7 @@ impl crate::stubs::ProductSearch for ProductSearch {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/products", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -346,7 +346,7 @@ impl crate::stubs::ProductSearch for ProductSearch {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -374,7 +374,7 @@ impl crate::stubs::ProductSearch for ProductSearch {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -403,7 +403,7 @@ impl crate::stubs::ProductSearch for ProductSearch {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -425,7 +425,7 @@ impl crate::stubs::ProductSearch for ProductSearch {
                 reqwest::Method::POST,
                 format!("/v1/{}/referenceImages", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -445,7 +445,7 @@ impl crate::stubs::ProductSearch for ProductSearch {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -467,7 +467,7 @@ impl crate::stubs::ProductSearch for ProductSearch {
                 reqwest::Method::GET,
                 format!("/v1/{}/referenceImages", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -488,7 +488,7 @@ impl crate::stubs::ProductSearch for ProductSearch {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -510,7 +510,7 @@ impl crate::stubs::ProductSearch for ProductSearch {
                 reqwest::Method::POST,
                 format!("/v1/{}:addProduct", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -530,7 +530,7 @@ impl crate::stubs::ProductSearch for ProductSearch {
                 reqwest::Method::POST,
                 format!("/v1/{}:removeProduct", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -547,7 +547,7 @@ impl crate::stubs::ProductSearch for ProductSearch {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/products", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -571,7 +571,7 @@ impl crate::stubs::ProductSearch for ProductSearch {
                 reqwest::Method::POST,
                 format!("/v1/{}/productSets:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -591,7 +591,7 @@ impl crate::stubs::ProductSearch for ProductSearch {
                 reqwest::Method::POST,
                 format!("/v1/{}/products:purge", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -608,7 +608,7 @@ impl crate::stubs::ProductSearch for ProductSearch {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/vmmigration/v1/src/transport.rs
+++ b/src/generated/cloud/vmmigration/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/sources", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -91,7 +91,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/sources", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -119,7 +119,7 @@ impl crate::stubs::VmMigration for VmMigration {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -147,7 +147,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -170,7 +170,7 @@ impl crate::stubs::VmMigration for VmMigration {
                 reqwest::Method::GET,
                 format!("/v1/{}:fetchInventory", req.source),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -193,7 +193,7 @@ impl crate::stubs::VmMigration for VmMigration {
                 reqwest::Method::GET,
                 format!("/v1/{}/utilizationReports", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -217,7 +217,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -240,7 +240,7 @@ impl crate::stubs::VmMigration for VmMigration {
                 reqwest::Method::POST,
                 format!("/v1/{}/utilizationReports", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -261,7 +261,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -284,7 +284,7 @@ impl crate::stubs::VmMigration for VmMigration {
                 reqwest::Method::GET,
                 format!("/v1/{}/datacenterConnectors", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -307,7 +307,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -329,7 +329,7 @@ impl crate::stubs::VmMigration for VmMigration {
                 reqwest::Method::POST,
                 format!("/v1/{}/datacenterConnectors", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -350,7 +350,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -373,7 +373,7 @@ impl crate::stubs::VmMigration for VmMigration {
                 reqwest::Method::POST,
                 format!("/v1/{}:upgradeAppliance", req.datacenter_connector),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -393,7 +393,7 @@ impl crate::stubs::VmMigration for VmMigration {
                 reqwest::Method::POST,
                 format!("/v1/{}/migratingVms", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -417,7 +417,7 @@ impl crate::stubs::VmMigration for VmMigration {
                 reqwest::Method::GET,
                 format!("/v1/{}/migratingVms", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -441,7 +441,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -470,7 +470,7 @@ impl crate::stubs::VmMigration for VmMigration {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -500,7 +500,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -522,7 +522,7 @@ impl crate::stubs::VmMigration for VmMigration {
                 reqwest::Method::POST,
                 format!("/v1/{}:startMigration", req.migrating_vm),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -542,7 +542,7 @@ impl crate::stubs::VmMigration for VmMigration {
                 reqwest::Method::POST,
                 format!("/v1/{}:resumeMigration", req.migrating_vm),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -562,7 +562,7 @@ impl crate::stubs::VmMigration for VmMigration {
                 reqwest::Method::POST,
                 format!("/v1/{}:pauseMigration", req.migrating_vm),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -582,7 +582,7 @@ impl crate::stubs::VmMigration for VmMigration {
                 reqwest::Method::POST,
                 format!("/v1/{}:finalizeMigration", req.migrating_vm),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -602,7 +602,7 @@ impl crate::stubs::VmMigration for VmMigration {
                 reqwest::Method::POST,
                 format!("/v1/{}/cloneJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -623,7 +623,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -643,7 +643,7 @@ impl crate::stubs::VmMigration for VmMigration {
                 reqwest::Method::GET,
                 format!("/v1/{}/cloneJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -666,7 +666,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -688,7 +688,7 @@ impl crate::stubs::VmMigration for VmMigration {
                 reqwest::Method::POST,
                 format!("/v1/{}/cutoverJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -709,7 +709,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -729,7 +729,7 @@ impl crate::stubs::VmMigration for VmMigration {
                 reqwest::Method::GET,
                 format!("/v1/{}/cutoverJobs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -752,7 +752,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -771,7 +771,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/groups", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -794,7 +794,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -813,7 +813,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/groups", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -841,7 +841,7 @@ impl crate::stubs::VmMigration for VmMigration {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -869,7 +869,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -892,7 +892,7 @@ impl crate::stubs::VmMigration for VmMigration {
                 reqwest::Method::POST,
                 format!("/v1/{}:addGroupMigration", req.group),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -912,7 +912,7 @@ impl crate::stubs::VmMigration for VmMigration {
                 reqwest::Method::POST,
                 format!("/v1/{}:removeGroupMigration", req.group),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -932,7 +932,7 @@ impl crate::stubs::VmMigration for VmMigration {
                 reqwest::Method::GET,
                 format!("/v1/{}/targetProjects", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -955,7 +955,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -977,7 +977,7 @@ impl crate::stubs::VmMigration for VmMigration {
                 reqwest::Method::POST,
                 format!("/v1/{}/targetProjects", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1007,7 +1007,7 @@ impl crate::stubs::VmMigration for VmMigration {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1037,7 +1037,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1060,7 +1060,7 @@ impl crate::stubs::VmMigration for VmMigration {
                 reqwest::Method::GET,
                 format!("/v1/{}/replicationCycles", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1083,7 +1083,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1102,7 +1102,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1124,7 +1124,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1143,7 +1143,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1165,7 +1165,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1184,7 +1184,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1203,7 +1203,7 @@ impl crate::stubs::VmMigration for VmMigration {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/vmwareengine/v1/src/model.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/model.rs
@@ -7068,103 +7068,141 @@ pub mod private_cloud {
 
     /// Enum State defines possible states of private clouds.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The default value. This value should never be used.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The private cloud is ready.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(1);
 
         /// The private cloud is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(2);
 
         /// The private cloud is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(3);
 
         /// The private cloud is in failed state.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(5);
 
         /// The private cloud is scheduled for deletion. The deletion process can be
         /// cancelled by using the corresponding undelete method.
-        pub const DELETED: State = State::new("DELETED");
+        pub const DELETED: State = State::new(6);
 
         /// The private cloud is irreversibly deleted and is being removed from the
         /// system.
-        pub const PURGING: State = State::new("PURGING");
+        pub const PURGING: State = State::new(7);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("CREATING"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                5 => std::borrow::Cow::Borrowed("FAILED"),
+                6 => std::borrow::Cow::Borrowed("DELETED"),
+                7 => std::borrow::Cow::Borrowed("PURGING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "DELETED" => std::option::Option::Some(Self::DELETED),
+                "PURGING" => std::option::Option::Some(Self::PURGING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Enum Type defines private cloud type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// Standard private is a zonal resource, with 3+ nodes. Default type.
-        pub const STANDARD: Type = Type::new("STANDARD");
+        pub const STANDARD: Type = Type::new(0);
 
         /// Time limited private cloud is a zonal resource, can have only 1 node and
         /// has limited life span. Will be deleted after defined period of time,
         /// can be converted into standard private cloud by expanding it up to 3
         /// or more nodes.
-        pub const TIME_LIMITED: Type = Type::new("TIME_LIMITED");
+        pub const TIME_LIMITED: Type = Type::new(1);
 
         /// Stretched private cloud is a regional resource with redundancy,
         /// with a minimum of 6 nodes, nodes count has to be even.
-        pub const STRETCHED: Type = Type::new("STRETCHED");
+        pub const STRETCHED: Type = Type::new(2);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STANDARD"),
+                1 => std::borrow::Cow::Borrowed("TIME_LIMITED"),
+                2 => std::borrow::Cow::Borrowed("STRETCHED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STANDARD" => std::option::Option::Some(Self::STANDARD),
+                "TIME_LIMITED" => std::option::Option::Some(Self::TIME_LIMITED),
+                "STRETCHED" => std::option::Option::Some(Self::STRETCHED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::STANDARD
+            Self::new(0)
         }
     }
 }
@@ -7314,54 +7352,75 @@ pub mod cluster {
 
     /// Enum State defines possible states of private cloud clusters.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The default value. This value should never be used.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The Cluster is operational and can be used by the user.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(1);
 
         /// The Cluster is being deployed.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(2);
 
         /// Adding or removing of a node to the cluster, any other cluster specific
         /// updates.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(3);
 
         /// The Cluster is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(4);
 
         /// The Cluster is undergoing maintenance, for example: a failed node is
         /// getting replaced.
-        pub const REPAIRING: State = State::new("REPAIRING");
+        pub const REPAIRING: State = State::new(5);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("CREATING"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("REPAIRING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "REPAIRING" => std::option::Option::Some(Self::REPAIRING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7468,49 +7527,68 @@ pub mod node {
 
     /// Enum State defines possible states of a node in a cluster.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The default value. This value should never be used.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Node is operational and can be used by the user.
+        pub const ACTIVE: State = State::new(1);
+
+        /// Node is being provisioned.
+        pub const CREATING: State = State::new(2);
+
+        /// Node is in a failed state.
+        pub const FAILED: State = State::new(3);
+
+        /// Node is undergoing maintenance, e.g.: during private cloud upgrade.
+        pub const UPGRADING: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("CREATING"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                4 => std::borrow::Cow::Borrowed("UPGRADING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "UPGRADING" => std::option::Option::Some(Self::UPGRADING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The default value. This value should never be used.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Node is operational and can be used by the user.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// Node is being provisioned.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// Node is in a failed state.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// Node is undergoing maintenance, e.g.: during private cloud upgrade.
-        pub const UPGRADING: State = State::new("UPGRADING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7634,49 +7712,68 @@ pub mod external_address {
 
     /// Enum State defines possible states of external addresses.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The default value. This value should never be used.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The address is ready.
+        pub const ACTIVE: State = State::new(1);
+
+        /// The address is being created.
+        pub const CREATING: State = State::new(2);
+
+        /// The address is being updated.
+        pub const UPDATING: State = State::new(3);
+
+        /// The address is being deleted.
+        pub const DELETING: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("CREATING"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The default value. This value should never be used.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The address is ready.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The address is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The address is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// The address is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7773,56 +7870,79 @@ pub mod subnet {
 
     /// Defines possible states of subnets.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The default value. This value should never be used.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The subnet is ready.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(1);
 
         /// The subnet is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(2);
 
         /// The subnet is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(3);
 
         /// The subnet is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(4);
 
         /// Changes requested in the last operation are being propagated.
-        pub const RECONCILING: State = State::new("RECONCILING");
+        pub const RECONCILING: State = State::new(5);
 
         /// Last operation on the subnet did not succeed. Subnet's payload is
         /// reverted back to its most recent working state.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(6);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("CREATING"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("RECONCILING"),
+                6 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "RECONCILING" => std::option::Option::Some(Self::RECONCILING),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8184,91 +8304,125 @@ pub mod external_access_rule {
     /// Action determines whether the external access rule permits or blocks
     /// traffic, subject to the other components of the rule matching the traffic.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(std::borrow::Cow<'static, str>);
+    pub struct Action(i32);
 
     impl Action {
+        /// Defaults to allow.
+        pub const ACTION_UNSPECIFIED: Action = Action::new(0);
+
+        /// Allows connections that match the other specified components.
+        pub const ALLOW: Action = Action::new(1);
+
+        /// Blocks connections that match the other specified components.
+        pub const DENY: Action = Action::new(2);
+
         /// Creates a new Action instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ACTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALLOW"),
+                2 => std::borrow::Cow::Borrowed("DENY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ACTION_UNSPECIFIED" => std::option::Option::Some(Self::ACTION_UNSPECIFIED),
+                "ALLOW" => std::option::Option::Some(Self::ALLOW),
+                "DENY" => std::option::Option::Some(Self::DENY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Action](Action)
-    pub mod action {
-        use super::Action;
-
-        /// Defaults to allow.
-        pub const ACTION_UNSPECIFIED: Action = Action::new("ACTION_UNSPECIFIED");
-
-        /// Allows connections that match the other specified components.
-        pub const ALLOW: Action = Action::new("ALLOW");
-
-        /// Blocks connections that match the other specified components.
-        pub const DENY: Action = Action::new("DENY");
-    }
-
-    impl std::convert::From<std::string::String> for Action {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            action::ACTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Defines possible states of external access firewall rules.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The default value. This value is used if the state is omitted.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The rule is ready.
+        pub const ACTIVE: State = State::new(1);
+
+        /// The rule is being created.
+        pub const CREATING: State = State::new(2);
+
+        /// The rule is being updated.
+        pub const UPDATING: State = State::new(3);
+
+        /// The rule is being deleted.
+        pub const DELETING: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("CREATING"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The rule is ready.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The rule is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The rule is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// The rule is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8395,94 +8549,132 @@ pub mod logging_server {
     /// Defines possible protocols used to send logs to
     /// a logging server.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Protocol(std::borrow::Cow<'static, str>);
+    pub struct Protocol(i32);
 
     impl Protocol {
+        /// Unspecified communications protocol. This is the default value.
+        pub const PROTOCOL_UNSPECIFIED: Protocol = Protocol::new(0);
+
+        /// UDP
+        pub const UDP: Protocol = Protocol::new(1);
+
+        /// TCP
+        pub const TCP: Protocol = Protocol::new(2);
+
+        /// TLS
+        pub const TLS: Protocol = Protocol::new(3);
+
+        /// SSL
+        pub const SSL: Protocol = Protocol::new(4);
+
+        /// RELP
+        pub const RELP: Protocol = Protocol::new(5);
+
         /// Creates a new Protocol instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PROTOCOL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("UDP"),
+                2 => std::borrow::Cow::Borrowed("TCP"),
+                3 => std::borrow::Cow::Borrowed("TLS"),
+                4 => std::borrow::Cow::Borrowed("SSL"),
+                5 => std::borrow::Cow::Borrowed("RELP"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PROTOCOL_UNSPECIFIED" => std::option::Option::Some(Self::PROTOCOL_UNSPECIFIED),
+                "UDP" => std::option::Option::Some(Self::UDP),
+                "TCP" => std::option::Option::Some(Self::TCP),
+                "TLS" => std::option::Option::Some(Self::TLS),
+                "SSL" => std::option::Option::Some(Self::SSL),
+                "RELP" => std::option::Option::Some(Self::RELP),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Protocol](Protocol)
-    pub mod protocol {
-        use super::Protocol;
-
-        /// Unspecified communications protocol. This is the default value.
-        pub const PROTOCOL_UNSPECIFIED: Protocol = Protocol::new("PROTOCOL_UNSPECIFIED");
-
-        /// UDP
-        pub const UDP: Protocol = Protocol::new("UDP");
-
-        /// TCP
-        pub const TCP: Protocol = Protocol::new("TCP");
-
-        /// TLS
-        pub const TLS: Protocol = Protocol::new("TLS");
-
-        /// SSL
-        pub const SSL: Protocol = Protocol::new("SSL");
-
-        /// RELP
-        pub const RELP: Protocol = Protocol::new("RELP");
-    }
-
-    impl std::convert::From<std::string::String> for Protocol {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Protocol {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Protocol {
         fn default() -> Self {
-            protocol::PROTOCOL_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Defines possible types of component that produces logs.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SourceType(std::borrow::Cow<'static, str>);
+    pub struct SourceType(i32);
 
     impl SourceType {
+        /// The default value. This value should never be used.
+        pub const SOURCE_TYPE_UNSPECIFIED: SourceType = SourceType::new(0);
+
+        /// Logs produced by ESXI hosts
+        pub const ESXI: SourceType = SourceType::new(1);
+
+        /// Logs produced by vCenter server
+        pub const VCSA: SourceType = SourceType::new(2);
+
         /// Creates a new SourceType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SOURCE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ESXI"),
+                2 => std::borrow::Cow::Borrowed("VCSA"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SOURCE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SOURCE_TYPE_UNSPECIFIED)
+                }
+                "ESXI" => std::option::Option::Some(Self::ESXI),
+                "VCSA" => std::option::Option::Some(Self::VCSA),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SourceType](SourceType)
-    pub mod source_type {
-        use super::SourceType;
-
-        /// The default value. This value should never be used.
-        pub const SOURCE_TYPE_UNSPECIFIED: SourceType = SourceType::new("SOURCE_TYPE_UNSPECIFIED");
-
-        /// Logs produced by ESXI hosts
-        pub const ESXI: SourceType = SourceType::new("ESXI");
-
-        /// Logs produced by vCenter server
-        pub const VCSA: SourceType = SourceType::new("VCSA");
-    }
-
-    impl std::convert::From<std::string::String> for SourceType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SourceType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SourceType {
         fn default() -> Self {
-            source_type::SOURCE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8641,83 +8833,111 @@ pub mod node_type {
 
     /// Enum Kind defines possible types of a NodeType.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Kind(std::borrow::Cow<'static, str>);
+    pub struct Kind(i32);
 
     impl Kind {
+        /// The default value. This value should never be used.
+        pub const KIND_UNSPECIFIED: Kind = Kind::new(0);
+
+        /// Standard HCI node.
+        pub const STANDARD: Kind = Kind::new(1);
+
+        /// Storage only Node.
+        pub const STORAGE_ONLY: Kind = Kind::new(2);
+
         /// Creates a new Kind instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("KIND_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STANDARD"),
+                2 => std::borrow::Cow::Borrowed("STORAGE_ONLY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "KIND_UNSPECIFIED" => std::option::Option::Some(Self::KIND_UNSPECIFIED),
+                "STANDARD" => std::option::Option::Some(Self::STANDARD),
+                "STORAGE_ONLY" => std::option::Option::Some(Self::STORAGE_ONLY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Kind](Kind)
-    pub mod kind {
-        use super::Kind;
-
-        /// The default value. This value should never be used.
-        pub const KIND_UNSPECIFIED: Kind = Kind::new("KIND_UNSPECIFIED");
-
-        /// Standard HCI node.
-        pub const STANDARD: Kind = Kind::new("STANDARD");
-
-        /// Storage only Node.
-        pub const STORAGE_ONLY: Kind = Kind::new("STORAGE_ONLY");
-    }
-
-    impl std::convert::From<std::string::String> for Kind {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Kind {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Kind {
         fn default() -> Self {
-            kind::KIND_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Capability of a node type.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Capability(std::borrow::Cow<'static, str>);
+    pub struct Capability(i32);
 
     impl Capability {
+        /// The default value. This value is used if the capability is omitted or
+        /// unknown.
+        pub const CAPABILITY_UNSPECIFIED: Capability = Capability::new(0);
+
+        /// This node type supports stretch clusters.
+        pub const STRETCHED_CLUSTERS: Capability = Capability::new(1);
+
         /// Creates a new Capability instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CAPABILITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STRETCHED_CLUSTERS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CAPABILITY_UNSPECIFIED" => std::option::Option::Some(Self::CAPABILITY_UNSPECIFIED),
+                "STRETCHED_CLUSTERS" => std::option::Option::Some(Self::STRETCHED_CLUSTERS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Capability](Capability)
-    pub mod capability {
-        use super::Capability;
-
-        /// The default value. This value is used if the capability is omitted or
-        /// unknown.
-        pub const CAPABILITY_UNSPECIFIED: Capability = Capability::new("CAPABILITY_UNSPECIFIED");
-
-        /// This node type supports stretch clusters.
-        pub const STRETCHED_CLUSTERS: Capability = Capability::new("STRETCHED_CLUSTERS");
-    }
-
-    impl std::convert::From<std::string::String> for Capability {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Capability {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Capability {
         fn default() -> Self {
-            capability::CAPABILITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8856,46 +9076,63 @@ pub mod hcx_activation_key {
 
     /// State of HCX activation key
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// State of a newly generated activation key.
+        pub const AVAILABLE: State = State::new(1);
+
+        /// State of key when it has been used to activate HCX appliance.
+        pub const CONSUMED: State = State::new(2);
+
+        /// State of key when it is being created.
+        pub const CREATING: State = State::new(3);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AVAILABLE"),
+                2 => std::borrow::Cow::Borrowed("CONSUMED"),
+                3 => std::borrow::Cow::Borrowed("CREATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
+                "CONSUMED" => std::option::Option::Some(Self::CONSUMED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// State of a newly generated activation key.
-        pub const AVAILABLE: State = State::new("AVAILABLE");
-
-        /// State of key when it has been used to activate HCX appliance.
-        pub const CONSUMED: State = State::new("CONSUMED");
-
-        /// State of key when it is being created.
-        pub const CREATING: State = State::new("CREATING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8965,46 +9202,63 @@ pub mod hcx {
 
     /// State of the appliance
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified appliance state. This is the default value.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The appliance is operational and can be used.
+        pub const ACTIVE: State = State::new(1);
+
+        /// The appliance is being deployed.
+        pub const CREATING: State = State::new(2);
+
+        /// The appliance is being activated.
+        pub const ACTIVATING: State = State::new(3);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("CREATING"),
+                3 => std::borrow::Cow::Borrowed("ACTIVATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVATING" => std::option::Option::Some(Self::ACTIVATING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified appliance state. This is the default value.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The appliance is operational and can be used.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The appliance is being deployed.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The appliance is being activated.
-        pub const ACTIVATING: State = State::new("ACTIVATING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -9074,43 +9328,58 @@ pub mod nsx {
 
     /// State of the appliance
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified appliance state. This is the default value.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The appliance is operational and can be used.
+        pub const ACTIVE: State = State::new(1);
+
+        /// The appliance is being deployed.
+        pub const CREATING: State = State::new(2);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("CREATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified appliance state. This is the default value.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The appliance is operational and can be used.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The appliance is being deployed.
-        pub const CREATING: State = State::new("CREATING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -9180,43 +9449,58 @@ pub mod vcenter {
 
     /// State of the appliance
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified appliance state. This is the default value.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The appliance is operational and can be used.
+        pub const ACTIVE: State = State::new(1);
+
+        /// The appliance is being deployed.
+        pub const CREATING: State = State::new(2);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("CREATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified appliance state. This is the default value.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The appliance is operational and can be used.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The appliance is being deployed.
-        pub const CREATING: State = State::new("CREATING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -9845,117 +10129,161 @@ pub mod network_peering {
 
     /// Possible states of a network peering.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Unspecified network peering state. This is the default value.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The peering is not active.
+        pub const INACTIVE: State = State::new(1);
+
+        /// The peering is active.
+        pub const ACTIVE: State = State::new(2);
+
+        /// The peering is being created.
+        pub const CREATING: State = State::new(3);
+
+        /// The peering is being deleted.
+        pub const DELETING: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INACTIVE"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("CREATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Unspecified network peering state. This is the default value.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The peering is not active.
-        pub const INACTIVE: State = State::new("INACTIVE");
-
-        /// The peering is active.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The peering is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The peering is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Type or purpose of the network peering connection.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PeerNetworkType(std::borrow::Cow<'static, str>);
+    pub struct PeerNetworkType(i32);
 
     impl PeerNetworkType {
-        /// Creates a new PeerNetworkType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PeerNetworkType](PeerNetworkType)
-    pub mod peer_network_type {
-        use super::PeerNetworkType;
-
         /// Unspecified
-        pub const PEER_NETWORK_TYPE_UNSPECIFIED: PeerNetworkType =
-            PeerNetworkType::new("PEER_NETWORK_TYPE_UNSPECIFIED");
+        pub const PEER_NETWORK_TYPE_UNSPECIFIED: PeerNetworkType = PeerNetworkType::new(0);
 
         /// Peering connection used for connecting to another VPC network established
         /// by the same user. For example, a peering connection to another VPC
         /// network in the same project or to an on-premises network.
-        pub const STANDARD: PeerNetworkType = PeerNetworkType::new("STANDARD");
+        pub const STANDARD: PeerNetworkType = PeerNetworkType::new(1);
 
         /// Peering connection used for connecting to another VMware Engine network.
-        pub const VMWARE_ENGINE_NETWORK: PeerNetworkType =
-            PeerNetworkType::new("VMWARE_ENGINE_NETWORK");
+        pub const VMWARE_ENGINE_NETWORK: PeerNetworkType = PeerNetworkType::new(2);
 
         /// Peering connection used for establishing [private services
         /// access](https://cloud.google.com/vpc/docs/private-services-access).
-        pub const PRIVATE_SERVICES_ACCESS: PeerNetworkType =
-            PeerNetworkType::new("PRIVATE_SERVICES_ACCESS");
+        pub const PRIVATE_SERVICES_ACCESS: PeerNetworkType = PeerNetworkType::new(3);
 
         /// Peering connection used for connecting to NetApp Cloud Volumes.
-        pub const NETAPP_CLOUD_VOLUMES: PeerNetworkType =
-            PeerNetworkType::new("NETAPP_CLOUD_VOLUMES");
+        pub const NETAPP_CLOUD_VOLUMES: PeerNetworkType = PeerNetworkType::new(4);
 
         /// Peering connection used for connecting to third-party services. Most
         /// third-party services require manual setup of reverse peering on the VPC
         /// network associated with the third-party service.
-        pub const THIRD_PARTY_SERVICE: PeerNetworkType =
-            PeerNetworkType::new("THIRD_PARTY_SERVICE");
+        pub const THIRD_PARTY_SERVICE: PeerNetworkType = PeerNetworkType::new(5);
 
         /// Peering connection used for connecting to Dell PowerScale Filers
-        pub const DELL_POWERSCALE: PeerNetworkType = PeerNetworkType::new("DELL_POWERSCALE");
+        pub const DELL_POWERSCALE: PeerNetworkType = PeerNetworkType::new(6);
 
         /// Peering connection used for connecting to Google Cloud NetApp Volumes.
-        pub const GOOGLE_CLOUD_NETAPP_VOLUMES: PeerNetworkType =
-            PeerNetworkType::new("GOOGLE_CLOUD_NETAPP_VOLUMES");
+        pub const GOOGLE_CLOUD_NETAPP_VOLUMES: PeerNetworkType = PeerNetworkType::new(7);
+
+        /// Creates a new PeerNetworkType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PEER_NETWORK_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STANDARD"),
+                2 => std::borrow::Cow::Borrowed("VMWARE_ENGINE_NETWORK"),
+                3 => std::borrow::Cow::Borrowed("PRIVATE_SERVICES_ACCESS"),
+                4 => std::borrow::Cow::Borrowed("NETAPP_CLOUD_VOLUMES"),
+                5 => std::borrow::Cow::Borrowed("THIRD_PARTY_SERVICE"),
+                6 => std::borrow::Cow::Borrowed("DELL_POWERSCALE"),
+                7 => std::borrow::Cow::Borrowed("GOOGLE_CLOUD_NETAPP_VOLUMES"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PEER_NETWORK_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PEER_NETWORK_TYPE_UNSPECIFIED)
+                }
+                "STANDARD" => std::option::Option::Some(Self::STANDARD),
+                "VMWARE_ENGINE_NETWORK" => std::option::Option::Some(Self::VMWARE_ENGINE_NETWORK),
+                "PRIVATE_SERVICES_ACCESS" => {
+                    std::option::Option::Some(Self::PRIVATE_SERVICES_ACCESS)
+                }
+                "NETAPP_CLOUD_VOLUMES" => std::option::Option::Some(Self::NETAPP_CLOUD_VOLUMES),
+                "THIRD_PARTY_SERVICE" => std::option::Option::Some(Self::THIRD_PARTY_SERVICE),
+                "DELL_POWERSCALE" => std::option::Option::Some(Self::DELL_POWERSCALE),
+                "GOOGLE_CLOUD_NETAPP_VOLUMES" => {
+                    std::option::Option::Some(Self::GOOGLE_CLOUD_NETAPP_VOLUMES)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PeerNetworkType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PeerNetworkType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PeerNetworkType {
         fn default() -> Self {
-            peer_network_type::PEER_NETWORK_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -10060,89 +10388,121 @@ pub mod peering_route {
 
     /// The type of the peering route.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// Unspecified peering route type. This is the default value.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// Dynamic routes in the peer network.
-        pub const DYNAMIC_PEERING_ROUTE: Type = Type::new("DYNAMIC_PEERING_ROUTE");
+        pub const DYNAMIC_PEERING_ROUTE: Type = Type::new(1);
 
         /// Static routes in the peer network.
-        pub const STATIC_PEERING_ROUTE: Type = Type::new("STATIC_PEERING_ROUTE");
+        pub const STATIC_PEERING_ROUTE: Type = Type::new(2);
 
         /// Created, updated, and removed automatically by Google Cloud when subnets
         /// are created, modified, or deleted in the peer network.
-        pub const SUBNET_PEERING_ROUTE: Type = Type::new("SUBNET_PEERING_ROUTE");
+        pub const SUBNET_PEERING_ROUTE: Type = Type::new(3);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DYNAMIC_PEERING_ROUTE"),
+                2 => std::borrow::Cow::Borrowed("STATIC_PEERING_ROUTE"),
+                3 => std::borrow::Cow::Borrowed("SUBNET_PEERING_ROUTE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "DYNAMIC_PEERING_ROUTE" => std::option::Option::Some(Self::DYNAMIC_PEERING_ROUTE),
+                "STATIC_PEERING_ROUTE" => std::option::Option::Some(Self::STATIC_PEERING_ROUTE),
+                "SUBNET_PEERING_ROUTE" => std::option::Option::Some(Self::SUBNET_PEERING_ROUTE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The direction of the exchanged routes.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Direction(std::borrow::Cow<'static, str>);
+    pub struct Direction(i32);
 
     impl Direction {
+        /// Unspecified exchanged routes direction. This is default.
+        pub const DIRECTION_UNSPECIFIED: Direction = Direction::new(0);
+
+        /// Routes imported from the peer network.
+        pub const INCOMING: Direction = Direction::new(1);
+
+        /// Routes exported to the peer network.
+        pub const OUTGOING: Direction = Direction::new(2);
+
         /// Creates a new Direction instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DIRECTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INCOMING"),
+                2 => std::borrow::Cow::Borrowed("OUTGOING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DIRECTION_UNSPECIFIED" => std::option::Option::Some(Self::DIRECTION_UNSPECIFIED),
+                "INCOMING" => std::option::Option::Some(Self::INCOMING),
+                "OUTGOING" => std::option::Option::Some(Self::OUTGOING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Direction](Direction)
-    pub mod direction {
-        use super::Direction;
-
-        /// Unspecified exchanged routes direction. This is default.
-        pub const DIRECTION_UNSPECIFIED: Direction = Direction::new("DIRECTION_UNSPECIFIED");
-
-        /// Routes imported from the peer network.
-        pub const INCOMING: Direction = Direction::new("INCOMING");
-
-        /// Routes exported to the peer network.
-        pub const OUTGOING: Direction = Direction::new("OUTGOING");
-    }
-
-    impl std::convert::From<std::string::String> for Direction {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Direction {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Direction {
         fn default() -> Self {
-            direction::DIRECTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -10369,46 +10729,63 @@ pub mod network_policy {
         /// Enum State defines possible states of a network policy controlled
         /// service.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(std::borrow::Cow<'static, str>);
+        pub struct State(i32);
 
         impl State {
+            /// Unspecified service state. This is the default value.
+            pub const STATE_UNSPECIFIED: State = State::new(0);
+
+            /// Service is not provisioned.
+            pub const UNPROVISIONED: State = State::new(1);
+
+            /// Service is in the process of being provisioned/deprovisioned.
+            pub const RECONCILING: State = State::new(2);
+
+            /// Service is active.
+            pub const ACTIVE: State = State::new(3);
+
             /// Creates a new State instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("UNPROVISIONED"),
+                    2 => std::borrow::Cow::Borrowed("RECONCILING"),
+                    3 => std::borrow::Cow::Borrowed("ACTIVE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                    "UNPROVISIONED" => std::option::Option::Some(Self::UNPROVISIONED),
+                    "RECONCILING" => std::option::Option::Some(Self::RECONCILING),
+                    "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [State](State)
-        pub mod state {
-            use super::State;
-
-            /// Unspecified service state. This is the default value.
-            pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-            /// Service is not provisioned.
-            pub const UNPROVISIONED: State = State::new("UNPROVISIONED");
-
-            /// Service is in the process of being provisioned/deprovisioned.
-            pub const RECONCILING: State = State::new("RECONCILING");
-
-            /// Service is active.
-            pub const ACTIVE: State = State::new("ACTIVE");
-        }
-
-        impl std::convert::From<std::string::String> for State {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                state::STATE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -10589,52 +10966,73 @@ pub mod management_dns_zone_binding {
     /// Enum State defines possible states of binding between the consumer VPC
     /// network and the management DNS zone.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The default value. This value should never be used.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The binding is ready.
+        pub const ACTIVE: State = State::new(1);
+
+        /// The binding is being created.
+        pub const CREATING: State = State::new(2);
+
+        /// The binding is being updated.
+        pub const UPDATING: State = State::new(3);
+
+        /// The binding is being deleted.
+        pub const DELETING: State = State::new(4);
+
+        /// The binding has failed.
+        pub const FAILED: State = State::new(5);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("CREATING"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The default value. This value should never be used.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The binding is ready.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The binding is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The binding is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// The binding is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// The binding has failed.
-        pub const FAILED: State = State::new("FAILED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -10854,143 +11252,194 @@ pub mod vmware_engine_network {
         /// Enum Type defines possible types of a VMware Engine network controlled
         /// service.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(std::borrow::Cow<'static, str>);
+        pub struct Type(i32);
 
         impl Type {
-            /// Creates a new Type instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [Type](Type)
-        pub mod r#type {
-            use super::Type;
-
             /// The default value. This value should never be used.
-            pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
             /// VPC network that will be peered with a consumer VPC network or the
             /// intranet VPC of another VMware Engine network. Access a private cloud
             /// through Compute Engine VMs on a peered VPC network or an on-premises
             /// resource connected to a peered consumer VPC network.
-            pub const INTRANET: Type = Type::new("INTRANET");
+            pub const INTRANET: Type = Type::new(1);
 
             /// VPC network used for internet access to and from a private cloud.
-            pub const INTERNET: Type = Type::new("INTERNET");
+            pub const INTERNET: Type = Type::new(2);
 
             /// VPC network used for access to Google Cloud services like
             /// Cloud Storage.
-            pub const GOOGLE_CLOUD: Type = Type::new("GOOGLE_CLOUD");
+            pub const GOOGLE_CLOUD: Type = Type::new(3);
+
+            /// Creates a new Type instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("INTRANET"),
+                    2 => std::borrow::Cow::Borrowed("INTERNET"),
+                    3 => std::borrow::Cow::Borrowed("GOOGLE_CLOUD"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                    "INTRANET" => std::option::Option::Some(Self::INTRANET),
+                    "INTERNET" => std::option::Option::Some(Self::INTERNET),
+                    "GOOGLE_CLOUD" => std::option::Option::Some(Self::GOOGLE_CLOUD),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for Type {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                r#type::TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// Enum State defines possible states of VMware Engine network.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The default value. This value is used if the state is omitted.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The VMware Engine network is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// The VMware Engine network is ready.
+        pub const ACTIVE: State = State::new(2);
+
+        /// The VMware Engine network is being updated.
+        pub const UPDATING: State = State::new(3);
+
+        /// The VMware Engine network is being deleted.
+        pub const DELETING: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The VMware Engine network is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// The VMware Engine network is ready.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The VMware Engine network is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-
-        /// The VMware Engine network is being deleted.
-        pub const DELETING: State = State::new("DELETING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Enum Type defines possible types of VMware Engine network.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// The default value. This value should never be used.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// Network type used by private clouds created in projects without a network
         /// of type `STANDARD`. This network type is no longer used for new VMware
         /// Engine private cloud deployments.
-        pub const LEGACY: Type = Type::new("LEGACY");
+        pub const LEGACY: Type = Type::new(1);
 
         /// Standard network type used for private cloud connectivity.
-        pub const STANDARD: Type = Type::new("STANDARD");
+        pub const STANDARD: Type = Type::new(2);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LEGACY"),
+                2 => std::borrow::Cow::Borrowed("STANDARD"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "LEGACY" => std::option::Option::Some(Self::LEGACY),
+                "STANDARD" => std::option::Option::Some(Self::STANDARD),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -11204,193 +11653,267 @@ pub mod private_connection {
 
     /// Enum State defines possible states of private connection.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The private connection is being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The private connection is ready.
-        pub const ACTIVE: State = State::new("ACTIVE");
+        pub const ACTIVE: State = State::new(2);
 
         /// The private connection is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
+        pub const UPDATING: State = State::new(3);
 
         /// The private connection is being deleted.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(4);
 
         /// The private connection is not provisioned, since no private cloud is
         /// present for which this private connection is needed.
-        pub const UNPROVISIONED: State = State::new("UNPROVISIONED");
+        pub const UNPROVISIONED: State = State::new(5);
 
         /// The private connection is in failed state.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(6);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                3 => std::borrow::Cow::Borrowed("UPDATING"),
+                4 => std::borrow::Cow::Borrowed("DELETING"),
+                5 => std::borrow::Cow::Borrowed("UNPROVISIONED"),
+                6 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "UNPROVISIONED" => std::option::Option::Some(Self::UNPROVISIONED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Enum Type defines possible types of private connection.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// The default value. This value should never be used.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// Connection used for establishing [private services
         /// access](https://cloud.google.com/vpc/docs/private-services-access).
-        pub const PRIVATE_SERVICE_ACCESS: Type = Type::new("PRIVATE_SERVICE_ACCESS");
+        pub const PRIVATE_SERVICE_ACCESS: Type = Type::new(1);
 
         /// Connection used for connecting to NetApp Cloud Volumes.
-        pub const NETAPP_CLOUD_VOLUMES: Type = Type::new("NETAPP_CLOUD_VOLUMES");
+        pub const NETAPP_CLOUD_VOLUMES: Type = Type::new(2);
 
         /// Connection used for connecting to Dell PowerScale.
-        pub const DELL_POWERSCALE: Type = Type::new("DELL_POWERSCALE");
+        pub const DELL_POWERSCALE: Type = Type::new(3);
 
         /// Connection used for connecting to third-party services.
-        pub const THIRD_PARTY_SERVICE: Type = Type::new("THIRD_PARTY_SERVICE");
+        pub const THIRD_PARTY_SERVICE: Type = Type::new(4);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PRIVATE_SERVICE_ACCESS"),
+                2 => std::borrow::Cow::Borrowed("NETAPP_CLOUD_VOLUMES"),
+                3 => std::borrow::Cow::Borrowed("DELL_POWERSCALE"),
+                4 => std::borrow::Cow::Borrowed("THIRD_PARTY_SERVICE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "PRIVATE_SERVICE_ACCESS" => std::option::Option::Some(Self::PRIVATE_SERVICE_ACCESS),
+                "NETAPP_CLOUD_VOLUMES" => std::option::Option::Some(Self::NETAPP_CLOUD_VOLUMES),
+                "DELL_POWERSCALE" => std::option::Option::Some(Self::DELL_POWERSCALE),
+                "THIRD_PARTY_SERVICE" => std::option::Option::Some(Self::THIRD_PARTY_SERVICE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Possible types for RoutingMode
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RoutingMode(std::borrow::Cow<'static, str>);
+    pub struct RoutingMode(i32);
 
     impl RoutingMode {
+        /// The default value. This value should never be used.
+        pub const ROUTING_MODE_UNSPECIFIED: RoutingMode = RoutingMode::new(0);
+
+        /// Global Routing Mode
+        pub const GLOBAL: RoutingMode = RoutingMode::new(1);
+
+        /// Regional Routing Mode
+        pub const REGIONAL: RoutingMode = RoutingMode::new(2);
+
         /// Creates a new RoutingMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ROUTING_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GLOBAL"),
+                2 => std::borrow::Cow::Borrowed("REGIONAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ROUTING_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ROUTING_MODE_UNSPECIFIED)
+                }
+                "GLOBAL" => std::option::Option::Some(Self::GLOBAL),
+                "REGIONAL" => std::option::Option::Some(Self::REGIONAL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RoutingMode](RoutingMode)
-    pub mod routing_mode {
-        use super::RoutingMode;
-
-        /// The default value. This value should never be used.
-        pub const ROUTING_MODE_UNSPECIFIED: RoutingMode =
-            RoutingMode::new("ROUTING_MODE_UNSPECIFIED");
-
-        /// Global Routing Mode
-        pub const GLOBAL: RoutingMode = RoutingMode::new("GLOBAL");
-
-        /// Regional Routing Mode
-        pub const REGIONAL: RoutingMode = RoutingMode::new("REGIONAL");
-    }
-
-    impl std::convert::From<std::string::String> for RoutingMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RoutingMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RoutingMode {
         fn default() -> Self {
-            routing_mode::ROUTING_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Enum PeeringState defines the possible states of peering between service
     /// network and the vpc network peered to service network
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PeeringState(std::borrow::Cow<'static, str>);
+    pub struct PeeringState(i32);
 
     impl PeeringState {
+        /// The default value. This value is used if the peering state is omitted or
+        /// unknown.
+        pub const PEERING_STATE_UNSPECIFIED: PeeringState = PeeringState::new(0);
+
+        /// The peering is in active state.
+        pub const PEERING_ACTIVE: PeeringState = PeeringState::new(1);
+
+        /// The peering is in inactive state.
+        pub const PEERING_INACTIVE: PeeringState = PeeringState::new(2);
+
         /// Creates a new PeeringState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PEERING_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PEERING_ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("PEERING_INACTIVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PEERING_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PEERING_STATE_UNSPECIFIED)
+                }
+                "PEERING_ACTIVE" => std::option::Option::Some(Self::PEERING_ACTIVE),
+                "PEERING_INACTIVE" => std::option::Option::Some(Self::PEERING_INACTIVE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [PeeringState](PeeringState)
-    pub mod peering_state {
-        use super::PeeringState;
-
-        /// The default value. This value is used if the peering state is omitted or
-        /// unknown.
-        pub const PEERING_STATE_UNSPECIFIED: PeeringState =
-            PeeringState::new("PEERING_STATE_UNSPECIFIED");
-
-        /// The peering is in active state.
-        pub const PEERING_ACTIVE: PeeringState = PeeringState::new("PEERING_ACTIVE");
-
-        /// The peering is in inactive state.
-        pub const PEERING_INACTIVE: PeeringState = PeeringState::new("PEERING_INACTIVE");
-    }
-
-    impl std::convert::From<std::string::String> for PeeringState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PeeringState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PeeringState {
         fn default() -> Self {
-            peering_state::PEERING_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -11440,41 +11963,54 @@ pub mod location_metadata {
 
     /// Capability of a location.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Capability(std::borrow::Cow<'static, str>);
+    pub struct Capability(i32);
 
     impl Capability {
+        /// The default value. This value is used if the capability is omitted or
+        /// unknown.
+        pub const CAPABILITY_UNSPECIFIED: Capability = Capability::new(0);
+
+        /// Stretch clusters are supported in this location.
+        pub const STRETCHED_CLUSTERS: Capability = Capability::new(1);
+
         /// Creates a new Capability instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CAPABILITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STRETCHED_CLUSTERS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CAPABILITY_UNSPECIFIED" => std::option::Option::Some(Self::CAPABILITY_UNSPECIFIED),
+                "STRETCHED_CLUSTERS" => std::option::Option::Some(Self::STRETCHED_CLUSTERS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Capability](Capability)
-    pub mod capability {
-        use super::Capability;
-
-        /// The default value. This value is used if the capability is omitted or
-        /// unknown.
-        pub const CAPABILITY_UNSPECIFIED: Capability = Capability::new("CAPABILITY_UNSPECIFIED");
-
-        /// Stretch clusters are supported in this location.
-        pub const STRETCHED_CLUSTERS: Capability = Capability::new("STRETCHED_CLUSTERS");
-    }
-
-    impl std::convert::From<std::string::String> for Capability {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Capability {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Capability {
         fn default() -> Self {
-            capability::CAPABILITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/vmwareengine/v1/src/transport.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::GET,
                 format!("/v1/{}/privateClouds", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::POST,
                 format!("/v1/{}/privateClouds", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -128,7 +128,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -158,7 +158,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -183,7 +183,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:undelete", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -200,7 +200,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/clusters", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -223,7 +223,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -245,7 +245,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::POST,
                 format!("/v1/{}/clusters", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -276,7 +276,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -307,7 +307,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -327,7 +327,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/nodes", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -348,7 +348,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -370,7 +370,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::GET,
                 format!("/v1/{}/externalAddresses", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -396,7 +396,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::GET,
                 format!("/v1/{}:fetchExternalAddresses", req.network_policy),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -417,7 +417,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -439,7 +439,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::POST,
                 format!("/v1/{}/externalAddresses", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -469,7 +469,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -499,7 +499,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -519,7 +519,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/subnets", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -540,7 +540,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -568,7 +568,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -598,7 +598,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::GET,
                 format!("/v1/{}/externalAccessRules", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -621,7 +621,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -643,7 +643,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::POST,
                 format!("/v1/{}/externalAccessRules", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -673,7 +673,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -703,7 +703,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -726,7 +726,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::GET,
                 format!("/v1/{}/loggingServers", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -749,7 +749,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -771,7 +771,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::POST,
                 format!("/v1/{}/loggingServers", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -801,7 +801,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -831,7 +831,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -854,7 +854,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::GET,
                 format!("/v1/{}/nodeTypes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -876,7 +876,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -898,7 +898,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::GET,
                 format!("/v1/{}:showNsxCredentials", req.private_cloud),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -920,7 +920,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::GET,
                 format!("/v1/{}:showVcenterCredentials", req.private_cloud),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -943,7 +943,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::POST,
                 format!("/v1/{}:resetNsxCredentials", req.private_cloud),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -963,7 +963,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::POST,
                 format!("/v1/{}:resetVcenterCredentials", req.private_cloud),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -980,7 +980,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1008,7 +1008,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1038,7 +1038,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1060,7 +1060,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::GET,
                 format!("/v1/{}/networkPeerings", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1086,7 +1086,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::POST,
                 format!("/v1/{}/networkPeerings", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1107,7 +1107,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1136,7 +1136,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1169,7 +1169,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::GET,
                 format!("/v1/{}/peeringRoutes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1194,7 +1194,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::POST,
                 format!("/v1/{}/hcxActivationKeys", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1218,7 +1218,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::GET,
                 format!("/v1/{}/hcxActivationKeys", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1239,7 +1239,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1258,7 +1258,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1280,7 +1280,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::GET,
                 format!("/v1/{}/networkPolicies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1306,7 +1306,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::POST,
                 format!("/v1/{}/networkPolicies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1336,7 +1336,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1366,7 +1366,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1389,7 +1389,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::GET,
                 format!("/v1/{}/managementDnsZoneBindings", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1412,7 +1412,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1434,7 +1434,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::POST,
                 format!("/v1/{}/managementDnsZoneBindings", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1467,7 +1467,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1497,7 +1497,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1517,7 +1517,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:repair", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1537,7 +1537,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::POST,
                 format!("/v1/{}/vmwareEngineNetworks", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1567,7 +1567,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1597,7 +1597,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1618,7 +1618,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1640,7 +1640,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::GET,
                 format!("/v1/{}/vmwareEngineNetworks", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1666,7 +1666,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::POST,
                 format!("/v1/{}/privateConnections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1687,7 +1687,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1709,7 +1709,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::GET,
                 format!("/v1/{}/privateConnections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1741,7 +1741,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1771,7 +1771,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1794,7 +1794,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::GET,
                 format!("/v1/{}/peeringRoutes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1815,7 +1815,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:grant", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1832,7 +1832,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1851,7 +1851,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:revoke", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1868,7 +1868,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1890,7 +1890,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1912,7 +1912,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1932,7 +1932,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1964,7 +1964,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1981,7 +1981,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2003,7 +2003,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -2022,7 +2022,7 @@ impl crate::stubs::VmwareEngine for VmwareEngine {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/vpcaccess/v1/src/model.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/model.rs
@@ -221,52 +221,73 @@ pub mod connector {
 
     /// State of a connector.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Invalid state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Connector is deployed and ready to receive traffic.
+        pub const READY: State = State::new(1);
+
+        /// An Insert operation is in progress. Transient condition.
+        pub const CREATING: State = State::new(2);
+
+        /// A Delete operation is in progress. Transient condition.
+        pub const DELETING: State = State::new(3);
+
+        /// Connector is in a bad state, manual deletion recommended.
+        pub const ERROR: State = State::new(4);
+
+        /// The connector is being updated.
+        pub const UPDATING: State = State::new(5);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("READY"),
+                2 => std::borrow::Cow::Borrowed("CREATING"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("ERROR"),
+                5 => std::borrow::Cow::Borrowed("UPDATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "READY" => std::option::Option::Some(Self::READY),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Invalid state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Connector is deployed and ready to receive traffic.
-        pub const READY: State = State::new("READY");
-
-        /// An Insert operation is in progress. Transient condition.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// A Delete operation is in progress. Transient condition.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// Connector is in a bad state, manual deletion recommended.
-        pub const ERROR: State = State::new("ERROR");
-
-        /// The connector is being updated.
-        pub const UPDATING: State = State::new("UPDATING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/vpcaccess/v1/src/transport.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::VpcAccessService for VpcAccessService {
                 reqwest::Method::POST,
                 format!("/v1/{}/connectors", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::VpcAccessService for VpcAccessService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -94,7 +94,7 @@ impl crate::stubs::VpcAccessService for VpcAccessService {
                 reqwest::Method::GET,
                 format!("/v1/{}/connectors", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -115,7 +115,7 @@ impl crate::stubs::VpcAccessService for VpcAccessService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -134,7 +134,7 @@ impl crate::stubs::VpcAccessService for VpcAccessService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -156,7 +156,7 @@ impl crate::stubs::VpcAccessService for VpcAccessService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -178,7 +178,7 @@ impl crate::stubs::VpcAccessService for VpcAccessService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/webrisk/v1/src/model.rs
+++ b/src/generated/cloud/webrisk/v1/src/model.rs
@@ -310,46 +310,62 @@ pub mod compute_threat_list_diff_response {
 
     /// The type of response sent to the client.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ResponseType(std::borrow::Cow<'static, str>);
+    pub struct ResponseType(i32);
 
     impl ResponseType {
-        /// Creates a new ResponseType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ResponseType](ResponseType)
-    pub mod response_type {
-        use super::ResponseType;
-
         /// Unknown.
-        pub const RESPONSE_TYPE_UNSPECIFIED: ResponseType =
-            ResponseType::new("RESPONSE_TYPE_UNSPECIFIED");
+        pub const RESPONSE_TYPE_UNSPECIFIED: ResponseType = ResponseType::new(0);
 
         /// Partial updates are applied to the client's existing local database.
-        pub const DIFF: ResponseType = ResponseType::new("DIFF");
+        pub const DIFF: ResponseType = ResponseType::new(1);
 
         /// Full updates resets the client's entire local database. This means
         /// that either the client had no state, was seriously out-of-date,
         /// or the client is believed to be corrupt.
-        pub const RESET: ResponseType = ResponseType::new("RESET");
+        pub const RESET: ResponseType = ResponseType::new(2);
+
+        /// Creates a new ResponseType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RESPONSE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DIFF"),
+                2 => std::borrow::Cow::Borrowed("RESET"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RESPONSE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RESPONSE_TYPE_UNSPECIFIED)
+                }
+                "DIFF" => std::option::Option::Some(Self::DIFF),
+                "RESET" => std::option::Option::Some(Self::RESET),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ResponseType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ResponseType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ResponseType {
         fn default() -> Self {
-            response_type::RESPONSE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1113,47 +1129,65 @@ pub mod threat_info {
 
         /// Enum representation of confidence.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ConfidenceLevel(std::borrow::Cow<'static, str>);
+        pub struct ConfidenceLevel(i32);
 
         impl ConfidenceLevel {
+            /// Default.
+            pub const CONFIDENCE_LEVEL_UNSPECIFIED: ConfidenceLevel = ConfidenceLevel::new(0);
+
+            /// Less than 60% confidence that the URI is unsafe.
+            pub const LOW: ConfidenceLevel = ConfidenceLevel::new(1);
+
+            /// Between 60% and 80% confidence that the URI is unsafe.
+            pub const MEDIUM: ConfidenceLevel = ConfidenceLevel::new(2);
+
+            /// Greater than 80% confidence that the URI is unsafe.
+            pub const HIGH: ConfidenceLevel = ConfidenceLevel::new(3);
+
             /// Creates a new ConfidenceLevel instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("CONFIDENCE_LEVEL_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("LOW"),
+                    2 => std::borrow::Cow::Borrowed("MEDIUM"),
+                    3 => std::borrow::Cow::Borrowed("HIGH"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "CONFIDENCE_LEVEL_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::CONFIDENCE_LEVEL_UNSPECIFIED)
+                    }
+                    "LOW" => std::option::Option::Some(Self::LOW),
+                    "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
+                    "HIGH" => std::option::Option::Some(Self::HIGH),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [ConfidenceLevel](ConfidenceLevel)
-        pub mod confidence_level {
-            use super::ConfidenceLevel;
-
-            /// Default.
-            pub const CONFIDENCE_LEVEL_UNSPECIFIED: ConfidenceLevel =
-                ConfidenceLevel::new("CONFIDENCE_LEVEL_UNSPECIFIED");
-
-            /// Less than 60% confidence that the URI is unsafe.
-            pub const LOW: ConfidenceLevel = ConfidenceLevel::new("LOW");
-
-            /// Between 60% and 80% confidence that the URI is unsafe.
-            pub const MEDIUM: ConfidenceLevel = ConfidenceLevel::new("MEDIUM");
-
-            /// Greater than 80% confidence that the URI is unsafe.
-            pub const HIGH: ConfidenceLevel = ConfidenceLevel::new("HIGH");
-        }
-
-        impl std::convert::From<std::string::String> for ConfidenceLevel {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for ConfidenceLevel {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for ConfidenceLevel {
             fn default() -> Self {
-                confidence_level::CONFIDENCE_LEVEL_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -1229,95 +1263,129 @@ pub mod threat_info {
 
         /// Labels that explain how the URI was classified.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct JustificationLabel(std::borrow::Cow<'static, str>);
+        pub struct JustificationLabel(i32);
 
         impl JustificationLabel {
+            /// Default.
+            pub const JUSTIFICATION_LABEL_UNSPECIFIED: JustificationLabel =
+                JustificationLabel::new(0);
+
+            /// The submitter manually verified that the submission is unsafe.
+            pub const MANUAL_VERIFICATION: JustificationLabel = JustificationLabel::new(1);
+
+            /// The submitter received the submission from an end user.
+            pub const USER_REPORT: JustificationLabel = JustificationLabel::new(2);
+
+            /// The submitter received the submission from an automated system.
+            pub const AUTOMATED_REPORT: JustificationLabel = JustificationLabel::new(3);
+
             /// Creates a new JustificationLabel instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("JUSTIFICATION_LABEL_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("MANUAL_VERIFICATION"),
+                    2 => std::borrow::Cow::Borrowed("USER_REPORT"),
+                    3 => std::borrow::Cow::Borrowed("AUTOMATED_REPORT"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "JUSTIFICATION_LABEL_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::JUSTIFICATION_LABEL_UNSPECIFIED)
+                    }
+                    "MANUAL_VERIFICATION" => std::option::Option::Some(Self::MANUAL_VERIFICATION),
+                    "USER_REPORT" => std::option::Option::Some(Self::USER_REPORT),
+                    "AUTOMATED_REPORT" => std::option::Option::Some(Self::AUTOMATED_REPORT),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [JustificationLabel](JustificationLabel)
-        pub mod justification_label {
-            use super::JustificationLabel;
-
-            /// Default.
-            pub const JUSTIFICATION_LABEL_UNSPECIFIED: JustificationLabel =
-                JustificationLabel::new("JUSTIFICATION_LABEL_UNSPECIFIED");
-
-            /// The submitter manually verified that the submission is unsafe.
-            pub const MANUAL_VERIFICATION: JustificationLabel =
-                JustificationLabel::new("MANUAL_VERIFICATION");
-
-            /// The submitter received the submission from an end user.
-            pub const USER_REPORT: JustificationLabel = JustificationLabel::new("USER_REPORT");
-
-            /// The submitter received the submission from an automated system.
-            pub const AUTOMATED_REPORT: JustificationLabel =
-                JustificationLabel::new("AUTOMATED_REPORT");
-        }
-
-        impl std::convert::From<std::string::String> for JustificationLabel {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for JustificationLabel {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for JustificationLabel {
             fn default() -> Self {
-                justification_label::JUSTIFICATION_LABEL_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// The abuse type found on the URI.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AbuseType(std::borrow::Cow<'static, str>);
+    pub struct AbuseType(i32);
 
     impl AbuseType {
+        /// Default.
+        pub const ABUSE_TYPE_UNSPECIFIED: AbuseType = AbuseType::new(0);
+
+        /// The URI contains malware.
+        pub const MALWARE: AbuseType = AbuseType::new(1);
+
+        /// The URI contains social engineering.
+        pub const SOCIAL_ENGINEERING: AbuseType = AbuseType::new(2);
+
+        /// The URI contains unwanted software.
+        pub const UNWANTED_SOFTWARE: AbuseType = AbuseType::new(3);
+
         /// Creates a new AbuseType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ABUSE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MALWARE"),
+                2 => std::borrow::Cow::Borrowed("SOCIAL_ENGINEERING"),
+                3 => std::borrow::Cow::Borrowed("UNWANTED_SOFTWARE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ABUSE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::ABUSE_TYPE_UNSPECIFIED),
+                "MALWARE" => std::option::Option::Some(Self::MALWARE),
+                "SOCIAL_ENGINEERING" => std::option::Option::Some(Self::SOCIAL_ENGINEERING),
+                "UNWANTED_SOFTWARE" => std::option::Option::Some(Self::UNWANTED_SOFTWARE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AbuseType](AbuseType)
-    pub mod abuse_type {
-        use super::AbuseType;
-
-        /// Default.
-        pub const ABUSE_TYPE_UNSPECIFIED: AbuseType = AbuseType::new("ABUSE_TYPE_UNSPECIFIED");
-
-        /// The URI contains malware.
-        pub const MALWARE: AbuseType = AbuseType::new("MALWARE");
-
-        /// The URI contains social engineering.
-        pub const SOCIAL_ENGINEERING: AbuseType = AbuseType::new("SOCIAL_ENGINEERING");
-
-        /// The URI contains unwanted software.
-        pub const UNWANTED_SOFTWARE: AbuseType = AbuseType::new("UNWANTED_SOFTWARE");
-    }
-
-    impl std::convert::From<std::string::String> for AbuseType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AbuseType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AbuseType {
         fn default() -> Self {
-            abuse_type::ABUSE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1376,49 +1444,68 @@ pub mod threat_discovery {
 
     /// Platform types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Platform(std::borrow::Cow<'static, str>);
+    pub struct Platform(i32);
 
     impl Platform {
+        /// Default.
+        pub const PLATFORM_UNSPECIFIED: Platform = Platform::new(0);
+
+        /// General Android platform.
+        pub const ANDROID: Platform = Platform::new(1);
+
+        /// General iOS platform.
+        pub const IOS: Platform = Platform::new(2);
+
+        /// General macOS platform.
+        pub const MACOS: Platform = Platform::new(3);
+
+        /// General Windows platform.
+        pub const WINDOWS: Platform = Platform::new(4);
+
         /// Creates a new Platform instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PLATFORM_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ANDROID"),
+                2 => std::borrow::Cow::Borrowed("IOS"),
+                3 => std::borrow::Cow::Borrowed("MACOS"),
+                4 => std::borrow::Cow::Borrowed("WINDOWS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PLATFORM_UNSPECIFIED" => std::option::Option::Some(Self::PLATFORM_UNSPECIFIED),
+                "ANDROID" => std::option::Option::Some(Self::ANDROID),
+                "IOS" => std::option::Option::Some(Self::IOS),
+                "MACOS" => std::option::Option::Some(Self::MACOS),
+                "WINDOWS" => std::option::Option::Some(Self::WINDOWS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Platform](Platform)
-    pub mod platform {
-        use super::Platform;
-
-        /// Default.
-        pub const PLATFORM_UNSPECIFIED: Platform = Platform::new("PLATFORM_UNSPECIFIED");
-
-        /// General Android platform.
-        pub const ANDROID: Platform = Platform::new("ANDROID");
-
-        /// General iOS platform.
-        pub const IOS: Platform = Platform::new("IOS");
-
-        /// General macOS platform.
-        pub const MACOS: Platform = Platform::new("MACOS");
-
-        /// General Windows platform.
-        pub const WINDOWS: Platform = Platform::new("WINDOWS");
-    }
-
-    impl std::convert::From<std::string::String> for Platform {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Platform {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Platform {
         fn default() -> Self {
-            platform::PLATFORM_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1602,52 +1689,73 @@ pub mod submit_uri_metadata {
 
     /// Enum that represents the state of the long-running operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Default unspecified state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The operation is currently running.
+        pub const RUNNING: State = State::new(1);
+
+        /// The operation finished with a success status.
+        pub const SUCCEEDED: State = State::new(2);
+
+        /// The operation was cancelled.
+        pub const CANCELLED: State = State::new(3);
+
+        /// The operation finished with a failure status.
+        pub const FAILED: State = State::new(4);
+
+        /// The operation was closed with no action taken.
+        pub const CLOSED: State = State::new(5);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RUNNING"),
+                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                3 => std::borrow::Cow::Borrowed("CANCELLED"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                5 => std::borrow::Cow::Borrowed("CLOSED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "CLOSED" => std::option::Option::Some(Self::CLOSED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Default unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The operation is currently running.
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// The operation finished with a success status.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-        /// The operation was cancelled.
-        pub const CANCELLED: State = State::new("CANCELLED");
-
-        /// The operation finished with a failure status.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// The operation was closed with no action taken.
-        pub const CLOSED: State = State::new("CLOSED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1655,93 +1763,129 @@ pub mod submit_uri_metadata {
 /// The type of threat. This maps directly to the threat list a threat may
 /// belong to.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ThreatType(std::borrow::Cow<'static, str>);
+pub struct ThreatType(i32);
 
 impl ThreatType {
-    /// Creates a new ThreatType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ThreatType](ThreatType)
-pub mod threat_type {
-    use super::ThreatType;
-
     /// No entries should match this threat type. This threat type is unused.
-    pub const THREAT_TYPE_UNSPECIFIED: ThreatType = ThreatType::new("THREAT_TYPE_UNSPECIFIED");
+    pub const THREAT_TYPE_UNSPECIFIED: ThreatType = ThreatType::new(0);
 
     /// Malware targeting any platform.
-    pub const MALWARE: ThreatType = ThreatType::new("MALWARE");
+    pub const MALWARE: ThreatType = ThreatType::new(1);
 
     /// Social engineering targeting any platform.
-    pub const SOCIAL_ENGINEERING: ThreatType = ThreatType::new("SOCIAL_ENGINEERING");
+    pub const SOCIAL_ENGINEERING: ThreatType = ThreatType::new(2);
 
     /// Unwanted software targeting any platform.
-    pub const UNWANTED_SOFTWARE: ThreatType = ThreatType::new("UNWANTED_SOFTWARE");
+    pub const UNWANTED_SOFTWARE: ThreatType = ThreatType::new(3);
 
     /// A list of extended coverage social engineering URIs targeting any
     /// platform.
-    pub const SOCIAL_ENGINEERING_EXTENDED_COVERAGE: ThreatType =
-        ThreatType::new("SOCIAL_ENGINEERING_EXTENDED_COVERAGE");
+    pub const SOCIAL_ENGINEERING_EXTENDED_COVERAGE: ThreatType = ThreatType::new(4);
+
+    /// Creates a new ThreatType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("THREAT_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("MALWARE"),
+            2 => std::borrow::Cow::Borrowed("SOCIAL_ENGINEERING"),
+            3 => std::borrow::Cow::Borrowed("UNWANTED_SOFTWARE"),
+            4 => std::borrow::Cow::Borrowed("SOCIAL_ENGINEERING_EXTENDED_COVERAGE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "THREAT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::THREAT_TYPE_UNSPECIFIED),
+            "MALWARE" => std::option::Option::Some(Self::MALWARE),
+            "SOCIAL_ENGINEERING" => std::option::Option::Some(Self::SOCIAL_ENGINEERING),
+            "UNWANTED_SOFTWARE" => std::option::Option::Some(Self::UNWANTED_SOFTWARE),
+            "SOCIAL_ENGINEERING_EXTENDED_COVERAGE" => {
+                std::option::Option::Some(Self::SOCIAL_ENGINEERING_EXTENDED_COVERAGE)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ThreatType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ThreatType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ThreatType {
     fn default() -> Self {
-        threat_type::THREAT_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The ways in which threat entry sets can be compressed.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct CompressionType(std::borrow::Cow<'static, str>);
+pub struct CompressionType(i32);
 
 impl CompressionType {
+    /// Unknown.
+    pub const COMPRESSION_TYPE_UNSPECIFIED: CompressionType = CompressionType::new(0);
+
+    /// Raw, uncompressed data.
+    pub const RAW: CompressionType = CompressionType::new(1);
+
+    /// Rice-Golomb encoded data.
+    pub const RICE: CompressionType = CompressionType::new(2);
+
     /// Creates a new CompressionType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("COMPRESSION_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("RAW"),
+            2 => std::borrow::Cow::Borrowed("RICE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "COMPRESSION_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::COMPRESSION_TYPE_UNSPECIFIED)
+            }
+            "RAW" => std::option::Option::Some(Self::RAW),
+            "RICE" => std::option::Option::Some(Self::RICE),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [CompressionType](CompressionType)
-pub mod compression_type {
-    use super::CompressionType;
-
-    /// Unknown.
-    pub const COMPRESSION_TYPE_UNSPECIFIED: CompressionType =
-        CompressionType::new("COMPRESSION_TYPE_UNSPECIFIED");
-
-    /// Raw, uncompressed data.
-    pub const RAW: CompressionType = CompressionType::new("RAW");
-
-    /// Rice-Golomb encoded data.
-    pub const RICE: CompressionType = CompressionType::new("RICE");
-}
-
-impl std::convert::From<std::string::String> for CompressionType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for CompressionType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for CompressionType {
     fn default() -> Self {
-        compression_type::COMPRESSION_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/webrisk/v1/src/transport.rs
+++ b/src/generated/cloud/webrisk/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::WebRiskService for WebRiskService {
                 reqwest::Method::GET,
                 "/v1/threatLists:computeDiff".to_string(),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -83,7 +83,7 @@ impl crate::stubs::WebRiskService for WebRiskService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v1/uris:search".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -106,7 +106,7 @@ impl crate::stubs::WebRiskService for WebRiskService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v1/hashes:search".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -132,7 +132,7 @@ impl crate::stubs::WebRiskService for WebRiskService {
                 reqwest::Method::POST,
                 format!("/v1/{}/submissions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -154,7 +154,7 @@ impl crate::stubs::WebRiskService for WebRiskService {
                 reqwest::Method::POST,
                 format!("/v1/{}/uris:submit", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -171,7 +171,7 @@ impl crate::stubs::WebRiskService for WebRiskService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -193,7 +193,7 @@ impl crate::stubs::WebRiskService for WebRiskService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -212,7 +212,7 @@ impl crate::stubs::WebRiskService for WebRiskService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -231,7 +231,7 @@ impl crate::stubs::WebRiskService for WebRiskService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/websecurityscanner/v1/src/model.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/model.rs
@@ -334,49 +334,68 @@ pub mod finding {
 
     /// The severity level of a vulnerability.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(std::borrow::Cow<'static, str>);
+    pub struct Severity(i32);
 
     impl Severity {
+        /// No severity specified. The default value.
+        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
+
+        /// Critical severity.
+        pub const CRITICAL: Severity = Severity::new(1);
+
+        /// High severity.
+        pub const HIGH: Severity = Severity::new(2);
+
+        /// Medium severity.
+        pub const MEDIUM: Severity = Severity::new(3);
+
+        /// Low severity.
+        pub const LOW: Severity = Severity::new(4);
+
         /// Creates a new Severity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CRITICAL"),
+                2 => std::borrow::Cow::Borrowed("HIGH"),
+                3 => std::borrow::Cow::Borrowed("MEDIUM"),
+                4 => std::borrow::Cow::Borrowed("LOW"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
+                "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
+                "HIGH" => std::option::Option::Some(Self::HIGH),
+                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
+                "LOW" => std::option::Option::Some(Self::LOW),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Severity](Severity)
-    pub mod severity {
-        use super::Severity;
-
-        /// No severity specified. The default value.
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new("SEVERITY_UNSPECIFIED");
-
-        /// Critical severity.
-        pub const CRITICAL: Severity = Severity::new("CRITICAL");
-
-        /// High severity.
-        pub const HIGH: Severity = Severity::new("HIGH");
-
-        /// Medium severity.
-        pub const MEDIUM: Severity = Severity::new("MEDIUM");
-
-        /// Low severity.
-        pub const LOW: Severity = Severity::new("LOW");
-    }
-
-    impl std::convert::From<std::string::String> for Severity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            severity::SEVERITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -723,84 +742,126 @@ pub mod xss {
 
     /// Types of XSS attack vector.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AttackVector(std::borrow::Cow<'static, str>);
+    pub struct AttackVector(i32);
 
     impl AttackVector {
-        /// Creates a new AttackVector instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [AttackVector](AttackVector)
-    pub mod attack_vector {
-        use super::AttackVector;
-
         /// Unknown attack vector.
-        pub const ATTACK_VECTOR_UNSPECIFIED: AttackVector =
-            AttackVector::new("ATTACK_VECTOR_UNSPECIFIED");
+        pub const ATTACK_VECTOR_UNSPECIFIED: AttackVector = AttackVector::new(0);
 
         /// The attack comes from fuzzing the browser's localStorage.
-        pub const LOCAL_STORAGE: AttackVector = AttackVector::new("LOCAL_STORAGE");
+        pub const LOCAL_STORAGE: AttackVector = AttackVector::new(1);
 
         /// The attack comes from fuzzing the browser's sessionStorage.
-        pub const SESSION_STORAGE: AttackVector = AttackVector::new("SESSION_STORAGE");
+        pub const SESSION_STORAGE: AttackVector = AttackVector::new(2);
 
         /// The attack comes from fuzzing the window's name property.
-        pub const WINDOW_NAME: AttackVector = AttackVector::new("WINDOW_NAME");
+        pub const WINDOW_NAME: AttackVector = AttackVector::new(3);
 
         /// The attack comes from fuzzing the referrer property.
-        pub const REFERRER: AttackVector = AttackVector::new("REFERRER");
+        pub const REFERRER: AttackVector = AttackVector::new(4);
 
         /// The attack comes from fuzzing an input element.
-        pub const FORM_INPUT: AttackVector = AttackVector::new("FORM_INPUT");
+        pub const FORM_INPUT: AttackVector = AttackVector::new(5);
 
         /// The attack comes from fuzzing the browser's cookies.
-        pub const COOKIE: AttackVector = AttackVector::new("COOKIE");
+        pub const COOKIE: AttackVector = AttackVector::new(6);
 
         /// The attack comes from hijacking the post messaging mechanism.
-        pub const POST_MESSAGE: AttackVector = AttackVector::new("POST_MESSAGE");
+        pub const POST_MESSAGE: AttackVector = AttackVector::new(7);
 
         /// The attack comes from fuzzing parameters in the url.
-        pub const GET_PARAMETERS: AttackVector = AttackVector::new("GET_PARAMETERS");
+        pub const GET_PARAMETERS: AttackVector = AttackVector::new(8);
 
         /// The attack comes from fuzzing the fragment in the url.
-        pub const URL_FRAGMENT: AttackVector = AttackVector::new("URL_FRAGMENT");
+        pub const URL_FRAGMENT: AttackVector = AttackVector::new(9);
 
         /// The attack comes from fuzzing the HTML comments.
-        pub const HTML_COMMENT: AttackVector = AttackVector::new("HTML_COMMENT");
+        pub const HTML_COMMENT: AttackVector = AttackVector::new(10);
 
         /// The attack comes from fuzzing the POST parameters.
-        pub const POST_PARAMETERS: AttackVector = AttackVector::new("POST_PARAMETERS");
+        pub const POST_PARAMETERS: AttackVector = AttackVector::new(11);
 
         /// The attack comes from fuzzing the protocol.
-        pub const PROTOCOL: AttackVector = AttackVector::new("PROTOCOL");
+        pub const PROTOCOL: AttackVector = AttackVector::new(12);
 
         /// The attack comes from the server side and is stored.
-        pub const STORED_XSS: AttackVector = AttackVector::new("STORED_XSS");
+        pub const STORED_XSS: AttackVector = AttackVector::new(13);
 
         /// The attack is a Same-Origin Method Execution attack via a GET parameter.
-        pub const SAME_ORIGIN: AttackVector = AttackVector::new("SAME_ORIGIN");
+        pub const SAME_ORIGIN: AttackVector = AttackVector::new(14);
 
         /// The attack payload is received from a third-party host via a URL that is
         /// user-controllable
-        pub const USER_CONTROLLABLE_URL: AttackVector = AttackVector::new("USER_CONTROLLABLE_URL");
+        pub const USER_CONTROLLABLE_URL: AttackVector = AttackVector::new(15);
+
+        /// Creates a new AttackVector instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LOCAL_STORAGE"),
+                2 => std::borrow::Cow::Borrowed("SESSION_STORAGE"),
+                3 => std::borrow::Cow::Borrowed("WINDOW_NAME"),
+                4 => std::borrow::Cow::Borrowed("REFERRER"),
+                5 => std::borrow::Cow::Borrowed("FORM_INPUT"),
+                6 => std::borrow::Cow::Borrowed("COOKIE"),
+                7 => std::borrow::Cow::Borrowed("POST_MESSAGE"),
+                8 => std::borrow::Cow::Borrowed("GET_PARAMETERS"),
+                9 => std::borrow::Cow::Borrowed("URL_FRAGMENT"),
+                10 => std::borrow::Cow::Borrowed("HTML_COMMENT"),
+                11 => std::borrow::Cow::Borrowed("POST_PARAMETERS"),
+                12 => std::borrow::Cow::Borrowed("PROTOCOL"),
+                13 => std::borrow::Cow::Borrowed("STORED_XSS"),
+                14 => std::borrow::Cow::Borrowed("SAME_ORIGIN"),
+                15 => std::borrow::Cow::Borrowed("USER_CONTROLLABLE_URL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ATTACK_VECTOR_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ATTACK_VECTOR_UNSPECIFIED)
+                }
+                "LOCAL_STORAGE" => std::option::Option::Some(Self::LOCAL_STORAGE),
+                "SESSION_STORAGE" => std::option::Option::Some(Self::SESSION_STORAGE),
+                "WINDOW_NAME" => std::option::Option::Some(Self::WINDOW_NAME),
+                "REFERRER" => std::option::Option::Some(Self::REFERRER),
+                "FORM_INPUT" => std::option::Option::Some(Self::FORM_INPUT),
+                "COOKIE" => std::option::Option::Some(Self::COOKIE),
+                "POST_MESSAGE" => std::option::Option::Some(Self::POST_MESSAGE),
+                "GET_PARAMETERS" => std::option::Option::Some(Self::GET_PARAMETERS),
+                "URL_FRAGMENT" => std::option::Option::Some(Self::URL_FRAGMENT),
+                "HTML_COMMENT" => std::option::Option::Some(Self::HTML_COMMENT),
+                "POST_PARAMETERS" => std::option::Option::Some(Self::POST_PARAMETERS),
+                "PROTOCOL" => std::option::Option::Some(Self::PROTOCOL),
+                "STORED_XSS" => std::option::Option::Some(Self::STORED_XSS),
+                "SAME_ORIGIN" => std::option::Option::Some(Self::SAME_ORIGIN),
+                "USER_CONTROLLABLE_URL" => std::option::Option::Some(Self::USER_CONTROLLABLE_URL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for AttackVector {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AttackVector {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AttackVector {
         fn default() -> Self {
-            attack_vector::ATTACK_VECTOR_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -854,40 +915,53 @@ pub mod xxe {
 
     /// Locations within a request where XML was substituted.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Location(std::borrow::Cow<'static, str>);
+    pub struct Location(i32);
 
     impl Location {
+        /// Unknown Location.
+        pub const LOCATION_UNSPECIFIED: Location = Location::new(0);
+
+        /// The XML payload replaced the complete request body.
+        pub const COMPLETE_REQUEST_BODY: Location = Location::new(1);
+
         /// Creates a new Location instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LOCATION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("COMPLETE_REQUEST_BODY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LOCATION_UNSPECIFIED" => std::option::Option::Some(Self::LOCATION_UNSPECIFIED),
+                "COMPLETE_REQUEST_BODY" => std::option::Option::Some(Self::COMPLETE_REQUEST_BODY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Location](Location)
-    pub mod location {
-        use super::Location;
-
-        /// Unknown Location.
-        pub const LOCATION_UNSPECIFIED: Location = Location::new("LOCATION_UNSPECIFIED");
-
-        /// The XML payload replaced the complete request body.
-        pub const COMPLETE_REQUEST_BODY: Location = Location::new("COMPLETE_REQUEST_BODY");
-    }
-
-    impl std::convert::From<std::string::String> for Location {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Location {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Location {
         fn default() -> Self {
-            location::LOCATION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1557,46 +1631,63 @@ pub mod scan_config {
 
     /// Type of user agents used for scanning.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct UserAgent(std::borrow::Cow<'static, str>);
+    pub struct UserAgent(i32);
 
     impl UserAgent {
+        /// The user agent is unknown. Service will default to CHROME_LINUX.
+        pub const USER_AGENT_UNSPECIFIED: UserAgent = UserAgent::new(0);
+
+        /// Chrome on Linux. This is the service default if unspecified.
+        pub const CHROME_LINUX: UserAgent = UserAgent::new(1);
+
+        /// Chrome on Android.
+        pub const CHROME_ANDROID: UserAgent = UserAgent::new(2);
+
+        /// Safari on IPhone.
+        pub const SAFARI_IPHONE: UserAgent = UserAgent::new(3);
+
         /// Creates a new UserAgent instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("USER_AGENT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CHROME_LINUX"),
+                2 => std::borrow::Cow::Borrowed("CHROME_ANDROID"),
+                3 => std::borrow::Cow::Borrowed("SAFARI_IPHONE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "USER_AGENT_UNSPECIFIED" => std::option::Option::Some(Self::USER_AGENT_UNSPECIFIED),
+                "CHROME_LINUX" => std::option::Option::Some(Self::CHROME_LINUX),
+                "CHROME_ANDROID" => std::option::Option::Some(Self::CHROME_ANDROID),
+                "SAFARI_IPHONE" => std::option::Option::Some(Self::SAFARI_IPHONE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [UserAgent](UserAgent)
-    pub mod user_agent {
-        use super::UserAgent;
-
-        /// The user agent is unknown. Service will default to CHROME_LINUX.
-        pub const USER_AGENT_UNSPECIFIED: UserAgent = UserAgent::new("USER_AGENT_UNSPECIFIED");
-
-        /// Chrome on Linux. This is the service default if unspecified.
-        pub const CHROME_LINUX: UserAgent = UserAgent::new("CHROME_LINUX");
-
-        /// Chrome on Android.
-        pub const CHROME_ANDROID: UserAgent = UserAgent::new("CHROME_ANDROID");
-
-        /// Safari on IPhone.
-        pub const SAFARI_IPHONE: UserAgent = UserAgent::new("SAFARI_IPHONE");
-    }
-
-    impl std::convert::From<std::string::String> for UserAgent {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for UserAgent {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for UserAgent {
         fn default() -> Self {
-            user_agent::USER_AGENT_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1604,89 +1695,119 @@ pub mod scan_config {
     /// scanning will minimize requests with the potential to modify data. To
     /// achieve the maximum scan coverage, NORMAL risk level is recommended.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RiskLevel(std::borrow::Cow<'static, str>);
+    pub struct RiskLevel(i32);
 
     impl RiskLevel {
+        /// Use default, which is NORMAL.
+        pub const RISK_LEVEL_UNSPECIFIED: RiskLevel = RiskLevel::new(0);
+
+        /// Normal scanning (Recommended)
+        pub const NORMAL: RiskLevel = RiskLevel::new(1);
+
+        /// Lower impact scanning
+        pub const LOW: RiskLevel = RiskLevel::new(2);
+
         /// Creates a new RiskLevel instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RISK_LEVEL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NORMAL"),
+                2 => std::borrow::Cow::Borrowed("LOW"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RISK_LEVEL_UNSPECIFIED" => std::option::Option::Some(Self::RISK_LEVEL_UNSPECIFIED),
+                "NORMAL" => std::option::Option::Some(Self::NORMAL),
+                "LOW" => std::option::Option::Some(Self::LOW),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RiskLevel](RiskLevel)
-    pub mod risk_level {
-        use super::RiskLevel;
-
-        /// Use default, which is NORMAL.
-        pub const RISK_LEVEL_UNSPECIFIED: RiskLevel = RiskLevel::new("RISK_LEVEL_UNSPECIFIED");
-
-        /// Normal scanning (Recommended)
-        pub const NORMAL: RiskLevel = RiskLevel::new("NORMAL");
-
-        /// Lower impact scanning
-        pub const LOW: RiskLevel = RiskLevel::new("LOW");
-    }
-
-    impl std::convert::From<std::string::String> for RiskLevel {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RiskLevel {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RiskLevel {
         fn default() -> Self {
-            risk_level::RISK_LEVEL_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Controls export of scan configurations and results to Security
     /// Command Center.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ExportToSecurityCommandCenter(std::borrow::Cow<'static, str>);
+    pub struct ExportToSecurityCommandCenter(i32);
 
     impl ExportToSecurityCommandCenter {
+        /// Use default, which is ENABLED.
+        pub const EXPORT_TO_SECURITY_COMMAND_CENTER_UNSPECIFIED: ExportToSecurityCommandCenter =
+            ExportToSecurityCommandCenter::new(0);
+
+        /// Export results of this scan to Security Command Center.
+        pub const ENABLED: ExportToSecurityCommandCenter = ExportToSecurityCommandCenter::new(1);
+
+        /// Do not export results of this scan to Security Command Center.
+        pub const DISABLED: ExportToSecurityCommandCenter = ExportToSecurityCommandCenter::new(2);
+
         /// Creates a new ExportToSecurityCommandCenter instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EXPORT_TO_SECURITY_COMMAND_CENTER_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENABLED"),
+                2 => std::borrow::Cow::Borrowed("DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EXPORT_TO_SECURITY_COMMAND_CENTER_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::EXPORT_TO_SECURITY_COMMAND_CENTER_UNSPECIFIED)
+                }
+                "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ExportToSecurityCommandCenter](ExportToSecurityCommandCenter)
-    pub mod export_to_security_command_center {
-        use super::ExportToSecurityCommandCenter;
-
-        /// Use default, which is ENABLED.
-        pub const EXPORT_TO_SECURITY_COMMAND_CENTER_UNSPECIFIED: ExportToSecurityCommandCenter =
-            ExportToSecurityCommandCenter::new("EXPORT_TO_SECURITY_COMMAND_CENTER_UNSPECIFIED");
-
-        /// Export results of this scan to Security Command Center.
-        pub const ENABLED: ExportToSecurityCommandCenter =
-            ExportToSecurityCommandCenter::new("ENABLED");
-
-        /// Do not export results of this scan to Security Command Center.
-        pub const DISABLED: ExportToSecurityCommandCenter =
-            ExportToSecurityCommandCenter::new("DISABLED");
-    }
-
-    impl std::convert::From<std::string::String> for ExportToSecurityCommandCenter {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ExportToSecurityCommandCenter {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ExportToSecurityCommandCenter {
         fn default() -> Self {
-            export_to_security_command_center::EXPORT_TO_SECURITY_COMMAND_CENTER_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1747,192 +1868,326 @@ pub mod scan_config_error {
     /// Defines an error reason code.
     /// Next id: 44
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Code(std::borrow::Cow<'static, str>);
+    pub struct Code(i32);
 
     impl Code {
-        /// Creates a new Code instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Code](Code)
-    pub mod code {
-        use super::Code;
+        /// There is no error.
+        pub const CODE_UNSPECIFIED: Code = Code::new(0);
 
         /// There is no error.
-        pub const CODE_UNSPECIFIED: Code = Code::new("CODE_UNSPECIFIED");
-
-        /// There is no error.
-        pub const OK: Code = Code::new("OK");
+        pub const OK: Code = Code::new(0);
 
         /// Indicates an internal server error.
         /// Please DO NOT USE THIS ERROR CODE unless the root cause is truly unknown.
-        pub const INTERNAL_ERROR: Code = Code::new("INTERNAL_ERROR");
+        pub const INTERNAL_ERROR: Code = Code::new(1);
 
         /// One of the seed URLs is an App Engine URL but we cannot validate the scan
         /// settings due to an App Engine API backend error.
-        pub const APPENGINE_API_BACKEND_ERROR: Code = Code::new("APPENGINE_API_BACKEND_ERROR");
+        pub const APPENGINE_API_BACKEND_ERROR: Code = Code::new(2);
 
         /// One of the seed URLs is an App Engine URL but we cannot access the
         /// App Engine API to validate scan settings.
-        pub const APPENGINE_API_NOT_ACCESSIBLE: Code = Code::new("APPENGINE_API_NOT_ACCESSIBLE");
+        pub const APPENGINE_API_NOT_ACCESSIBLE: Code = Code::new(3);
 
         /// One of the seed URLs is an App Engine URL but the Default Host of the
         /// App Engine is not set.
-        pub const APPENGINE_DEFAULT_HOST_MISSING: Code =
-            Code::new("APPENGINE_DEFAULT_HOST_MISSING");
+        pub const APPENGINE_DEFAULT_HOST_MISSING: Code = Code::new(4);
 
         /// Google corporate accounts can not be used for scanning.
-        pub const CANNOT_USE_GOOGLE_COM_ACCOUNT: Code = Code::new("CANNOT_USE_GOOGLE_COM_ACCOUNT");
+        pub const CANNOT_USE_GOOGLE_COM_ACCOUNT: Code = Code::new(6);
 
         /// The account of the scan creator can not be used for scanning.
-        pub const CANNOT_USE_OWNER_ACCOUNT: Code = Code::new("CANNOT_USE_OWNER_ACCOUNT");
+        pub const CANNOT_USE_OWNER_ACCOUNT: Code = Code::new(7);
 
         /// This scan targets Compute Engine, but we cannot validate scan settings
         /// due to a Compute Engine API backend error.
-        pub const COMPUTE_API_BACKEND_ERROR: Code = Code::new("COMPUTE_API_BACKEND_ERROR");
+        pub const COMPUTE_API_BACKEND_ERROR: Code = Code::new(8);
 
         /// This scan targets Compute Engine, but we cannot access the Compute Engine
         /// API to validate the scan settings.
-        pub const COMPUTE_API_NOT_ACCESSIBLE: Code = Code::new("COMPUTE_API_NOT_ACCESSIBLE");
+        pub const COMPUTE_API_NOT_ACCESSIBLE: Code = Code::new(9);
 
         /// The Custom Login URL does not belong to the current project.
-        pub const CUSTOM_LOGIN_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT: Code =
-            Code::new("CUSTOM_LOGIN_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT");
+        pub const CUSTOM_LOGIN_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT: Code = Code::new(10);
 
         /// The Custom Login URL is malformed (can not be parsed).
-        pub const CUSTOM_LOGIN_URL_MALFORMED: Code = Code::new("CUSTOM_LOGIN_URL_MALFORMED");
+        pub const CUSTOM_LOGIN_URL_MALFORMED: Code = Code::new(11);
 
         /// The Custom Login URL is mapped to a non-routable IP address in DNS.
-        pub const CUSTOM_LOGIN_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS: Code =
-            Code::new("CUSTOM_LOGIN_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS");
+        pub const CUSTOM_LOGIN_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS: Code = Code::new(12);
 
         /// The Custom Login URL is mapped to an IP address which is not reserved for
         /// the current project.
-        pub const CUSTOM_LOGIN_URL_MAPPED_TO_UNRESERVED_ADDRESS: Code =
-            Code::new("CUSTOM_LOGIN_URL_MAPPED_TO_UNRESERVED_ADDRESS");
+        pub const CUSTOM_LOGIN_URL_MAPPED_TO_UNRESERVED_ADDRESS: Code = Code::new(13);
 
         /// The Custom Login URL has a non-routable IP address.
-        pub const CUSTOM_LOGIN_URL_HAS_NON_ROUTABLE_IP_ADDRESS: Code =
-            Code::new("CUSTOM_LOGIN_URL_HAS_NON_ROUTABLE_IP_ADDRESS");
+        pub const CUSTOM_LOGIN_URL_HAS_NON_ROUTABLE_IP_ADDRESS: Code = Code::new(14);
 
         /// The Custom Login URL has an IP address which is not reserved for the
         /// current project.
-        pub const CUSTOM_LOGIN_URL_HAS_UNRESERVED_IP_ADDRESS: Code =
-            Code::new("CUSTOM_LOGIN_URL_HAS_UNRESERVED_IP_ADDRESS");
+        pub const CUSTOM_LOGIN_URL_HAS_UNRESERVED_IP_ADDRESS: Code = Code::new(15);
 
         /// Another scan with the same name (case-sensitive) already exists.
-        pub const DUPLICATE_SCAN_NAME: Code = Code::new("DUPLICATE_SCAN_NAME");
+        pub const DUPLICATE_SCAN_NAME: Code = Code::new(16);
 
         /// A field is set to an invalid value.
-        pub const INVALID_FIELD_VALUE: Code = Code::new("INVALID_FIELD_VALUE");
+        pub const INVALID_FIELD_VALUE: Code = Code::new(18);
 
         /// There was an error trying to authenticate to the scan target.
-        pub const FAILED_TO_AUTHENTICATE_TO_TARGET: Code =
-            Code::new("FAILED_TO_AUTHENTICATE_TO_TARGET");
+        pub const FAILED_TO_AUTHENTICATE_TO_TARGET: Code = Code::new(19);
 
         /// Finding type value is not specified in the list findings request.
-        pub const FINDING_TYPE_UNSPECIFIED: Code = Code::new("FINDING_TYPE_UNSPECIFIED");
+        pub const FINDING_TYPE_UNSPECIFIED: Code = Code::new(20);
 
         /// Scan targets Compute Engine, yet current project was not whitelisted for
         /// Google Compute Engine Scanning Alpha access.
-        pub const FORBIDDEN_TO_SCAN_COMPUTE: Code = Code::new("FORBIDDEN_TO_SCAN_COMPUTE");
+        pub const FORBIDDEN_TO_SCAN_COMPUTE: Code = Code::new(21);
 
         /// User tries to update managed scan
-        pub const FORBIDDEN_UPDATE_TO_MANAGED_SCAN: Code =
-            Code::new("FORBIDDEN_UPDATE_TO_MANAGED_SCAN");
+        pub const FORBIDDEN_UPDATE_TO_MANAGED_SCAN: Code = Code::new(43);
 
         /// The supplied filter is malformed. For example, it can not be parsed, does
         /// not have a filter type in expression, or the same filter type appears
         /// more than once.
-        pub const MALFORMED_FILTER: Code = Code::new("MALFORMED_FILTER");
+        pub const MALFORMED_FILTER: Code = Code::new(22);
 
         /// The supplied resource name is malformed (can not be parsed).
-        pub const MALFORMED_RESOURCE_NAME: Code = Code::new("MALFORMED_RESOURCE_NAME");
+        pub const MALFORMED_RESOURCE_NAME: Code = Code::new(23);
 
         /// The current project is not in an active state.
-        pub const PROJECT_INACTIVE: Code = Code::new("PROJECT_INACTIVE");
+        pub const PROJECT_INACTIVE: Code = Code::new(24);
 
         /// A required field is not set.
-        pub const REQUIRED_FIELD: Code = Code::new("REQUIRED_FIELD");
+        pub const REQUIRED_FIELD: Code = Code::new(25);
 
         /// Project id, scanconfig id, scanrun id, or finding id are not consistent
         /// with each other in resource name.
-        pub const RESOURCE_NAME_INCONSISTENT: Code = Code::new("RESOURCE_NAME_INCONSISTENT");
+        pub const RESOURCE_NAME_INCONSISTENT: Code = Code::new(26);
 
         /// The scan being requested to start is already running.
-        pub const SCAN_ALREADY_RUNNING: Code = Code::new("SCAN_ALREADY_RUNNING");
+        pub const SCAN_ALREADY_RUNNING: Code = Code::new(27);
 
         /// The scan that was requested to be stopped is not running.
-        pub const SCAN_NOT_RUNNING: Code = Code::new("SCAN_NOT_RUNNING");
+        pub const SCAN_NOT_RUNNING: Code = Code::new(28);
 
         /// One of the seed URLs does not belong to the current project.
-        pub const SEED_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT: Code =
-            Code::new("SEED_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT");
+        pub const SEED_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT: Code = Code::new(29);
 
         /// One of the seed URLs is malformed (can not be parsed).
-        pub const SEED_URL_MALFORMED: Code = Code::new("SEED_URL_MALFORMED");
+        pub const SEED_URL_MALFORMED: Code = Code::new(30);
 
         /// One of the seed URLs is mapped to a non-routable IP address in DNS.
-        pub const SEED_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS: Code =
-            Code::new("SEED_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS");
+        pub const SEED_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS: Code = Code::new(31);
 
         /// One of the seed URLs is mapped to an IP address which is not reserved
         /// for the current project.
-        pub const SEED_URL_MAPPED_TO_UNRESERVED_ADDRESS: Code =
-            Code::new("SEED_URL_MAPPED_TO_UNRESERVED_ADDRESS");
+        pub const SEED_URL_MAPPED_TO_UNRESERVED_ADDRESS: Code = Code::new(32);
 
         /// One of the seed URLs has on-routable IP address.
-        pub const SEED_URL_HAS_NON_ROUTABLE_IP_ADDRESS: Code =
-            Code::new("SEED_URL_HAS_NON_ROUTABLE_IP_ADDRESS");
+        pub const SEED_URL_HAS_NON_ROUTABLE_IP_ADDRESS: Code = Code::new(33);
 
         /// One of the seed URLs has an IP address that is not reserved
         /// for the current project.
-        pub const SEED_URL_HAS_UNRESERVED_IP_ADDRESS: Code =
-            Code::new("SEED_URL_HAS_UNRESERVED_IP_ADDRESS");
+        pub const SEED_URL_HAS_UNRESERVED_IP_ADDRESS: Code = Code::new(35);
 
         /// The Web Security Scanner service account is not configured under the
         /// project.
-        pub const SERVICE_ACCOUNT_NOT_CONFIGURED: Code =
-            Code::new("SERVICE_ACCOUNT_NOT_CONFIGURED");
+        pub const SERVICE_ACCOUNT_NOT_CONFIGURED: Code = Code::new(36);
 
         /// A project has reached the maximum number of scans.
-        pub const TOO_MANY_SCANS: Code = Code::new("TOO_MANY_SCANS");
+        pub const TOO_MANY_SCANS: Code = Code::new(37);
 
         /// Resolving the details of the current project fails.
-        pub const UNABLE_TO_RESOLVE_PROJECT_INFO: Code =
-            Code::new("UNABLE_TO_RESOLVE_PROJECT_INFO");
+        pub const UNABLE_TO_RESOLVE_PROJECT_INFO: Code = Code::new(38);
 
         /// One or more blacklist patterns were in the wrong format.
-        pub const UNSUPPORTED_BLACKLIST_PATTERN_FORMAT: Code =
-            Code::new("UNSUPPORTED_BLACKLIST_PATTERN_FORMAT");
+        pub const UNSUPPORTED_BLACKLIST_PATTERN_FORMAT: Code = Code::new(39);
 
         /// The supplied filter is not supported.
-        pub const UNSUPPORTED_FILTER: Code = Code::new("UNSUPPORTED_FILTER");
+        pub const UNSUPPORTED_FILTER: Code = Code::new(40);
 
         /// The supplied finding type is not supported. For example, we do not
         /// provide findings of the given finding type.
-        pub const UNSUPPORTED_FINDING_TYPE: Code = Code::new("UNSUPPORTED_FINDING_TYPE");
+        pub const UNSUPPORTED_FINDING_TYPE: Code = Code::new(41);
 
         /// The URL scheme of one or more of the supplied URLs is not supported.
-        pub const UNSUPPORTED_URL_SCHEME: Code = Code::new("UNSUPPORTED_URL_SCHEME");
+        pub const UNSUPPORTED_URL_SCHEME: Code = Code::new(42);
+
+        /// Creates a new Code instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("OK"),
+                1 => std::borrow::Cow::Borrowed("INTERNAL_ERROR"),
+                2 => std::borrow::Cow::Borrowed("APPENGINE_API_BACKEND_ERROR"),
+                3 => std::borrow::Cow::Borrowed("APPENGINE_API_NOT_ACCESSIBLE"),
+                4 => std::borrow::Cow::Borrowed("APPENGINE_DEFAULT_HOST_MISSING"),
+                6 => std::borrow::Cow::Borrowed("CANNOT_USE_GOOGLE_COM_ACCOUNT"),
+                7 => std::borrow::Cow::Borrowed("CANNOT_USE_OWNER_ACCOUNT"),
+                8 => std::borrow::Cow::Borrowed("COMPUTE_API_BACKEND_ERROR"),
+                9 => std::borrow::Cow::Borrowed("COMPUTE_API_NOT_ACCESSIBLE"),
+                10 => std::borrow::Cow::Borrowed(
+                    "CUSTOM_LOGIN_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT",
+                ),
+                11 => std::borrow::Cow::Borrowed("CUSTOM_LOGIN_URL_MALFORMED"),
+                12 => std::borrow::Cow::Borrowed("CUSTOM_LOGIN_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS"),
+                13 => std::borrow::Cow::Borrowed("CUSTOM_LOGIN_URL_MAPPED_TO_UNRESERVED_ADDRESS"),
+                14 => std::borrow::Cow::Borrowed("CUSTOM_LOGIN_URL_HAS_NON_ROUTABLE_IP_ADDRESS"),
+                15 => std::borrow::Cow::Borrowed("CUSTOM_LOGIN_URL_HAS_UNRESERVED_IP_ADDRESS"),
+                16 => std::borrow::Cow::Borrowed("DUPLICATE_SCAN_NAME"),
+                18 => std::borrow::Cow::Borrowed("INVALID_FIELD_VALUE"),
+                19 => std::borrow::Cow::Borrowed("FAILED_TO_AUTHENTICATE_TO_TARGET"),
+                20 => std::borrow::Cow::Borrowed("FINDING_TYPE_UNSPECIFIED"),
+                21 => std::borrow::Cow::Borrowed("FORBIDDEN_TO_SCAN_COMPUTE"),
+                22 => std::borrow::Cow::Borrowed("MALFORMED_FILTER"),
+                23 => std::borrow::Cow::Borrowed("MALFORMED_RESOURCE_NAME"),
+                24 => std::borrow::Cow::Borrowed("PROJECT_INACTIVE"),
+                25 => std::borrow::Cow::Borrowed("REQUIRED_FIELD"),
+                26 => std::borrow::Cow::Borrowed("RESOURCE_NAME_INCONSISTENT"),
+                27 => std::borrow::Cow::Borrowed("SCAN_ALREADY_RUNNING"),
+                28 => std::borrow::Cow::Borrowed("SCAN_NOT_RUNNING"),
+                29 => std::borrow::Cow::Borrowed("SEED_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT"),
+                30 => std::borrow::Cow::Borrowed("SEED_URL_MALFORMED"),
+                31 => std::borrow::Cow::Borrowed("SEED_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS"),
+                32 => std::borrow::Cow::Borrowed("SEED_URL_MAPPED_TO_UNRESERVED_ADDRESS"),
+                33 => std::borrow::Cow::Borrowed("SEED_URL_HAS_NON_ROUTABLE_IP_ADDRESS"),
+                35 => std::borrow::Cow::Borrowed("SEED_URL_HAS_UNRESERVED_IP_ADDRESS"),
+                36 => std::borrow::Cow::Borrowed("SERVICE_ACCOUNT_NOT_CONFIGURED"),
+                37 => std::borrow::Cow::Borrowed("TOO_MANY_SCANS"),
+                38 => std::borrow::Cow::Borrowed("UNABLE_TO_RESOLVE_PROJECT_INFO"),
+                39 => std::borrow::Cow::Borrowed("UNSUPPORTED_BLACKLIST_PATTERN_FORMAT"),
+                40 => std::borrow::Cow::Borrowed("UNSUPPORTED_FILTER"),
+                41 => std::borrow::Cow::Borrowed("UNSUPPORTED_FINDING_TYPE"),
+                42 => std::borrow::Cow::Borrowed("UNSUPPORTED_URL_SCHEME"),
+                43 => std::borrow::Cow::Borrowed("FORBIDDEN_UPDATE_TO_MANAGED_SCAN"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CODE_UNSPECIFIED" => std::option::Option::Some(Self::CODE_UNSPECIFIED),
+                "OK" => std::option::Option::Some(Self::OK),
+                "INTERNAL_ERROR" => std::option::Option::Some(Self::INTERNAL_ERROR),
+                "APPENGINE_API_BACKEND_ERROR" => {
+                    std::option::Option::Some(Self::APPENGINE_API_BACKEND_ERROR)
+                }
+                "APPENGINE_API_NOT_ACCESSIBLE" => {
+                    std::option::Option::Some(Self::APPENGINE_API_NOT_ACCESSIBLE)
+                }
+                "APPENGINE_DEFAULT_HOST_MISSING" => {
+                    std::option::Option::Some(Self::APPENGINE_DEFAULT_HOST_MISSING)
+                }
+                "CANNOT_USE_GOOGLE_COM_ACCOUNT" => {
+                    std::option::Option::Some(Self::CANNOT_USE_GOOGLE_COM_ACCOUNT)
+                }
+                "CANNOT_USE_OWNER_ACCOUNT" => {
+                    std::option::Option::Some(Self::CANNOT_USE_OWNER_ACCOUNT)
+                }
+                "COMPUTE_API_BACKEND_ERROR" => {
+                    std::option::Option::Some(Self::COMPUTE_API_BACKEND_ERROR)
+                }
+                "COMPUTE_API_NOT_ACCESSIBLE" => {
+                    std::option::Option::Some(Self::COMPUTE_API_NOT_ACCESSIBLE)
+                }
+                "CUSTOM_LOGIN_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT" => std::option::Option::Some(
+                    Self::CUSTOM_LOGIN_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT,
+                ),
+                "CUSTOM_LOGIN_URL_MALFORMED" => {
+                    std::option::Option::Some(Self::CUSTOM_LOGIN_URL_MALFORMED)
+                }
+                "CUSTOM_LOGIN_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS" => {
+                    std::option::Option::Some(Self::CUSTOM_LOGIN_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS)
+                }
+                "CUSTOM_LOGIN_URL_MAPPED_TO_UNRESERVED_ADDRESS" => {
+                    std::option::Option::Some(Self::CUSTOM_LOGIN_URL_MAPPED_TO_UNRESERVED_ADDRESS)
+                }
+                "CUSTOM_LOGIN_URL_HAS_NON_ROUTABLE_IP_ADDRESS" => {
+                    std::option::Option::Some(Self::CUSTOM_LOGIN_URL_HAS_NON_ROUTABLE_IP_ADDRESS)
+                }
+                "CUSTOM_LOGIN_URL_HAS_UNRESERVED_IP_ADDRESS" => {
+                    std::option::Option::Some(Self::CUSTOM_LOGIN_URL_HAS_UNRESERVED_IP_ADDRESS)
+                }
+                "DUPLICATE_SCAN_NAME" => std::option::Option::Some(Self::DUPLICATE_SCAN_NAME),
+                "INVALID_FIELD_VALUE" => std::option::Option::Some(Self::INVALID_FIELD_VALUE),
+                "FAILED_TO_AUTHENTICATE_TO_TARGET" => {
+                    std::option::Option::Some(Self::FAILED_TO_AUTHENTICATE_TO_TARGET)
+                }
+                "FINDING_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::FINDING_TYPE_UNSPECIFIED)
+                }
+                "FORBIDDEN_TO_SCAN_COMPUTE" => {
+                    std::option::Option::Some(Self::FORBIDDEN_TO_SCAN_COMPUTE)
+                }
+                "FORBIDDEN_UPDATE_TO_MANAGED_SCAN" => {
+                    std::option::Option::Some(Self::FORBIDDEN_UPDATE_TO_MANAGED_SCAN)
+                }
+                "MALFORMED_FILTER" => std::option::Option::Some(Self::MALFORMED_FILTER),
+                "MALFORMED_RESOURCE_NAME" => {
+                    std::option::Option::Some(Self::MALFORMED_RESOURCE_NAME)
+                }
+                "PROJECT_INACTIVE" => std::option::Option::Some(Self::PROJECT_INACTIVE),
+                "REQUIRED_FIELD" => std::option::Option::Some(Self::REQUIRED_FIELD),
+                "RESOURCE_NAME_INCONSISTENT" => {
+                    std::option::Option::Some(Self::RESOURCE_NAME_INCONSISTENT)
+                }
+                "SCAN_ALREADY_RUNNING" => std::option::Option::Some(Self::SCAN_ALREADY_RUNNING),
+                "SCAN_NOT_RUNNING" => std::option::Option::Some(Self::SCAN_NOT_RUNNING),
+                "SEED_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT" => {
+                    std::option::Option::Some(Self::SEED_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT)
+                }
+                "SEED_URL_MALFORMED" => std::option::Option::Some(Self::SEED_URL_MALFORMED),
+                "SEED_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS" => {
+                    std::option::Option::Some(Self::SEED_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS)
+                }
+                "SEED_URL_MAPPED_TO_UNRESERVED_ADDRESS" => {
+                    std::option::Option::Some(Self::SEED_URL_MAPPED_TO_UNRESERVED_ADDRESS)
+                }
+                "SEED_URL_HAS_NON_ROUTABLE_IP_ADDRESS" => {
+                    std::option::Option::Some(Self::SEED_URL_HAS_NON_ROUTABLE_IP_ADDRESS)
+                }
+                "SEED_URL_HAS_UNRESERVED_IP_ADDRESS" => {
+                    std::option::Option::Some(Self::SEED_URL_HAS_UNRESERVED_IP_ADDRESS)
+                }
+                "SERVICE_ACCOUNT_NOT_CONFIGURED" => {
+                    std::option::Option::Some(Self::SERVICE_ACCOUNT_NOT_CONFIGURED)
+                }
+                "TOO_MANY_SCANS" => std::option::Option::Some(Self::TOO_MANY_SCANS),
+                "UNABLE_TO_RESOLVE_PROJECT_INFO" => {
+                    std::option::Option::Some(Self::UNABLE_TO_RESOLVE_PROJECT_INFO)
+                }
+                "UNSUPPORTED_BLACKLIST_PATTERN_FORMAT" => {
+                    std::option::Option::Some(Self::UNSUPPORTED_BLACKLIST_PATTERN_FORMAT)
+                }
+                "UNSUPPORTED_FILTER" => std::option::Option::Some(Self::UNSUPPORTED_FILTER),
+                "UNSUPPORTED_FINDING_TYPE" => {
+                    std::option::Option::Some(Self::UNSUPPORTED_FINDING_TYPE)
+                }
+                "UNSUPPORTED_URL_SCHEME" => std::option::Option::Some(Self::UNSUPPORTED_URL_SCHEME),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Code {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Code {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Code {
         fn default() -> Self {
-            code::CODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2104,95 +2359,131 @@ pub mod scan_run {
 
     /// Types of ScanRun execution state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ExecutionState(std::borrow::Cow<'static, str>);
+    pub struct ExecutionState(i32);
 
     impl ExecutionState {
+        /// Represents an invalid state caused by internal server error. This value
+        /// should never be returned.
+        pub const EXECUTION_STATE_UNSPECIFIED: ExecutionState = ExecutionState::new(0);
+
+        /// The scan is waiting in the queue.
+        pub const QUEUED: ExecutionState = ExecutionState::new(1);
+
+        /// The scan is in progress.
+        pub const SCANNING: ExecutionState = ExecutionState::new(2);
+
+        /// The scan is either finished or stopped by user.
+        pub const FINISHED: ExecutionState = ExecutionState::new(3);
+
         /// Creates a new ExecutionState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EXECUTION_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("QUEUED"),
+                2 => std::borrow::Cow::Borrowed("SCANNING"),
+                3 => std::borrow::Cow::Borrowed("FINISHED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EXECUTION_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::EXECUTION_STATE_UNSPECIFIED)
+                }
+                "QUEUED" => std::option::Option::Some(Self::QUEUED),
+                "SCANNING" => std::option::Option::Some(Self::SCANNING),
+                "FINISHED" => std::option::Option::Some(Self::FINISHED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ExecutionState](ExecutionState)
-    pub mod execution_state {
-        use super::ExecutionState;
-
-        /// Represents an invalid state caused by internal server error. This value
-        /// should never be returned.
-        pub const EXECUTION_STATE_UNSPECIFIED: ExecutionState =
-            ExecutionState::new("EXECUTION_STATE_UNSPECIFIED");
-
-        /// The scan is waiting in the queue.
-        pub const QUEUED: ExecutionState = ExecutionState::new("QUEUED");
-
-        /// The scan is in progress.
-        pub const SCANNING: ExecutionState = ExecutionState::new("SCANNING");
-
-        /// The scan is either finished or stopped by user.
-        pub const FINISHED: ExecutionState = ExecutionState::new("FINISHED");
-    }
-
-    impl std::convert::From<std::string::String> for ExecutionState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ExecutionState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ExecutionState {
         fn default() -> Self {
-            execution_state::EXECUTION_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Types of ScanRun result state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ResultState(std::borrow::Cow<'static, str>);
+    pub struct ResultState(i32);
 
     impl ResultState {
+        /// Default value. This value is returned when the ScanRun is not yet
+        /// finished.
+        pub const RESULT_STATE_UNSPECIFIED: ResultState = ResultState::new(0);
+
+        /// The scan finished without errors.
+        pub const SUCCESS: ResultState = ResultState::new(1);
+
+        /// The scan finished with errors.
+        pub const ERROR: ResultState = ResultState::new(2);
+
+        /// The scan was terminated by user.
+        pub const KILLED: ResultState = ResultState::new(3);
+
         /// Creates a new ResultState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RESULT_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SUCCESS"),
+                2 => std::borrow::Cow::Borrowed("ERROR"),
+                3 => std::borrow::Cow::Borrowed("KILLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RESULT_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::RESULT_STATE_UNSPECIFIED)
+                }
+                "SUCCESS" => std::option::Option::Some(Self::SUCCESS),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "KILLED" => std::option::Option::Some(Self::KILLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ResultState](ResultState)
-    pub mod result_state {
-        use super::ResultState;
-
-        /// Default value. This value is returned when the ScanRun is not yet
-        /// finished.
-        pub const RESULT_STATE_UNSPECIFIED: ResultState =
-            ResultState::new("RESULT_STATE_UNSPECIFIED");
-
-        /// The scan finished without errors.
-        pub const SUCCESS: ResultState = ResultState::new("SUCCESS");
-
-        /// The scan finished with errors.
-        pub const ERROR: ResultState = ResultState::new("ERROR");
-
-        /// The scan was terminated by user.
-        pub const KILLED: ResultState = ResultState::new("KILLED");
-    }
-
-    impl std::convert::From<std::string::String> for ResultState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ResultState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ResultState {
         fn default() -> Self {
-            result_state::RESULT_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2266,60 +2557,87 @@ pub mod scan_run_error_trace {
     /// Defines an error reason code.
     /// Next id: 8
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Code(std::borrow::Cow<'static, str>);
+    pub struct Code(i32);
 
     impl Code {
-        /// Creates a new Code instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Code](Code)
-    pub mod code {
-        use super::Code;
-
         /// Default value is never used.
-        pub const CODE_UNSPECIFIED: Code = Code::new("CODE_UNSPECIFIED");
+        pub const CODE_UNSPECIFIED: Code = Code::new(0);
 
         /// Indicates that the scan run failed due to an internal server error.
-        pub const INTERNAL_ERROR: Code = Code::new("INTERNAL_ERROR");
+        pub const INTERNAL_ERROR: Code = Code::new(1);
 
         /// Indicates a scan configuration error, usually due to outdated ScanConfig
         /// settings, such as starting_urls or the DNS configuration.
-        pub const SCAN_CONFIG_ISSUE: Code = Code::new("SCAN_CONFIG_ISSUE");
+        pub const SCAN_CONFIG_ISSUE: Code = Code::new(2);
 
         /// Indicates an authentication error, usually due to outdated ScanConfig
         /// authentication settings.
-        pub const AUTHENTICATION_CONFIG_ISSUE: Code = Code::new("AUTHENTICATION_CONFIG_ISSUE");
+        pub const AUTHENTICATION_CONFIG_ISSUE: Code = Code::new(3);
 
         /// Indicates a scan operation timeout, usually caused by a very large site.
-        pub const TIMED_OUT_WHILE_SCANNING: Code = Code::new("TIMED_OUT_WHILE_SCANNING");
+        pub const TIMED_OUT_WHILE_SCANNING: Code = Code::new(4);
 
         /// Indicates that a scan encountered excessive redirects, either to
         /// authentication or some other page outside of the scan scope.
-        pub const TOO_MANY_REDIRECTS: Code = Code::new("TOO_MANY_REDIRECTS");
+        pub const TOO_MANY_REDIRECTS: Code = Code::new(5);
 
         /// Indicates that a scan encountered numerous errors from the web site
         /// pages. When available, most_common_http_error_code field indicates the
         /// most common HTTP error code encountered during the scan.
-        pub const TOO_MANY_HTTP_ERRORS: Code = Code::new("TOO_MANY_HTTP_ERRORS");
+        pub const TOO_MANY_HTTP_ERRORS: Code = Code::new(6);
+
+        /// Creates a new Code instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INTERNAL_ERROR"),
+                2 => std::borrow::Cow::Borrowed("SCAN_CONFIG_ISSUE"),
+                3 => std::borrow::Cow::Borrowed("AUTHENTICATION_CONFIG_ISSUE"),
+                4 => std::borrow::Cow::Borrowed("TIMED_OUT_WHILE_SCANNING"),
+                5 => std::borrow::Cow::Borrowed("TOO_MANY_REDIRECTS"),
+                6 => std::borrow::Cow::Borrowed("TOO_MANY_HTTP_ERRORS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CODE_UNSPECIFIED" => std::option::Option::Some(Self::CODE_UNSPECIFIED),
+                "INTERNAL_ERROR" => std::option::Option::Some(Self::INTERNAL_ERROR),
+                "SCAN_CONFIG_ISSUE" => std::option::Option::Some(Self::SCAN_CONFIG_ISSUE),
+                "AUTHENTICATION_CONFIG_ISSUE" => {
+                    std::option::Option::Some(Self::AUTHENTICATION_CONFIG_ISSUE)
+                }
+                "TIMED_OUT_WHILE_SCANNING" => {
+                    std::option::Option::Some(Self::TIMED_OUT_WHILE_SCANNING)
+                }
+                "TOO_MANY_REDIRECTS" => std::option::Option::Some(Self::TOO_MANY_REDIRECTS),
+                "TOO_MANY_HTTP_ERRORS" => std::option::Option::Some(Self::TOO_MANY_HTTP_ERRORS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Code {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Code {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Code {
         fn default() -> Self {
-            code::CODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2473,58 +2791,82 @@ pub mod scan_run_warning_trace {
     /// Defines a warning message code.
     /// Next id: 6
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Code(std::borrow::Cow<'static, str>);
+    pub struct Code(i32);
 
     impl Code {
-        /// Creates a new Code instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Code](Code)
-    pub mod code {
-        use super::Code;
-
         /// Default value is never used.
-        pub const CODE_UNSPECIFIED: Code = Code::new("CODE_UNSPECIFIED");
+        pub const CODE_UNSPECIFIED: Code = Code::new(0);
 
         /// Indicates that a scan discovered an unexpectedly low number of URLs. This
         /// is sometimes caused by complex navigation features or by using a single
         /// URL for numerous pages.
-        pub const INSUFFICIENT_CRAWL_RESULTS: Code = Code::new("INSUFFICIENT_CRAWL_RESULTS");
+        pub const INSUFFICIENT_CRAWL_RESULTS: Code = Code::new(1);
 
         /// Indicates that a scan discovered too many URLs to test, or excessive
         /// redundant URLs.
-        pub const TOO_MANY_CRAWL_RESULTS: Code = Code::new("TOO_MANY_CRAWL_RESULTS");
+        pub const TOO_MANY_CRAWL_RESULTS: Code = Code::new(2);
 
         /// Indicates that too many tests have been generated for the scan. Customer
         /// should try reducing the number of starting URLs, increasing the QPS rate,
         /// or narrowing down the scope of the scan using the excluded patterns.
-        pub const TOO_MANY_FUZZ_TASKS: Code = Code::new("TOO_MANY_FUZZ_TASKS");
+        pub const TOO_MANY_FUZZ_TASKS: Code = Code::new(3);
 
         /// Indicates that a scan is blocked by IAP.
-        pub const BLOCKED_BY_IAP: Code = Code::new("BLOCKED_BY_IAP");
+        pub const BLOCKED_BY_IAP: Code = Code::new(4);
 
         /// Indicates that no seeds is found for a scan
-        pub const NO_STARTING_URL_FOUND_FOR_MANAGED_SCAN: Code =
-            Code::new("NO_STARTING_URL_FOUND_FOR_MANAGED_SCAN");
+        pub const NO_STARTING_URL_FOUND_FOR_MANAGED_SCAN: Code = Code::new(5);
+
+        /// Creates a new Code instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INSUFFICIENT_CRAWL_RESULTS"),
+                2 => std::borrow::Cow::Borrowed("TOO_MANY_CRAWL_RESULTS"),
+                3 => std::borrow::Cow::Borrowed("TOO_MANY_FUZZ_TASKS"),
+                4 => std::borrow::Cow::Borrowed("BLOCKED_BY_IAP"),
+                5 => std::borrow::Cow::Borrowed("NO_STARTING_URL_FOUND_FOR_MANAGED_SCAN"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CODE_UNSPECIFIED" => std::option::Option::Some(Self::CODE_UNSPECIFIED),
+                "INSUFFICIENT_CRAWL_RESULTS" => {
+                    std::option::Option::Some(Self::INSUFFICIENT_CRAWL_RESULTS)
+                }
+                "TOO_MANY_CRAWL_RESULTS" => std::option::Option::Some(Self::TOO_MANY_CRAWL_RESULTS),
+                "TOO_MANY_FUZZ_TASKS" => std::option::Option::Some(Self::TOO_MANY_FUZZ_TASKS),
+                "BLOCKED_BY_IAP" => std::option::Option::Some(Self::BLOCKED_BY_IAP),
+                "NO_STARTING_URL_FOUND_FOR_MANAGED_SCAN" => {
+                    std::option::Option::Some(Self::NO_STARTING_URL_FOUND_FOR_MANAGED_SCAN)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Code {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Code {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Code {
         fn default() -> Self {
-            code::CODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/websecurityscanner/v1/src/transport.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::WebSecurityScanner for WebSecurityScanner {
                 reqwest::Method::POST,
                 format!("/v1/{}/scanConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -71,7 +71,7 @@ impl crate::stubs::WebSecurityScanner for WebSecurityScanner {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -90,7 +90,7 @@ impl crate::stubs::WebSecurityScanner for WebSecurityScanner {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -112,7 +112,7 @@ impl crate::stubs::WebSecurityScanner for WebSecurityScanner {
                 reqwest::Method::GET,
                 format!("/v1/{}/scanConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -142,7 +142,7 @@ impl crate::stubs::WebSecurityScanner for WebSecurityScanner {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -171,7 +171,7 @@ impl crate::stubs::WebSecurityScanner for WebSecurityScanner {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:start", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -188,7 +188,7 @@ impl crate::stubs::WebSecurityScanner for WebSecurityScanner {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -207,7 +207,7 @@ impl crate::stubs::WebSecurityScanner for WebSecurityScanner {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/scanRuns", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -228,7 +228,7 @@ impl crate::stubs::WebSecurityScanner for WebSecurityScanner {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:stop", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -248,7 +248,7 @@ impl crate::stubs::WebSecurityScanner for WebSecurityScanner {
                 reqwest::Method::GET,
                 format!("/v1/{}/crawledUrls", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -269,7 +269,7 @@ impl crate::stubs::WebSecurityScanner for WebSecurityScanner {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -288,7 +288,7 @@ impl crate::stubs::WebSecurityScanner for WebSecurityScanner {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/findings", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -313,7 +313,7 @@ impl crate::stubs::WebSecurityScanner for WebSecurityScanner {
                 reqwest::Method::GET,
                 format!("/v1/{}/findingTypeStats", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/workflows/executions/v1/src/model.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/model.rs
@@ -574,40 +574,53 @@ pub mod execution {
 
         /// Describes the possible types of a state error.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(std::borrow::Cow<'static, str>);
+        pub struct Type(i32);
 
         impl Type {
+            /// No type specified.
+            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+            /// Caused by an issue with KMS.
+            pub const KMS_ERROR: Type = Type::new(1);
+
             /// Creates a new Type instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("KMS_ERROR"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                    "KMS_ERROR" => std::option::Option::Some(Self::KMS_ERROR),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Type](Type)
-        pub mod r#type {
-            use super::Type;
-
-            /// No type specified.
-            pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-            /// Caused by an issue with KMS.
-            pub const KMS_ERROR: Type = Type::new("KMS_ERROR");
-        }
-
-        impl std::convert::From<std::string::String> for Type {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                r#type::TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -615,103 +628,144 @@ pub mod execution {
     /// Describes the current state of the execution. More states might be added
     /// in the future.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Invalid state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The execution is in progress.
+        pub const ACTIVE: State = State::new(1);
+
+        /// The execution finished successfully.
+        pub const SUCCEEDED: State = State::new(2);
+
+        /// The execution failed with an error.
+        pub const FAILED: State = State::new(3);
+
+        /// The execution was stopped intentionally.
+        pub const CANCELLED: State = State::new(4);
+
+        /// Execution data is unavailable. See the `state_error` field.
+        pub const UNAVAILABLE: State = State::new(5);
+
+        /// Request has been placed in the backlog for processing at a later time.
+        pub const QUEUED: State = State::new(6);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                3 => std::borrow::Cow::Borrowed("FAILED"),
+                4 => std::borrow::Cow::Borrowed("CANCELLED"),
+                5 => std::borrow::Cow::Borrowed("UNAVAILABLE"),
+                6 => std::borrow::Cow::Borrowed("QUEUED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                "UNAVAILABLE" => std::option::Option::Some(Self::UNAVAILABLE),
+                "QUEUED" => std::option::Option::Some(Self::QUEUED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Invalid state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The execution is in progress.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// The execution finished successfully.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-        /// The execution failed with an error.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// The execution was stopped intentionally.
-        pub const CANCELLED: State = State::new("CANCELLED");
-
-        /// Execution data is unavailable. See the `state_error` field.
-        pub const UNAVAILABLE: State = State::new("UNAVAILABLE");
-
-        /// Request has been placed in the backlog for processing at a later time.
-        pub const QUEUED: State = State::new("QUEUED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Describes the level of platform logging to apply to calls and call
     /// responses during workflow executions.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CallLogLevel(std::borrow::Cow<'static, str>);
+    pub struct CallLogLevel(i32);
 
     impl CallLogLevel {
-        /// Creates a new CallLogLevel instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CallLogLevel](CallLogLevel)
-    pub mod call_log_level {
-        use super::CallLogLevel;
-
         /// No call logging level specified.
-        pub const CALL_LOG_LEVEL_UNSPECIFIED: CallLogLevel =
-            CallLogLevel::new("CALL_LOG_LEVEL_UNSPECIFIED");
+        pub const CALL_LOG_LEVEL_UNSPECIFIED: CallLogLevel = CallLogLevel::new(0);
 
         /// Log all call steps within workflows, all call returns, and all exceptions
         /// raised.
-        pub const LOG_ALL_CALLS: CallLogLevel = CallLogLevel::new("LOG_ALL_CALLS");
+        pub const LOG_ALL_CALLS: CallLogLevel = CallLogLevel::new(1);
 
         /// Log only exceptions that are raised from call steps within workflows.
-        pub const LOG_ERRORS_ONLY: CallLogLevel = CallLogLevel::new("LOG_ERRORS_ONLY");
+        pub const LOG_ERRORS_ONLY: CallLogLevel = CallLogLevel::new(2);
 
         /// Explicitly log nothing.
-        pub const LOG_NONE: CallLogLevel = CallLogLevel::new("LOG_NONE");
+        pub const LOG_NONE: CallLogLevel = CallLogLevel::new(3);
+
+        /// Creates a new CallLogLevel instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CALL_LOG_LEVEL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LOG_ALL_CALLS"),
+                2 => std::borrow::Cow::Borrowed("LOG_ERRORS_ONLY"),
+                3 => std::borrow::Cow::Borrowed("LOG_NONE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CALL_LOG_LEVEL_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CALL_LOG_LEVEL_UNSPECIFIED)
+                }
+                "LOG_ALL_CALLS" => std::option::Option::Some(Self::LOG_ALL_CALLS),
+                "LOG_ERRORS_ONLY" => std::option::Option::Some(Self::LOG_ERRORS_ONLY),
+                "LOG_NONE" => std::option::Option::Some(Self::LOG_NONE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CallLogLevel {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CallLogLevel {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CallLogLevel {
         fn default() -> Self {
-            call_log_level::CALL_LOG_LEVEL_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1006,45 +1060,61 @@ impl wkt::message::Message for CancelExecutionRequest {
 
 /// Defines possible views for execution resource.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ExecutionView(std::borrow::Cow<'static, str>);
+pub struct ExecutionView(i32);
 
 impl ExecutionView {
-    /// Creates a new ExecutionView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ExecutionView](ExecutionView)
-pub mod execution_view {
-    use super::ExecutionView;
-
     /// The default / unset value.
-    pub const EXECUTION_VIEW_UNSPECIFIED: ExecutionView =
-        ExecutionView::new("EXECUTION_VIEW_UNSPECIFIED");
+    pub const EXECUTION_VIEW_UNSPECIFIED: ExecutionView = ExecutionView::new(0);
 
     /// Includes only basic metadata about the execution.
     /// The following fields are returned: name, start_time, end_time, duration,
     /// state, and workflow_revision_id.
-    pub const BASIC: ExecutionView = ExecutionView::new("BASIC");
+    pub const BASIC: ExecutionView = ExecutionView::new(1);
 
     /// Includes all data.
-    pub const FULL: ExecutionView = ExecutionView::new("FULL");
+    pub const FULL: ExecutionView = ExecutionView::new(2);
+
+    /// Creates a new ExecutionView instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("EXECUTION_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("BASIC"),
+            2 => std::borrow::Cow::Borrowed("FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "EXECUTION_VIEW_UNSPECIFIED" => {
+                std::option::Option::Some(Self::EXECUTION_VIEW_UNSPECIFIED)
+            }
+            "BASIC" => std::option::Option::Some(Self::BASIC),
+            "FULL" => std::option::Option::Some(Self::FULL),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ExecutionView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ExecutionView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ExecutionView {
     fn default() -> Self {
-        execution_view::EXECUTION_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/cloud/workflows/executions/v1/src/transport.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::Executions for Executions {
                 reqwest::Method::GET,
                 format!("/v1/{}/executions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -79,7 +79,7 @@ impl crate::stubs::Executions for Executions {
                 reqwest::Method::POST,
                 format!("/v1/{}/executions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -98,7 +98,7 @@ impl crate::stubs::Executions for Executions {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -118,7 +118,7 @@ impl crate::stubs::Executions for Executions {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/workflows/v1/src/model.rs
+++ b/src/generated/cloud/workflows/v1/src/model.rs
@@ -350,131 +350,177 @@ pub mod workflow {
 
         /// Describes the possibled types of a state error.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(std::borrow::Cow<'static, str>);
+        pub struct Type(i32);
 
         impl Type {
+            /// No type specified.
+            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+            /// Caused by an issue with KMS.
+            pub const KMS_ERROR: Type = Type::new(1);
+
             /// Creates a new Type instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("KMS_ERROR"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                    "KMS_ERROR" => std::option::Option::Some(Self::KMS_ERROR),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Type](Type)
-        pub mod r#type {
-            use super::Type;
-
-            /// No type specified.
-            pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-            /// Caused by an issue with KMS.
-            pub const KMS_ERROR: Type = Type::new("KMS_ERROR");
-        }
-
-        impl std::convert::From<std::string::String> for Type {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                r#type::TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// Describes the current state of workflow deployment.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Invalid state.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The workflow has been deployed successfully and is serving.
+        pub const ACTIVE: State = State::new(1);
+
+        /// Workflow data is unavailable. See the `state_error` field.
+        pub const UNAVAILABLE: State = State::new(2);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("UNAVAILABLE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "UNAVAILABLE" => std::option::Option::Some(Self::UNAVAILABLE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Invalid state.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The workflow has been deployed successfully and is serving.
-        pub const ACTIVE: State = State::new("ACTIVE");
-
-        /// Workflow data is unavailable. See the `state_error` field.
-        pub const UNAVAILABLE: State = State::new("UNAVAILABLE");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Describes the level of platform logging to apply to calls and call
     /// responses during workflow executions.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CallLogLevel(std::borrow::Cow<'static, str>);
+    pub struct CallLogLevel(i32);
 
     impl CallLogLevel {
-        /// Creates a new CallLogLevel instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CallLogLevel](CallLogLevel)
-    pub mod call_log_level {
-        use super::CallLogLevel;
-
         /// No call logging level specified.
-        pub const CALL_LOG_LEVEL_UNSPECIFIED: CallLogLevel =
-            CallLogLevel::new("CALL_LOG_LEVEL_UNSPECIFIED");
+        pub const CALL_LOG_LEVEL_UNSPECIFIED: CallLogLevel = CallLogLevel::new(0);
 
         /// Log all call steps within workflows, all call returns, and all exceptions
         /// raised.
-        pub const LOG_ALL_CALLS: CallLogLevel = CallLogLevel::new("LOG_ALL_CALLS");
+        pub const LOG_ALL_CALLS: CallLogLevel = CallLogLevel::new(1);
 
         /// Log only exceptions that are raised from call steps within workflows.
-        pub const LOG_ERRORS_ONLY: CallLogLevel = CallLogLevel::new("LOG_ERRORS_ONLY");
+        pub const LOG_ERRORS_ONLY: CallLogLevel = CallLogLevel::new(2);
 
         /// Explicitly log nothing.
-        pub const LOG_NONE: CallLogLevel = CallLogLevel::new("LOG_NONE");
+        pub const LOG_NONE: CallLogLevel = CallLogLevel::new(3);
+
+        /// Creates a new CallLogLevel instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CALL_LOG_LEVEL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LOG_ALL_CALLS"),
+                2 => std::borrow::Cow::Borrowed("LOG_ERRORS_ONLY"),
+                3 => std::borrow::Cow::Borrowed("LOG_NONE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CALL_LOG_LEVEL_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CALL_LOG_LEVEL_UNSPECIFIED)
+                }
+                "LOG_ALL_CALLS" => std::option::Option::Some(Self::LOG_ALL_CALLS),
+                "LOG_ERRORS_ONLY" => std::option::Option::Some(Self::LOG_ERRORS_ONLY),
+                "LOG_NONE" => std::option::Option::Some(Self::LOG_NONE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CallLogLevel {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CallLogLevel {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CallLogLevel {
         fn default() -> Self {
-            call_log_level::CALL_LOG_LEVEL_UNSPECIFIED
+            Self::new(0)
         }
     }
 

--- a/src/generated/cloud/workflows/v1/src/transport.rs
+++ b/src/generated/cloud/workflows/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::Workflows for Workflows {
                 reqwest::Method::GET,
                 format!("/v1/{}/workflows", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::Workflows for Workflows {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -98,7 +98,7 @@ impl crate::stubs::Workflows for Workflows {
                 reqwest::Method::POST,
                 format!("/v1/{}/workflows", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -118,7 +118,7 @@ impl crate::stubs::Workflows for Workflows {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -146,7 +146,7 @@ impl crate::stubs::Workflows for Workflows {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -175,7 +175,7 @@ impl crate::stubs::Workflows for Workflows {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -197,7 +197,7 @@ impl crate::stubs::Workflows for Workflows {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -216,7 +216,7 @@ impl crate::stubs::Workflows for Workflows {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -238,7 +238,7 @@ impl crate::stubs::Workflows for Workflows {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -257,7 +257,7 @@ impl crate::stubs::Workflows for Workflows {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/cloud/workstations/v1/src/model.rs
+++ b/src/generated/cloud/workstations/v1/src/model.rs
@@ -1331,45 +1331,61 @@ pub mod workstation_config {
             /// Value representing what should happen to the disk after the workstation
             /// is deleted.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct ReclaimPolicy(std::borrow::Cow<'static, str>);
+            pub struct ReclaimPolicy(i32);
 
             impl ReclaimPolicy {
-                /// Creates a new ReclaimPolicy instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [ReclaimPolicy](ReclaimPolicy)
-            pub mod reclaim_policy {
-                use super::ReclaimPolicy;
-
                 /// Do not use.
-                pub const RECLAIM_POLICY_UNSPECIFIED: ReclaimPolicy =
-                    ReclaimPolicy::new("RECLAIM_POLICY_UNSPECIFIED");
+                pub const RECLAIM_POLICY_UNSPECIFIED: ReclaimPolicy = ReclaimPolicy::new(0);
 
                 /// Delete the persistent disk when deleting the workstation.
-                pub const DELETE: ReclaimPolicy = ReclaimPolicy::new("DELETE");
+                pub const DELETE: ReclaimPolicy = ReclaimPolicy::new(1);
 
                 /// Keep the persistent disk when deleting the workstation.
                 /// An administrator must manually delete the disk.
-                pub const RETAIN: ReclaimPolicy = ReclaimPolicy::new("RETAIN");
+                pub const RETAIN: ReclaimPolicy = ReclaimPolicy::new(2);
+
+                /// Creates a new ReclaimPolicy instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("RECLAIM_POLICY_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("DELETE"),
+                        2 => std::borrow::Cow::Borrowed("RETAIN"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "RECLAIM_POLICY_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::RECLAIM_POLICY_UNSPECIFIED)
+                        }
+                        "DELETE" => std::option::Option::Some(Self::DELETE),
+                        "RETAIN" => std::option::Option::Some(Self::RETAIN),
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for ReclaimPolicy {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for ReclaimPolicy {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for ReclaimPolicy {
                 fn default() -> Self {
-                    reclaim_policy::RECLAIM_POLICY_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -1777,51 +1793,70 @@ pub mod workstation {
 
     /// Whether a workstation is running and ready to receive user requests.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Do not use.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The workstation is not yet ready to accept requests from users but will
         /// be soon.
-        pub const STATE_STARTING: State = State::new("STATE_STARTING");
+        pub const STATE_STARTING: State = State::new(1);
 
         /// The workstation is ready to accept requests from users.
-        pub const STATE_RUNNING: State = State::new("STATE_RUNNING");
+        pub const STATE_RUNNING: State = State::new(2);
 
         /// The workstation is being stopped.
-        pub const STATE_STOPPING: State = State::new("STATE_STOPPING");
+        pub const STATE_STOPPING: State = State::new(3);
 
         /// The workstation is stopped and will not be able to receive requests until
         /// it is started.
-        pub const STATE_STOPPED: State = State::new("STATE_STOPPED");
+        pub const STATE_STOPPED: State = State::new(4);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STATE_STARTING"),
+                2 => std::borrow::Cow::Borrowed("STATE_RUNNING"),
+                3 => std::borrow::Cow::Borrowed("STATE_STOPPING"),
+                4 => std::borrow::Cow::Borrowed("STATE_STOPPED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "STATE_STARTING" => std::option::Option::Some(Self::STATE_STARTING),
+                "STATE_RUNNING" => std::option::Option::Some(Self::STATE_RUNNING),
+                "STATE_STOPPING" => std::option::Option::Some(Self::STATE_STOPPING),
+                "STATE_STOPPED" => std::option::Option::Some(Self::STATE_STOPPED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/cloud/workstations/v1/src/transport.rs
+++ b/src/generated/cloud/workstations/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::Workstations for Workstations {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -71,7 +71,7 @@ impl crate::stubs::Workstations for Workstations {
                 reqwest::Method::GET,
                 format!("/v1/{}/workstationClusters", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -95,7 +95,7 @@ impl crate::stubs::Workstations for Workstations {
                 reqwest::Method::POST,
                 format!("/v1/{}/workstationClusters", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -125,7 +125,7 @@ impl crate::stubs::Workstations for Workstations {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -156,7 +156,7 @@ impl crate::stubs::Workstations for Workstations {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -178,7 +178,7 @@ impl crate::stubs::Workstations for Workstations {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -200,7 +200,7 @@ impl crate::stubs::Workstations for Workstations {
                 reqwest::Method::GET,
                 format!("/v1/{}/workstationConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -224,7 +224,7 @@ impl crate::stubs::Workstations for Workstations {
                 reqwest::Method::GET,
                 format!("/v1/{}/workstationConfigs:listUsable", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -248,7 +248,7 @@ impl crate::stubs::Workstations for Workstations {
                 reqwest::Method::POST,
                 format!("/v1/{}/workstationConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -278,7 +278,7 @@ impl crate::stubs::Workstations for Workstations {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -309,7 +309,7 @@ impl crate::stubs::Workstations for Workstations {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -331,7 +331,7 @@ impl crate::stubs::Workstations for Workstations {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -353,7 +353,7 @@ impl crate::stubs::Workstations for Workstations {
                 reqwest::Method::GET,
                 format!("/v1/{}/workstations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -377,7 +377,7 @@ impl crate::stubs::Workstations for Workstations {
                 reqwest::Method::GET,
                 format!("/v1/{}/workstations:listUsable", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -401,7 +401,7 @@ impl crate::stubs::Workstations for Workstations {
                 reqwest::Method::POST,
                 format!("/v1/{}/workstations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -431,7 +431,7 @@ impl crate::stubs::Workstations for Workstations {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -462,7 +462,7 @@ impl crate::stubs::Workstations for Workstations {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -483,7 +483,7 @@ impl crate::stubs::Workstations for Workstations {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:start", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -500,7 +500,7 @@ impl crate::stubs::Workstations for Workstations {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:stop", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -520,7 +520,7 @@ impl crate::stubs::Workstations for Workstations {
                 reqwest::Method::POST,
                 format!("/v1/{}:generateAccessToken", req.workstation),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -540,7 +540,7 @@ impl crate::stubs::Workstations for Workstations {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -560,7 +560,7 @@ impl crate::stubs::Workstations for Workstations {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -592,7 +592,7 @@ impl crate::stubs::Workstations for Workstations {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -609,7 +609,7 @@ impl crate::stubs::Workstations for Workstations {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -631,7 +631,7 @@ impl crate::stubs::Workstations for Workstations {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -650,7 +650,7 @@ impl crate::stubs::Workstations for Workstations {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -669,7 +669,7 @@ impl crate::stubs::Workstations for Workstations {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/container/v1/src/model.rs
+++ b/src/generated/container/v1/src/model.rs
@@ -164,46 +164,63 @@ pub mod linux_node_config {
 
     /// Possible cgroup modes that can be used.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CgroupMode(std::borrow::Cow<'static, str>);
+    pub struct CgroupMode(i32);
 
     impl CgroupMode {
-        /// Creates a new CgroupMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CgroupMode](CgroupMode)
-    pub mod cgroup_mode {
-        use super::CgroupMode;
-
         /// CGROUP_MODE_UNSPECIFIED is when unspecified cgroup configuration is used.
         /// The default for the GKE node OS image will be used.
-        pub const CGROUP_MODE_UNSPECIFIED: CgroupMode = CgroupMode::new("CGROUP_MODE_UNSPECIFIED");
+        pub const CGROUP_MODE_UNSPECIFIED: CgroupMode = CgroupMode::new(0);
 
         /// CGROUP_MODE_V1 specifies to use cgroupv1 for the cgroup configuration on
         /// the node image.
-        pub const CGROUP_MODE_V1: CgroupMode = CgroupMode::new("CGROUP_MODE_V1");
+        pub const CGROUP_MODE_V1: CgroupMode = CgroupMode::new(1);
 
         /// CGROUP_MODE_V2 specifies to use cgroupv2 for the cgroup configuration on
         /// the node image.
-        pub const CGROUP_MODE_V2: CgroupMode = CgroupMode::new("CGROUP_MODE_V2");
+        pub const CGROUP_MODE_V2: CgroupMode = CgroupMode::new(2);
+
+        /// Creates a new CgroupMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CGROUP_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CGROUP_MODE_V1"),
+                2 => std::borrow::Cow::Borrowed("CGROUP_MODE_V2"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CGROUP_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CGROUP_MODE_UNSPECIFIED)
+                }
+                "CGROUP_MODE_V1" => std::option::Option::Some(Self::CGROUP_MODE_V1),
+                "CGROUP_MODE_V2" => std::option::Option::Some(Self::CGROUP_MODE_V2),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CgroupMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CgroupMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CgroupMode {
         fn default() -> Self {
-            cgroup_mode::CGROUP_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -248,43 +265,58 @@ pub mod windows_node_config {
 
     /// Possible OS version that can be used.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OSVersion(std::borrow::Cow<'static, str>);
+    pub struct OSVersion(i32);
 
     impl OSVersion {
+        /// When OSVersion is not specified
+        pub const OS_VERSION_UNSPECIFIED: OSVersion = OSVersion::new(0);
+
+        /// LTSC2019 specifies to use LTSC2019 as the Windows Servercore Base Image
+        pub const OS_VERSION_LTSC2019: OSVersion = OSVersion::new(1);
+
+        /// LTSC2022 specifies to use LTSC2022 as the Windows Servercore Base Image
+        pub const OS_VERSION_LTSC2022: OSVersion = OSVersion::new(2);
+
         /// Creates a new OSVersion instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("OS_VERSION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("OS_VERSION_LTSC2019"),
+                2 => std::borrow::Cow::Borrowed("OS_VERSION_LTSC2022"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "OS_VERSION_UNSPECIFIED" => std::option::Option::Some(Self::OS_VERSION_UNSPECIFIED),
+                "OS_VERSION_LTSC2019" => std::option::Option::Some(Self::OS_VERSION_LTSC2019),
+                "OS_VERSION_LTSC2022" => std::option::Option::Some(Self::OS_VERSION_LTSC2022),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [OSVersion](OSVersion)
-    pub mod os_version {
-        use super::OSVersion;
-
-        /// When OSVersion is not specified
-        pub const OS_VERSION_UNSPECIFIED: OSVersion = OSVersion::new("OS_VERSION_UNSPECIFIED");
-
-        /// LTSC2019 specifies to use LTSC2019 as the Windows Servercore Base Image
-        pub const OS_VERSION_LTSC2019: OSVersion = OSVersion::new("OS_VERSION_LTSC2019");
-
-        /// LTSC2022 specifies to use LTSC2022 as the Windows Servercore Base Image
-        pub const OS_VERSION_LTSC2022: OSVersion = OSVersion::new("OS_VERSION_LTSC2022");
-    }
-
-    impl std::convert::From<std::string::String> for OSVersion {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for OSVersion {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for OSVersion {
         fn default() -> Self {
-            os_version::OS_VERSION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1110,101 +1142,137 @@ pub mod node_config {
     /// LocalSsdEncryptionMode specifies the method used for encrypting the Local
     /// SSDs attached to the node.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LocalSsdEncryptionMode(std::borrow::Cow<'static, str>);
+    pub struct LocalSsdEncryptionMode(i32);
 
     impl LocalSsdEncryptionMode {
-        /// Creates a new LocalSsdEncryptionMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [LocalSsdEncryptionMode](LocalSsdEncryptionMode)
-    pub mod local_ssd_encryption_mode {
-        use super::LocalSsdEncryptionMode;
-
         /// The given node will be encrypted using keys managed by Google
         /// infrastructure and the keys will be deleted when the node is
         /// deleted.
         pub const LOCAL_SSD_ENCRYPTION_MODE_UNSPECIFIED: LocalSsdEncryptionMode =
-            LocalSsdEncryptionMode::new("LOCAL_SSD_ENCRYPTION_MODE_UNSPECIFIED");
+            LocalSsdEncryptionMode::new(0);
 
         /// The given node will be encrypted using keys managed by Google
         /// infrastructure and the keys will be deleted when the node is
         /// deleted.
-        pub const STANDARD_ENCRYPTION: LocalSsdEncryptionMode =
-            LocalSsdEncryptionMode::new("STANDARD_ENCRYPTION");
+        pub const STANDARD_ENCRYPTION: LocalSsdEncryptionMode = LocalSsdEncryptionMode::new(1);
 
         /// The given node will opt-in for using ephemeral key for
         /// encryption of Local SSDs.
         /// The Local SSDs will not be able to recover data in case of node
         /// crash.
-        pub const EPHEMERAL_KEY_ENCRYPTION: LocalSsdEncryptionMode =
-            LocalSsdEncryptionMode::new("EPHEMERAL_KEY_ENCRYPTION");
+        pub const EPHEMERAL_KEY_ENCRYPTION: LocalSsdEncryptionMode = LocalSsdEncryptionMode::new(2);
+
+        /// Creates a new LocalSsdEncryptionMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LOCAL_SSD_ENCRYPTION_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STANDARD_ENCRYPTION"),
+                2 => std::borrow::Cow::Borrowed("EPHEMERAL_KEY_ENCRYPTION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LOCAL_SSD_ENCRYPTION_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::LOCAL_SSD_ENCRYPTION_MODE_UNSPECIFIED)
+                }
+                "STANDARD_ENCRYPTION" => std::option::Option::Some(Self::STANDARD_ENCRYPTION),
+                "EPHEMERAL_KEY_ENCRYPTION" => {
+                    std::option::Option::Some(Self::EPHEMERAL_KEY_ENCRYPTION)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for LocalSsdEncryptionMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LocalSsdEncryptionMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LocalSsdEncryptionMode {
         fn default() -> Self {
-            local_ssd_encryption_mode::LOCAL_SSD_ENCRYPTION_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Possible effective cgroup modes for the node.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EffectiveCgroupMode(std::borrow::Cow<'static, str>);
+    pub struct EffectiveCgroupMode(i32);
 
     impl EffectiveCgroupMode {
-        /// Creates a new EffectiveCgroupMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [EffectiveCgroupMode](EffectiveCgroupMode)
-    pub mod effective_cgroup_mode {
-        use super::EffectiveCgroupMode;
-
         /// EFFECTIVE_CGROUP_MODE_UNSPECIFIED means the cgroup configuration for the
         /// node pool is unspecified, i.e. the node pool is a Windows node pool.
         pub const EFFECTIVE_CGROUP_MODE_UNSPECIFIED: EffectiveCgroupMode =
-            EffectiveCgroupMode::new("EFFECTIVE_CGROUP_MODE_UNSPECIFIED");
+            EffectiveCgroupMode::new(0);
 
         /// CGROUP_MODE_V1 means the node pool is configured to use cgroupv1 for the
         /// cgroup configuration.
-        pub const EFFECTIVE_CGROUP_MODE_V1: EffectiveCgroupMode =
-            EffectiveCgroupMode::new("EFFECTIVE_CGROUP_MODE_V1");
+        pub const EFFECTIVE_CGROUP_MODE_V1: EffectiveCgroupMode = EffectiveCgroupMode::new(1);
 
         /// CGROUP_MODE_V2 means the node pool is configured to use cgroupv2 for the
         /// cgroup configuration.
-        pub const EFFECTIVE_CGROUP_MODE_V2: EffectiveCgroupMode =
-            EffectiveCgroupMode::new("EFFECTIVE_CGROUP_MODE_V2");
+        pub const EFFECTIVE_CGROUP_MODE_V2: EffectiveCgroupMode = EffectiveCgroupMode::new(2);
+
+        /// Creates a new EffectiveCgroupMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EFFECTIVE_CGROUP_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("EFFECTIVE_CGROUP_MODE_V1"),
+                2 => std::borrow::Cow::Borrowed("EFFECTIVE_CGROUP_MODE_V2"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EFFECTIVE_CGROUP_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::EFFECTIVE_CGROUP_MODE_UNSPECIFIED)
+                }
+                "EFFECTIVE_CGROUP_MODE_V1" => {
+                    std::option::Option::Some(Self::EFFECTIVE_CGROUP_MODE_V1)
+                }
+                "EFFECTIVE_CGROUP_MODE_V2" => {
+                    std::option::Option::Some(Self::EFFECTIVE_CGROUP_MODE_V2)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for EffectiveCgroupMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EffectiveCgroupMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EffectiveCgroupMode {
         fn default() -> Self {
-            effective_cgroup_mode::EFFECTIVE_CGROUP_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1495,40 +1563,53 @@ pub mod node_network_config {
 
         /// Node network tier
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Tier(std::borrow::Cow<'static, str>);
+        pub struct Tier(i32);
 
         impl Tier {
+            /// Default value
+            pub const TIER_UNSPECIFIED: Tier = Tier::new(0);
+
+            /// Higher bandwidth, actual values based on VM size.
+            pub const TIER_1: Tier = Tier::new(1);
+
             /// Creates a new Tier instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("TIER_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("TIER_1"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "TIER_UNSPECIFIED" => std::option::Option::Some(Self::TIER_UNSPECIFIED),
+                    "TIER_1" => std::option::Option::Some(Self::TIER_1),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Tier](Tier)
-        pub mod tier {
-            use super::Tier;
-
-            /// Default value
-            pub const TIER_UNSPECIFIED: Tier = Tier::new("TIER_UNSPECIFIED");
-
-            /// Higher bandwidth, actual values based on VM size.
-            pub const TIER_1: Tier = Tier::new("TIER_1");
-        }
-
-        impl std::convert::From<std::string::String> for Tier {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Tier {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Tier {
             fn default() -> Self {
-                tier::TIER_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -1718,40 +1799,53 @@ pub mod sandbox_config {
 
     /// Possible types of sandboxes.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Default value. This should not be used.
+        pub const UNSPECIFIED: Type = Type::new(0);
+
+        /// Run sandbox using gvisor.
+        pub const GVISOR: Type = Type::new(1);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GVISOR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
+                "GVISOR" => std::option::Option::Some(Self::GVISOR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Default value. This should not be used.
-        pub const UNSPECIFIED: Type = Type::new("UNSPECIFIED");
-
-        /// Run sandbox using gvisor.
-        pub const GVISOR: Type = Type::new("GVISOR");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1855,47 +1949,64 @@ pub mod reservation_affinity {
 
     /// Indicates whether to consume capacity from a reservation or not.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// Default value. This should not be used.
-        pub const UNSPECIFIED: Type = Type::new("UNSPECIFIED");
+        pub const UNSPECIFIED: Type = Type::new(0);
 
         /// Do not consume from any reserved capacity.
-        pub const NO_RESERVATION: Type = Type::new("NO_RESERVATION");
+        pub const NO_RESERVATION: Type = Type::new(1);
 
         /// Consume any reservation available.
-        pub const ANY_RESERVATION: Type = Type::new("ANY_RESERVATION");
+        pub const ANY_RESERVATION: Type = Type::new(2);
 
         /// Must consume from a specific reservation. Must specify key value fields
         /// for specifying the reservations.
-        pub const SPECIFIC_RESERVATION: Type = Type::new("SPECIFIC_RESERVATION");
+        pub const SPECIFIC_RESERVATION: Type = Type::new(3);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NO_RESERVATION"),
+                2 => std::borrow::Cow::Borrowed("ANY_RESERVATION"),
+                3 => std::borrow::Cow::Borrowed("SPECIFIC_RESERVATION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
+                "NO_RESERVATION" => std::option::Option::Some(Self::NO_RESERVATION),
+                "ANY_RESERVATION" => std::option::Option::Some(Self::ANY_RESERVATION),
+                "SPECIFIC_RESERVATION" => std::option::Option::Some(Self::SPECIFIC_RESERVATION),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2008,43 +2119,58 @@ pub mod sole_tenant_config {
         /// Operator allows user to specify affinity or anti-affinity for the
         /// given key values.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Operator(std::borrow::Cow<'static, str>);
+        pub struct Operator(i32);
 
         impl Operator {
+            /// Invalid or unspecified affinity operator.
+            pub const OPERATOR_UNSPECIFIED: Operator = Operator::new(0);
+
+            /// Affinity operator.
+            pub const IN: Operator = Operator::new(1);
+
+            /// Anti-affinity operator.
+            pub const NOT_IN: Operator = Operator::new(2);
+
             /// Creates a new Operator instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("OPERATOR_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("IN"),
+                    2 => std::borrow::Cow::Borrowed("NOT_IN"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "OPERATOR_UNSPECIFIED" => std::option::Option::Some(Self::OPERATOR_UNSPECIFIED),
+                    "IN" => std::option::Option::Some(Self::IN),
+                    "NOT_IN" => std::option::Option::Some(Self::NOT_IN),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Operator](Operator)
-        pub mod operator {
-            use super::Operator;
-
-            /// Invalid or unspecified affinity operator.
-            pub const OPERATOR_UNSPECIFIED: Operator = Operator::new("OPERATOR_UNSPECIFIED");
-
-            /// Affinity operator.
-            pub const IN: Operator = Operator::new("IN");
-
-            /// Anti-affinity operator.
-            pub const NOT_IN: Operator = Operator::new("NOT_IN");
-        }
-
-        impl std::convert::From<std::string::String> for Operator {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Operator {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Operator {
             fn default() -> Self {
-                operator::OPERATOR_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -2340,46 +2466,63 @@ pub mod node_taint {
 
     /// Possible values for Effect in taint.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Effect(std::borrow::Cow<'static, str>);
+    pub struct Effect(i32);
 
     impl Effect {
+        /// Not set
+        pub const EFFECT_UNSPECIFIED: Effect = Effect::new(0);
+
+        /// NoSchedule
+        pub const NO_SCHEDULE: Effect = Effect::new(1);
+
+        /// PreferNoSchedule
+        pub const PREFER_NO_SCHEDULE: Effect = Effect::new(2);
+
+        /// NoExecute
+        pub const NO_EXECUTE: Effect = Effect::new(3);
+
         /// Creates a new Effect instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EFFECT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NO_SCHEDULE"),
+                2 => std::borrow::Cow::Borrowed("PREFER_NO_SCHEDULE"),
+                3 => std::borrow::Cow::Borrowed("NO_EXECUTE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EFFECT_UNSPECIFIED" => std::option::Option::Some(Self::EFFECT_UNSPECIFIED),
+                "NO_SCHEDULE" => std::option::Option::Some(Self::NO_SCHEDULE),
+                "PREFER_NO_SCHEDULE" => std::option::Option::Some(Self::PREFER_NO_SCHEDULE),
+                "NO_EXECUTE" => std::option::Option::Some(Self::NO_EXECUTE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Effect](Effect)
-    pub mod effect {
-        use super::Effect;
-
-        /// Not set
-        pub const EFFECT_UNSPECIFIED: Effect = Effect::new("EFFECT_UNSPECIFIED");
-
-        /// NoSchedule
-        pub const NO_SCHEDULE: Effect = Effect::new("NO_SCHEDULE");
-
-        /// PreferNoSchedule
-        pub const PREFER_NO_SCHEDULE: Effect = Effect::new("PREFER_NO_SCHEDULE");
-
-        /// NoExecute
-        pub const NO_EXECUTE: Effect = Effect::new("NO_EXECUTE");
-    }
-
-    impl std::convert::From<std::string::String> for Effect {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Effect {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Effect {
         fn default() -> Self {
-            effect::EFFECT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3332,46 +3475,64 @@ pub mod cloud_run_config {
 
     /// Load balancer type of ingress service of Cloud Run.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LoadBalancerType(std::borrow::Cow<'static, str>);
+    pub struct LoadBalancerType(i32);
 
     impl LoadBalancerType {
+        /// Load balancer type for Cloud Run is unspecified.
+        pub const LOAD_BALANCER_TYPE_UNSPECIFIED: LoadBalancerType = LoadBalancerType::new(0);
+
+        /// Install external load balancer for Cloud Run.
+        pub const LOAD_BALANCER_TYPE_EXTERNAL: LoadBalancerType = LoadBalancerType::new(1);
+
+        /// Install internal load balancer for Cloud Run.
+        pub const LOAD_BALANCER_TYPE_INTERNAL: LoadBalancerType = LoadBalancerType::new(2);
+
         /// Creates a new LoadBalancerType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LOAD_BALANCER_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LOAD_BALANCER_TYPE_EXTERNAL"),
+                2 => std::borrow::Cow::Borrowed("LOAD_BALANCER_TYPE_INTERNAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LOAD_BALANCER_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::LOAD_BALANCER_TYPE_UNSPECIFIED)
+                }
+                "LOAD_BALANCER_TYPE_EXTERNAL" => {
+                    std::option::Option::Some(Self::LOAD_BALANCER_TYPE_EXTERNAL)
+                }
+                "LOAD_BALANCER_TYPE_INTERNAL" => {
+                    std::option::Option::Some(Self::LOAD_BALANCER_TYPE_INTERNAL)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [LoadBalancerType](LoadBalancerType)
-    pub mod load_balancer_type {
-        use super::LoadBalancerType;
-
-        /// Load balancer type for Cloud Run is unspecified.
-        pub const LOAD_BALANCER_TYPE_UNSPECIFIED: LoadBalancerType =
-            LoadBalancerType::new("LOAD_BALANCER_TYPE_UNSPECIFIED");
-
-        /// Install external load balancer for Cloud Run.
-        pub const LOAD_BALANCER_TYPE_EXTERNAL: LoadBalancerType =
-            LoadBalancerType::new("LOAD_BALANCER_TYPE_EXTERNAL");
-
-        /// Install internal load balancer for Cloud Run.
-        pub const LOAD_BALANCER_TYPE_INTERNAL: LoadBalancerType =
-            LoadBalancerType::new("LOAD_BALANCER_TYPE_INTERNAL");
-    }
-
-    impl std::convert::From<std::string::String> for LoadBalancerType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LoadBalancerType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LoadBalancerType {
         fn default() -> Self {
-            load_balancer_type::LOAD_BALANCER_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3835,40 +3996,53 @@ pub mod network_policy {
 
     /// Allowed Network Policy providers.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Provider(std::borrow::Cow<'static, str>);
+    pub struct Provider(i32);
 
     impl Provider {
+        /// Not set
+        pub const PROVIDER_UNSPECIFIED: Provider = Provider::new(0);
+
+        /// Tigera (Calico Felix).
+        pub const CALICO: Provider = Provider::new(1);
+
         /// Creates a new Provider instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PROVIDER_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CALICO"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PROVIDER_UNSPECIFIED" => std::option::Option::Some(Self::PROVIDER_UNSPECIFIED),
+                "CALICO" => std::option::Option::Some(Self::CALICO),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Provider](Provider)
-    pub mod provider {
-        use super::Provider;
-
-        /// Not set
-        pub const PROVIDER_UNSPECIFIED: Provider = Provider::new("PROVIDER_UNSPECIFIED");
-
-        /// Tigera (Calico Felix).
-        pub const CALICO: Provider = Provider::new("CALICO");
-    }
-
-    impl std::convert::From<std::string::String> for Provider {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Provider {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Provider {
         fn default() -> Self {
-            provider::PROVIDER_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3925,47 +4099,64 @@ pub mod binary_authorization {
 
     /// Binary Authorization mode of operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EvaluationMode(std::borrow::Cow<'static, str>);
+    pub struct EvaluationMode(i32);
 
     impl EvaluationMode {
-        /// Creates a new EvaluationMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [EvaluationMode](EvaluationMode)
-    pub mod evaluation_mode {
-        use super::EvaluationMode;
-
         /// Default value
-        pub const EVALUATION_MODE_UNSPECIFIED: EvaluationMode =
-            EvaluationMode::new("EVALUATION_MODE_UNSPECIFIED");
+        pub const EVALUATION_MODE_UNSPECIFIED: EvaluationMode = EvaluationMode::new(0);
 
         /// Disable BinaryAuthorization
-        pub const DISABLED: EvaluationMode = EvaluationMode::new("DISABLED");
+        pub const DISABLED: EvaluationMode = EvaluationMode::new(1);
 
         /// Enforce Kubernetes admission requests with BinaryAuthorization using the
         /// project's singleton policy. This is equivalent to setting the
         /// enabled boolean to true.
-        pub const PROJECT_SINGLETON_POLICY_ENFORCE: EvaluationMode =
-            EvaluationMode::new("PROJECT_SINGLETON_POLICY_ENFORCE");
+        pub const PROJECT_SINGLETON_POLICY_ENFORCE: EvaluationMode = EvaluationMode::new(2);
+
+        /// Creates a new EvaluationMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EVALUATION_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DISABLED"),
+                2 => std::borrow::Cow::Borrowed("PROJECT_SINGLETON_POLICY_ENFORCE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EVALUATION_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::EVALUATION_MODE_UNSPECIFIED)
+                }
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "PROJECT_SINGLETON_POLICY_ENFORCE" => {
+                    std::option::Option::Some(Self::PROJECT_SINGLETON_POLICY_ENFORCE)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for EvaluationMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EvaluationMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EvaluationMode {
         fn default() -> Self {
-            evaluation_mode::EVALUATION_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5498,60 +5689,83 @@ pub mod cluster {
 
     /// The current status of the cluster.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(std::borrow::Cow<'static, str>);
+    pub struct Status(i32);
 
     impl Status {
-        /// Creates a new Status instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Status](Status)
-    pub mod status {
-        use super::Status;
-
         /// Not set.
-        pub const STATUS_UNSPECIFIED: Status = Status::new("STATUS_UNSPECIFIED");
+        pub const STATUS_UNSPECIFIED: Status = Status::new(0);
 
         /// The PROVISIONING state indicates the cluster is being created.
-        pub const PROVISIONING: Status = Status::new("PROVISIONING");
+        pub const PROVISIONING: Status = Status::new(1);
 
         /// The RUNNING state indicates the cluster has been created and is fully
         /// usable.
-        pub const RUNNING: Status = Status::new("RUNNING");
+        pub const RUNNING: Status = Status::new(2);
 
         /// The RECONCILING state indicates that some work is actively being done on
         /// the cluster, such as upgrading the master or node software. Details can
         /// be found in the `statusMessage` field.
-        pub const RECONCILING: Status = Status::new("RECONCILING");
+        pub const RECONCILING: Status = Status::new(3);
 
         /// The STOPPING state indicates the cluster is being deleted.
-        pub const STOPPING: Status = Status::new("STOPPING");
+        pub const STOPPING: Status = Status::new(4);
 
         /// The ERROR state indicates the cluster is unusable. It will be
         /// automatically deleted. Details can be found in the `statusMessage` field.
-        pub const ERROR: Status = Status::new("ERROR");
+        pub const ERROR: Status = Status::new(5);
 
         /// The DEGRADED state indicates the cluster requires user action to restore
         /// full functionality. Details can be found in the `statusMessage` field.
-        pub const DEGRADED: Status = Status::new("DEGRADED");
+        pub const DEGRADED: Status = Status::new(6);
+
+        /// Creates a new Status instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATUS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("RECONCILING"),
+                4 => std::borrow::Cow::Borrowed("STOPPING"),
+                5 => std::borrow::Cow::Borrowed("ERROR"),
+                6 => std::borrow::Cow::Borrowed("DEGRADED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATUS_UNSPECIFIED" => std::option::Option::Some(Self::STATUS_UNSPECIFIED),
+                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "RECONCILING" => std::option::Option::Some(Self::RECONCILING),
+                "STOPPING" => std::option::Option::Some(Self::STOPPING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "DEGRADED" => std::option::Option::Some(Self::DEGRADED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Status {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            status::STATUS_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5828,43 +6042,58 @@ pub mod compliance_posture_config {
 
     /// Mode defines enablement mode for Compliance Posture.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(std::borrow::Cow<'static, str>);
+    pub struct Mode(i32);
 
     impl Mode {
+        /// Default value not specified.
+        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
+
+        /// Disables Compliance Posture features on the cluster.
+        pub const DISABLED: Mode = Mode::new(1);
+
+        /// Enables Compliance Posture features on the cluster.
+        pub const ENABLED: Mode = Mode::new(2);
+
         /// Creates a new Mode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DISABLED"),
+                2 => std::borrow::Cow::Borrowed("ENABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Mode](Mode)
-    pub mod mode {
-        use super::Mode;
-
-        /// Default value not specified.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new("MODE_UNSPECIFIED");
-
-        /// Disables Compliance Posture features on the cluster.
-        pub const DISABLED: Mode = Mode::new("DISABLED");
-
-        /// Enables Compliance Posture features on the cluster.
-        pub const ENABLED: Mode = Mode::new("ENABLED");
-    }
-
-    impl std::convert::From<std::string::String> for Mode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            mode::MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5963,96 +6192,130 @@ pub mod security_posture_config {
 
     /// Mode defines enablement mode for GKE Security posture features.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(std::borrow::Cow<'static, str>);
+    pub struct Mode(i32);
 
     impl Mode {
+        /// Default value not specified.
+        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
+
+        /// Disables Security Posture features on the cluster.
+        pub const DISABLED: Mode = Mode::new(1);
+
+        /// Applies Security Posture features on the cluster.
+        pub const BASIC: Mode = Mode::new(2);
+
+        /// Applies the Security Posture off cluster Enterprise level features.
+        pub const ENTERPRISE: Mode = Mode::new(3);
+
         /// Creates a new Mode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DISABLED"),
+                2 => std::borrow::Cow::Borrowed("BASIC"),
+                3 => std::borrow::Cow::Borrowed("ENTERPRISE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "BASIC" => std::option::Option::Some(Self::BASIC),
+                "ENTERPRISE" => std::option::Option::Some(Self::ENTERPRISE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Mode](Mode)
-    pub mod mode {
-        use super::Mode;
-
-        /// Default value not specified.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new("MODE_UNSPECIFIED");
-
-        /// Disables Security Posture features on the cluster.
-        pub const DISABLED: Mode = Mode::new("DISABLED");
-
-        /// Applies Security Posture features on the cluster.
-        pub const BASIC: Mode = Mode::new("BASIC");
-
-        /// Applies the Security Posture off cluster Enterprise level features.
-        pub const ENTERPRISE: Mode = Mode::new("ENTERPRISE");
-    }
-
-    impl std::convert::From<std::string::String> for Mode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            mode::MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// VulnerabilityMode defines enablement mode for vulnerability scanning.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VulnerabilityMode(std::borrow::Cow<'static, str>);
+    pub struct VulnerabilityMode(i32);
 
     impl VulnerabilityMode {
-        /// Creates a new VulnerabilityMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [VulnerabilityMode](VulnerabilityMode)
-    pub mod vulnerability_mode {
-        use super::VulnerabilityMode;
-
         /// Default value not specified.
-        pub const VULNERABILITY_MODE_UNSPECIFIED: VulnerabilityMode =
-            VulnerabilityMode::new("VULNERABILITY_MODE_UNSPECIFIED");
+        pub const VULNERABILITY_MODE_UNSPECIFIED: VulnerabilityMode = VulnerabilityMode::new(0);
 
         /// Disables vulnerability scanning on the cluster.
-        pub const VULNERABILITY_DISABLED: VulnerabilityMode =
-            VulnerabilityMode::new("VULNERABILITY_DISABLED");
+        pub const VULNERABILITY_DISABLED: VulnerabilityMode = VulnerabilityMode::new(1);
 
         /// Applies basic vulnerability scanning on the cluster.
-        pub const VULNERABILITY_BASIC: VulnerabilityMode =
-            VulnerabilityMode::new("VULNERABILITY_BASIC");
+        pub const VULNERABILITY_BASIC: VulnerabilityMode = VulnerabilityMode::new(2);
 
         /// Applies the Security Posture's vulnerability on cluster Enterprise level
         /// features.
-        pub const VULNERABILITY_ENTERPRISE: VulnerabilityMode =
-            VulnerabilityMode::new("VULNERABILITY_ENTERPRISE");
+        pub const VULNERABILITY_ENTERPRISE: VulnerabilityMode = VulnerabilityMode::new(3);
+
+        /// Creates a new VulnerabilityMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VULNERABILITY_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("VULNERABILITY_DISABLED"),
+                2 => std::borrow::Cow::Borrowed("VULNERABILITY_BASIC"),
+                3 => std::borrow::Cow::Borrowed("VULNERABILITY_ENTERPRISE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VULNERABILITY_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::VULNERABILITY_MODE_UNSPECIFIED)
+                }
+                "VULNERABILITY_DISABLED" => std::option::Option::Some(Self::VULNERABILITY_DISABLED),
+                "VULNERABILITY_BASIC" => std::option::Option::Some(Self::VULNERABILITY_BASIC),
+                "VULNERABILITY_ENTERPRISE" => {
+                    std::option::Option::Some(Self::VULNERABILITY_ENTERPRISE)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for VulnerabilityMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for VulnerabilityMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for VulnerabilityMode {
         fn default() -> Self {
-            vulnerability_mode::VULNERABILITY_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7670,74 +7933,78 @@ pub mod operation {
 
     /// Current status of the operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(std::borrow::Cow<'static, str>);
+    pub struct Status(i32);
 
     impl Status {
+        /// Not set.
+        pub const STATUS_UNSPECIFIED: Status = Status::new(0);
+
+        /// The operation has been created.
+        pub const PENDING: Status = Status::new(1);
+
+        /// The operation is currently running.
+        pub const RUNNING: Status = Status::new(2);
+
+        /// The operation is done, either cancelled or completed.
+        pub const DONE: Status = Status::new(3);
+
+        /// The operation is aborting.
+        pub const ABORTING: Status = Status::new(4);
+
         /// Creates a new Status instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATUS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("DONE"),
+                4 => std::borrow::Cow::Borrowed("ABORTING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATUS_UNSPECIFIED" => std::option::Option::Some(Self::STATUS_UNSPECIFIED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "DONE" => std::option::Option::Some(Self::DONE),
+                "ABORTING" => std::option::Option::Some(Self::ABORTING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Status](Status)
-    pub mod status {
-        use super::Status;
-
-        /// Not set.
-        pub const STATUS_UNSPECIFIED: Status = Status::new("STATUS_UNSPECIFIED");
-
-        /// The operation has been created.
-        pub const PENDING: Status = Status::new("PENDING");
-
-        /// The operation is currently running.
-        pub const RUNNING: Status = Status::new("RUNNING");
-
-        /// The operation is done, either cancelled or completed.
-        pub const DONE: Status = Status::new("DONE");
-
-        /// The operation is aborting.
-        pub const ABORTING: Status = Status::new("ABORTING");
-    }
-
-    impl std::convert::From<std::string::String> for Status {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            status::STATUS_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Operation type categorizes the operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// Not set.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// The cluster is being created. The cluster should be assumed to be
         /// unusable until the operation finishes.
@@ -7746,7 +8013,7 @@ pub mod operation {
         /// state][Cluster.Status.ERROR] and eventually be deleted.
         ///
         /// [Cluster.Status.ERROR]: crate::model::cluster::status::ERROR
-        pub const CREATE_CLUSTER: Type = Type::new("CREATE_CLUSTER");
+        pub const CREATE_CLUSTER: Type = Type::new(1);
 
         /// The cluster is being deleted. The cluster should be assumed to be
         /// unusable as soon as this operation starts.
@@ -7756,7 +8023,7 @@ pub mod operation {
         /// retried until completed.
         ///
         /// [Cluster.Status.ERROR]: crate::model::cluster::status::ERROR
-        pub const DELETE_CLUSTER: Type = Type::new("DELETE_CLUSTER");
+        pub const DELETE_CLUSTER: Type = Type::new(2);
 
         /// The [cluster
         /// version][google.container.v1.ClusterUpdate.desired_master_version] is
@@ -7767,7 +8034,7 @@ pub mod operation {
         /// upgrades](https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-upgrades#cluster_upgrades).
         ///
         /// [google.container.v1.ClusterUpdate.desired_master_version]: crate::model::ClusterUpdate::desired_master_version
-        pub const UPGRADE_MASTER: Type = Type::new("UPGRADE_MASTER");
+        pub const UPGRADE_MASTER: Type = Type::new(3);
 
         /// A node pool is being updated. Despite calling this an "upgrade", this
         /// includes most forms of updates to node pools. This also includes
@@ -7783,13 +8050,13 @@ pub mod operation {
         ///
         /// [google.container.v1.ClusterManager.CancelOperation]: crate::client::ClusterManager::cancel_operation
         /// [google.container.v1.Operation.progress]: crate::model::Operation::progress
-        pub const UPGRADE_NODES: Type = Type::new("UPGRADE_NODES");
+        pub const UPGRADE_NODES: Type = Type::new(4);
 
         /// A problem has been detected with the control plane and is being repaired.
         /// This operation type is initiated by GKE. For more details, see
         /// [documentation on
         /// repairs](https://cloud.google.com/kubernetes-engine/docs/concepts/maintenance-windows-and-exclusions#repairs).
-        pub const REPAIR_CLUSTER: Type = Type::new("REPAIR_CLUSTER");
+        pub const REPAIR_CLUSTER: Type = Type::new(5);
 
         /// The cluster is being updated. This is a broad category of operations and
         /// includes operations that only change metadata as well as those that must
@@ -7804,7 +8071,7 @@ pub mod operation {
         ///
         /// Some GKE-initiated operations use this type. This includes certain types
         /// of auto-upgrades and incident mitigations.
-        pub const UPDATE_CLUSTER: Type = Type::new("UPDATE_CLUSTER");
+        pub const UPDATE_CLUSTER: Type = Type::new(6);
 
         /// A node pool is being created. The node pool should be assumed to be
         /// unusable until this operation finishes. In the event of an error, the
@@ -7813,59 +8080,59 @@ pub mod operation {
         /// If enabled, [node
         /// autoprovisioning](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning)
         /// may have automatically initiated such operations.
-        pub const CREATE_NODE_POOL: Type = Type::new("CREATE_NODE_POOL");
+        pub const CREATE_NODE_POOL: Type = Type::new(7);
 
         /// The node pool is being deleted. The node pool should be assumed to be
         /// unusable as soon as this operation starts.
-        pub const DELETE_NODE_POOL: Type = Type::new("DELETE_NODE_POOL");
+        pub const DELETE_NODE_POOL: Type = Type::new(8);
 
         /// The node pool's [manamagent][google.container.v1.NodePool.management]
         /// field is being updated. These operations only update metadata and may be
         /// concurrent with most other operations.
         ///
         /// [google.container.v1.NodePool.management]: crate::model::NodePool::management
-        pub const SET_NODE_POOL_MANAGEMENT: Type = Type::new("SET_NODE_POOL_MANAGEMENT");
+        pub const SET_NODE_POOL_MANAGEMENT: Type = Type::new(9);
 
         /// A problem has been detected with nodes and [they are being
         /// repaired](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-repair).
         /// This operation type is initiated by GKE, typically automatically. This
         /// operation may be concurrent with other operations and there may be
         /// multiple repairs occurring on the same node pool.
-        pub const AUTO_REPAIR_NODES: Type = Type::new("AUTO_REPAIR_NODES");
+        pub const AUTO_REPAIR_NODES: Type = Type::new(10);
 
         /// Unused. Automatic node upgrade uses
         /// [UPGRADE_NODES][google.container.v1.Operation.Type.UPGRADE_NODES].
         ///
         /// [google.container.v1.Operation.Type.UPGRADE_NODES]: crate::model::operation::r#type::UPGRADE_NODES
-        pub const AUTO_UPGRADE_NODES: Type = Type::new("AUTO_UPGRADE_NODES");
+        pub const AUTO_UPGRADE_NODES: Type = Type::new(11);
 
         /// Unused. Updating labels uses
         /// [UPDATE_CLUSTER][google.container.v1.Operation.Type.UPDATE_CLUSTER].
         ///
         /// [google.container.v1.Operation.Type.UPDATE_CLUSTER]: crate::model::operation::r#type::UPDATE_CLUSTER
-        pub const SET_LABELS: Type = Type::new("SET_LABELS");
+        pub const SET_LABELS: Type = Type::new(12);
 
         /// Unused. Updating master auth uses
         /// [UPDATE_CLUSTER][google.container.v1.Operation.Type.UPDATE_CLUSTER].
         ///
         /// [google.container.v1.Operation.Type.UPDATE_CLUSTER]: crate::model::operation::r#type::UPDATE_CLUSTER
-        pub const SET_MASTER_AUTH: Type = Type::new("SET_MASTER_AUTH");
+        pub const SET_MASTER_AUTH: Type = Type::new(13);
 
         /// The node pool is being resized. With the exception of resizing to or from
         /// size zero, the node pool is generally usable during this operation.
-        pub const SET_NODE_POOL_SIZE: Type = Type::new("SET_NODE_POOL_SIZE");
+        pub const SET_NODE_POOL_SIZE: Type = Type::new(14);
 
         /// Unused. Updating network policy uses
         /// [UPDATE_CLUSTER][google.container.v1.Operation.Type.UPDATE_CLUSTER].
         ///
         /// [google.container.v1.Operation.Type.UPDATE_CLUSTER]: crate::model::operation::r#type::UPDATE_CLUSTER
-        pub const SET_NETWORK_POLICY: Type = Type::new("SET_NETWORK_POLICY");
+        pub const SET_NETWORK_POLICY: Type = Type::new(15);
 
         /// Unused. Updating maintenance policy uses
         /// [UPDATE_CLUSTER][google.container.v1.Operation.Type.UPDATE_CLUSTER].
         ///
         /// [google.container.v1.Operation.Type.UPDATE_CLUSTER]: crate::model::operation::r#type::UPDATE_CLUSTER
-        pub const SET_MAINTENANCE_POLICY: Type = Type::new("SET_MAINTENANCE_POLICY");
+        pub const SET_MAINTENANCE_POLICY: Type = Type::new(16);
 
         /// The control plane is being resized. This operation type is initiated by
         /// GKE. These operations are often performed preemptively to ensure that the
@@ -7873,22 +8140,86 @@ pub mod operation {
         /// of issues. For more details, see
         /// [documentation on
         /// resizes](https://cloud.google.com/kubernetes-engine/docs/concepts/maintenance-windows-and-exclusions#repairs).
-        pub const RESIZE_CLUSTER: Type = Type::new("RESIZE_CLUSTER");
+        pub const RESIZE_CLUSTER: Type = Type::new(18);
 
         /// Fleet features of GKE Enterprise are being upgraded. The cluster should
         /// be assumed to be blocked for other upgrades until the operation finishes.
-        pub const FLEET_FEATURE_UPGRADE: Type = Type::new("FLEET_FEATURE_UPGRADE");
+        pub const FLEET_FEATURE_UPGRADE: Type = Type::new(19);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATE_CLUSTER"),
+                2 => std::borrow::Cow::Borrowed("DELETE_CLUSTER"),
+                3 => std::borrow::Cow::Borrowed("UPGRADE_MASTER"),
+                4 => std::borrow::Cow::Borrowed("UPGRADE_NODES"),
+                5 => std::borrow::Cow::Borrowed("REPAIR_CLUSTER"),
+                6 => std::borrow::Cow::Borrowed("UPDATE_CLUSTER"),
+                7 => std::borrow::Cow::Borrowed("CREATE_NODE_POOL"),
+                8 => std::borrow::Cow::Borrowed("DELETE_NODE_POOL"),
+                9 => std::borrow::Cow::Borrowed("SET_NODE_POOL_MANAGEMENT"),
+                10 => std::borrow::Cow::Borrowed("AUTO_REPAIR_NODES"),
+                11 => std::borrow::Cow::Borrowed("AUTO_UPGRADE_NODES"),
+                12 => std::borrow::Cow::Borrowed("SET_LABELS"),
+                13 => std::borrow::Cow::Borrowed("SET_MASTER_AUTH"),
+                14 => std::borrow::Cow::Borrowed("SET_NODE_POOL_SIZE"),
+                15 => std::borrow::Cow::Borrowed("SET_NETWORK_POLICY"),
+                16 => std::borrow::Cow::Borrowed("SET_MAINTENANCE_POLICY"),
+                18 => std::borrow::Cow::Borrowed("RESIZE_CLUSTER"),
+                19 => std::borrow::Cow::Borrowed("FLEET_FEATURE_UPGRADE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "CREATE_CLUSTER" => std::option::Option::Some(Self::CREATE_CLUSTER),
+                "DELETE_CLUSTER" => std::option::Option::Some(Self::DELETE_CLUSTER),
+                "UPGRADE_MASTER" => std::option::Option::Some(Self::UPGRADE_MASTER),
+                "UPGRADE_NODES" => std::option::Option::Some(Self::UPGRADE_NODES),
+                "REPAIR_CLUSTER" => std::option::Option::Some(Self::REPAIR_CLUSTER),
+                "UPDATE_CLUSTER" => std::option::Option::Some(Self::UPDATE_CLUSTER),
+                "CREATE_NODE_POOL" => std::option::Option::Some(Self::CREATE_NODE_POOL),
+                "DELETE_NODE_POOL" => std::option::Option::Some(Self::DELETE_NODE_POOL),
+                "SET_NODE_POOL_MANAGEMENT" => {
+                    std::option::Option::Some(Self::SET_NODE_POOL_MANAGEMENT)
+                }
+                "AUTO_REPAIR_NODES" => std::option::Option::Some(Self::AUTO_REPAIR_NODES),
+                "AUTO_UPGRADE_NODES" => std::option::Option::Some(Self::AUTO_UPGRADE_NODES),
+                "SET_LABELS" => std::option::Option::Some(Self::SET_LABELS),
+                "SET_MASTER_AUTH" => std::option::Option::Some(Self::SET_MASTER_AUTH),
+                "SET_NODE_POOL_SIZE" => std::option::Option::Some(Self::SET_NODE_POOL_SIZE),
+                "SET_NETWORK_POLICY" => std::option::Option::Some(Self::SET_NETWORK_POLICY),
+                "SET_MAINTENANCE_POLICY" => std::option::Option::Some(Self::SET_MAINTENANCE_POLICY),
+                "RESIZE_CLUSTER" => std::option::Option::Some(Self::RESIZE_CLUSTER),
+                "FLEET_FEATURE_UPGRADE" => std::option::Option::Some(Self::FLEET_FEATURE_UPGRADE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -9437,49 +9768,66 @@ pub mod set_master_auth_request {
 
     /// Operation type: what type update to perform.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(std::borrow::Cow<'static, str>);
+    pub struct Action(i32);
 
     impl Action {
-        /// Creates a new Action instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Action](Action)
-    pub mod action {
-        use super::Action;
-
         /// Operation is unknown and will error out.
-        pub const UNKNOWN: Action = Action::new("UNKNOWN");
+        pub const UNKNOWN: Action = Action::new(0);
 
         /// Set the password to a user generated value.
-        pub const SET_PASSWORD: Action = Action::new("SET_PASSWORD");
+        pub const SET_PASSWORD: Action = Action::new(1);
 
         /// Generate a new password and set it to that.
-        pub const GENERATE_PASSWORD: Action = Action::new("GENERATE_PASSWORD");
+        pub const GENERATE_PASSWORD: Action = Action::new(2);
 
         /// Set the username.  If an empty username is provided, basic authentication
         /// is disabled for the cluster.  If a non-empty username is provided, basic
         /// authentication is enabled, with either a provided password or a generated
         /// one.
-        pub const SET_USERNAME: Action = Action::new("SET_USERNAME");
+        pub const SET_USERNAME: Action = Action::new(3);
+
+        /// Creates a new Action instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("SET_PASSWORD"),
+                2 => std::borrow::Cow::Borrowed("GENERATE_PASSWORD"),
+                3 => std::borrow::Cow::Borrowed("SET_USERNAME"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                "SET_PASSWORD" => std::option::Option::Some(Self::SET_PASSWORD),
+                "GENERATE_PASSWORD" => std::option::Option::Some(Self::GENERATE_PASSWORD),
+                "SET_USERNAME" => std::option::Option::Some(Self::SET_USERNAME),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Action {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            action::UNKNOWN
+            Self::new(0)
         }
     }
 }
@@ -11250,58 +11598,87 @@ pub mod node_pool {
 
             /// Phase represents the different stages blue-green upgrade is running in.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct Phase(std::borrow::Cow<'static, str>);
+            pub struct Phase(i32);
 
             impl Phase {
+                /// Unspecified phase.
+                pub const PHASE_UNSPECIFIED: Phase = Phase::new(0);
+
+                /// blue-green upgrade has been initiated.
+                pub const UPDATE_STARTED: Phase = Phase::new(1);
+
+                /// Start creating green pool nodes.
+                pub const CREATING_GREEN_POOL: Phase = Phase::new(2);
+
+                /// Start cordoning blue pool nodes.
+                pub const CORDONING_BLUE_POOL: Phase = Phase::new(3);
+
+                /// Start draining blue pool nodes.
+                pub const DRAINING_BLUE_POOL: Phase = Phase::new(4);
+
+                /// Start soaking time after draining entire blue pool.
+                pub const NODE_POOL_SOAKING: Phase = Phase::new(5);
+
+                /// Start deleting blue nodes.
+                pub const DELETING_BLUE_POOL: Phase = Phase::new(6);
+
+                /// Rollback has been initiated.
+                pub const ROLLBACK_STARTED: Phase = Phase::new(7);
+
                 /// Creates a new Phase instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
                 }
 
                 /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("PHASE_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("UPDATE_STARTED"),
+                        2 => std::borrow::Cow::Borrowed("CREATING_GREEN_POOL"),
+                        3 => std::borrow::Cow::Borrowed("CORDONING_BLUE_POOL"),
+                        4 => std::borrow::Cow::Borrowed("DRAINING_BLUE_POOL"),
+                        5 => std::borrow::Cow::Borrowed("NODE_POOL_SOAKING"),
+                        6 => std::borrow::Cow::Borrowed("DELETING_BLUE_POOL"),
+                        7 => std::borrow::Cow::Borrowed("ROLLBACK_STARTED"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "PHASE_UNSPECIFIED" => std::option::Option::Some(Self::PHASE_UNSPECIFIED),
+                        "UPDATE_STARTED" => std::option::Option::Some(Self::UPDATE_STARTED),
+                        "CREATING_GREEN_POOL" => {
+                            std::option::Option::Some(Self::CREATING_GREEN_POOL)
+                        }
+                        "CORDONING_BLUE_POOL" => {
+                            std::option::Option::Some(Self::CORDONING_BLUE_POOL)
+                        }
+                        "DRAINING_BLUE_POOL" => std::option::Option::Some(Self::DRAINING_BLUE_POOL),
+                        "NODE_POOL_SOAKING" => std::option::Option::Some(Self::NODE_POOL_SOAKING),
+                        "DELETING_BLUE_POOL" => std::option::Option::Some(Self::DELETING_BLUE_POOL),
+                        "ROLLBACK_STARTED" => std::option::Option::Some(Self::ROLLBACK_STARTED),
+                        _ => std::option::Option::None,
+                    }
                 }
             }
 
-            /// Useful constants to work with [Phase](Phase)
-            pub mod phase {
-                use super::Phase;
-
-                /// Unspecified phase.
-                pub const PHASE_UNSPECIFIED: Phase = Phase::new("PHASE_UNSPECIFIED");
-
-                /// blue-green upgrade has been initiated.
-                pub const UPDATE_STARTED: Phase = Phase::new("UPDATE_STARTED");
-
-                /// Start creating green pool nodes.
-                pub const CREATING_GREEN_POOL: Phase = Phase::new("CREATING_GREEN_POOL");
-
-                /// Start cordoning blue pool nodes.
-                pub const CORDONING_BLUE_POOL: Phase = Phase::new("CORDONING_BLUE_POOL");
-
-                /// Start draining blue pool nodes.
-                pub const DRAINING_BLUE_POOL: Phase = Phase::new("DRAINING_BLUE_POOL");
-
-                /// Start soaking time after draining entire blue pool.
-                pub const NODE_POOL_SOAKING: Phase = Phase::new("NODE_POOL_SOAKING");
-
-                /// Start deleting blue nodes.
-                pub const DELETING_BLUE_POOL: Phase = Phase::new("DELETING_BLUE_POOL");
-
-                /// Rollback has been initiated.
-                pub const ROLLBACK_STARTED: Phase = Phase::new("ROLLBACK_STARTED");
-            }
-
-            impl std::convert::From<std::string::String> for Phase {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for Phase {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for Phase {
                 fn default() -> Self {
-                    phase::PHASE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -11372,42 +11749,55 @@ pub mod node_pool {
 
         /// Type defines the type of placement policy.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(std::borrow::Cow<'static, str>);
+        pub struct Type(i32);
 
         impl Type {
-            /// Creates a new Type instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [Type](Type)
-        pub mod r#type {
-            use super::Type;
-
             /// TYPE_UNSPECIFIED specifies no requirements on nodes
             /// placement.
-            pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
             /// COMPACT specifies node placement in the same availability domain to
             /// ensure low communication latency.
-            pub const COMPACT: Type = Type::new("COMPACT");
+            pub const COMPACT: Type = Type::new(1);
+
+            /// Creates a new Type instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("COMPACT"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                    "COMPACT" => std::option::Option::Some(Self::COMPACT),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for Type {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                r#type::TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -11444,62 +11834,85 @@ pub mod node_pool {
 
     /// The current status of the node pool instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(std::borrow::Cow<'static, str>);
+    pub struct Status(i32);
 
     impl Status {
-        /// Creates a new Status instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Status](Status)
-    pub mod status {
-        use super::Status;
-
         /// Not set.
-        pub const STATUS_UNSPECIFIED: Status = Status::new("STATUS_UNSPECIFIED");
+        pub const STATUS_UNSPECIFIED: Status = Status::new(0);
 
         /// The PROVISIONING state indicates the node pool is being created.
-        pub const PROVISIONING: Status = Status::new("PROVISIONING");
+        pub const PROVISIONING: Status = Status::new(1);
 
         /// The RUNNING state indicates the node pool has been created
         /// and is fully usable.
-        pub const RUNNING: Status = Status::new("RUNNING");
+        pub const RUNNING: Status = Status::new(2);
 
         /// The RUNNING_WITH_ERROR state indicates the node pool has been created
         /// and is partially usable. Some error state has occurred and some
         /// functionality may be impaired. Customer may need to reissue a request
         /// or trigger a new update.
-        pub const RUNNING_WITH_ERROR: Status = Status::new("RUNNING_WITH_ERROR");
+        pub const RUNNING_WITH_ERROR: Status = Status::new(3);
 
         /// The RECONCILING state indicates that some work is actively being done on
         /// the node pool, such as upgrading node software. Details can
         /// be found in the `statusMessage` field.
-        pub const RECONCILING: Status = Status::new("RECONCILING");
+        pub const RECONCILING: Status = Status::new(4);
 
         /// The STOPPING state indicates the node pool is being deleted.
-        pub const STOPPING: Status = Status::new("STOPPING");
+        pub const STOPPING: Status = Status::new(5);
 
         /// The ERROR state indicates the node pool may be unusable. Details
         /// can be found in the `statusMessage` field.
-        pub const ERROR: Status = Status::new("ERROR");
+        pub const ERROR: Status = Status::new(6);
+
+        /// Creates a new Status instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATUS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("RUNNING_WITH_ERROR"),
+                4 => std::borrow::Cow::Borrowed("RECONCILING"),
+                5 => std::borrow::Cow::Borrowed("STOPPING"),
+                6 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATUS_UNSPECIFIED" => std::option::Option::Some(Self::STATUS_UNSPECIFIED),
+                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "RUNNING_WITH_ERROR" => std::option::Option::Some(Self::RUNNING_WITH_ERROR),
+                "RECONCILING" => std::option::Option::Some(Self::RECONCILING),
+                "STOPPING" => std::option::Option::Some(Self::STOPPING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Status {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            status::STATUS_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -11979,48 +12392,65 @@ pub mod maintenance_exclusion_options {
 
     /// Scope of exclusion.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Scope(std::borrow::Cow<'static, str>);
+    pub struct Scope(i32);
 
     impl Scope {
-        /// Creates a new Scope instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Scope](Scope)
-    pub mod scope {
-        use super::Scope;
-
         /// NO_UPGRADES excludes all upgrades, including patch upgrades and minor
         /// upgrades across control planes and nodes. This is the default exclusion
         /// behavior.
-        pub const NO_UPGRADES: Scope = Scope::new("NO_UPGRADES");
+        pub const NO_UPGRADES: Scope = Scope::new(0);
 
         /// NO_MINOR_UPGRADES excludes all minor upgrades for the cluster, only
         /// patches are allowed.
-        pub const NO_MINOR_UPGRADES: Scope = Scope::new("NO_MINOR_UPGRADES");
+        pub const NO_MINOR_UPGRADES: Scope = Scope::new(1);
 
         /// NO_MINOR_OR_NODE_UPGRADES excludes all minor upgrades for the cluster,
         /// and also exclude all node pool upgrades. Only control
         /// plane patches are allowed.
-        pub const NO_MINOR_OR_NODE_UPGRADES: Scope = Scope::new("NO_MINOR_OR_NODE_UPGRADES");
+        pub const NO_MINOR_OR_NODE_UPGRADES: Scope = Scope::new(2);
+
+        /// Creates a new Scope instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("NO_UPGRADES"),
+                1 => std::borrow::Cow::Borrowed("NO_MINOR_UPGRADES"),
+                2 => std::borrow::Cow::Borrowed("NO_MINOR_OR_NODE_UPGRADES"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "NO_UPGRADES" => std::option::Option::Some(Self::NO_UPGRADES),
+                "NO_MINOR_UPGRADES" => std::option::Option::Some(Self::NO_MINOR_UPGRADES),
+                "NO_MINOR_OR_NODE_UPGRADES" => {
+                    std::option::Option::Some(Self::NO_MINOR_OR_NODE_UPGRADES)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Scope {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Scope {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Scope {
         fn default() -> Self {
-            scope::NO_UPGRADES
+            Self::new(0)
         }
     }
 }
@@ -12583,45 +13013,58 @@ pub mod cluster_autoscaling {
 
     /// Defines possible options for autoscaling_profile field.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AutoscalingProfile(std::borrow::Cow<'static, str>);
+    pub struct AutoscalingProfile(i32);
 
     impl AutoscalingProfile {
+        /// No change to autoscaling configuration.
+        pub const PROFILE_UNSPECIFIED: AutoscalingProfile = AutoscalingProfile::new(0);
+
+        /// Prioritize optimizing utilization of resources.
+        pub const OPTIMIZE_UTILIZATION: AutoscalingProfile = AutoscalingProfile::new(1);
+
+        /// Use default (balanced) autoscaling configuration.
+        pub const BALANCED: AutoscalingProfile = AutoscalingProfile::new(2);
+
         /// Creates a new AutoscalingProfile instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PROFILE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("OPTIMIZE_UTILIZATION"),
+                2 => std::borrow::Cow::Borrowed("BALANCED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PROFILE_UNSPECIFIED" => std::option::Option::Some(Self::PROFILE_UNSPECIFIED),
+                "OPTIMIZE_UTILIZATION" => std::option::Option::Some(Self::OPTIMIZE_UTILIZATION),
+                "BALANCED" => std::option::Option::Some(Self::BALANCED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AutoscalingProfile](AutoscalingProfile)
-    pub mod autoscaling_profile {
-        use super::AutoscalingProfile;
-
-        /// No change to autoscaling configuration.
-        pub const PROFILE_UNSPECIFIED: AutoscalingProfile =
-            AutoscalingProfile::new("PROFILE_UNSPECIFIED");
-
-        /// Prioritize optimizing utilization of resources.
-        pub const OPTIMIZE_UTILIZATION: AutoscalingProfile =
-            AutoscalingProfile::new("OPTIMIZE_UTILIZATION");
-
-        /// Use default (balanced) autoscaling configuration.
-        pub const BALANCED: AutoscalingProfile = AutoscalingProfile::new("BALANCED");
-    }
-
-    impl std::convert::From<std::string::String> for AutoscalingProfile {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AutoscalingProfile {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AutoscalingProfile {
         fn default() -> Self {
-            autoscaling_profile::PROFILE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -12963,45 +13406,61 @@ pub mod node_pool_autoscaling {
     /// Location policy specifies how zones are picked when scaling up the
     /// nodepool.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LocationPolicy(std::borrow::Cow<'static, str>);
+    pub struct LocationPolicy(i32);
 
     impl LocationPolicy {
-        /// Creates a new LocationPolicy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [LocationPolicy](LocationPolicy)
-    pub mod location_policy {
-        use super::LocationPolicy;
-
         /// Not set.
-        pub const LOCATION_POLICY_UNSPECIFIED: LocationPolicy =
-            LocationPolicy::new("LOCATION_POLICY_UNSPECIFIED");
+        pub const LOCATION_POLICY_UNSPECIFIED: LocationPolicy = LocationPolicy::new(0);
 
         /// BALANCED is a best effort policy that aims to balance the sizes of
         /// different zones.
-        pub const BALANCED: LocationPolicy = LocationPolicy::new("BALANCED");
+        pub const BALANCED: LocationPolicy = LocationPolicy::new(1);
 
         /// ANY policy picks zones that have the highest capacity available.
-        pub const ANY: LocationPolicy = LocationPolicy::new("ANY");
+        pub const ANY: LocationPolicy = LocationPolicy::new(2);
+
+        /// Creates a new LocationPolicy instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LOCATION_POLICY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BALANCED"),
+                2 => std::borrow::Cow::Borrowed("ANY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LOCATION_POLICY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::LOCATION_POLICY_UNSPECIFIED)
+                }
+                "BALANCED" => std::option::Option::Some(Self::BALANCED),
+                "ANY" => std::option::Option::Some(Self::ANY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for LocationPolicy {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LocationPolicy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LocationPolicy {
         fn default() -> Self {
-            location_policy::LOCATION_POLICY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -13470,44 +13929,60 @@ pub mod gpu_sharing_config {
 
     /// The type of GPU sharing strategy currently provided.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct GPUSharingStrategy(std::borrow::Cow<'static, str>);
+    pub struct GPUSharingStrategy(i32);
 
     impl GPUSharingStrategy {
+        /// Default value.
+        pub const GPU_SHARING_STRATEGY_UNSPECIFIED: GPUSharingStrategy = GPUSharingStrategy::new(0);
+
+        /// GPUs are time-shared between containers.
+        pub const TIME_SHARING: GPUSharingStrategy = GPUSharingStrategy::new(1);
+
+        /// GPUs are shared between containers with NVIDIA MPS.
+        pub const MPS: GPUSharingStrategy = GPUSharingStrategy::new(2);
+
         /// Creates a new GPUSharingStrategy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("GPU_SHARING_STRATEGY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TIME_SHARING"),
+                2 => std::borrow::Cow::Borrowed("MPS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "GPU_SHARING_STRATEGY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::GPU_SHARING_STRATEGY_UNSPECIFIED)
+                }
+                "TIME_SHARING" => std::option::Option::Some(Self::TIME_SHARING),
+                "MPS" => std::option::Option::Some(Self::MPS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [GPUSharingStrategy](GPUSharingStrategy)
-    pub mod gpu_sharing_strategy {
-        use super::GPUSharingStrategy;
-
-        /// Default value.
-        pub const GPU_SHARING_STRATEGY_UNSPECIFIED: GPUSharingStrategy =
-            GPUSharingStrategy::new("GPU_SHARING_STRATEGY_UNSPECIFIED");
-
-        /// GPUs are time-shared between containers.
-        pub const TIME_SHARING: GPUSharingStrategy = GPUSharingStrategy::new("TIME_SHARING");
-
-        /// GPUs are shared between containers with NVIDIA MPS.
-        pub const MPS: GPUSharingStrategy = GPUSharingStrategy::new("MPS");
-    }
-
-    impl std::convert::From<std::string::String> for GPUSharingStrategy {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for GPUSharingStrategy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for GPUSharingStrategy {
         fn default() -> Self {
-            gpu_sharing_strategy::GPU_SHARING_STRATEGY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -13557,48 +14032,65 @@ pub mod gpu_driver_installation_config {
 
     /// The GPU driver version to install.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct GPUDriverVersion(std::borrow::Cow<'static, str>);
+    pub struct GPUDriverVersion(i32);
 
     impl GPUDriverVersion {
+        /// Default value is to not install any GPU driver.
+        pub const GPU_DRIVER_VERSION_UNSPECIFIED: GPUDriverVersion = GPUDriverVersion::new(0);
+
+        /// Disable GPU driver auto installation and needs manual installation
+        pub const INSTALLATION_DISABLED: GPUDriverVersion = GPUDriverVersion::new(1);
+
+        /// "Default" GPU driver in COS and Ubuntu.
+        pub const DEFAULT: GPUDriverVersion = GPUDriverVersion::new(2);
+
+        /// "Latest" GPU driver in COS.
+        pub const LATEST: GPUDriverVersion = GPUDriverVersion::new(3);
+
         /// Creates a new GPUDriverVersion instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("GPU_DRIVER_VERSION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INSTALLATION_DISABLED"),
+                2 => std::borrow::Cow::Borrowed("DEFAULT"),
+                3 => std::borrow::Cow::Borrowed("LATEST"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "GPU_DRIVER_VERSION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::GPU_DRIVER_VERSION_UNSPECIFIED)
+                }
+                "INSTALLATION_DISABLED" => std::option::Option::Some(Self::INSTALLATION_DISABLED),
+                "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
+                "LATEST" => std::option::Option::Some(Self::LATEST),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [GPUDriverVersion](GPUDriverVersion)
-    pub mod gpu_driver_version {
-        use super::GPUDriverVersion;
-
-        /// Default value is to not install any GPU driver.
-        pub const GPU_DRIVER_VERSION_UNSPECIFIED: GPUDriverVersion =
-            GPUDriverVersion::new("GPU_DRIVER_VERSION_UNSPECIFIED");
-
-        /// Disable GPU driver auto installation and needs manual installation
-        pub const INSTALLATION_DISABLED: GPUDriverVersion =
-            GPUDriverVersion::new("INSTALLATION_DISABLED");
-
-        /// "Default" GPU driver in COS and Ubuntu.
-        pub const DEFAULT: GPUDriverVersion = GPUDriverVersion::new("DEFAULT");
-
-        /// "Latest" GPU driver in COS.
-        pub const LATEST: GPUDriverVersion = GPUDriverVersion::new("LATEST");
-    }
-
-    impl std::convert::From<std::string::String> for GPUDriverVersion {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for GPUDriverVersion {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for GPUDriverVersion {
         fn default() -> Self {
-            gpu_driver_version::GPU_DRIVER_VERSION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -13644,47 +14136,62 @@ pub mod workload_metadata_config {
     /// Mode is the configuration for how to expose metadata to workloads running
     /// on the node.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(std::borrow::Cow<'static, str>);
+    pub struct Mode(i32);
 
     impl Mode {
-        /// Creates a new Mode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Mode](Mode)
-    pub mod mode {
-        use super::Mode;
-
         /// Not set.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new("MODE_UNSPECIFIED");
+        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
 
         /// Expose all Compute Engine metadata to pods.
-        pub const GCE_METADATA: Mode = Mode::new("GCE_METADATA");
+        pub const GCE_METADATA: Mode = Mode::new(1);
 
         /// Run the GKE Metadata Server on this node. The GKE Metadata Server exposes
         /// a metadata API to workloads that is compatible with the V1 Compute
         /// Metadata APIs exposed by the Compute Engine and App Engine Metadata
         /// Servers. This feature can only be enabled if Workload Identity is enabled
         /// at the cluster level.
-        pub const GKE_METADATA: Mode = Mode::new("GKE_METADATA");
+        pub const GKE_METADATA: Mode = Mode::new(2);
+
+        /// Creates a new Mode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GCE_METADATA"),
+                2 => std::borrow::Cow::Borrowed("GKE_METADATA"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
+                "GCE_METADATA" => std::option::Option::Some(Self::GCE_METADATA),
+                "GKE_METADATA" => std::option::Option::Some(Self::GKE_METADATA),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Mode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            mode::MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -13909,58 +14416,83 @@ pub mod status_condition {
 
     /// Code for each condition
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Code(std::borrow::Cow<'static, str>);
+    pub struct Code(i32);
 
     impl Code {
-        /// Creates a new Code instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Code](Code)
-    pub mod code {
-        use super::Code;
-
         /// UNKNOWN indicates a generic condition.
-        pub const UNKNOWN: Code = Code::new("UNKNOWN");
+        pub const UNKNOWN: Code = Code::new(0);
 
         /// GCE_STOCKOUT indicates that Google Compute Engine resources are
         /// temporarily unavailable.
-        pub const GCE_STOCKOUT: Code = Code::new("GCE_STOCKOUT");
+        pub const GCE_STOCKOUT: Code = Code::new(1);
 
         /// GKE_SERVICE_ACCOUNT_DELETED indicates that the user deleted their robot
         /// service account.
-        pub const GKE_SERVICE_ACCOUNT_DELETED: Code = Code::new("GKE_SERVICE_ACCOUNT_DELETED");
+        pub const GKE_SERVICE_ACCOUNT_DELETED: Code = Code::new(2);
 
         /// Google Compute Engine quota was exceeded.
-        pub const GCE_QUOTA_EXCEEDED: Code = Code::new("GCE_QUOTA_EXCEEDED");
+        pub const GCE_QUOTA_EXCEEDED: Code = Code::new(3);
 
         /// Cluster state was manually changed by an SRE due to a system logic error.
-        pub const SET_BY_OPERATOR: Code = Code::new("SET_BY_OPERATOR");
+        pub const SET_BY_OPERATOR: Code = Code::new(4);
 
         /// Unable to perform an encrypt operation against the CloudKMS key used for
         /// etcd level encryption.
-        pub const CLOUD_KMS_KEY_ERROR: Code = Code::new("CLOUD_KMS_KEY_ERROR");
+        pub const CLOUD_KMS_KEY_ERROR: Code = Code::new(7);
 
         /// Cluster CA is expiring soon.
-        pub const CA_EXPIRING: Code = Code::new("CA_EXPIRING");
+        pub const CA_EXPIRING: Code = Code::new(9);
+
+        /// Creates a new Code instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("GCE_STOCKOUT"),
+                2 => std::borrow::Cow::Borrowed("GKE_SERVICE_ACCOUNT_DELETED"),
+                3 => std::borrow::Cow::Borrowed("GCE_QUOTA_EXCEEDED"),
+                4 => std::borrow::Cow::Borrowed("SET_BY_OPERATOR"),
+                7 => std::borrow::Cow::Borrowed("CLOUD_KMS_KEY_ERROR"),
+                9 => std::borrow::Cow::Borrowed("CA_EXPIRING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                "GCE_STOCKOUT" => std::option::Option::Some(Self::GCE_STOCKOUT),
+                "GKE_SERVICE_ACCOUNT_DELETED" => {
+                    std::option::Option::Some(Self::GKE_SERVICE_ACCOUNT_DELETED)
+                }
+                "GCE_QUOTA_EXCEEDED" => std::option::Option::Some(Self::GCE_QUOTA_EXCEEDED),
+                "SET_BY_OPERATOR" => std::option::Option::Some(Self::SET_BY_OPERATOR),
+                "CLOUD_KMS_KEY_ERROR" => std::option::Option::Some(Self::CLOUD_KMS_KEY_ERROR),
+                "CA_EXPIRING" => std::option::Option::Some(Self::CA_EXPIRING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Code {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Code {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Code {
         fn default() -> Self {
-            code::UNKNOWN
+            Self::new(0)
         }
     }
 }
@@ -14264,40 +14796,53 @@ pub mod network_config {
 
         /// Node network tier
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Tier(std::borrow::Cow<'static, str>);
+        pub struct Tier(i32);
 
         impl Tier {
+            /// Default value
+            pub const TIER_UNSPECIFIED: Tier = Tier::new(0);
+
+            /// Higher bandwidth, actual values based on VM size.
+            pub const TIER_1: Tier = Tier::new(1);
+
             /// Creates a new Tier instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("TIER_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("TIER_1"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "TIER_UNSPECIFIED" => std::option::Option::Some(Self::TIER_UNSPECIFIED),
+                    "TIER_1" => std::option::Option::Some(Self::TIER_1),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Tier](Tier)
-        pub mod tier {
-            use super::Tier;
-
-            /// Default value
-            pub const TIER_UNSPECIFIED: Tier = Tier::new("TIER_UNSPECIFIED");
-
-            /// Higher bandwidth, actual values based on VM size.
-            pub const TIER_1: Tier = Tier::new("TIER_1");
-        }
-
-        impl std::convert::From<std::string::String> for Tier {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Tier {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Tier {
             fn default() -> Self {
-                tier::TIER_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -14342,47 +14887,64 @@ pub mod gateway_api_config {
     /// Channel describes if/how Gateway API should be installed and implemented in
     /// a cluster.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Channel(std::borrow::Cow<'static, str>);
+    pub struct Channel(i32);
 
     impl Channel {
-        /// Creates a new Channel instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Channel](Channel)
-    pub mod channel {
-        use super::Channel;
-
         /// Default value.
-        pub const CHANNEL_UNSPECIFIED: Channel = Channel::new("CHANNEL_UNSPECIFIED");
+        pub const CHANNEL_UNSPECIFIED: Channel = Channel::new(0);
 
         /// Gateway API support is disabled
-        pub const CHANNEL_DISABLED: Channel = Channel::new("CHANNEL_DISABLED");
+        pub const CHANNEL_DISABLED: Channel = Channel::new(1);
 
         /// Deprecated: use CHANNEL_STANDARD instead.
         /// Gateway API support is enabled, experimental CRDs are installed
-        pub const CHANNEL_EXPERIMENTAL: Channel = Channel::new("CHANNEL_EXPERIMENTAL");
+        pub const CHANNEL_EXPERIMENTAL: Channel = Channel::new(3);
 
         /// Gateway API support is enabled, standard CRDs are installed
-        pub const CHANNEL_STANDARD: Channel = Channel::new("CHANNEL_STANDARD");
+        pub const CHANNEL_STANDARD: Channel = Channel::new(4);
+
+        /// Creates a new Channel instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CHANNEL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CHANNEL_DISABLED"),
+                3 => std::borrow::Cow::Borrowed("CHANNEL_EXPERIMENTAL"),
+                4 => std::borrow::Cow::Borrowed("CHANNEL_STANDARD"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CHANNEL_UNSPECIFIED" => std::option::Option::Some(Self::CHANNEL_UNSPECIFIED),
+                "CHANNEL_DISABLED" => std::option::Option::Some(Self::CHANNEL_DISABLED),
+                "CHANNEL_EXPERIMENTAL" => std::option::Option::Some(Self::CHANNEL_EXPERIMENTAL),
+                "CHANNEL_STANDARD" => std::option::Option::Some(Self::CHANNEL_STANDARD),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Channel {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Channel {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Channel {
         fn default() -> Self {
-            channel::CHANNEL_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -14872,52 +15434,71 @@ pub mod autopilot_compatibility_issue {
 
     /// The type of the reported issue.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IssueType(std::borrow::Cow<'static, str>);
+    pub struct IssueType(i32);
 
     impl IssueType {
-        /// Creates a new IssueType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [IssueType](IssueType)
-    pub mod issue_type {
-        use super::IssueType;
-
         /// Default value, should not be used.
-        pub const UNSPECIFIED: IssueType = IssueType::new("UNSPECIFIED");
+        pub const UNSPECIFIED: IssueType = IssueType::new(0);
 
         /// Indicates that the issue is a known incompatibility between the
         /// cluster and Autopilot mode.
-        pub const INCOMPATIBILITY: IssueType = IssueType::new("INCOMPATIBILITY");
+        pub const INCOMPATIBILITY: IssueType = IssueType::new(1);
 
         /// Indicates the issue is an incompatibility if customers take no further
         /// action to resolve.
-        pub const ADDITIONAL_CONFIG_REQUIRED: IssueType =
-            IssueType::new("ADDITIONAL_CONFIG_REQUIRED");
+        pub const ADDITIONAL_CONFIG_REQUIRED: IssueType = IssueType::new(2);
 
         /// Indicates the issue is not an incompatibility, but depending on the
         /// workloads business logic, there is a potential that they won't work on
         /// Autopilot.
-        pub const PASSED_WITH_OPTIONAL_CONFIG: IssueType =
-            IssueType::new("PASSED_WITH_OPTIONAL_CONFIG");
+        pub const PASSED_WITH_OPTIONAL_CONFIG: IssueType = IssueType::new(3);
+
+        /// Creates a new IssueType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INCOMPATIBILITY"),
+                2 => std::borrow::Cow::Borrowed("ADDITIONAL_CONFIG_REQUIRED"),
+                3 => std::borrow::Cow::Borrowed("PASSED_WITH_OPTIONAL_CONFIG"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
+                "INCOMPATIBILITY" => std::option::Option::Some(Self::INCOMPATIBILITY),
+                "ADDITIONAL_CONFIG_REQUIRED" => {
+                    std::option::Option::Some(Self::ADDITIONAL_CONFIG_REQUIRED)
+                }
+                "PASSED_WITH_OPTIONAL_CONFIG" => {
+                    std::option::Option::Some(Self::PASSED_WITH_OPTIONAL_CONFIG)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for IssueType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for IssueType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for IssueType {
         fn default() -> Self {
-            issue_type::UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -15009,26 +15590,11 @@ pub mod release_channel {
 
     /// Possible values for 'channel'.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Channel(std::borrow::Cow<'static, str>);
+    pub struct Channel(i32);
 
     impl Channel {
-        /// Creates a new Channel instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Channel](Channel)
-    pub mod channel {
-        use super::Channel;
-
         /// No channel specified.
-        pub const UNSPECIFIED: Channel = Channel::new("UNSPECIFIED");
+        pub const UNSPECIFIED: Channel = Channel::new(0);
 
         /// RAPID channel is offered on an early access basis for customers who want
         /// to test new releases.
@@ -15036,31 +15602,65 @@ pub mod release_channel {
         /// WARNING: Versions available in the RAPID Channel may be subject to
         /// unresolved issues with no known workaround and are not subject to any
         /// SLAs.
-        pub const RAPID: Channel = Channel::new("RAPID");
+        pub const RAPID: Channel = Channel::new(1);
 
         /// Clusters subscribed to REGULAR receive versions that are considered GA
         /// quality. REGULAR is intended for production users who want to take
         /// advantage of new features.
-        pub const REGULAR: Channel = Channel::new("REGULAR");
+        pub const REGULAR: Channel = Channel::new(2);
 
         /// Clusters subscribed to STABLE receive versions that are known to be
         /// stable and reliable in production.
-        pub const STABLE: Channel = Channel::new("STABLE");
+        pub const STABLE: Channel = Channel::new(3);
 
         /// Clusters subscribed to EXTENDED receive extended support and availability
         /// for versions which are known to be stable and reliable in production.
-        pub const EXTENDED: Channel = Channel::new("EXTENDED");
+        pub const EXTENDED: Channel = Channel::new(4);
+
+        /// Creates a new Channel instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RAPID"),
+                2 => std::borrow::Cow::Borrowed("REGULAR"),
+                3 => std::borrow::Cow::Borrowed("STABLE"),
+                4 => std::borrow::Cow::Borrowed("EXTENDED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
+                "RAPID" => std::option::Option::Some(Self::RAPID),
+                "REGULAR" => std::option::Option::Some(Self::REGULAR),
+                "STABLE" => std::option::Option::Some(Self::STABLE),
+                "EXTENDED" => std::option::Option::Some(Self::EXTENDED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Channel {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Channel {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Channel {
         fn default() -> Self {
-            channel::UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -15227,88 +15827,120 @@ pub mod dns_config {
 
     /// Provider lists the various in-cluster DNS providers.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Provider(std::borrow::Cow<'static, str>);
+    pub struct Provider(i32);
 
     impl Provider {
+        /// Default value
+        pub const PROVIDER_UNSPECIFIED: Provider = Provider::new(0);
+
+        /// Use GKE default DNS provider(kube-dns) for DNS resolution.
+        pub const PLATFORM_DEFAULT: Provider = Provider::new(1);
+
+        /// Use CloudDNS for DNS resolution.
+        pub const CLOUD_DNS: Provider = Provider::new(2);
+
+        /// Use KubeDNS for DNS resolution.
+        pub const KUBE_DNS: Provider = Provider::new(3);
+
         /// Creates a new Provider instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PROVIDER_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PLATFORM_DEFAULT"),
+                2 => std::borrow::Cow::Borrowed("CLOUD_DNS"),
+                3 => std::borrow::Cow::Borrowed("KUBE_DNS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PROVIDER_UNSPECIFIED" => std::option::Option::Some(Self::PROVIDER_UNSPECIFIED),
+                "PLATFORM_DEFAULT" => std::option::Option::Some(Self::PLATFORM_DEFAULT),
+                "CLOUD_DNS" => std::option::Option::Some(Self::CLOUD_DNS),
+                "KUBE_DNS" => std::option::Option::Some(Self::KUBE_DNS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Provider](Provider)
-    pub mod provider {
-        use super::Provider;
-
-        /// Default value
-        pub const PROVIDER_UNSPECIFIED: Provider = Provider::new("PROVIDER_UNSPECIFIED");
-
-        /// Use GKE default DNS provider(kube-dns) for DNS resolution.
-        pub const PLATFORM_DEFAULT: Provider = Provider::new("PLATFORM_DEFAULT");
-
-        /// Use CloudDNS for DNS resolution.
-        pub const CLOUD_DNS: Provider = Provider::new("CLOUD_DNS");
-
-        /// Use KubeDNS for DNS resolution.
-        pub const KUBE_DNS: Provider = Provider::new("KUBE_DNS");
-    }
-
-    impl std::convert::From<std::string::String> for Provider {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Provider {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Provider {
         fn default() -> Self {
-            provider::PROVIDER_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// DNSScope lists the various scopes of access to cluster DNS records.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DNSScope(std::borrow::Cow<'static, str>);
+    pub struct DNSScope(i32);
 
     impl DNSScope {
+        /// Default value, will be inferred as cluster scope.
+        pub const DNS_SCOPE_UNSPECIFIED: DNSScope = DNSScope::new(0);
+
+        /// DNS records are accessible from within the cluster.
+        pub const CLUSTER_SCOPE: DNSScope = DNSScope::new(1);
+
+        /// DNS records are accessible from within the VPC.
+        pub const VPC_SCOPE: DNSScope = DNSScope::new(2);
+
         /// Creates a new DNSScope instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DNS_SCOPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CLUSTER_SCOPE"),
+                2 => std::borrow::Cow::Borrowed("VPC_SCOPE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DNS_SCOPE_UNSPECIFIED" => std::option::Option::Some(Self::DNS_SCOPE_UNSPECIFIED),
+                "CLUSTER_SCOPE" => std::option::Option::Some(Self::CLUSTER_SCOPE),
+                "VPC_SCOPE" => std::option::Option::Some(Self::VPC_SCOPE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DNSScope](DNSScope)
-    pub mod dns_scope {
-        use super::DNSScope;
-
-        /// Default value, will be inferred as cluster scope.
-        pub const DNS_SCOPE_UNSPECIFIED: DNSScope = DNSScope::new("DNS_SCOPE_UNSPECIFIED");
-
-        /// DNS records are accessible from within the cluster.
-        pub const CLUSTER_SCOPE: DNSScope = DNSScope::new("CLUSTER_SCOPE");
-
-        /// DNS records are accessible from within the VPC.
-        pub const VPC_SCOPE: DNSScope = DNSScope::new("VPC_SCOPE");
-    }
-
-    impl std::convert::From<std::string::String> for DNSScope {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DNSScope {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DNSScope {
         fn default() -> Self {
-            dns_scope::DNS_SCOPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -15597,108 +16229,153 @@ pub mod database_encryption {
 
     /// State of etcd encryption.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Should never be set
-        pub const UNKNOWN: State = State::new("UNKNOWN");
+        pub const UNKNOWN: State = State::new(0);
 
         /// Secrets in etcd are encrypted.
-        pub const ENCRYPTED: State = State::new("ENCRYPTED");
+        pub const ENCRYPTED: State = State::new(1);
 
         /// Secrets in etcd are stored in plain text (at etcd level) - this is
         /// unrelated to Compute Engine level full disk encryption.
-        pub const DECRYPTED: State = State::new("DECRYPTED");
+        pub const DECRYPTED: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("ENCRYPTED"),
+                2 => std::borrow::Cow::Borrowed("DECRYPTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                "ENCRYPTED" => std::option::Option::Some(Self::ENCRYPTED),
+                "DECRYPTED" => std::option::Option::Some(Self::DECRYPTED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::UNKNOWN
+            Self::new(0)
         }
     }
 
     /// Current State of etcd encryption.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CurrentState(std::borrow::Cow<'static, str>);
+    pub struct CurrentState(i32);
 
     impl CurrentState {
-        /// Creates a new CurrentState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CurrentState](CurrentState)
-    pub mod current_state {
-        use super::CurrentState;
-
         /// Should never be set
-        pub const CURRENT_STATE_UNSPECIFIED: CurrentState =
-            CurrentState::new("CURRENT_STATE_UNSPECIFIED");
+        pub const CURRENT_STATE_UNSPECIFIED: CurrentState = CurrentState::new(0);
 
         /// Secrets in etcd are encrypted.
-        pub const CURRENT_STATE_ENCRYPTED: CurrentState =
-            CurrentState::new("CURRENT_STATE_ENCRYPTED");
+        pub const CURRENT_STATE_ENCRYPTED: CurrentState = CurrentState::new(7);
 
         /// Secrets in etcd are stored in plain text (at etcd level) - this is
         /// unrelated to Compute Engine level full disk encryption.
-        pub const CURRENT_STATE_DECRYPTED: CurrentState =
-            CurrentState::new("CURRENT_STATE_DECRYPTED");
+        pub const CURRENT_STATE_DECRYPTED: CurrentState = CurrentState::new(2);
 
         /// Encryption (or re-encryption with a different CloudKMS key)
         /// of Secrets is in progress.
-        pub const CURRENT_STATE_ENCRYPTION_PENDING: CurrentState =
-            CurrentState::new("CURRENT_STATE_ENCRYPTION_PENDING");
+        pub const CURRENT_STATE_ENCRYPTION_PENDING: CurrentState = CurrentState::new(3);
 
         /// Encryption (or re-encryption with a different CloudKMS key) of Secrets in
         /// etcd encountered an error.
-        pub const CURRENT_STATE_ENCRYPTION_ERROR: CurrentState =
-            CurrentState::new("CURRENT_STATE_ENCRYPTION_ERROR");
+        pub const CURRENT_STATE_ENCRYPTION_ERROR: CurrentState = CurrentState::new(4);
 
         /// De-crypting Secrets to plain text in etcd is in progress.
-        pub const CURRENT_STATE_DECRYPTION_PENDING: CurrentState =
-            CurrentState::new("CURRENT_STATE_DECRYPTION_PENDING");
+        pub const CURRENT_STATE_DECRYPTION_PENDING: CurrentState = CurrentState::new(5);
 
         /// De-crypting Secrets to plain text in etcd encountered an error.
-        pub const CURRENT_STATE_DECRYPTION_ERROR: CurrentState =
-            CurrentState::new("CURRENT_STATE_DECRYPTION_ERROR");
+        pub const CURRENT_STATE_DECRYPTION_ERROR: CurrentState = CurrentState::new(6);
+
+        /// Creates a new CurrentState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CURRENT_STATE_UNSPECIFIED"),
+                2 => std::borrow::Cow::Borrowed("CURRENT_STATE_DECRYPTED"),
+                3 => std::borrow::Cow::Borrowed("CURRENT_STATE_ENCRYPTION_PENDING"),
+                4 => std::borrow::Cow::Borrowed("CURRENT_STATE_ENCRYPTION_ERROR"),
+                5 => std::borrow::Cow::Borrowed("CURRENT_STATE_DECRYPTION_PENDING"),
+                6 => std::borrow::Cow::Borrowed("CURRENT_STATE_DECRYPTION_ERROR"),
+                7 => std::borrow::Cow::Borrowed("CURRENT_STATE_ENCRYPTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CURRENT_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CURRENT_STATE_UNSPECIFIED)
+                }
+                "CURRENT_STATE_ENCRYPTED" => {
+                    std::option::Option::Some(Self::CURRENT_STATE_ENCRYPTED)
+                }
+                "CURRENT_STATE_DECRYPTED" => {
+                    std::option::Option::Some(Self::CURRENT_STATE_DECRYPTED)
+                }
+                "CURRENT_STATE_ENCRYPTION_PENDING" => {
+                    std::option::Option::Some(Self::CURRENT_STATE_ENCRYPTION_PENDING)
+                }
+                "CURRENT_STATE_ENCRYPTION_ERROR" => {
+                    std::option::Option::Some(Self::CURRENT_STATE_ENCRYPTION_ERROR)
+                }
+                "CURRENT_STATE_DECRYPTION_PENDING" => {
+                    std::option::Option::Some(Self::CURRENT_STATE_DECRYPTION_PENDING)
+                }
+                "CURRENT_STATE_DECRYPTION_ERROR" => {
+                    std::option::Option::Some(Self::CURRENT_STATE_DECRYPTION_ERROR)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CurrentState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CurrentState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CurrentState {
         fn default() -> Self {
-            current_state::CURRENT_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -15892,54 +16569,73 @@ pub mod usable_subnetwork_secondary_range {
 
     /// Status shows the current usage of a secondary IP range.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(std::borrow::Cow<'static, str>);
+    pub struct Status(i32);
 
     impl Status {
-        /// Creates a new Status instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Status](Status)
-    pub mod status {
-        use super::Status;
-
         /// UNKNOWN is the zero value of the Status enum. It's not a valid status.
-        pub const UNKNOWN: Status = Status::new("UNKNOWN");
+        pub const UNKNOWN: Status = Status::new(0);
 
         /// UNUSED denotes that this range is unclaimed by any cluster.
-        pub const UNUSED: Status = Status::new("UNUSED");
+        pub const UNUSED: Status = Status::new(1);
 
         /// IN_USE_SERVICE denotes that this range is claimed by cluster(s) for
         /// services. User-managed services range can be shared between clusters
         /// within the same subnetwork.
-        pub const IN_USE_SERVICE: Status = Status::new("IN_USE_SERVICE");
+        pub const IN_USE_SERVICE: Status = Status::new(2);
 
         /// IN_USE_SHAREABLE_POD denotes this range was created by the network admin
         /// and is currently claimed by a cluster for pods. It can only be used by
         /// other clusters as a pod range.
-        pub const IN_USE_SHAREABLE_POD: Status = Status::new("IN_USE_SHAREABLE_POD");
+        pub const IN_USE_SHAREABLE_POD: Status = Status::new(3);
 
         /// IN_USE_MANAGED_POD denotes this range was created by GKE and is claimed
         /// for pods. It cannot be used for other clusters.
-        pub const IN_USE_MANAGED_POD: Status = Status::new("IN_USE_MANAGED_POD");
+        pub const IN_USE_MANAGED_POD: Status = Status::new(4);
+
+        /// Creates a new Status instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("UNUSED"),
+                2 => std::borrow::Cow::Borrowed("IN_USE_SERVICE"),
+                3 => std::borrow::Cow::Borrowed("IN_USE_SHAREABLE_POD"),
+                4 => std::borrow::Cow::Borrowed("IN_USE_MANAGED_POD"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                "UNUSED" => std::option::Option::Some(Self::UNUSED),
+                "IN_USE_SERVICE" => std::option::Option::Some(Self::IN_USE_SERVICE),
+                "IN_USE_SHAREABLE_POD" => std::option::Option::Some(Self::IN_USE_SHAREABLE_POD),
+                "IN_USE_MANAGED_POD" => std::option::Option::Some(Self::IN_USE_MANAGED_POD),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Status {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            status::UNKNOWN
+            Self::new(0)
         }
     }
 }
@@ -16434,46 +17130,67 @@ pub mod notification_config {
     /// Types of notifications currently supported. Can be used to filter what
     /// notifications are sent.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EventType(std::borrow::Cow<'static, str>);
+    pub struct EventType(i32);
 
     impl EventType {
+        /// Not set, will be ignored.
+        pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new(0);
+
+        /// Corresponds with UpgradeAvailableEvent.
+        pub const UPGRADE_AVAILABLE_EVENT: EventType = EventType::new(1);
+
+        /// Corresponds with UpgradeEvent.
+        pub const UPGRADE_EVENT: EventType = EventType::new(2);
+
+        /// Corresponds with SecurityBulletinEvent.
+        pub const SECURITY_BULLETIN_EVENT: EventType = EventType::new(3);
+
         /// Creates a new EventType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EVENT_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("UPGRADE_AVAILABLE_EVENT"),
+                2 => std::borrow::Cow::Borrowed("UPGRADE_EVENT"),
+                3 => std::borrow::Cow::Borrowed("SECURITY_BULLETIN_EVENT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EVENT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::EVENT_TYPE_UNSPECIFIED),
+                "UPGRADE_AVAILABLE_EVENT" => {
+                    std::option::Option::Some(Self::UPGRADE_AVAILABLE_EVENT)
+                }
+                "UPGRADE_EVENT" => std::option::Option::Some(Self::UPGRADE_EVENT),
+                "SECURITY_BULLETIN_EVENT" => {
+                    std::option::Option::Some(Self::SECURITY_BULLETIN_EVENT)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [EventType](EventType)
-    pub mod event_type {
-        use super::EventType;
-
-        /// Not set, will be ignored.
-        pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new("EVENT_TYPE_UNSPECIFIED");
-
-        /// Corresponds with UpgradeAvailableEvent.
-        pub const UPGRADE_AVAILABLE_EVENT: EventType = EventType::new("UPGRADE_AVAILABLE_EVENT");
-
-        /// Corresponds with UpgradeEvent.
-        pub const UPGRADE_EVENT: EventType = EventType::new("UPGRADE_EVENT");
-
-        /// Corresponds with SecurityBulletinEvent.
-        pub const SECURITY_BULLETIN_EVENT: EventType = EventType::new("SECURITY_BULLETIN_EVENT");
-    }
-
-    impl std::convert::From<std::string::String> for EventType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EventType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EventType {
         fn default() -> Self {
-            event_type::EVENT_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -16721,49 +17438,68 @@ pub mod upgrade_info_event {
 
     /// The state of the upgrade.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// STATE_UNSPECIFIED indicates the state is unspecified.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// STARTED indicates the upgrade has started.
+        pub const STARTED: State = State::new(3);
+
+        /// SUCCEEDED indicates the upgrade has completed successfully.
+        pub const SUCCEEDED: State = State::new(4);
+
+        /// FAILED indicates the upgrade has failed.
+        pub const FAILED: State = State::new(5);
+
+        /// CANCELED indicates the upgrade has canceled.
+        pub const CANCELED: State = State::new(6);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                3 => std::borrow::Cow::Borrowed("STARTED"),
+                4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                5 => std::borrow::Cow::Borrowed("FAILED"),
+                6 => std::borrow::Cow::Borrowed("CANCELED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "STARTED" => std::option::Option::Some(Self::STARTED),
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "CANCELED" => std::option::Option::Some(Self::CANCELED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// STATE_UNSPECIFIED indicates the state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// STARTED indicates the upgrade has started.
-        pub const STARTED: State = State::new("STARTED");
-
-        /// SUCCEEDED indicates the upgrade has completed successfully.
-        pub const SUCCEEDED: State = State::new("SUCCEEDED");
-
-        /// FAILED indicates the upgrade has failed.
-        pub const FAILED: State = State::new("FAILED");
-
-        /// CANCELED indicates the upgrade has canceled.
-        pub const CANCELED: State = State::new("CANCELED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -17139,58 +17875,83 @@ pub mod logging_component_config {
 
     /// GKE components exposing logs
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Component(std::borrow::Cow<'static, str>);
+    pub struct Component(i32);
 
     impl Component {
+        /// Default value. This shouldn't be used.
+        pub const COMPONENT_UNSPECIFIED: Component = Component::new(0);
+
+        /// system components
+        pub const SYSTEM_COMPONENTS: Component = Component::new(1);
+
+        /// workloads
+        pub const WORKLOADS: Component = Component::new(2);
+
+        /// kube-apiserver
+        pub const APISERVER: Component = Component::new(3);
+
+        /// kube-scheduler
+        pub const SCHEDULER: Component = Component::new(4);
+
+        /// kube-controller-manager
+        pub const CONTROLLER_MANAGER: Component = Component::new(5);
+
+        /// kcp-sshd
+        pub const KCP_SSHD: Component = Component::new(7);
+
+        /// kcp connection logs
+        pub const KCP_CONNECTION: Component = Component::new(8);
+
         /// Creates a new Component instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COMPONENT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SYSTEM_COMPONENTS"),
+                2 => std::borrow::Cow::Borrowed("WORKLOADS"),
+                3 => std::borrow::Cow::Borrowed("APISERVER"),
+                4 => std::borrow::Cow::Borrowed("SCHEDULER"),
+                5 => std::borrow::Cow::Borrowed("CONTROLLER_MANAGER"),
+                7 => std::borrow::Cow::Borrowed("KCP_SSHD"),
+                8 => std::borrow::Cow::Borrowed("KCP_CONNECTION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COMPONENT_UNSPECIFIED" => std::option::Option::Some(Self::COMPONENT_UNSPECIFIED),
+                "SYSTEM_COMPONENTS" => std::option::Option::Some(Self::SYSTEM_COMPONENTS),
+                "WORKLOADS" => std::option::Option::Some(Self::WORKLOADS),
+                "APISERVER" => std::option::Option::Some(Self::APISERVER),
+                "SCHEDULER" => std::option::Option::Some(Self::SCHEDULER),
+                "CONTROLLER_MANAGER" => std::option::Option::Some(Self::CONTROLLER_MANAGER),
+                "KCP_SSHD" => std::option::Option::Some(Self::KCP_SSHD),
+                "KCP_CONNECTION" => std::option::Option::Some(Self::KCP_CONNECTION),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Component](Component)
-    pub mod component {
-        use super::Component;
-
-        /// Default value. This shouldn't be used.
-        pub const COMPONENT_UNSPECIFIED: Component = Component::new("COMPONENT_UNSPECIFIED");
-
-        /// system components
-        pub const SYSTEM_COMPONENTS: Component = Component::new("SYSTEM_COMPONENTS");
-
-        /// workloads
-        pub const WORKLOADS: Component = Component::new("WORKLOADS");
-
-        /// kube-apiserver
-        pub const APISERVER: Component = Component::new("APISERVER");
-
-        /// kube-scheduler
-        pub const SCHEDULER: Component = Component::new("SCHEDULER");
-
-        /// kube-controller-manager
-        pub const CONTROLLER_MANAGER: Component = Component::new("CONTROLLER_MANAGER");
-
-        /// kcp-sshd
-        pub const KCP_SSHD: Component = Component::new("KCP_SSHD");
-
-        /// kcp connection logs
-        pub const KCP_CONNECTION: Component = Component::new("KCP_CONNECTION");
-    }
-
-    impl std::convert::From<std::string::String> for Component {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Component {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Component {
         fn default() -> Self {
-            component::COMPONENT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -17352,46 +18113,63 @@ pub mod advanced_datapath_observability_config {
 
     /// Supported Relay modes
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RelayMode(std::borrow::Cow<'static, str>);
+    pub struct RelayMode(i32);
 
     impl RelayMode {
+        /// Default value. This shouldn't be used.
+        pub const RELAY_MODE_UNSPECIFIED: RelayMode = RelayMode::new(0);
+
+        /// disabled
+        pub const DISABLED: RelayMode = RelayMode::new(1);
+
+        /// exposed via internal load balancer
+        pub const INTERNAL_VPC_LB: RelayMode = RelayMode::new(3);
+
+        /// exposed via external load balancer
+        pub const EXTERNAL_LB: RelayMode = RelayMode::new(4);
+
         /// Creates a new RelayMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RELAY_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DISABLED"),
+                3 => std::borrow::Cow::Borrowed("INTERNAL_VPC_LB"),
+                4 => std::borrow::Cow::Borrowed("EXTERNAL_LB"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RELAY_MODE_UNSPECIFIED" => std::option::Option::Some(Self::RELAY_MODE_UNSPECIFIED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "INTERNAL_VPC_LB" => std::option::Option::Some(Self::INTERNAL_VPC_LB),
+                "EXTERNAL_LB" => std::option::Option::Some(Self::EXTERNAL_LB),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RelayMode](RelayMode)
-    pub mod relay_mode {
-        use super::RelayMode;
-
-        /// Default value. This shouldn't be used.
-        pub const RELAY_MODE_UNSPECIFIED: RelayMode = RelayMode::new("RELAY_MODE_UNSPECIFIED");
-
-        /// disabled
-        pub const DISABLED: RelayMode = RelayMode::new("DISABLED");
-
-        /// exposed via internal load balancer
-        pub const INTERNAL_VPC_LB: RelayMode = RelayMode::new("INTERNAL_VPC_LB");
-
-        /// exposed via external load balancer
-        pub const EXTERNAL_LB: RelayMode = RelayMode::new("EXTERNAL_LB");
-    }
-
-    impl std::convert::From<std::string::String> for RelayMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RelayMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RelayMode {
         fn default() -> Self {
-            relay_mode::RELAY_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -17497,43 +18275,58 @@ pub mod logging_variant_config {
 
     /// Logging component variants.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Variant(std::borrow::Cow<'static, str>);
+    pub struct Variant(i32);
 
     impl Variant {
+        /// Default value. This shouldn't be used.
+        pub const VARIANT_UNSPECIFIED: Variant = Variant::new(0);
+
+        /// default logging variant.
+        pub const DEFAULT: Variant = Variant::new(1);
+
+        /// maximum logging throughput variant.
+        pub const MAX_THROUGHPUT: Variant = Variant::new(2);
+
         /// Creates a new Variant instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VARIANT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DEFAULT"),
+                2 => std::borrow::Cow::Borrowed("MAX_THROUGHPUT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VARIANT_UNSPECIFIED" => std::option::Option::Some(Self::VARIANT_UNSPECIFIED),
+                "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
+                "MAX_THROUGHPUT" => std::option::Option::Some(Self::MAX_THROUGHPUT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Variant](Variant)
-    pub mod variant {
-        use super::Variant;
-
-        /// Default value. This shouldn't be used.
-        pub const VARIANT_UNSPECIFIED: Variant = Variant::new("VARIANT_UNSPECIFIED");
-
-        /// default logging variant.
-        pub const DEFAULT: Variant = Variant::new("DEFAULT");
-
-        /// maximum logging throughput variant.
-        pub const MAX_THROUGHPUT: Variant = Variant::new("MAX_THROUGHPUT");
-    }
-
-    impl std::convert::From<std::string::String> for Variant {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Variant {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Variant {
         fn default() -> Self {
-            variant::VARIANT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -17580,76 +18373,113 @@ pub mod monitoring_component_config {
 
     /// GKE components exposing metrics
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Component(std::borrow::Cow<'static, str>);
+    pub struct Component(i32);
 
     impl Component {
+        /// Default value. This shouldn't be used.
+        pub const COMPONENT_UNSPECIFIED: Component = Component::new(0);
+
+        /// system components
+        pub const SYSTEM_COMPONENTS: Component = Component::new(1);
+
+        /// kube-apiserver
+        pub const APISERVER: Component = Component::new(3);
+
+        /// kube-scheduler
+        pub const SCHEDULER: Component = Component::new(4);
+
+        /// kube-controller-manager
+        pub const CONTROLLER_MANAGER: Component = Component::new(5);
+
+        /// Storage
+        pub const STORAGE: Component = Component::new(7);
+
+        /// Horizontal Pod Autoscaling
+        pub const HPA: Component = Component::new(8);
+
+        /// Pod
+        pub const POD: Component = Component::new(9);
+
+        /// DaemonSet
+        pub const DAEMONSET: Component = Component::new(10);
+
+        /// Deployment
+        pub const DEPLOYMENT: Component = Component::new(11);
+
+        /// Statefulset
+        pub const STATEFULSET: Component = Component::new(12);
+
+        /// CADVISOR
+        pub const CADVISOR: Component = Component::new(13);
+
+        /// KUBELET
+        pub const KUBELET: Component = Component::new(14);
+
+        /// NVIDIA Data Center GPU Manager (DCGM)
+        pub const DCGM: Component = Component::new(15);
+
         /// Creates a new Component instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COMPONENT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SYSTEM_COMPONENTS"),
+                3 => std::borrow::Cow::Borrowed("APISERVER"),
+                4 => std::borrow::Cow::Borrowed("SCHEDULER"),
+                5 => std::borrow::Cow::Borrowed("CONTROLLER_MANAGER"),
+                7 => std::borrow::Cow::Borrowed("STORAGE"),
+                8 => std::borrow::Cow::Borrowed("HPA"),
+                9 => std::borrow::Cow::Borrowed("POD"),
+                10 => std::borrow::Cow::Borrowed("DAEMONSET"),
+                11 => std::borrow::Cow::Borrowed("DEPLOYMENT"),
+                12 => std::borrow::Cow::Borrowed("STATEFULSET"),
+                13 => std::borrow::Cow::Borrowed("CADVISOR"),
+                14 => std::borrow::Cow::Borrowed("KUBELET"),
+                15 => std::borrow::Cow::Borrowed("DCGM"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COMPONENT_UNSPECIFIED" => std::option::Option::Some(Self::COMPONENT_UNSPECIFIED),
+                "SYSTEM_COMPONENTS" => std::option::Option::Some(Self::SYSTEM_COMPONENTS),
+                "APISERVER" => std::option::Option::Some(Self::APISERVER),
+                "SCHEDULER" => std::option::Option::Some(Self::SCHEDULER),
+                "CONTROLLER_MANAGER" => std::option::Option::Some(Self::CONTROLLER_MANAGER),
+                "STORAGE" => std::option::Option::Some(Self::STORAGE),
+                "HPA" => std::option::Option::Some(Self::HPA),
+                "POD" => std::option::Option::Some(Self::POD),
+                "DAEMONSET" => std::option::Option::Some(Self::DAEMONSET),
+                "DEPLOYMENT" => std::option::Option::Some(Self::DEPLOYMENT),
+                "STATEFULSET" => std::option::Option::Some(Self::STATEFULSET),
+                "CADVISOR" => std::option::Option::Some(Self::CADVISOR),
+                "KUBELET" => std::option::Option::Some(Self::KUBELET),
+                "DCGM" => std::option::Option::Some(Self::DCGM),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Component](Component)
-    pub mod component {
-        use super::Component;
-
-        /// Default value. This shouldn't be used.
-        pub const COMPONENT_UNSPECIFIED: Component = Component::new("COMPONENT_UNSPECIFIED");
-
-        /// system components
-        pub const SYSTEM_COMPONENTS: Component = Component::new("SYSTEM_COMPONENTS");
-
-        /// kube-apiserver
-        pub const APISERVER: Component = Component::new("APISERVER");
-
-        /// kube-scheduler
-        pub const SCHEDULER: Component = Component::new("SCHEDULER");
-
-        /// kube-controller-manager
-        pub const CONTROLLER_MANAGER: Component = Component::new("CONTROLLER_MANAGER");
-
-        /// Storage
-        pub const STORAGE: Component = Component::new("STORAGE");
-
-        /// Horizontal Pod Autoscaling
-        pub const HPA: Component = Component::new("HPA");
-
-        /// Pod
-        pub const POD: Component = Component::new("POD");
-
-        /// DaemonSet
-        pub const DAEMONSET: Component = Component::new("DAEMONSET");
-
-        /// Deployment
-        pub const DEPLOYMENT: Component = Component::new("DEPLOYMENT");
-
-        /// Statefulset
-        pub const STATEFULSET: Component = Component::new("STATEFULSET");
-
-        /// CADVISOR
-        pub const CADVISOR: Component = Component::new("CADVISOR");
-
-        /// KUBELET
-        pub const KUBELET: Component = Component::new("KUBELET");
-
-        /// NVIDIA Data Center GPU Manager (DCGM)
-        pub const DCGM: Component = Component::new("DCGM");
-    }
-
-    impl std::convert::From<std::string::String> for Component {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Component {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Component {
         fn default() -> Self {
-            component::COMPONENT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -18164,44 +18994,60 @@ pub mod enterprise_config {
 
     /// Premium tiers for GKE Cluster.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ClusterTier(std::borrow::Cow<'static, str>);
+    pub struct ClusterTier(i32);
 
     impl ClusterTier {
+        /// CLUSTER_TIER_UNSPECIFIED is when cluster_tier is not set.
+        pub const CLUSTER_TIER_UNSPECIFIED: ClusterTier = ClusterTier::new(0);
+
+        /// STANDARD indicates a standard GKE cluster.
+        pub const STANDARD: ClusterTier = ClusterTier::new(1);
+
+        /// ENTERPRISE indicates a GKE Enterprise cluster.
+        pub const ENTERPRISE: ClusterTier = ClusterTier::new(2);
+
         /// Creates a new ClusterTier instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CLUSTER_TIER_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STANDARD"),
+                2 => std::borrow::Cow::Borrowed("ENTERPRISE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CLUSTER_TIER_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CLUSTER_TIER_UNSPECIFIED)
+                }
+                "STANDARD" => std::option::Option::Some(Self::STANDARD),
+                "ENTERPRISE" => std::option::Option::Some(Self::ENTERPRISE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ClusterTier](ClusterTier)
-    pub mod cluster_tier {
-        use super::ClusterTier;
-
-        /// CLUSTER_TIER_UNSPECIFIED is when cluster_tier is not set.
-        pub const CLUSTER_TIER_UNSPECIFIED: ClusterTier =
-            ClusterTier::new("CLUSTER_TIER_UNSPECIFIED");
-
-        /// STANDARD indicates a standard GKE cluster.
-        pub const STANDARD: ClusterTier = ClusterTier::new("STANDARD");
-
-        /// ENTERPRISE indicates a GKE Enterprise cluster.
-        pub const ENTERPRISE: ClusterTier = ClusterTier::new("ENTERPRISE");
-    }
-
-    impl std::convert::From<std::string::String> for ClusterTier {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ClusterTier {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ClusterTier {
         fn default() -> Self {
-            cluster_tier::CLUSTER_TIER_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -18285,41 +19131,54 @@ pub mod secondary_boot_disk {
     /// Mode specifies how the secondary boot disk will be used.
     /// This triggers mode-specified logic in the control plane.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(std::borrow::Cow<'static, str>);
+    pub struct Mode(i32);
 
     impl Mode {
-        /// Creates a new Mode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Mode](Mode)
-    pub mod mode {
-        use super::Mode;
-
         /// MODE_UNSPECIFIED is when mode is not set.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new("MODE_UNSPECIFIED");
+        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
 
         /// CONTAINER_IMAGE_CACHE is for using the secondary boot disk as
         /// a container image cache.
-        pub const CONTAINER_IMAGE_CACHE: Mode = Mode::new("CONTAINER_IMAGE_CACHE");
+        pub const CONTAINER_IMAGE_CACHE: Mode = Mode::new(1);
+
+        /// Creates a new Mode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CONTAINER_IMAGE_CACHE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
+                "CONTAINER_IMAGE_CACHE" => std::option::Option::Some(Self::CONTAINER_IMAGE_CACHE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Mode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            mode::MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -18347,316 +19206,442 @@ impl wkt::message::Message for SecondaryBootDiskUpdateStrategy {
 /// PrivateIPv6GoogleAccess controls whether and how the pods can communicate
 /// with Google Services through gRPC over IPv6.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PrivateIPv6GoogleAccess(std::borrow::Cow<'static, str>);
+pub struct PrivateIPv6GoogleAccess(i32);
 
 impl PrivateIPv6GoogleAccess {
-    /// Creates a new PrivateIPv6GoogleAccess instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [PrivateIPv6GoogleAccess](PrivateIPv6GoogleAccess)
-pub mod private_i_pv_6_google_access {
-    use super::PrivateIPv6GoogleAccess;
-
     /// Default value. Same as DISABLED
     pub const PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED: PrivateIPv6GoogleAccess =
-        PrivateIPv6GoogleAccess::new("PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED");
+        PrivateIPv6GoogleAccess::new(0);
 
     /// No private access to or from Google Services
     pub const PRIVATE_IPV6_GOOGLE_ACCESS_DISABLED: PrivateIPv6GoogleAccess =
-        PrivateIPv6GoogleAccess::new("PRIVATE_IPV6_GOOGLE_ACCESS_DISABLED");
+        PrivateIPv6GoogleAccess::new(1);
 
     /// Enables private IPv6 access to Google Services from GKE
     pub const PRIVATE_IPV6_GOOGLE_ACCESS_TO_GOOGLE: PrivateIPv6GoogleAccess =
-        PrivateIPv6GoogleAccess::new("PRIVATE_IPV6_GOOGLE_ACCESS_TO_GOOGLE");
+        PrivateIPv6GoogleAccess::new(2);
 
     /// Enables private IPv6 access to and from Google Services
     pub const PRIVATE_IPV6_GOOGLE_ACCESS_BIDIRECTIONAL: PrivateIPv6GoogleAccess =
-        PrivateIPv6GoogleAccess::new("PRIVATE_IPV6_GOOGLE_ACCESS_BIDIRECTIONAL");
+        PrivateIPv6GoogleAccess::new(3);
+
+    /// Creates a new PrivateIPv6GoogleAccess instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PRIVATE_IPV6_GOOGLE_ACCESS_DISABLED"),
+            2 => std::borrow::Cow::Borrowed("PRIVATE_IPV6_GOOGLE_ACCESS_TO_GOOGLE"),
+            3 => std::borrow::Cow::Borrowed("PRIVATE_IPV6_GOOGLE_ACCESS_BIDIRECTIONAL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED" => {
+                std::option::Option::Some(Self::PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED)
+            }
+            "PRIVATE_IPV6_GOOGLE_ACCESS_DISABLED" => {
+                std::option::Option::Some(Self::PRIVATE_IPV6_GOOGLE_ACCESS_DISABLED)
+            }
+            "PRIVATE_IPV6_GOOGLE_ACCESS_TO_GOOGLE" => {
+                std::option::Option::Some(Self::PRIVATE_IPV6_GOOGLE_ACCESS_TO_GOOGLE)
+            }
+            "PRIVATE_IPV6_GOOGLE_ACCESS_BIDIRECTIONAL" => {
+                std::option::Option::Some(Self::PRIVATE_IPV6_GOOGLE_ACCESS_BIDIRECTIONAL)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for PrivateIPv6GoogleAccess {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for PrivateIPv6GoogleAccess {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for PrivateIPv6GoogleAccess {
     fn default() -> Self {
-        private_i_pv_6_google_access::PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// UpgradeResourceType is the resource type that is upgrading. It is used
 /// in upgrade notifications.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct UpgradeResourceType(std::borrow::Cow<'static, str>);
+pub struct UpgradeResourceType(i32);
 
 impl UpgradeResourceType {
+    /// Default value. This shouldn't be used.
+    pub const UPGRADE_RESOURCE_TYPE_UNSPECIFIED: UpgradeResourceType = UpgradeResourceType::new(0);
+
+    /// Master / control plane
+    pub const MASTER: UpgradeResourceType = UpgradeResourceType::new(1);
+
+    /// Node pool
+    pub const NODE_POOL: UpgradeResourceType = UpgradeResourceType::new(2);
+
     /// Creates a new UpgradeResourceType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("UPGRADE_RESOURCE_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("MASTER"),
+            2 => std::borrow::Cow::Borrowed("NODE_POOL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "UPGRADE_RESOURCE_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::UPGRADE_RESOURCE_TYPE_UNSPECIFIED)
+            }
+            "MASTER" => std::option::Option::Some(Self::MASTER),
+            "NODE_POOL" => std::option::Option::Some(Self::NODE_POOL),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [UpgradeResourceType](UpgradeResourceType)
-pub mod upgrade_resource_type {
-    use super::UpgradeResourceType;
-
-    /// Default value. This shouldn't be used.
-    pub const UPGRADE_RESOURCE_TYPE_UNSPECIFIED: UpgradeResourceType =
-        UpgradeResourceType::new("UPGRADE_RESOURCE_TYPE_UNSPECIFIED");
-
-    /// Master / control plane
-    pub const MASTER: UpgradeResourceType = UpgradeResourceType::new("MASTER");
-
-    /// Node pool
-    pub const NODE_POOL: UpgradeResourceType = UpgradeResourceType::new("NODE_POOL");
-}
-
-impl std::convert::From<std::string::String> for UpgradeResourceType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for UpgradeResourceType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for UpgradeResourceType {
     fn default() -> Self {
-        upgrade_resource_type::UPGRADE_RESOURCE_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The datapath provider selects the implementation of the Kubernetes networking
 /// model for service resolution and network policy enforcement.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DatapathProvider(std::borrow::Cow<'static, str>);
+pub struct DatapathProvider(i32);
 
 impl DatapathProvider {
-    /// Creates a new DatapathProvider instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [DatapathProvider](DatapathProvider)
-pub mod datapath_provider {
-    use super::DatapathProvider;
-
     /// Default value.
-    pub const DATAPATH_PROVIDER_UNSPECIFIED: DatapathProvider =
-        DatapathProvider::new("DATAPATH_PROVIDER_UNSPECIFIED");
+    pub const DATAPATH_PROVIDER_UNSPECIFIED: DatapathProvider = DatapathProvider::new(0);
 
     /// Use the IPTables implementation based on kube-proxy.
-    pub const LEGACY_DATAPATH: DatapathProvider = DatapathProvider::new("LEGACY_DATAPATH");
+    pub const LEGACY_DATAPATH: DatapathProvider = DatapathProvider::new(1);
 
     /// Use the eBPF based GKE Dataplane V2 with additional features. See the [GKE
     /// Dataplane V2
     /// documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/dataplane-v2)
     /// for more.
-    pub const ADVANCED_DATAPATH: DatapathProvider = DatapathProvider::new("ADVANCED_DATAPATH");
+    pub const ADVANCED_DATAPATH: DatapathProvider = DatapathProvider::new(2);
+
+    /// Creates a new DatapathProvider instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DATAPATH_PROVIDER_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("LEGACY_DATAPATH"),
+            2 => std::borrow::Cow::Borrowed("ADVANCED_DATAPATH"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DATAPATH_PROVIDER_UNSPECIFIED" => {
+                std::option::Option::Some(Self::DATAPATH_PROVIDER_UNSPECIFIED)
+            }
+            "LEGACY_DATAPATH" => std::option::Option::Some(Self::LEGACY_DATAPATH),
+            "ADVANCED_DATAPATH" => std::option::Option::Some(Self::ADVANCED_DATAPATH),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for DatapathProvider {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DatapathProvider {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DatapathProvider {
     fn default() -> Self {
-        datapath_provider::DATAPATH_PROVIDER_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Strategy used for node pool update.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct NodePoolUpdateStrategy(std::borrow::Cow<'static, str>);
+pub struct NodePoolUpdateStrategy(i32);
 
 impl NodePoolUpdateStrategy {
-    /// Creates a new NodePoolUpdateStrategy instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [NodePoolUpdateStrategy](NodePoolUpdateStrategy)
-pub mod node_pool_update_strategy {
-    use super::NodePoolUpdateStrategy;
-
     /// Default value if unset. GKE internally defaults the update strategy to
     /// SURGE for unspecified strategies.
     pub const NODE_POOL_UPDATE_STRATEGY_UNSPECIFIED: NodePoolUpdateStrategy =
-        NodePoolUpdateStrategy::new("NODE_POOL_UPDATE_STRATEGY_UNSPECIFIED");
+        NodePoolUpdateStrategy::new(0);
 
     /// blue-green upgrade.
-    pub const BLUE_GREEN: NodePoolUpdateStrategy = NodePoolUpdateStrategy::new("BLUE_GREEN");
+    pub const BLUE_GREEN: NodePoolUpdateStrategy = NodePoolUpdateStrategy::new(2);
 
     /// SURGE is the traditional way of upgrade a node pool.
     /// max_surge and max_unavailable determines the level of upgrade parallelism.
-    pub const SURGE: NodePoolUpdateStrategy = NodePoolUpdateStrategy::new("SURGE");
+    pub const SURGE: NodePoolUpdateStrategy = NodePoolUpdateStrategy::new(3);
+
+    /// Creates a new NodePoolUpdateStrategy instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("NODE_POOL_UPDATE_STRATEGY_UNSPECIFIED"),
+            2 => std::borrow::Cow::Borrowed("BLUE_GREEN"),
+            3 => std::borrow::Cow::Borrowed("SURGE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "NODE_POOL_UPDATE_STRATEGY_UNSPECIFIED" => {
+                std::option::Option::Some(Self::NODE_POOL_UPDATE_STRATEGY_UNSPECIFIED)
+            }
+            "BLUE_GREEN" => std::option::Option::Some(Self::BLUE_GREEN),
+            "SURGE" => std::option::Option::Some(Self::SURGE),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for NodePoolUpdateStrategy {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for NodePoolUpdateStrategy {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for NodePoolUpdateStrategy {
     fn default() -> Self {
-        node_pool_update_strategy::NODE_POOL_UPDATE_STRATEGY_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Possible values for IP stack type
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct StackType(std::borrow::Cow<'static, str>);
+pub struct StackType(i32);
 
 impl StackType {
+    /// Default value, will be defaulted as IPV4 only
+    pub const STACK_TYPE_UNSPECIFIED: StackType = StackType::new(0);
+
+    /// Cluster is IPV4 only
+    pub const IPV4: StackType = StackType::new(1);
+
+    /// Cluster can use both IPv4 and IPv6
+    pub const IPV4_IPV6: StackType = StackType::new(2);
+
     /// Creates a new StackType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("STACK_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("IPV4"),
+            2 => std::borrow::Cow::Borrowed("IPV4_IPV6"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "STACK_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::STACK_TYPE_UNSPECIFIED),
+            "IPV4" => std::option::Option::Some(Self::IPV4),
+            "IPV4_IPV6" => std::option::Option::Some(Self::IPV4_IPV6),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [StackType](StackType)
-pub mod stack_type {
-    use super::StackType;
-
-    /// Default value, will be defaulted as IPV4 only
-    pub const STACK_TYPE_UNSPECIFIED: StackType = StackType::new("STACK_TYPE_UNSPECIFIED");
-
-    /// Cluster is IPV4 only
-    pub const IPV4: StackType = StackType::new("IPV4");
-
-    /// Cluster can use both IPv4 and IPv6
-    pub const IPV4_IPV6: StackType = StackType::new("IPV4_IPV6");
-}
-
-impl std::convert::From<std::string::String> for StackType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for StackType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for StackType {
     fn default() -> Self {
-        stack_type::STACK_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Possible values for IPv6 access type
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct IPv6AccessType(std::borrow::Cow<'static, str>);
+pub struct IPv6AccessType(i32);
 
 impl IPv6AccessType {
+    /// Default value, will be defaulted as type external.
+    pub const IPV6_ACCESS_TYPE_UNSPECIFIED: IPv6AccessType = IPv6AccessType::new(0);
+
+    /// Access type internal (all v6 addresses are internal IPs)
+    pub const INTERNAL: IPv6AccessType = IPv6AccessType::new(1);
+
+    /// Access type external (all v6 addresses are external IPs)
+    pub const EXTERNAL: IPv6AccessType = IPv6AccessType::new(2);
+
     /// Creates a new IPv6AccessType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("IPV6_ACCESS_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("INTERNAL"),
+            2 => std::borrow::Cow::Borrowed("EXTERNAL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "IPV6_ACCESS_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::IPV6_ACCESS_TYPE_UNSPECIFIED)
+            }
+            "INTERNAL" => std::option::Option::Some(Self::INTERNAL),
+            "EXTERNAL" => std::option::Option::Some(Self::EXTERNAL),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [IPv6AccessType](IPv6AccessType)
-pub mod i_pv_6_access_type {
-    use super::IPv6AccessType;
-
-    /// Default value, will be defaulted as type external.
-    pub const IPV6_ACCESS_TYPE_UNSPECIFIED: IPv6AccessType =
-        IPv6AccessType::new("IPV6_ACCESS_TYPE_UNSPECIFIED");
-
-    /// Access type internal (all v6 addresses are internal IPs)
-    pub const INTERNAL: IPv6AccessType = IPv6AccessType::new("INTERNAL");
-
-    /// Access type external (all v6 addresses are external IPs)
-    pub const EXTERNAL: IPv6AccessType = IPv6AccessType::new("EXTERNAL");
-}
-
-impl std::convert::From<std::string::String> for IPv6AccessType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for IPv6AccessType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for IPv6AccessType {
     fn default() -> Self {
-        i_pv_6_access_type::IPV6_ACCESS_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Options for in-transit encryption.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct InTransitEncryptionConfig(std::borrow::Cow<'static, str>);
+pub struct InTransitEncryptionConfig(i32);
 
 impl InTransitEncryptionConfig {
-    /// Creates a new InTransitEncryptionConfig instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [InTransitEncryptionConfig](InTransitEncryptionConfig)
-pub mod in_transit_encryption_config {
-    use super::InTransitEncryptionConfig;
-
     /// Unspecified, will be inferred as default -
     /// IN_TRANSIT_ENCRYPTION_UNSPECIFIED.
     pub const IN_TRANSIT_ENCRYPTION_CONFIG_UNSPECIFIED: InTransitEncryptionConfig =
-        InTransitEncryptionConfig::new("IN_TRANSIT_ENCRYPTION_CONFIG_UNSPECIFIED");
+        InTransitEncryptionConfig::new(0);
 
     /// In-transit encryption is disabled.
     pub const IN_TRANSIT_ENCRYPTION_DISABLED: InTransitEncryptionConfig =
-        InTransitEncryptionConfig::new("IN_TRANSIT_ENCRYPTION_DISABLED");
+        InTransitEncryptionConfig::new(1);
 
     /// Data in-transit is encrypted using inter-node transparent encryption.
     pub const IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT: InTransitEncryptionConfig =
-        InTransitEncryptionConfig::new("IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT");
+        InTransitEncryptionConfig::new(2);
+
+    /// Creates a new InTransitEncryptionConfig instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("IN_TRANSIT_ENCRYPTION_CONFIG_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("IN_TRANSIT_ENCRYPTION_DISABLED"),
+            2 => std::borrow::Cow::Borrowed("IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "IN_TRANSIT_ENCRYPTION_CONFIG_UNSPECIFIED" => {
+                std::option::Option::Some(Self::IN_TRANSIT_ENCRYPTION_CONFIG_UNSPECIFIED)
+            }
+            "IN_TRANSIT_ENCRYPTION_DISABLED" => {
+                std::option::Option::Some(Self::IN_TRANSIT_ENCRYPTION_DISABLED)
+            }
+            "IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT" => {
+                std::option::Option::Some(Self::IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for InTransitEncryptionConfig {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for InTransitEncryptionConfig {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for InTransitEncryptionConfig {
     fn default() -> Self {
-        in_transit_encryption_config::IN_TRANSIT_ENCRYPTION_CONFIG_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/container/v1/src/transport.rs
+++ b/src/generated/container/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/clusters", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -70,7 +70,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -95,7 +95,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/clusters", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -112,7 +112,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
         let builder = self
             .inner
             .builder(reqwest::Method::PUT, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -129,7 +129,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
         let builder = self
             .inner
             .builder(reqwest::Method::PUT, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -149,7 +149,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:setAutoscaling", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -169,7 +169,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:setLogging", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -189,7 +189,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:setMonitoring", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -206,7 +206,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:setAddons", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -226,7 +226,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:setLocations", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -246,7 +246,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:updateMaster", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -266,7 +266,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:setMasterAuth", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -283,7 +283,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -308,7 +308,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/operations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -329,7 +329,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -351,7 +351,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -371,7 +371,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/serverConfig", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -392,7 +392,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/jwks", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -414,7 +414,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/nodePools", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -436,7 +436,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -462,7 +462,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/nodePools", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -479,7 +479,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -505,7 +505,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:completeUpgrade", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -522,7 +522,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:rollback", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -542,7 +542,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:setManagement", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -562,7 +562,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:setResourceLabels", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -582,7 +582,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:setLegacyAbac", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -602,7 +602,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:startIpRotation", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -622,7 +622,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:completeIpRotation", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -639,7 +639,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:setSize", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -659,7 +659,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:setNetworkPolicy", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -679,7 +679,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:setMaintenancePolicy", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -699,7 +699,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/aggregated/usableSubnetworks", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -724,7 +724,7 @@ impl crate::stubs::ClusterManager for ClusterManager {
                 reqwest::Method::GET,
                 format!("/v1/{}:checkAutopilotCompatibility", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/datastore/admin/v1/src/model.rs
+++ b/src/generated/datastore/admin/v1/src/model.rs
@@ -125,60 +125,85 @@ pub mod common_metadata {
 
     /// The various possible states for an ongoing Operation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// Request is being prepared for processing.
-        pub const INITIALIZING: State = State::new("INITIALIZING");
+        pub const INITIALIZING: State = State::new(1);
 
         /// Request is actively being processed.
-        pub const PROCESSING: State = State::new("PROCESSING");
+        pub const PROCESSING: State = State::new(2);
 
         /// Request is in the process of being cancelled after user called
         /// google.longrunning.Operations.CancelOperation on the operation.
-        pub const CANCELLING: State = State::new("CANCELLING");
+        pub const CANCELLING: State = State::new(3);
 
         /// Request has been processed and is in its finalization stage.
-        pub const FINALIZING: State = State::new("FINALIZING");
+        pub const FINALIZING: State = State::new(4);
 
         /// Request has completed successfully.
-        pub const SUCCESSFUL: State = State::new("SUCCESSFUL");
+        pub const SUCCESSFUL: State = State::new(5);
 
         /// Request has finished being processed, but encountered an error.
-        pub const FAILED: State = State::new("FAILED");
+        pub const FAILED: State = State::new(6);
 
         /// Request has finished being cancelled after user called
         /// google.longrunning.Operations.CancelOperation.
-        pub const CANCELLED: State = State::new("CANCELLED");
+        pub const CANCELLED: State = State::new(7);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INITIALIZING"),
+                2 => std::borrow::Cow::Borrowed("PROCESSING"),
+                3 => std::borrow::Cow::Borrowed("CANCELLING"),
+                4 => std::borrow::Cow::Borrowed("FINALIZING"),
+                5 => std::borrow::Cow::Borrowed("SUCCESSFUL"),
+                6 => std::borrow::Cow::Borrowed("FAILED"),
+                7 => std::borrow::Cow::Borrowed("CANCELLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "INITIALIZING" => std::option::Option::Some(Self::INITIALIZING),
+                "PROCESSING" => std::option::Option::Some(Self::PROCESSING),
+                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
+                "FINALIZING" => std::option::Option::Some(Self::FINALIZING),
+                "SUCCESSFUL" => std::option::Option::Some(Self::SUCCESSFUL),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1209,130 +1234,146 @@ pub mod index {
     /// For an ordered index, specifies whether each of the entity's ancestors
     /// will be included.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AncestorMode(std::borrow::Cow<'static, str>);
+    pub struct AncestorMode(i32);
 
     impl AncestorMode {
+        /// The ancestor mode is unspecified.
+        pub const ANCESTOR_MODE_UNSPECIFIED: AncestorMode = AncestorMode::new(0);
+
+        /// Do not include the entity's ancestors in the index.
+        pub const NONE: AncestorMode = AncestorMode::new(1);
+
+        /// Include all the entity's ancestors in the index.
+        pub const ALL_ANCESTORS: AncestorMode = AncestorMode::new(2);
+
         /// Creates a new AncestorMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ANCESTOR_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NONE"),
+                2 => std::borrow::Cow::Borrowed("ALL_ANCESTORS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ANCESTOR_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ANCESTOR_MODE_UNSPECIFIED)
+                }
+                "NONE" => std::option::Option::Some(Self::NONE),
+                "ALL_ANCESTORS" => std::option::Option::Some(Self::ALL_ANCESTORS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AncestorMode](AncestorMode)
-    pub mod ancestor_mode {
-        use super::AncestorMode;
-
-        /// The ancestor mode is unspecified.
-        pub const ANCESTOR_MODE_UNSPECIFIED: AncestorMode =
-            AncestorMode::new("ANCESTOR_MODE_UNSPECIFIED");
-
-        /// Do not include the entity's ancestors in the index.
-        pub const NONE: AncestorMode = AncestorMode::new("NONE");
-
-        /// Include all the entity's ancestors in the index.
-        pub const ALL_ANCESTORS: AncestorMode = AncestorMode::new("ALL_ANCESTORS");
-    }
-
-    impl std::convert::From<std::string::String> for AncestorMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AncestorMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AncestorMode {
         fn default() -> Self {
-            ancestor_mode::ANCESTOR_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The direction determines how a property is indexed.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Direction(std::borrow::Cow<'static, str>);
+    pub struct Direction(i32);
 
     impl Direction {
-        /// Creates a new Direction instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Direction](Direction)
-    pub mod direction {
-        use super::Direction;
-
         /// The direction is unspecified.
-        pub const DIRECTION_UNSPECIFIED: Direction = Direction::new("DIRECTION_UNSPECIFIED");
+        pub const DIRECTION_UNSPECIFIED: Direction = Direction::new(0);
 
         /// The property's values are indexed so as to support sequencing in
         /// ascending order and also query by <, >, <=, >=, and =.
-        pub const ASCENDING: Direction = Direction::new("ASCENDING");
+        pub const ASCENDING: Direction = Direction::new(1);
 
         /// The property's values are indexed so as to support sequencing in
         /// descending order and also query by <, >, <=, >=, and =.
-        pub const DESCENDING: Direction = Direction::new("DESCENDING");
+        pub const DESCENDING: Direction = Direction::new(2);
+
+        /// Creates a new Direction instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DIRECTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ASCENDING"),
+                2 => std::borrow::Cow::Borrowed("DESCENDING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DIRECTION_UNSPECIFIED" => std::option::Option::Some(Self::DIRECTION_UNSPECIFIED),
+                "ASCENDING" => std::option::Option::Some(Self::ASCENDING),
+                "DESCENDING" => std::option::Option::Some(Self::DESCENDING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Direction {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Direction {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Direction {
         fn default() -> Self {
-            direction::DIRECTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The possible set of states of an index.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The index is being created, and cannot be used by queries.
         /// There is an active long-running operation for the index.
         /// The index is updated when writing an entity.
         /// Some index data may exist.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The index is ready to be used.
         /// The index is updated when writing an entity.
         /// The index is fully populated from all stored entities it applies to.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(2);
 
         /// The index is being deleted, and cannot be used by queries.
         /// There is an active long-running operation for the index.
         /// The index is not updated when writing an entity.
         /// Some index data may exist.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(3);
 
         /// The index was being created or deleted, but something went wrong.
         /// The index cannot by used by queries.
@@ -1340,18 +1381,52 @@ pub mod index {
         /// and the most recently finished long-running operation failed.
         /// The index is not updated when writing an entity.
         /// Some index data may exist.
-        pub const ERROR: State = State::new("ERROR");
+        pub const ERROR: State = State::new(4);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1584,48 +1659,67 @@ pub mod migration_progress_event {
 
     /// Concurrency modes for transactions in Cloud Firestore.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConcurrencyMode(std::borrow::Cow<'static, str>);
+    pub struct ConcurrencyMode(i32);
 
     impl ConcurrencyMode {
+        /// Unspecified.
+        pub const CONCURRENCY_MODE_UNSPECIFIED: ConcurrencyMode = ConcurrencyMode::new(0);
+
+        /// Pessimistic concurrency.
+        pub const PESSIMISTIC: ConcurrencyMode = ConcurrencyMode::new(1);
+
+        /// Optimistic concurrency.
+        pub const OPTIMISTIC: ConcurrencyMode = ConcurrencyMode::new(2);
+
+        /// Optimistic concurrency with entity groups.
+        pub const OPTIMISTIC_WITH_ENTITY_GROUPS: ConcurrencyMode = ConcurrencyMode::new(3);
+
         /// Creates a new ConcurrencyMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CONCURRENCY_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PESSIMISTIC"),
+                2 => std::borrow::Cow::Borrowed("OPTIMISTIC"),
+                3 => std::borrow::Cow::Borrowed("OPTIMISTIC_WITH_ENTITY_GROUPS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CONCURRENCY_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CONCURRENCY_MODE_UNSPECIFIED)
+                }
+                "PESSIMISTIC" => std::option::Option::Some(Self::PESSIMISTIC),
+                "OPTIMISTIC" => std::option::Option::Some(Self::OPTIMISTIC),
+                "OPTIMISTIC_WITH_ENTITY_GROUPS" => {
+                    std::option::Option::Some(Self::OPTIMISTIC_WITH_ENTITY_GROUPS)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ConcurrencyMode](ConcurrencyMode)
-    pub mod concurrency_mode {
-        use super::ConcurrencyMode;
-
-        /// Unspecified.
-        pub const CONCURRENCY_MODE_UNSPECIFIED: ConcurrencyMode =
-            ConcurrencyMode::new("CONCURRENCY_MODE_UNSPECIFIED");
-
-        /// Pessimistic concurrency.
-        pub const PESSIMISTIC: ConcurrencyMode = ConcurrencyMode::new("PESSIMISTIC");
-
-        /// Optimistic concurrency.
-        pub const OPTIMISTIC: ConcurrencyMode = ConcurrencyMode::new("OPTIMISTIC");
-
-        /// Optimistic concurrency with entity groups.
-        pub const OPTIMISTIC_WITH_ENTITY_GROUPS: ConcurrencyMode =
-            ConcurrencyMode::new("OPTIMISTIC_WITH_ENTITY_GROUPS");
-    }
-
-    impl std::convert::From<std::string::String> for ConcurrencyMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ConcurrencyMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ConcurrencyMode {
         fn default() -> Self {
-            concurrency_mode::CONCURRENCY_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1647,157 +1741,224 @@ pub mod migration_progress_event {
 
 /// Operation types.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OperationType(std::borrow::Cow<'static, str>);
+pub struct OperationType(i32);
 
 impl OperationType {
+    /// Unspecified.
+    pub const OPERATION_TYPE_UNSPECIFIED: OperationType = OperationType::new(0);
+
+    /// ExportEntities.
+    pub const EXPORT_ENTITIES: OperationType = OperationType::new(1);
+
+    /// ImportEntities.
+    pub const IMPORT_ENTITIES: OperationType = OperationType::new(2);
+
+    /// CreateIndex.
+    pub const CREATE_INDEX: OperationType = OperationType::new(3);
+
+    /// DeleteIndex.
+    pub const DELETE_INDEX: OperationType = OperationType::new(4);
+
     /// Creates a new OperationType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("OPERATION_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("EXPORT_ENTITIES"),
+            2 => std::borrow::Cow::Borrowed("IMPORT_ENTITIES"),
+            3 => std::borrow::Cow::Borrowed("CREATE_INDEX"),
+            4 => std::borrow::Cow::Borrowed("DELETE_INDEX"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "OPERATION_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::OPERATION_TYPE_UNSPECIFIED)
+            }
+            "EXPORT_ENTITIES" => std::option::Option::Some(Self::EXPORT_ENTITIES),
+            "IMPORT_ENTITIES" => std::option::Option::Some(Self::IMPORT_ENTITIES),
+            "CREATE_INDEX" => std::option::Option::Some(Self::CREATE_INDEX),
+            "DELETE_INDEX" => std::option::Option::Some(Self::DELETE_INDEX),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [OperationType](OperationType)
-pub mod operation_type {
-    use super::OperationType;
-
-    /// Unspecified.
-    pub const OPERATION_TYPE_UNSPECIFIED: OperationType =
-        OperationType::new("OPERATION_TYPE_UNSPECIFIED");
-
-    /// ExportEntities.
-    pub const EXPORT_ENTITIES: OperationType = OperationType::new("EXPORT_ENTITIES");
-
-    /// ImportEntities.
-    pub const IMPORT_ENTITIES: OperationType = OperationType::new("IMPORT_ENTITIES");
-
-    /// CreateIndex.
-    pub const CREATE_INDEX: OperationType = OperationType::new("CREATE_INDEX");
-
-    /// DeleteIndex.
-    pub const DELETE_INDEX: OperationType = OperationType::new("DELETE_INDEX");
-}
-
-impl std::convert::From<std::string::String> for OperationType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for OperationType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for OperationType {
     fn default() -> Self {
-        operation_type::OPERATION_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// States for a migration.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct MigrationState(std::borrow::Cow<'static, str>);
+pub struct MigrationState(i32);
 
 impl MigrationState {
+    /// Unspecified.
+    pub const MIGRATION_STATE_UNSPECIFIED: MigrationState = MigrationState::new(0);
+
+    /// The migration is running.
+    pub const RUNNING: MigrationState = MigrationState::new(1);
+
+    /// The migration is paused.
+    pub const PAUSED: MigrationState = MigrationState::new(2);
+
+    /// The migration is complete.
+    pub const COMPLETE: MigrationState = MigrationState::new(3);
+
     /// Creates a new MigrationState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("MIGRATION_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("RUNNING"),
+            2 => std::borrow::Cow::Borrowed("PAUSED"),
+            3 => std::borrow::Cow::Borrowed("COMPLETE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "MIGRATION_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::MIGRATION_STATE_UNSPECIFIED)
+            }
+            "RUNNING" => std::option::Option::Some(Self::RUNNING),
+            "PAUSED" => std::option::Option::Some(Self::PAUSED),
+            "COMPLETE" => std::option::Option::Some(Self::COMPLETE),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [MigrationState](MigrationState)
-pub mod migration_state {
-    use super::MigrationState;
-
-    /// Unspecified.
-    pub const MIGRATION_STATE_UNSPECIFIED: MigrationState =
-        MigrationState::new("MIGRATION_STATE_UNSPECIFIED");
-
-    /// The migration is running.
-    pub const RUNNING: MigrationState = MigrationState::new("RUNNING");
-
-    /// The migration is paused.
-    pub const PAUSED: MigrationState = MigrationState::new("PAUSED");
-
-    /// The migration is complete.
-    pub const COMPLETE: MigrationState = MigrationState::new("COMPLETE");
-}
-
-impl std::convert::From<std::string::String> for MigrationState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for MigrationState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for MigrationState {
     fn default() -> Self {
-        migration_state::MIGRATION_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Steps in a migration.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct MigrationStep(std::borrow::Cow<'static, str>);
+pub struct MigrationStep(i32);
 
 impl MigrationStep {
-    /// Creates a new MigrationStep instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [MigrationStep](MigrationStep)
-pub mod migration_step {
-    use super::MigrationStep;
-
     /// Unspecified.
-    pub const MIGRATION_STEP_UNSPECIFIED: MigrationStep =
-        MigrationStep::new("MIGRATION_STEP_UNSPECIFIED");
+    pub const MIGRATION_STEP_UNSPECIFIED: MigrationStep = MigrationStep::new(0);
 
     /// Pre-migration: the database is prepared for migration.
-    pub const PREPARE: MigrationStep = MigrationStep::new("PREPARE");
+    pub const PREPARE: MigrationStep = MigrationStep::new(6);
 
     /// Start of migration.
-    pub const START: MigrationStep = MigrationStep::new("START");
+    pub const START: MigrationStep = MigrationStep::new(1);
 
     /// Writes are applied synchronously to at least one replica.
-    pub const APPLY_WRITES_SYNCHRONOUSLY: MigrationStep =
-        MigrationStep::new("APPLY_WRITES_SYNCHRONOUSLY");
+    pub const APPLY_WRITES_SYNCHRONOUSLY: MigrationStep = MigrationStep::new(7);
 
     /// Data is copied to Cloud Firestore and then verified to match the data in
     /// Cloud Datastore.
-    pub const COPY_AND_VERIFY: MigrationStep = MigrationStep::new("COPY_AND_VERIFY");
+    pub const COPY_AND_VERIFY: MigrationStep = MigrationStep::new(2);
 
     /// Eventually-consistent reads are redirected to Cloud Firestore.
-    pub const REDIRECT_EVENTUALLY_CONSISTENT_READS: MigrationStep =
-        MigrationStep::new("REDIRECT_EVENTUALLY_CONSISTENT_READS");
+    pub const REDIRECT_EVENTUALLY_CONSISTENT_READS: MigrationStep = MigrationStep::new(3);
 
     /// Strongly-consistent reads are redirected to Cloud Firestore.
-    pub const REDIRECT_STRONGLY_CONSISTENT_READS: MigrationStep =
-        MigrationStep::new("REDIRECT_STRONGLY_CONSISTENT_READS");
+    pub const REDIRECT_STRONGLY_CONSISTENT_READS: MigrationStep = MigrationStep::new(4);
 
     /// Writes are redirected to Cloud Firestore.
-    pub const REDIRECT_WRITES: MigrationStep = MigrationStep::new("REDIRECT_WRITES");
+    pub const REDIRECT_WRITES: MigrationStep = MigrationStep::new(5);
+
+    /// Creates a new MigrationStep instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("MIGRATION_STEP_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("START"),
+            2 => std::borrow::Cow::Borrowed("COPY_AND_VERIFY"),
+            3 => std::borrow::Cow::Borrowed("REDIRECT_EVENTUALLY_CONSISTENT_READS"),
+            4 => std::borrow::Cow::Borrowed("REDIRECT_STRONGLY_CONSISTENT_READS"),
+            5 => std::borrow::Cow::Borrowed("REDIRECT_WRITES"),
+            6 => std::borrow::Cow::Borrowed("PREPARE"),
+            7 => std::borrow::Cow::Borrowed("APPLY_WRITES_SYNCHRONOUSLY"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "MIGRATION_STEP_UNSPECIFIED" => {
+                std::option::Option::Some(Self::MIGRATION_STEP_UNSPECIFIED)
+            }
+            "PREPARE" => std::option::Option::Some(Self::PREPARE),
+            "START" => std::option::Option::Some(Self::START),
+            "APPLY_WRITES_SYNCHRONOUSLY" => {
+                std::option::Option::Some(Self::APPLY_WRITES_SYNCHRONOUSLY)
+            }
+            "COPY_AND_VERIFY" => std::option::Option::Some(Self::COPY_AND_VERIFY),
+            "REDIRECT_EVENTUALLY_CONSISTENT_READS" => {
+                std::option::Option::Some(Self::REDIRECT_EVENTUALLY_CONSISTENT_READS)
+            }
+            "REDIRECT_STRONGLY_CONSISTENT_READS" => {
+                std::option::Option::Some(Self::REDIRECT_STRONGLY_CONSISTENT_READS)
+            }
+            "REDIRECT_WRITES" => std::option::Option::Some(Self::REDIRECT_WRITES),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for MigrationStep {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for MigrationStep {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for MigrationStep {
     fn default() -> Self {
-        migration_step::MIGRATION_STEP_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/datastore/admin/v1/src/transport.rs
+++ b/src/generated/datastore/admin/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::DatastoreAdmin for DatastoreAdmin {
                 reqwest::Method::POST,
                 format!("/v1/projects/{}:export", req.project_id),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::DatastoreAdmin for DatastoreAdmin {
                 reqwest::Method::POST,
                 format!("/v1/projects/{}:import", req.project_id),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -92,7 +92,7 @@ impl crate::stubs::DatastoreAdmin for DatastoreAdmin {
                 reqwest::Method::POST,
                 format!("/v1/projects/{}/indexes", req.project_id),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -112,7 +112,7 @@ impl crate::stubs::DatastoreAdmin for DatastoreAdmin {
                 reqwest::Method::DELETE,
                 format!("/v1/projects/{}/indexes/{}", req.project_id, req.index_id),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -134,7 +134,7 @@ impl crate::stubs::DatastoreAdmin for DatastoreAdmin {
                 reqwest::Method::GET,
                 format!("/v1/projects/{}/indexes/{}", req.project_id, req.index_id),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -156,7 +156,7 @@ impl crate::stubs::DatastoreAdmin for DatastoreAdmin {
                 reqwest::Method::GET,
                 format!("/v1/projects/{}/indexes", req.project_id),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -178,7 +178,7 @@ impl crate::stubs::DatastoreAdmin for DatastoreAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -200,7 +200,7 @@ impl crate::stubs::DatastoreAdmin for DatastoreAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -219,7 +219,7 @@ impl crate::stubs::DatastoreAdmin for DatastoreAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -238,7 +238,7 @@ impl crate::stubs::DatastoreAdmin for DatastoreAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/devtools/artifactregistry/v1/src/model.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/model.rs
@@ -126,44 +126,60 @@ pub mod apt_artifact {
 
     /// Package type is either binary or source.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PackageType(std::borrow::Cow<'static, str>);
+    pub struct PackageType(i32);
 
     impl PackageType {
+        /// Package type is not specified.
+        pub const PACKAGE_TYPE_UNSPECIFIED: PackageType = PackageType::new(0);
+
+        /// Binary package.
+        pub const BINARY: PackageType = PackageType::new(1);
+
+        /// Source package.
+        pub const SOURCE: PackageType = PackageType::new(2);
+
         /// Creates a new PackageType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PACKAGE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BINARY"),
+                2 => std::borrow::Cow::Borrowed("SOURCE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PACKAGE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PACKAGE_TYPE_UNSPECIFIED)
+                }
+                "BINARY" => std::option::Option::Some(Self::BINARY),
+                "SOURCE" => std::option::Option::Some(Self::SOURCE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [PackageType](PackageType)
-    pub mod package_type {
-        use super::PackageType;
-
-        /// Package type is not specified.
-        pub const PACKAGE_TYPE_UNSPECIFIED: PackageType =
-            PackageType::new("PACKAGE_TYPE_UNSPECIFIED");
-
-        /// Binary package.
-        pub const BINARY: PackageType = PackageType::new("BINARY");
-
-        /// Source package.
-        pub const SOURCE: PackageType = PackageType::new("SOURCE");
-    }
-
-    impl std::convert::From<std::string::String> for PackageType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PackageType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PackageType {
         fn default() -> Self {
-            package_type::PACKAGE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1882,43 +1898,58 @@ pub mod hash {
 
     /// The algorithm used to compute the hash.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HashType(std::borrow::Cow<'static, str>);
+    pub struct HashType(i32);
 
     impl HashType {
+        /// Unspecified.
+        pub const HASH_TYPE_UNSPECIFIED: HashType = HashType::new(0);
+
+        /// SHA256 hash.
+        pub const SHA256: HashType = HashType::new(1);
+
+        /// MD5 hash.
+        pub const MD5: HashType = HashType::new(2);
+
         /// Creates a new HashType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("HASH_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SHA256"),
+                2 => std::borrow::Cow::Borrowed("MD5"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "HASH_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::HASH_TYPE_UNSPECIFIED),
+                "SHA256" => std::option::Option::Some(Self::SHA256),
+                "MD5" => std::option::Option::Some(Self::MD5),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [HashType](HashType)
-    pub mod hash_type {
-        use super::HashType;
-
-        /// Unspecified.
-        pub const HASH_TYPE_UNSPECIFIED: HashType = HashType::new("HASH_TYPE_UNSPECIFIED");
-
-        /// SHA256 hash.
-        pub const SHA256: HashType = HashType::new("SHA256");
-
-        /// MD5 hash.
-        pub const MD5: HashType = HashType::new("MD5");
-    }
-
-    impl std::convert::From<std::string::String> for HashType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for HashType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for HashType {
         fn default() -> Self {
-            hash_type::HASH_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2917,46 +2948,63 @@ pub mod cleanup_policy_condition {
 
     /// Statuses applying to versions.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TagState(std::borrow::Cow<'static, str>);
+    pub struct TagState(i32);
 
     impl TagState {
+        /// Tag status not specified.
+        pub const TAG_STATE_UNSPECIFIED: TagState = TagState::new(0);
+
+        /// Applies to tagged versions only.
+        pub const TAGGED: TagState = TagState::new(1);
+
+        /// Applies to untagged versions only.
+        pub const UNTAGGED: TagState = TagState::new(2);
+
+        /// Applies to all versions.
+        pub const ANY: TagState = TagState::new(3);
+
         /// Creates a new TagState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TAG_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TAGGED"),
+                2 => std::borrow::Cow::Borrowed("UNTAGGED"),
+                3 => std::borrow::Cow::Borrowed("ANY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TAG_STATE_UNSPECIFIED" => std::option::Option::Some(Self::TAG_STATE_UNSPECIFIED),
+                "TAGGED" => std::option::Option::Some(Self::TAGGED),
+                "UNTAGGED" => std::option::Option::Some(Self::UNTAGGED),
+                "ANY" => std::option::Option::Some(Self::ANY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [TagState](TagState)
-    pub mod tag_state {
-        use super::TagState;
-
-        /// Tag status not specified.
-        pub const TAG_STATE_UNSPECIFIED: TagState = TagState::new("TAG_STATE_UNSPECIFIED");
-
-        /// Applies to tagged versions only.
-        pub const TAGGED: TagState = TagState::new("TAGGED");
-
-        /// Applies to untagged versions only.
-        pub const UNTAGGED: TagState = TagState::new("UNTAGGED");
-
-        /// Applies to all versions.
-        pub const ANY: TagState = TagState::new("ANY");
-    }
-
-    impl std::convert::From<std::string::String> for TagState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TagState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TagState {
         fn default() -> Self {
-            tag_state::TAG_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3132,43 +3180,58 @@ pub mod cleanup_policy {
 
     /// Action type for a cleanup policy.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(std::borrow::Cow<'static, str>);
+    pub struct Action(i32);
 
     impl Action {
+        /// Action not specified.
+        pub const ACTION_UNSPECIFIED: Action = Action::new(0);
+
+        /// Delete action.
+        pub const DELETE: Action = Action::new(1);
+
+        /// Keep action.
+        pub const KEEP: Action = Action::new(2);
+
         /// Creates a new Action instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ACTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DELETE"),
+                2 => std::borrow::Cow::Borrowed("KEEP"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ACTION_UNSPECIFIED" => std::option::Option::Some(Self::ACTION_UNSPECIFIED),
+                "DELETE" => std::option::Option::Some(Self::DELETE),
+                "KEEP" => std::option::Option::Some(Self::KEEP),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Action](Action)
-    pub mod action {
-        use super::Action;
-
-        /// Action not specified.
-        pub const ACTION_UNSPECIFIED: Action = Action::new("ACTION_UNSPECIFIED");
-
-        /// Delete action.
-        pub const DELETE: Action = Action::new("DELETE");
-
-        /// Keep action.
-        pub const KEEP: Action = Action::new("KEEP");
-    }
-
-    impl std::convert::From<std::string::String> for Action {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            action::ACTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -3820,41 +3883,55 @@ pub mod remote_repository_config {
         /// Predefined list of publicly available Docker repositories like Docker
         /// Hub.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct PublicRepository(std::borrow::Cow<'static, str>);
+        pub struct PublicRepository(i32);
 
         impl PublicRepository {
+            /// Unspecified repository.
+            pub const PUBLIC_REPOSITORY_UNSPECIFIED: PublicRepository = PublicRepository::new(0);
+
+            /// Docker Hub.
+            pub const DOCKER_HUB: PublicRepository = PublicRepository::new(1);
+
             /// Creates a new PublicRepository instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("PUBLIC_REPOSITORY_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("DOCKER_HUB"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "PUBLIC_REPOSITORY_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::PUBLIC_REPOSITORY_UNSPECIFIED)
+                    }
+                    "DOCKER_HUB" => std::option::Option::Some(Self::DOCKER_HUB),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [PublicRepository](PublicRepository)
-        pub mod public_repository {
-            use super::PublicRepository;
-
-            /// Unspecified repository.
-            pub const PUBLIC_REPOSITORY_UNSPECIFIED: PublicRepository =
-                PublicRepository::new("PUBLIC_REPOSITORY_UNSPECIFIED");
-
-            /// Docker Hub.
-            pub const DOCKER_HUB: PublicRepository = PublicRepository::new("DOCKER_HUB");
-        }
-
-        impl std::convert::From<std::string::String> for PublicRepository {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for PublicRepository {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for PublicRepository {
             fn default() -> Self {
-                public_repository::PUBLIC_REPOSITORY_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -4030,41 +4107,55 @@ pub mod remote_repository_config {
         /// Predefined list of publicly available Maven repositories like Maven
         /// Central.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct PublicRepository(std::borrow::Cow<'static, str>);
+        pub struct PublicRepository(i32);
 
         impl PublicRepository {
+            /// Unspecified repository.
+            pub const PUBLIC_REPOSITORY_UNSPECIFIED: PublicRepository = PublicRepository::new(0);
+
+            /// Maven Central.
+            pub const MAVEN_CENTRAL: PublicRepository = PublicRepository::new(1);
+
             /// Creates a new PublicRepository instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("PUBLIC_REPOSITORY_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("MAVEN_CENTRAL"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "PUBLIC_REPOSITORY_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::PUBLIC_REPOSITORY_UNSPECIFIED)
+                    }
+                    "MAVEN_CENTRAL" => std::option::Option::Some(Self::MAVEN_CENTRAL),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [PublicRepository](PublicRepository)
-        pub mod public_repository {
-            use super::PublicRepository;
-
-            /// Unspecified repository.
-            pub const PUBLIC_REPOSITORY_UNSPECIFIED: PublicRepository =
-                PublicRepository::new("PUBLIC_REPOSITORY_UNSPECIFIED");
-
-            /// Maven Central.
-            pub const MAVEN_CENTRAL: PublicRepository = PublicRepository::new("MAVEN_CENTRAL");
-        }
-
-        impl std::convert::From<std::string::String> for PublicRepository {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for PublicRepository {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for PublicRepository {
             fn default() -> Self {
-                public_repository::PUBLIC_REPOSITORY_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -4239,41 +4330,55 @@ pub mod remote_repository_config {
 
         /// Predefined list of publicly available NPM repositories like npmjs.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct PublicRepository(std::borrow::Cow<'static, str>);
+        pub struct PublicRepository(i32);
 
         impl PublicRepository {
+            /// Unspecified repository.
+            pub const PUBLIC_REPOSITORY_UNSPECIFIED: PublicRepository = PublicRepository::new(0);
+
+            /// npmjs.
+            pub const NPMJS: PublicRepository = PublicRepository::new(1);
+
             /// Creates a new PublicRepository instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("PUBLIC_REPOSITORY_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("NPMJS"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "PUBLIC_REPOSITORY_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::PUBLIC_REPOSITORY_UNSPECIFIED)
+                    }
+                    "NPMJS" => std::option::Option::Some(Self::NPMJS),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [PublicRepository](PublicRepository)
-        pub mod public_repository {
-            use super::PublicRepository;
-
-            /// Unspecified repository.
-            pub const PUBLIC_REPOSITORY_UNSPECIFIED: PublicRepository =
-                PublicRepository::new("PUBLIC_REPOSITORY_UNSPECIFIED");
-
-            /// npmjs.
-            pub const NPMJS: PublicRepository = PublicRepository::new("NPMJS");
-        }
-
-        impl std::convert::From<std::string::String> for PublicRepository {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for PublicRepository {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for PublicRepository {
             fn default() -> Self {
-                public_repository::PUBLIC_REPOSITORY_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -4449,41 +4554,55 @@ pub mod remote_repository_config {
 
         /// Predefined list of publicly available Python repositories like PyPI.org.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct PublicRepository(std::borrow::Cow<'static, str>);
+        pub struct PublicRepository(i32);
 
         impl PublicRepository {
+            /// Unspecified repository.
+            pub const PUBLIC_REPOSITORY_UNSPECIFIED: PublicRepository = PublicRepository::new(0);
+
+            /// PyPI.
+            pub const PYPI: PublicRepository = PublicRepository::new(1);
+
             /// Creates a new PublicRepository instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("PUBLIC_REPOSITORY_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("PYPI"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "PUBLIC_REPOSITORY_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::PUBLIC_REPOSITORY_UNSPECIFIED)
+                    }
+                    "PYPI" => std::option::Option::Some(Self::PYPI),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [PublicRepository](PublicRepository)
-        pub mod public_repository {
-            use super::PublicRepository;
-
-            /// Unspecified repository.
-            pub const PUBLIC_REPOSITORY_UNSPECIFIED: PublicRepository =
-                PublicRepository::new("PUBLIC_REPOSITORY_UNSPECIFIED");
-
-            /// PyPI.
-            pub const PYPI: PublicRepository = PublicRepository::new("PYPI");
-        }
-
-        impl std::convert::From<std::string::String> for PublicRepository {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for PublicRepository {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for PublicRepository {
             fn default() -> Self {
-                public_repository::PUBLIC_REPOSITORY_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -4680,47 +4799,65 @@ pub mod remote_repository_config {
 
             /// Predefined list of publicly available repository bases for Apt.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct RepositoryBase(std::borrow::Cow<'static, str>);
+            pub struct RepositoryBase(i32);
 
             impl RepositoryBase {
+                /// Unspecified repository base.
+                pub const REPOSITORY_BASE_UNSPECIFIED: RepositoryBase = RepositoryBase::new(0);
+
+                /// Debian.
+                pub const DEBIAN: RepositoryBase = RepositoryBase::new(1);
+
+                /// Ubuntu LTS/Pro.
+                pub const UBUNTU: RepositoryBase = RepositoryBase::new(2);
+
+                /// Archived Debian.
+                pub const DEBIAN_SNAPSHOT: RepositoryBase = RepositoryBase::new(3);
+
                 /// Creates a new RepositoryBase instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
                 }
 
                 /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("REPOSITORY_BASE_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("DEBIAN"),
+                        2 => std::borrow::Cow::Borrowed("UBUNTU"),
+                        3 => std::borrow::Cow::Borrowed("DEBIAN_SNAPSHOT"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "REPOSITORY_BASE_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::REPOSITORY_BASE_UNSPECIFIED)
+                        }
+                        "DEBIAN" => std::option::Option::Some(Self::DEBIAN),
+                        "UBUNTU" => std::option::Option::Some(Self::UBUNTU),
+                        "DEBIAN_SNAPSHOT" => std::option::Option::Some(Self::DEBIAN_SNAPSHOT),
+                        _ => std::option::Option::None,
+                    }
                 }
             }
 
-            /// Useful constants to work with [RepositoryBase](RepositoryBase)
-            pub mod repository_base {
-                use super::RepositoryBase;
-
-                /// Unspecified repository base.
-                pub const REPOSITORY_BASE_UNSPECIFIED: RepositoryBase =
-                    RepositoryBase::new("REPOSITORY_BASE_UNSPECIFIED");
-
-                /// Debian.
-                pub const DEBIAN: RepositoryBase = RepositoryBase::new("DEBIAN");
-
-                /// Ubuntu LTS/Pro.
-                pub const UBUNTU: RepositoryBase = RepositoryBase::new("UBUNTU");
-
-                /// Archived Debian.
-                pub const DEBIAN_SNAPSHOT: RepositoryBase = RepositoryBase::new("DEBIAN_SNAPSHOT");
-            }
-
-            impl std::convert::From<std::string::String> for RepositoryBase {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for RepositoryBase {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for RepositoryBase {
                 fn default() -> Self {
-                    repository_base::REPOSITORY_BASE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -4950,56 +5087,80 @@ pub mod remote_repository_config {
 
             /// Predefined list of publicly available repository bases for Yum.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct RepositoryBase(std::borrow::Cow<'static, str>);
+            pub struct RepositoryBase(i32);
 
             impl RepositoryBase {
+                /// Unspecified repository base.
+                pub const REPOSITORY_BASE_UNSPECIFIED: RepositoryBase = RepositoryBase::new(0);
+
+                /// CentOS.
+                pub const CENTOS: RepositoryBase = RepositoryBase::new(1);
+
+                /// CentOS Debug.
+                pub const CENTOS_DEBUG: RepositoryBase = RepositoryBase::new(2);
+
+                /// CentOS Vault.
+                pub const CENTOS_VAULT: RepositoryBase = RepositoryBase::new(3);
+
+                /// CentOS Stream.
+                pub const CENTOS_STREAM: RepositoryBase = RepositoryBase::new(4);
+
+                /// Rocky.
+                pub const ROCKY: RepositoryBase = RepositoryBase::new(5);
+
+                /// Fedora Extra Packages for Enterprise Linux (EPEL).
+                pub const EPEL: RepositoryBase = RepositoryBase::new(6);
+
                 /// Creates a new RepositoryBase instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
                 }
 
                 /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("REPOSITORY_BASE_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("CENTOS"),
+                        2 => std::borrow::Cow::Borrowed("CENTOS_DEBUG"),
+                        3 => std::borrow::Cow::Borrowed("CENTOS_VAULT"),
+                        4 => std::borrow::Cow::Borrowed("CENTOS_STREAM"),
+                        5 => std::borrow::Cow::Borrowed("ROCKY"),
+                        6 => std::borrow::Cow::Borrowed("EPEL"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "REPOSITORY_BASE_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::REPOSITORY_BASE_UNSPECIFIED)
+                        }
+                        "CENTOS" => std::option::Option::Some(Self::CENTOS),
+                        "CENTOS_DEBUG" => std::option::Option::Some(Self::CENTOS_DEBUG),
+                        "CENTOS_VAULT" => std::option::Option::Some(Self::CENTOS_VAULT),
+                        "CENTOS_STREAM" => std::option::Option::Some(Self::CENTOS_STREAM),
+                        "ROCKY" => std::option::Option::Some(Self::ROCKY),
+                        "EPEL" => std::option::Option::Some(Self::EPEL),
+                        _ => std::option::Option::None,
+                    }
                 }
             }
 
-            /// Useful constants to work with [RepositoryBase](RepositoryBase)
-            pub mod repository_base {
-                use super::RepositoryBase;
-
-                /// Unspecified repository base.
-                pub const REPOSITORY_BASE_UNSPECIFIED: RepositoryBase =
-                    RepositoryBase::new("REPOSITORY_BASE_UNSPECIFIED");
-
-                /// CentOS.
-                pub const CENTOS: RepositoryBase = RepositoryBase::new("CENTOS");
-
-                /// CentOS Debug.
-                pub const CENTOS_DEBUG: RepositoryBase = RepositoryBase::new("CENTOS_DEBUG");
-
-                /// CentOS Vault.
-                pub const CENTOS_VAULT: RepositoryBase = RepositoryBase::new("CENTOS_VAULT");
-
-                /// CentOS Stream.
-                pub const CENTOS_STREAM: RepositoryBase = RepositoryBase::new("CENTOS_STREAM");
-
-                /// Rocky.
-                pub const ROCKY: RepositoryBase = RepositoryBase::new("ROCKY");
-
-                /// Fedora Extra Packages for Enterprise Linux (EPEL).
-                pub const EPEL: RepositoryBase = RepositoryBase::new("EPEL");
-            }
-
-            impl std::convert::From<std::string::String> for RepositoryBase {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for RepositoryBase {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for RepositoryBase {
                 fn default() -> Self {
-                    repository_base::REPOSITORY_BASE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -5533,46 +5694,62 @@ pub mod repository {
 
         /// VersionPolicy is the version policy for the repository.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct VersionPolicy(std::borrow::Cow<'static, str>);
+        pub struct VersionPolicy(i32);
 
         impl VersionPolicy {
-            /// Creates a new VersionPolicy instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [VersionPolicy](VersionPolicy)
-        pub mod version_policy {
-            use super::VersionPolicy;
-
             /// VERSION_POLICY_UNSPECIFIED - the version policy is not defined.
             /// When the version policy is not defined, no validation is performed
             /// for the versions.
-            pub const VERSION_POLICY_UNSPECIFIED: VersionPolicy =
-                VersionPolicy::new("VERSION_POLICY_UNSPECIFIED");
+            pub const VERSION_POLICY_UNSPECIFIED: VersionPolicy = VersionPolicy::new(0);
 
             /// RELEASE - repository will accept only Release versions.
-            pub const RELEASE: VersionPolicy = VersionPolicy::new("RELEASE");
+            pub const RELEASE: VersionPolicy = VersionPolicy::new(1);
 
             /// SNAPSHOT - repository will accept only Snapshot versions.
-            pub const SNAPSHOT: VersionPolicy = VersionPolicy::new("SNAPSHOT");
+            pub const SNAPSHOT: VersionPolicy = VersionPolicy::new(2);
+
+            /// Creates a new VersionPolicy instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("VERSION_POLICY_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("RELEASE"),
+                    2 => std::borrow::Cow::Borrowed("SNAPSHOT"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "VERSION_POLICY_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::VERSION_POLICY_UNSPECIFIED)
+                    }
+                    "RELEASE" => std::option::Option::Some(Self::RELEASE),
+                    "SNAPSHOT" => std::option::Option::Some(Self::SNAPSHOT),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for VersionPolicy {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for VersionPolicy {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for VersionPolicy {
             fn default() -> Self {
-                version_policy::VERSION_POLICY_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -5698,204 +5875,282 @@ pub mod repository {
 
         /// Config for vulnerability scanning of resources in this repository.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct EnablementConfig(std::borrow::Cow<'static, str>);
+        pub struct EnablementConfig(i32);
 
         impl EnablementConfig {
-            /// Creates a new EnablementConfig instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [EnablementConfig](EnablementConfig)
-        pub mod enablement_config {
-            use super::EnablementConfig;
-
             /// Not set. This will be treated as INHERITED.
-            pub const ENABLEMENT_CONFIG_UNSPECIFIED: EnablementConfig =
-                EnablementConfig::new("ENABLEMENT_CONFIG_UNSPECIFIED");
+            pub const ENABLEMENT_CONFIG_UNSPECIFIED: EnablementConfig = EnablementConfig::new(0);
 
             /// Scanning is Enabled, but dependent on API enablement.
-            pub const INHERITED: EnablementConfig = EnablementConfig::new("INHERITED");
+            pub const INHERITED: EnablementConfig = EnablementConfig::new(1);
 
             /// No automatic vulnerability scanning will be performed for this
             /// repository.
-            pub const DISABLED: EnablementConfig = EnablementConfig::new("DISABLED");
+            pub const DISABLED: EnablementConfig = EnablementConfig::new(2);
+
+            /// Creates a new EnablementConfig instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("ENABLEMENT_CONFIG_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("INHERITED"),
+                    2 => std::borrow::Cow::Borrowed("DISABLED"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "ENABLEMENT_CONFIG_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::ENABLEMENT_CONFIG_UNSPECIFIED)
+                    }
+                    "INHERITED" => std::option::Option::Some(Self::INHERITED),
+                    "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for EnablementConfig {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for EnablementConfig {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for EnablementConfig {
             fn default() -> Self {
-                enablement_config::ENABLEMENT_CONFIG_UNSPECIFIED
+                Self::new(0)
             }
         }
 
         /// Describes the state of vulnerability scanning in this repository,
         /// including both repository enablement and API enablement.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct EnablementState(std::borrow::Cow<'static, str>);
+        pub struct EnablementState(i32);
 
         impl EnablementState {
+            /// Enablement state is unclear.
+            pub const ENABLEMENT_STATE_UNSPECIFIED: EnablementState = EnablementState::new(0);
+
+            /// Repository does not support vulnerability scanning.
+            pub const SCANNING_UNSUPPORTED: EnablementState = EnablementState::new(1);
+
+            /// Vulnerability scanning is disabled for this repository.
+            pub const SCANNING_DISABLED: EnablementState = EnablementState::new(2);
+
+            /// Vulnerability scanning is active for this repository.
+            pub const SCANNING_ACTIVE: EnablementState = EnablementState::new(3);
+
             /// Creates a new EnablementState instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("ENABLEMENT_STATE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("SCANNING_UNSUPPORTED"),
+                    2 => std::borrow::Cow::Borrowed("SCANNING_DISABLED"),
+                    3 => std::borrow::Cow::Borrowed("SCANNING_ACTIVE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "ENABLEMENT_STATE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::ENABLEMENT_STATE_UNSPECIFIED)
+                    }
+                    "SCANNING_UNSUPPORTED" => std::option::Option::Some(Self::SCANNING_UNSUPPORTED),
+                    "SCANNING_DISABLED" => std::option::Option::Some(Self::SCANNING_DISABLED),
+                    "SCANNING_ACTIVE" => std::option::Option::Some(Self::SCANNING_ACTIVE),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [EnablementState](EnablementState)
-        pub mod enablement_state {
-            use super::EnablementState;
-
-            /// Enablement state is unclear.
-            pub const ENABLEMENT_STATE_UNSPECIFIED: EnablementState =
-                EnablementState::new("ENABLEMENT_STATE_UNSPECIFIED");
-
-            /// Repository does not support vulnerability scanning.
-            pub const SCANNING_UNSUPPORTED: EnablementState =
-                EnablementState::new("SCANNING_UNSUPPORTED");
-
-            /// Vulnerability scanning is disabled for this repository.
-            pub const SCANNING_DISABLED: EnablementState =
-                EnablementState::new("SCANNING_DISABLED");
-
-            /// Vulnerability scanning is active for this repository.
-            pub const SCANNING_ACTIVE: EnablementState = EnablementState::new("SCANNING_ACTIVE");
-        }
-
-        impl std::convert::From<std::string::String> for EnablementState {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for EnablementState {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for EnablementState {
             fn default() -> Self {
-                enablement_state::ENABLEMENT_STATE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// A package format.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Format(std::borrow::Cow<'static, str>);
+    pub struct Format(i32);
 
     impl Format {
+        /// Unspecified package format.
+        pub const FORMAT_UNSPECIFIED: Format = Format::new(0);
+
+        /// Docker package format.
+        pub const DOCKER: Format = Format::new(1);
+
+        /// Maven package format.
+        pub const MAVEN: Format = Format::new(2);
+
+        /// NPM package format.
+        pub const NPM: Format = Format::new(3);
+
+        /// APT package format.
+        pub const APT: Format = Format::new(5);
+
+        /// YUM package format.
+        pub const YUM: Format = Format::new(6);
+
+        /// Python package format.
+        pub const PYTHON: Format = Format::new(8);
+
+        /// Kubeflow Pipelines package format.
+        pub const KFP: Format = Format::new(9);
+
+        /// Go package format.
+        pub const GO: Format = Format::new(10);
+
+        /// Generic package format.
+        pub const GENERIC: Format = Format::new(11);
+
         /// Creates a new Format instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FORMAT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DOCKER"),
+                2 => std::borrow::Cow::Borrowed("MAVEN"),
+                3 => std::borrow::Cow::Borrowed("NPM"),
+                5 => std::borrow::Cow::Borrowed("APT"),
+                6 => std::borrow::Cow::Borrowed("YUM"),
+                8 => std::borrow::Cow::Borrowed("PYTHON"),
+                9 => std::borrow::Cow::Borrowed("KFP"),
+                10 => std::borrow::Cow::Borrowed("GO"),
+                11 => std::borrow::Cow::Borrowed("GENERIC"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FORMAT_UNSPECIFIED" => std::option::Option::Some(Self::FORMAT_UNSPECIFIED),
+                "DOCKER" => std::option::Option::Some(Self::DOCKER),
+                "MAVEN" => std::option::Option::Some(Self::MAVEN),
+                "NPM" => std::option::Option::Some(Self::NPM),
+                "APT" => std::option::Option::Some(Self::APT),
+                "YUM" => std::option::Option::Some(Self::YUM),
+                "PYTHON" => std::option::Option::Some(Self::PYTHON),
+                "KFP" => std::option::Option::Some(Self::KFP),
+                "GO" => std::option::Option::Some(Self::GO),
+                "GENERIC" => std::option::Option::Some(Self::GENERIC),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Format](Format)
-    pub mod format {
-        use super::Format;
-
-        /// Unspecified package format.
-        pub const FORMAT_UNSPECIFIED: Format = Format::new("FORMAT_UNSPECIFIED");
-
-        /// Docker package format.
-        pub const DOCKER: Format = Format::new("DOCKER");
-
-        /// Maven package format.
-        pub const MAVEN: Format = Format::new("MAVEN");
-
-        /// NPM package format.
-        pub const NPM: Format = Format::new("NPM");
-
-        /// APT package format.
-        pub const APT: Format = Format::new("APT");
-
-        /// YUM package format.
-        pub const YUM: Format = Format::new("YUM");
-
-        /// Python package format.
-        pub const PYTHON: Format = Format::new("PYTHON");
-
-        /// Kubeflow Pipelines package format.
-        pub const KFP: Format = Format::new("KFP");
-
-        /// Go package format.
-        pub const GO: Format = Format::new("GO");
-
-        /// Generic package format.
-        pub const GENERIC: Format = Format::new("GENERIC");
-    }
-
-    impl std::convert::From<std::string::String> for Format {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Format {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Format {
         fn default() -> Self {
-            format::FORMAT_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The mode configures the repository to serve artifacts from different
     /// sources.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(std::borrow::Cow<'static, str>);
+    pub struct Mode(i32);
 
     impl Mode {
+        /// Unspecified mode.
+        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
+
+        /// A standard repository storing artifacts.
+        pub const STANDARD_REPOSITORY: Mode = Mode::new(1);
+
+        /// A virtual repository to serve artifacts from one or more sources.
+        pub const VIRTUAL_REPOSITORY: Mode = Mode::new(2);
+
+        /// A remote repository to serve artifacts from a remote source.
+        pub const REMOTE_REPOSITORY: Mode = Mode::new(3);
+
         /// Creates a new Mode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STANDARD_REPOSITORY"),
+                2 => std::borrow::Cow::Borrowed("VIRTUAL_REPOSITORY"),
+                3 => std::borrow::Cow::Borrowed("REMOTE_REPOSITORY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
+                "STANDARD_REPOSITORY" => std::option::Option::Some(Self::STANDARD_REPOSITORY),
+                "VIRTUAL_REPOSITORY" => std::option::Option::Some(Self::VIRTUAL_REPOSITORY),
+                "REMOTE_REPOSITORY" => std::option::Option::Some(Self::REMOTE_REPOSITORY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Mode](Mode)
-    pub mod mode {
-        use super::Mode;
-
-        /// Unspecified mode.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new("MODE_UNSPECIFIED");
-
-        /// A standard repository storing artifacts.
-        pub const STANDARD_REPOSITORY: Mode = Mode::new("STANDARD_REPOSITORY");
-
-        /// A virtual repository to serve artifacts from one or more sources.
-        pub const VIRTUAL_REPOSITORY: Mode = Mode::new("VIRTUAL_REPOSITORY");
-
-        /// A remote repository to serve artifacts from a remote source.
-        pub const REMOTE_REPOSITORY: Mode = Mode::new("REMOTE_REPOSITORY");
-    }
-
-    impl std::convert::From<std::string::String> for Mode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            mode::MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -6312,82 +6567,110 @@ pub mod rule {
 
     /// Defines the action of the rule.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(std::borrow::Cow<'static, str>);
+    pub struct Action(i32);
 
     impl Action {
+        /// Action not specified.
+        pub const ACTION_UNSPECIFIED: Action = Action::new(0);
+
+        /// Allow the operation.
+        pub const ALLOW: Action = Action::new(1);
+
+        /// Deny the operation.
+        pub const DENY: Action = Action::new(2);
+
         /// Creates a new Action instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ACTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALLOW"),
+                2 => std::borrow::Cow::Borrowed("DENY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ACTION_UNSPECIFIED" => std::option::Option::Some(Self::ACTION_UNSPECIFIED),
+                "ALLOW" => std::option::Option::Some(Self::ALLOW),
+                "DENY" => std::option::Option::Some(Self::DENY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Action](Action)
-    pub mod action {
-        use super::Action;
-
-        /// Action not specified.
-        pub const ACTION_UNSPECIFIED: Action = Action::new("ACTION_UNSPECIFIED");
-
-        /// Allow the operation.
-        pub const ALLOW: Action = Action::new("ALLOW");
-
-        /// Deny the operation.
-        pub const DENY: Action = Action::new("DENY");
-    }
-
-    impl std::convert::From<std::string::String> for Action {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            action::ACTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The operation the rule applies to.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Operation(std::borrow::Cow<'static, str>);
+    pub struct Operation(i32);
 
     impl Operation {
+        /// Operation not specified.
+        pub const OPERATION_UNSPECIFIED: Operation = Operation::new(0);
+
+        /// Download operation.
+        pub const DOWNLOAD: Operation = Operation::new(1);
+
         /// Creates a new Operation instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("OPERATION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DOWNLOAD"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "OPERATION_UNSPECIFIED" => std::option::Option::Some(Self::OPERATION_UNSPECIFIED),
+                "DOWNLOAD" => std::option::Option::Some(Self::DOWNLOAD),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Operation](Operation)
-    pub mod operation {
-        use super::Operation;
-
-        /// Operation not specified.
-        pub const OPERATION_UNSPECIFIED: Operation = Operation::new("OPERATION_UNSPECIFIED");
-
-        /// Download operation.
-        pub const DOWNLOAD: Operation = Operation::new("DOWNLOAD");
-    }
-
-    impl std::convert::From<std::string::String> for Operation {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Operation {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Operation {
         fn default() -> Self {
-            operation::OPERATION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6742,58 +7025,87 @@ pub mod project_settings {
 
     /// The possible redirection states for legacy repositories.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RedirectionState(std::borrow::Cow<'static, str>);
+    pub struct RedirectionState(i32);
 
     impl RedirectionState {
-        /// Creates a new RedirectionState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RedirectionState](RedirectionState)
-    pub mod redirection_state {
-        use super::RedirectionState;
-
         /// No redirection status has been set.
-        pub const REDIRECTION_STATE_UNSPECIFIED: RedirectionState =
-            RedirectionState::new("REDIRECTION_STATE_UNSPECIFIED");
+        pub const REDIRECTION_STATE_UNSPECIFIED: RedirectionState = RedirectionState::new(0);
 
         /// Redirection is disabled.
-        pub const REDIRECTION_FROM_GCR_IO_DISABLED: RedirectionState =
-            RedirectionState::new("REDIRECTION_FROM_GCR_IO_DISABLED");
+        pub const REDIRECTION_FROM_GCR_IO_DISABLED: RedirectionState = RedirectionState::new(1);
 
         /// Redirection is enabled.
-        pub const REDIRECTION_FROM_GCR_IO_ENABLED: RedirectionState =
-            RedirectionState::new("REDIRECTION_FROM_GCR_IO_ENABLED");
+        pub const REDIRECTION_FROM_GCR_IO_ENABLED: RedirectionState = RedirectionState::new(2);
 
         /// Redirection is enabled, and has been finalized so cannot be reverted.
-        pub const REDIRECTION_FROM_GCR_IO_FINALIZED: RedirectionState =
-            RedirectionState::new("REDIRECTION_FROM_GCR_IO_FINALIZED");
+        pub const REDIRECTION_FROM_GCR_IO_FINALIZED: RedirectionState = RedirectionState::new(3);
 
         /// Redirection is enabled and missing images are copied from GCR
         pub const REDIRECTION_FROM_GCR_IO_ENABLED_AND_COPYING: RedirectionState =
-            RedirectionState::new("REDIRECTION_FROM_GCR_IO_ENABLED_AND_COPYING");
+            RedirectionState::new(5);
 
         /// Redirection is partially enabled and missing images are copied from GCR
         pub const REDIRECTION_FROM_GCR_IO_PARTIAL_AND_COPYING: RedirectionState =
-            RedirectionState::new("REDIRECTION_FROM_GCR_IO_PARTIAL_AND_COPYING");
+            RedirectionState::new(6);
+
+        /// Creates a new RedirectionState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("REDIRECTION_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REDIRECTION_FROM_GCR_IO_DISABLED"),
+                2 => std::borrow::Cow::Borrowed("REDIRECTION_FROM_GCR_IO_ENABLED"),
+                3 => std::borrow::Cow::Borrowed("REDIRECTION_FROM_GCR_IO_FINALIZED"),
+                5 => std::borrow::Cow::Borrowed("REDIRECTION_FROM_GCR_IO_ENABLED_AND_COPYING"),
+                6 => std::borrow::Cow::Borrowed("REDIRECTION_FROM_GCR_IO_PARTIAL_AND_COPYING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "REDIRECTION_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::REDIRECTION_STATE_UNSPECIFIED)
+                }
+                "REDIRECTION_FROM_GCR_IO_DISABLED" => {
+                    std::option::Option::Some(Self::REDIRECTION_FROM_GCR_IO_DISABLED)
+                }
+                "REDIRECTION_FROM_GCR_IO_ENABLED" => {
+                    std::option::Option::Some(Self::REDIRECTION_FROM_GCR_IO_ENABLED)
+                }
+                "REDIRECTION_FROM_GCR_IO_FINALIZED" => {
+                    std::option::Option::Some(Self::REDIRECTION_FROM_GCR_IO_FINALIZED)
+                }
+                "REDIRECTION_FROM_GCR_IO_ENABLED_AND_COPYING" => {
+                    std::option::Option::Some(Self::REDIRECTION_FROM_GCR_IO_ENABLED_AND_COPYING)
+                }
+                "REDIRECTION_FROM_GCR_IO_PARTIAL_AND_COPYING" => {
+                    std::option::Option::Some(Self::REDIRECTION_FROM_GCR_IO_PARTIAL_AND_COPYING)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RedirectionState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RedirectionState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RedirectionState {
         fn default() -> Self {
-            redirection_state::REDIRECTION_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7790,48 +8102,64 @@ pub mod vpcsc_config {
 
     /// VPCSCPolicy is the VPC SC policy for project and location.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VPCSCPolicy(std::borrow::Cow<'static, str>);
+    pub struct VPCSCPolicy(i32);
 
     impl VPCSCPolicy {
-        /// Creates a new VPCSCPolicy instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [VPCSCPolicy](VPCSCPolicy)
-    pub mod vpcsc_policy {
-        use super::VPCSCPolicy;
-
         /// VPCSC_POLICY_UNSPECIFIED - the VPS SC policy is not defined.
         /// When VPS SC policy is not defined - the Service will use the default
         /// behavior (VPCSC_DENY).
-        pub const VPCSC_POLICY_UNSPECIFIED: VPCSCPolicy =
-            VPCSCPolicy::new("VPCSC_POLICY_UNSPECIFIED");
+        pub const VPCSC_POLICY_UNSPECIFIED: VPCSCPolicy = VPCSCPolicy::new(0);
 
         /// VPCSC_DENY - repository will block the requests to the Upstreams for the
         /// Remote Repositories if the resource is in the perimeter.
-        pub const DENY: VPCSCPolicy = VPCSCPolicy::new("DENY");
+        pub const DENY: VPCSCPolicy = VPCSCPolicy::new(1);
 
         /// VPCSC_ALLOW - repository will allow the requests to the Upstreams for the
         /// Remote Repositories if the resource is in the perimeter.
-        pub const ALLOW: VPCSCPolicy = VPCSCPolicy::new("ALLOW");
+        pub const ALLOW: VPCSCPolicy = VPCSCPolicy::new(2);
+
+        /// Creates a new VPCSCPolicy instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VPCSC_POLICY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DENY"),
+                2 => std::borrow::Cow::Borrowed("ALLOW"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VPCSC_POLICY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::VPCSC_POLICY_UNSPECIFIED)
+                }
+                "DENY" => std::option::Option::Some(Self::DENY),
+                "ALLOW" => std::option::Option::Some(Self::ALLOW),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for VPCSCPolicy {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for VPCSCPolicy {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for VPCSCPolicy {
         fn default() -> Self {
-            vpcsc_policy::VPCSC_POLICY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7980,44 +8308,60 @@ pub mod yum_artifact {
 
     /// Package type is either binary or source.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PackageType(std::borrow::Cow<'static, str>);
+    pub struct PackageType(i32);
 
     impl PackageType {
+        /// Package type is not specified.
+        pub const PACKAGE_TYPE_UNSPECIFIED: PackageType = PackageType::new(0);
+
+        /// Binary package (.rpm).
+        pub const BINARY: PackageType = PackageType::new(1);
+
+        /// Source package (.srpm).
+        pub const SOURCE: PackageType = PackageType::new(2);
+
         /// Creates a new PackageType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PACKAGE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BINARY"),
+                2 => std::borrow::Cow::Borrowed("SOURCE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PACKAGE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PACKAGE_TYPE_UNSPECIFIED)
+                }
+                "BINARY" => std::option::Option::Some(Self::BINARY),
+                "SOURCE" => std::option::Option::Some(Self::SOURCE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [PackageType](PackageType)
-    pub mod package_type {
-        use super::PackageType;
-
-        /// Package type is not specified.
-        pub const PACKAGE_TYPE_UNSPECIFIED: PackageType =
-            PackageType::new("PACKAGE_TYPE_UNSPECIFIED");
-
-        /// Binary package (.rpm).
-        pub const BINARY: PackageType = PackageType::new("BINARY");
-
-        /// Source package (.srpm).
-        pub const SOURCE: PackageType = PackageType::new("SOURCE");
-    }
-
-    impl std::convert::From<std::string::String> for PackageType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PackageType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PackageType {
         fn default() -> Self {
-            package_type::PACKAGE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8323,43 +8667,58 @@ impl wkt::message::Message for ImportYumArtifactsMetadata {
 /// The view, which determines what version information is returned in a
 /// response.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct VersionView(std::borrow::Cow<'static, str>);
+pub struct VersionView(i32);
 
 impl VersionView {
+    /// The default / unset value.
+    /// The API will default to the BASIC view.
+    pub const VERSION_VIEW_UNSPECIFIED: VersionView = VersionView::new(0);
+
+    /// Includes basic information about the version, but not any related tags.
+    pub const BASIC: VersionView = VersionView::new(1);
+
+    /// Include everything.
+    pub const FULL: VersionView = VersionView::new(2);
+
     /// Creates a new VersionView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("VERSION_VIEW_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("BASIC"),
+            2 => std::borrow::Cow::Borrowed("FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "VERSION_VIEW_UNSPECIFIED" => std::option::Option::Some(Self::VERSION_VIEW_UNSPECIFIED),
+            "BASIC" => std::option::Option::Some(Self::BASIC),
+            "FULL" => std::option::Option::Some(Self::FULL),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [VersionView](VersionView)
-pub mod version_view {
-    use super::VersionView;
-
-    /// The default / unset value.
-    /// The API will default to the BASIC view.
-    pub const VERSION_VIEW_UNSPECIFIED: VersionView = VersionView::new("VERSION_VIEW_UNSPECIFIED");
-
-    /// Includes basic information about the version, but not any related tags.
-    pub const BASIC: VersionView = VersionView::new("BASIC");
-
-    /// Include everything.
-    pub const FULL: VersionView = VersionView::new("FULL");
-}
-
-impl std::convert::From<std::string::String> for VersionView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for VersionView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for VersionView {
     fn default() -> Self {
-        version_view::VERSION_VIEW_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/devtools/artifactregistry/v1/src/transport.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
                 reqwest::Method::GET,
                 format!("/v1/{}/dockerImages", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -74,7 +74,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -96,7 +96,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
                 reqwest::Method::GET,
                 format!("/v1/{}/mavenArtifacts", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -117,7 +117,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -139,7 +139,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
                 reqwest::Method::GET,
                 format!("/v1/{}/npmPackages", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -160,7 +160,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -182,7 +182,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
                 reqwest::Method::GET,
                 format!("/v1/{}/pythonPackages", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -203,7 +203,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -225,7 +225,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
                 reqwest::Method::POST,
                 format!("/v1/{}/aptArtifacts:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -245,7 +245,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
                 reqwest::Method::POST,
                 format!("/v1/{}/yumArtifacts:import", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -265,7 +265,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
                 reqwest::Method::GET,
                 format!("/v1/{}/repositories", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -288,7 +288,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -310,7 +310,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
                 reqwest::Method::POST,
                 format!("/v1/{}/repositories", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -339,7 +339,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -368,7 +368,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -387,7 +387,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/packages", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -410,7 +410,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -429,7 +429,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -448,7 +448,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/versions", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -472,7 +472,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -492,7 +492,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -515,7 +515,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
                 reqwest::Method::POST,
                 format!("/v1/{}/versions:batchDelete", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -541,7 +541,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -570,7 +570,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/files", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -593,7 +593,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -612,7 +612,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -640,7 +640,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -667,7 +667,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/tags", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -689,7 +689,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -708,7 +708,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/tags", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -735,7 +735,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -762,7 +762,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -781,7 +781,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/rules", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -799,7 +799,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/rules", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -820,7 +820,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -848,7 +848,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -875,7 +875,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -897,7 +897,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -917,7 +917,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
                 reqwest::Method::GET,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -949,7 +949,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -966,7 +966,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -994,7 +994,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1023,7 +1023,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1051,7 +1051,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1089,7 +1089,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1121,7 +1121,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
                 reqwest::Method::GET,
                 format!("/v1/{}/attachments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1143,7 +1143,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1165,7 +1165,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
                 reqwest::Method::POST,
                 format!("/v1/{}/attachments", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1185,7 +1185,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1204,7 +1204,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1226,7 +1226,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1245,7 +1245,7 @@ impl crate::stubs::ArtifactRegistry for ArtifactRegistry {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/devtools/cloudbuild/v1/src/model.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/model.rs
@@ -222,44 +222,60 @@ pub mod storage_source {
 
     /// Specifies the tool to fetch the source file for the build.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SourceFetcher(std::borrow::Cow<'static, str>);
+    pub struct SourceFetcher(i32);
 
     impl SourceFetcher {
+        /// Unspecified. Defaults to GSUTIL.
+        pub const SOURCE_FETCHER_UNSPECIFIED: SourceFetcher = SourceFetcher::new(0);
+
+        /// Use the "gsutil" tool to download the source file.
+        pub const GSUTIL: SourceFetcher = SourceFetcher::new(1);
+
+        /// Use the Cloud Storage Fetcher tool to download the source file.
+        pub const GCS_FETCHER: SourceFetcher = SourceFetcher::new(2);
+
         /// Creates a new SourceFetcher instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SOURCE_FETCHER_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GSUTIL"),
+                2 => std::borrow::Cow::Borrowed("GCS_FETCHER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SOURCE_FETCHER_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SOURCE_FETCHER_UNSPECIFIED)
+                }
+                "GSUTIL" => std::option::Option::Some(Self::GSUTIL),
+                "GCS_FETCHER" => std::option::Option::Some(Self::GCS_FETCHER),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SourceFetcher](SourceFetcher)
-    pub mod source_fetcher {
-        use super::SourceFetcher;
-
-        /// Unspecified. Defaults to GSUTIL.
-        pub const SOURCE_FETCHER_UNSPECIFIED: SourceFetcher =
-            SourceFetcher::new("SOURCE_FETCHER_UNSPECIFIED");
-
-        /// Use the "gsutil" tool to download the source file.
-        pub const GSUTIL: SourceFetcher = SourceFetcher::new("GSUTIL");
-
-        /// Use the Cloud Storage Fetcher tool to download the source file.
-        pub const GCS_FETCHER: SourceFetcher = SourceFetcher::new("GCS_FETCHER");
-    }
-
-    impl std::convert::From<std::string::String> for SourceFetcher {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SourceFetcher {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SourceFetcher {
         fn default() -> Self {
-            source_fetcher::SOURCE_FETCHER_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2118,46 +2134,63 @@ pub mod build {
 
         /// The relative importance of this warning.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Priority(std::borrow::Cow<'static, str>);
+        pub struct Priority(i32);
 
         impl Priority {
+            /// Should not be used.
+            pub const PRIORITY_UNSPECIFIED: Priority = Priority::new(0);
+
+            /// e.g. deprecation warnings and alternative feature highlights.
+            pub const INFO: Priority = Priority::new(1);
+
+            /// e.g. automated detection of possible issues with the build.
+            pub const WARNING: Priority = Priority::new(2);
+
+            /// e.g. alerts that a feature used in the build is pending removal
+            pub const ALERT: Priority = Priority::new(3);
+
             /// Creates a new Priority instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("PRIORITY_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("INFO"),
+                    2 => std::borrow::Cow::Borrowed("WARNING"),
+                    3 => std::borrow::Cow::Borrowed("ALERT"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "PRIORITY_UNSPECIFIED" => std::option::Option::Some(Self::PRIORITY_UNSPECIFIED),
+                    "INFO" => std::option::Option::Some(Self::INFO),
+                    "WARNING" => std::option::Option::Some(Self::WARNING),
+                    "ALERT" => std::option::Option::Some(Self::ALERT),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Priority](Priority)
-        pub mod priority {
-            use super::Priority;
-
-            /// Should not be used.
-            pub const PRIORITY_UNSPECIFIED: Priority = Priority::new("PRIORITY_UNSPECIFIED");
-
-            /// e.g. deprecation warnings and alternative feature highlights.
-            pub const INFO: Priority = Priority::new("INFO");
-
-            /// e.g. automated detection of possible issues with the build.
-            pub const WARNING: Priority = Priority::new("WARNING");
-
-            /// e.g. alerts that a feature used in the build is pending removal
-            pub const ALERT: Priority = Priority::new("ALERT");
-        }
-
-        impl std::convert::From<std::string::String> for Priority {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Priority {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Priority {
             fn default() -> Self {
-                priority::PRIORITY_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -2212,121 +2245,174 @@ pub mod build {
         /// The name of a fatal problem encountered during the execution of the
         /// build.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct FailureType(std::borrow::Cow<'static, str>);
+        pub struct FailureType(i32);
 
         impl FailureType {
+            /// Type unspecified
+            pub const FAILURE_TYPE_UNSPECIFIED: FailureType = FailureType::new(0);
+
+            /// Unable to push the image to the repository.
+            pub const PUSH_FAILED: FailureType = FailureType::new(1);
+
+            /// Final image not found.
+            pub const PUSH_IMAGE_NOT_FOUND: FailureType = FailureType::new(2);
+
+            /// Unauthorized push of the final image.
+            pub const PUSH_NOT_AUTHORIZED: FailureType = FailureType::new(3);
+
+            /// Backend logging failures. Should retry.
+            pub const LOGGING_FAILURE: FailureType = FailureType::new(4);
+
+            /// A build step has failed.
+            pub const USER_BUILD_STEP: FailureType = FailureType::new(5);
+
+            /// The source fetching has failed.
+            pub const FETCH_SOURCE_FAILED: FailureType = FailureType::new(6);
+
             /// Creates a new FailureType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("FAILURE_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("PUSH_FAILED"),
+                    2 => std::borrow::Cow::Borrowed("PUSH_IMAGE_NOT_FOUND"),
+                    3 => std::borrow::Cow::Borrowed("PUSH_NOT_AUTHORIZED"),
+                    4 => std::borrow::Cow::Borrowed("LOGGING_FAILURE"),
+                    5 => std::borrow::Cow::Borrowed("USER_BUILD_STEP"),
+                    6 => std::borrow::Cow::Borrowed("FETCH_SOURCE_FAILED"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "FAILURE_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::FAILURE_TYPE_UNSPECIFIED)
+                    }
+                    "PUSH_FAILED" => std::option::Option::Some(Self::PUSH_FAILED),
+                    "PUSH_IMAGE_NOT_FOUND" => std::option::Option::Some(Self::PUSH_IMAGE_NOT_FOUND),
+                    "PUSH_NOT_AUTHORIZED" => std::option::Option::Some(Self::PUSH_NOT_AUTHORIZED),
+                    "LOGGING_FAILURE" => std::option::Option::Some(Self::LOGGING_FAILURE),
+                    "USER_BUILD_STEP" => std::option::Option::Some(Self::USER_BUILD_STEP),
+                    "FETCH_SOURCE_FAILED" => std::option::Option::Some(Self::FETCH_SOURCE_FAILED),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [FailureType](FailureType)
-        pub mod failure_type {
-            use super::FailureType;
-
-            /// Type unspecified
-            pub const FAILURE_TYPE_UNSPECIFIED: FailureType =
-                FailureType::new("FAILURE_TYPE_UNSPECIFIED");
-
-            /// Unable to push the image to the repository.
-            pub const PUSH_FAILED: FailureType = FailureType::new("PUSH_FAILED");
-
-            /// Final image not found.
-            pub const PUSH_IMAGE_NOT_FOUND: FailureType = FailureType::new("PUSH_IMAGE_NOT_FOUND");
-
-            /// Unauthorized push of the final image.
-            pub const PUSH_NOT_AUTHORIZED: FailureType = FailureType::new("PUSH_NOT_AUTHORIZED");
-
-            /// Backend logging failures. Should retry.
-            pub const LOGGING_FAILURE: FailureType = FailureType::new("LOGGING_FAILURE");
-
-            /// A build step has failed.
-            pub const USER_BUILD_STEP: FailureType = FailureType::new("USER_BUILD_STEP");
-
-            /// The source fetching has failed.
-            pub const FETCH_SOURCE_FAILED: FailureType = FailureType::new("FETCH_SOURCE_FAILED");
-        }
-
-        impl std::convert::From<std::string::String> for FailureType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for FailureType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for FailureType {
             fn default() -> Self {
-                failure_type::FAILURE_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// Possible status of a build or build step.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(std::borrow::Cow<'static, str>);
+    pub struct Status(i32);
 
     impl Status {
-        /// Creates a new Status instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Status](Status)
-    pub mod status {
-        use super::Status;
-
         /// Status of the build is unknown.
-        pub const STATUS_UNKNOWN: Status = Status::new("STATUS_UNKNOWN");
+        pub const STATUS_UNKNOWN: Status = Status::new(0);
 
         /// Build has been created and is pending execution and queuing. It has not
         /// been queued.
-        pub const PENDING: Status = Status::new("PENDING");
+        pub const PENDING: Status = Status::new(10);
 
         /// Build or step is queued; work has not yet begun.
-        pub const QUEUED: Status = Status::new("QUEUED");
+        pub const QUEUED: Status = Status::new(1);
 
         /// Build or step is being executed.
-        pub const WORKING: Status = Status::new("WORKING");
+        pub const WORKING: Status = Status::new(2);
 
         /// Build or step finished successfully.
-        pub const SUCCESS: Status = Status::new("SUCCESS");
+        pub const SUCCESS: Status = Status::new(3);
 
         /// Build or step failed to complete successfully.
-        pub const FAILURE: Status = Status::new("FAILURE");
+        pub const FAILURE: Status = Status::new(4);
 
         /// Build or step failed due to an internal cause.
-        pub const INTERNAL_ERROR: Status = Status::new("INTERNAL_ERROR");
+        pub const INTERNAL_ERROR: Status = Status::new(5);
 
         /// Build or step took longer than was allowed.
-        pub const TIMEOUT: Status = Status::new("TIMEOUT");
+        pub const TIMEOUT: Status = Status::new(6);
 
         /// Build or step was canceled by a user.
-        pub const CANCELLED: Status = Status::new("CANCELLED");
+        pub const CANCELLED: Status = Status::new(7);
 
         /// Build was enqueued for longer than the value of `queue_ttl`.
-        pub const EXPIRED: Status = Status::new("EXPIRED");
+        pub const EXPIRED: Status = Status::new(9);
+
+        /// Creates a new Status instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATUS_UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("QUEUED"),
+                2 => std::borrow::Cow::Borrowed("WORKING"),
+                3 => std::borrow::Cow::Borrowed("SUCCESS"),
+                4 => std::borrow::Cow::Borrowed("FAILURE"),
+                5 => std::borrow::Cow::Borrowed("INTERNAL_ERROR"),
+                6 => std::borrow::Cow::Borrowed("TIMEOUT"),
+                7 => std::borrow::Cow::Borrowed("CANCELLED"),
+                9 => std::borrow::Cow::Borrowed("EXPIRED"),
+                10 => std::borrow::Cow::Borrowed("PENDING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATUS_UNKNOWN" => std::option::Option::Some(Self::STATUS_UNKNOWN),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "QUEUED" => std::option::Option::Some(Self::QUEUED),
+                "WORKING" => std::option::Option::Some(Self::WORKING),
+                "SUCCESS" => std::option::Option::Some(Self::SUCCESS),
+                "FAILURE" => std::option::Option::Some(Self::FAILURE),
+                "INTERNAL_ERROR" => std::option::Option::Some(Self::INTERNAL_ERROR),
+                "TIMEOUT" => std::option::Option::Some(Self::TIMEOUT),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                "EXPIRED" => std::option::Option::Some(Self::EXPIRED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Status {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            status::STATUS_UNKNOWN
+            Self::new(0)
         }
     }
 }
@@ -3450,49 +3536,68 @@ pub mod hash {
 
     /// Specifies the hash algorithm, if any.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HashType(std::borrow::Cow<'static, str>);
+    pub struct HashType(i32);
 
     impl HashType {
+        /// No hash requested.
+        pub const NONE: HashType = HashType::new(0);
+
+        /// Use a sha256 hash.
+        pub const SHA256: HashType = HashType::new(1);
+
+        /// Use a md5 hash.
+        pub const MD5: HashType = HashType::new(2);
+
+        /// Dirhash of a Go module's source code which is then hex-encoded.
+        pub const GO_MODULE_H1: HashType = HashType::new(3);
+
+        /// Use a sha512 hash.
+        pub const SHA512: HashType = HashType::new(4);
+
         /// Creates a new HashType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("NONE"),
+                1 => std::borrow::Cow::Borrowed("SHA256"),
+                2 => std::borrow::Cow::Borrowed("MD5"),
+                3 => std::borrow::Cow::Borrowed("GO_MODULE_H1"),
+                4 => std::borrow::Cow::Borrowed("SHA512"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "NONE" => std::option::Option::Some(Self::NONE),
+                "SHA256" => std::option::Option::Some(Self::SHA256),
+                "MD5" => std::option::Option::Some(Self::MD5),
+                "GO_MODULE_H1" => std::option::Option::Some(Self::GO_MODULE_H1),
+                "SHA512" => std::option::Option::Some(Self::SHA512),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [HashType](HashType)
-    pub mod hash_type {
-        use super::HashType;
-
-        /// No hash requested.
-        pub const NONE: HashType = HashType::new("NONE");
-
-        /// Use a sha256 hash.
-        pub const SHA256: HashType = HashType::new("SHA256");
-
-        /// Use a md5 hash.
-        pub const MD5: HashType = HashType::new("MD5");
-
-        /// Dirhash of a Go module's source code which is then hex-encoded.
-        pub const GO_MODULE_H1: HashType = HashType::new("GO_MODULE_H1");
-
-        /// Use a sha512 hash.
-        pub const SHA512: HashType = HashType::new("SHA512");
-    }
-
-    impl std::convert::From<std::string::String> for HashType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for HashType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for HashType {
         fn default() -> Self {
-            hash_type::NONE
+            Self::new(0)
         }
     }
 }
@@ -4095,49 +4200,68 @@ pub mod build_approval {
 
     /// Specifies the current state of a build's approval.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Default enum type. This should not be used.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Build approval is pending.
+        pub const PENDING: State = State::new(1);
+
+        /// Build approval has been approved.
+        pub const APPROVED: State = State::new(2);
+
+        /// Build approval has been rejected.
+        pub const REJECTED: State = State::new(3);
+
+        /// Build was cancelled while it was still pending approval.
+        pub const CANCELLED: State = State::new(5);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("APPROVED"),
+                3 => std::borrow::Cow::Borrowed("REJECTED"),
+                5 => std::borrow::Cow::Borrowed("CANCELLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "APPROVED" => std::option::Option::Some(Self::APPROVED),
+                "REJECTED" => std::option::Option::Some(Self::REJECTED),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Default enum type. This should not be used.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Build approval is pending.
-        pub const PENDING: State = State::new("PENDING");
-
-        /// Build approval has been approved.
-        pub const APPROVED: State = State::new("APPROVED");
-
-        /// Build approval has been rejected.
-        pub const REJECTED: State = State::new("REJECTED");
-
-        /// Build was cancelled while it was still pending approval.
-        pub const CANCELLED: State = State::new("CANCELLED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4262,43 +4386,58 @@ pub mod approval_result {
     /// Specifies whether or not this manual approval result is to approve
     /// or reject a build.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Decision(std::borrow::Cow<'static, str>);
+    pub struct Decision(i32);
 
     impl Decision {
+        /// Default enum type. This should not be used.
+        pub const DECISION_UNSPECIFIED: Decision = Decision::new(0);
+
+        /// Build is approved.
+        pub const APPROVED: Decision = Decision::new(1);
+
+        /// Build is rejected.
+        pub const REJECTED: Decision = Decision::new(2);
+
         /// Creates a new Decision instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DECISION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("APPROVED"),
+                2 => std::borrow::Cow::Borrowed("REJECTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DECISION_UNSPECIFIED" => std::option::Option::Some(Self::DECISION_UNSPECIFIED),
+                "APPROVED" => std::option::Option::Some(Self::APPROVED),
+                "REJECTED" => std::option::Option::Some(Self::REJECTED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Decision](Decision)
-    pub mod decision {
-        use super::Decision;
-
-        /// Default enum type. This should not be used.
-        pub const DECISION_UNSPECIFIED: Decision = Decision::new("DECISION_UNSPECIFIED");
-
-        /// Build is approved.
-        pub const APPROVED: Decision = Decision::new("APPROVED");
-
-        /// Build is rejected.
-        pub const REJECTED: Decision = Decision::new("REJECTED");
-    }
-
-    impl std::convert::From<std::string::String> for Decision {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Decision {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Decision {
         fn default() -> Self {
-            decision::DECISION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4625,51 +4764,72 @@ pub mod git_file_source {
     /// The type of the repo, since it may not be explicit from the `repo` field
     /// (e.g from a URL).
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RepoType(std::borrow::Cow<'static, str>);
+    pub struct RepoType(i32);
 
     impl RepoType {
-        /// Creates a new RepoType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RepoType](RepoType)
-    pub mod repo_type {
-        use super::RepoType;
-
         /// The default, unknown repo type. Don't use it, instead use one of
         /// the other repo types.
-        pub const UNKNOWN: RepoType = RepoType::new("UNKNOWN");
+        pub const UNKNOWN: RepoType = RepoType::new(0);
 
         /// A Google Cloud Source Repositories-hosted repo.
-        pub const CLOUD_SOURCE_REPOSITORIES: RepoType = RepoType::new("CLOUD_SOURCE_REPOSITORIES");
+        pub const CLOUD_SOURCE_REPOSITORIES: RepoType = RepoType::new(1);
 
         /// A GitHub-hosted repo not necessarily on "github.com" (i.e. GitHub
         /// Enterprise).
-        pub const GITHUB: RepoType = RepoType::new("GITHUB");
+        pub const GITHUB: RepoType = RepoType::new(2);
 
         /// A Bitbucket Server-hosted repo.
-        pub const BITBUCKET_SERVER: RepoType = RepoType::new("BITBUCKET_SERVER");
+        pub const BITBUCKET_SERVER: RepoType = RepoType::new(3);
 
         /// A GitLab-hosted repo.
-        pub const GITLAB: RepoType = RepoType::new("GITLAB");
+        pub const GITLAB: RepoType = RepoType::new(4);
+
+        /// Creates a new RepoType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("CLOUD_SOURCE_REPOSITORIES"),
+                2 => std::borrow::Cow::Borrowed("GITHUB"),
+                3 => std::borrow::Cow::Borrowed("BITBUCKET_SERVER"),
+                4 => std::borrow::Cow::Borrowed("GITLAB"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+                "CLOUD_SOURCE_REPOSITORIES" => {
+                    std::option::Option::Some(Self::CLOUD_SOURCE_REPOSITORIES)
+                }
+                "GITHUB" => std::option::Option::Some(Self::GITHUB),
+                "BITBUCKET_SERVER" => std::option::Option::Some(Self::BITBUCKET_SERVER),
+                "GITLAB" => std::option::Option::Some(Self::GITLAB),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RepoType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RepoType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RepoType {
         fn default() -> Self {
-            repo_type::UNKNOWN
+            Self::new(0)
         }
     }
 
@@ -5273,47 +5433,65 @@ pub mod repository_event_config {
 
     /// All possible SCM repo types from Repo API.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RepositoryType(std::borrow::Cow<'static, str>);
+    pub struct RepositoryType(i32);
 
     impl RepositoryType {
+        /// If unspecified, RepositoryType defaults to GITHUB.
+        pub const REPOSITORY_TYPE_UNSPECIFIED: RepositoryType = RepositoryType::new(0);
+
+        /// The SCM repo is GITHUB.
+        pub const GITHUB: RepositoryType = RepositoryType::new(1);
+
+        /// The SCM repo is GITHUB Enterprise.
+        pub const GITHUB_ENTERPRISE: RepositoryType = RepositoryType::new(2);
+
+        /// The SCM repo is GITLAB Enterprise.
+        pub const GITLAB_ENTERPRISE: RepositoryType = RepositoryType::new(3);
+
         /// Creates a new RepositoryType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("REPOSITORY_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GITHUB"),
+                2 => std::borrow::Cow::Borrowed("GITHUB_ENTERPRISE"),
+                3 => std::borrow::Cow::Borrowed("GITLAB_ENTERPRISE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "REPOSITORY_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::REPOSITORY_TYPE_UNSPECIFIED)
+                }
+                "GITHUB" => std::option::Option::Some(Self::GITHUB),
+                "GITHUB_ENTERPRISE" => std::option::Option::Some(Self::GITHUB_ENTERPRISE),
+                "GITLAB_ENTERPRISE" => std::option::Option::Some(Self::GITLAB_ENTERPRISE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RepositoryType](RepositoryType)
-    pub mod repository_type {
-        use super::RepositoryType;
-
-        /// If unspecified, RepositoryType defaults to GITHUB.
-        pub const REPOSITORY_TYPE_UNSPECIFIED: RepositoryType =
-            RepositoryType::new("REPOSITORY_TYPE_UNSPECIFIED");
-
-        /// The SCM repo is GITHUB.
-        pub const GITHUB: RepositoryType = RepositoryType::new("GITHUB");
-
-        /// The SCM repo is GITHUB Enterprise.
-        pub const GITHUB_ENTERPRISE: RepositoryType = RepositoryType::new("GITHUB_ENTERPRISE");
-
-        /// The SCM repo is GITLAB Enterprise.
-        pub const GITLAB_ENTERPRISE: RepositoryType = RepositoryType::new("GITLAB_ENTERPRISE");
-    }
-
-    impl std::convert::From<std::string::String> for RepositoryType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RepositoryType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RepositoryType {
         fn default() -> Self {
-            repository_type::REPOSITORY_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -5549,49 +5727,70 @@ pub mod pubsub_config {
     /// Enumerates potential issues with the underlying Pub/Sub subscription
     /// configuration.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The subscription configuration has not been checked.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The Pub/Sub subscription is properly configured.
+        pub const OK: State = State::new(1);
+
+        /// The subscription has been deleted.
+        pub const SUBSCRIPTION_DELETED: State = State::new(2);
+
+        /// The topic has been deleted.
+        pub const TOPIC_DELETED: State = State::new(3);
+
+        /// Some of the subscription's field are misconfigured.
+        pub const SUBSCRIPTION_MISCONFIGURED: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("OK"),
+                2 => std::borrow::Cow::Borrowed("SUBSCRIPTION_DELETED"),
+                3 => std::borrow::Cow::Borrowed("TOPIC_DELETED"),
+                4 => std::borrow::Cow::Borrowed("SUBSCRIPTION_MISCONFIGURED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "OK" => std::option::Option::Some(Self::OK),
+                "SUBSCRIPTION_DELETED" => std::option::Option::Some(Self::SUBSCRIPTION_DELETED),
+                "TOPIC_DELETED" => std::option::Option::Some(Self::TOPIC_DELETED),
+                "SUBSCRIPTION_MISCONFIGURED" => {
+                    std::option::Option::Some(Self::SUBSCRIPTION_MISCONFIGURED)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The subscription configuration has not been checked.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The Pub/Sub subscription is properly configured.
-        pub const OK: State = State::new("OK");
-
-        /// The subscription has been deleted.
-        pub const SUBSCRIPTION_DELETED: State = State::new("SUBSCRIPTION_DELETED");
-
-        /// The topic has been deleted.
-        pub const TOPIC_DELETED: State = State::new("TOPIC_DELETED");
-
-        /// Some of the subscription's field are misconfigured.
-        pub const SUBSCRIPTION_MISCONFIGURED: State = State::new("SUBSCRIPTION_MISCONFIGURED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5674,43 +5873,58 @@ pub mod webhook_config {
     /// Enumerates potential issues with the Secret Manager secret provided by the
     /// user.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// The webhook auth configuration not been checked.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// The auth configuration is properly setup.
+        pub const OK: State = State::new(1);
+
+        /// The secret provided in auth_method has been deleted.
+        pub const SECRET_DELETED: State = State::new(2);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("OK"),
+                2 => std::borrow::Cow::Borrowed("SECRET_DELETED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "OK" => std::option::Option::Some(Self::OK),
+                "SECRET_DELETED" => std::option::Option::Some(Self::SECRET_DELETED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// The webhook auth configuration not been checked.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// The auth configuration is properly setup.
-        pub const OK: State = State::new("OK");
-
-        /// The secret provided in auth_method has been deleted.
-        pub const SECRET_DELETED: State = State::new("SECRET_DELETED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -5827,29 +6041,14 @@ pub mod pull_request_filter {
     /// [GitLab](https://cloud.google.com/build/docs/automating-builds/gitlab/build-repos-from-gitlab#creating_a_gitlab_trigger)
     /// for details.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CommentControl(std::borrow::Cow<'static, str>);
+    pub struct CommentControl(i32);
 
     impl CommentControl {
-        /// Creates a new CommentControl instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CommentControl](CommentControl)
-    pub mod comment_control {
-        use super::CommentControl;
-
         /// Do not require `/gcbrun` comments from a user with repository write
         /// permission or above on pull requests before builds are triggered.
         /// Comments that contain `/gcbrun` will still fire builds so this should
         /// be thought of as comments not required.
-        pub const COMMENTS_DISABLED: CommentControl = CommentControl::new("COMMENTS_DISABLED");
+        pub const COMMENTS_DISABLED: CommentControl = CommentControl::new(0);
 
         /// Builds will only fire in response to pull requests if:
         ///
@@ -5857,7 +6056,7 @@ pub mod pull_request_filter {
         ///   `/gcbrun` is in the PR description.
         /// . A user with repository writer permissions or above comments `/gcbrun`
         ///   on a pull request authored by any user.
-        pub const COMMENTS_ENABLED: CommentControl = CommentControl::new("COMMENTS_ENABLED");
+        pub const COMMENTS_ENABLED: CommentControl = CommentControl::new(1);
 
         /// Builds will only fire in response to pull requests if:
         ///
@@ -5865,18 +6064,50 @@ pub mod pull_request_filter {
         /// . If the author does not have write permissions, a user with write
         ///   permissions or above must comment `/gcbrun` in order to fire a build.
         pub const COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY: CommentControl =
-            CommentControl::new("COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY");
+            CommentControl::new(2);
+
+        /// Creates a new CommentControl instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COMMENTS_DISABLED"),
+                1 => std::borrow::Cow::Borrowed("COMMENTS_ENABLED"),
+                2 => std::borrow::Cow::Borrowed("COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COMMENTS_DISABLED" => std::option::Option::Some(Self::COMMENTS_DISABLED),
+                "COMMENTS_ENABLED" => std::option::Option::Some(Self::COMMENTS_ENABLED),
+                "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY" => {
+                    std::option::Option::Some(Self::COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CommentControl {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CommentControl {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CommentControl {
         fn default() -> Self {
-            comment_control::COMMENTS_DISABLED
+            Self::new(0)
         }
     }
 
@@ -6654,40 +6885,53 @@ pub mod build_options {
     /// For more information, see [Viewing Build
     /// Provenance](https://cloud.google.com/build/docs/securing-builds/view-build-provenance).
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VerifyOption(std::borrow::Cow<'static, str>);
+    pub struct VerifyOption(i32);
 
     impl VerifyOption {
+        /// Not a verifiable build (the default).
+        pub const NOT_VERIFIED: VerifyOption = VerifyOption::new(0);
+
+        /// Build must be verified.
+        pub const VERIFIED: VerifyOption = VerifyOption::new(1);
+
         /// Creates a new VerifyOption instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("NOT_VERIFIED"),
+                1 => std::borrow::Cow::Borrowed("VERIFIED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "NOT_VERIFIED" => std::option::Option::Some(Self::NOT_VERIFIED),
+                "VERIFIED" => std::option::Option::Some(Self::VERIFIED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [VerifyOption](VerifyOption)
-    pub mod verify_option {
-        use super::VerifyOption;
-
-        /// Not a verifiable build (the default).
-        pub const NOT_VERIFIED: VerifyOption = VerifyOption::new("NOT_VERIFIED");
-
-        /// Build must be verified.
-        pub const VERIFIED: VerifyOption = VerifyOption::new("VERIFIED");
-    }
-
-    impl std::convert::From<std::string::String> for VerifyOption {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for VerifyOption {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for VerifyOption {
         fn default() -> Self {
-            verify_option::NOT_VERIFIED
+            Self::new(0)
         }
     }
 
@@ -6695,236 +6939,324 @@ pub mod build_options {
     /// For more information, see [Machine
     /// types](https://cloud.google.com/compute/docs/machine-types).
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MachineType(std::borrow::Cow<'static, str>);
+    pub struct MachineType(i32);
 
     impl MachineType {
+        /// Standard machine type.
+        pub const UNSPECIFIED: MachineType = MachineType::new(0);
+
+        /// Highcpu machine with 8 CPUs.
+        pub const N1_HIGHCPU_8: MachineType = MachineType::new(1);
+
+        /// Highcpu machine with 32 CPUs.
+        pub const N1_HIGHCPU_32: MachineType = MachineType::new(2);
+
+        /// Highcpu e2 machine with 8 CPUs.
+        pub const E2_HIGHCPU_8: MachineType = MachineType::new(5);
+
+        /// Highcpu e2 machine with 32 CPUs.
+        pub const E2_HIGHCPU_32: MachineType = MachineType::new(6);
+
+        /// E2 machine with 1 CPU.
+        pub const E2_MEDIUM: MachineType = MachineType::new(7);
+
         /// Creates a new MachineType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("N1_HIGHCPU_8"),
+                2 => std::borrow::Cow::Borrowed("N1_HIGHCPU_32"),
+                5 => std::borrow::Cow::Borrowed("E2_HIGHCPU_8"),
+                6 => std::borrow::Cow::Borrowed("E2_HIGHCPU_32"),
+                7 => std::borrow::Cow::Borrowed("E2_MEDIUM"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
+                "N1_HIGHCPU_8" => std::option::Option::Some(Self::N1_HIGHCPU_8),
+                "N1_HIGHCPU_32" => std::option::Option::Some(Self::N1_HIGHCPU_32),
+                "E2_HIGHCPU_8" => std::option::Option::Some(Self::E2_HIGHCPU_8),
+                "E2_HIGHCPU_32" => std::option::Option::Some(Self::E2_HIGHCPU_32),
+                "E2_MEDIUM" => std::option::Option::Some(Self::E2_MEDIUM),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [MachineType](MachineType)
-    pub mod machine_type {
-        use super::MachineType;
-
-        /// Standard machine type.
-        pub const UNSPECIFIED: MachineType = MachineType::new("UNSPECIFIED");
-
-        /// Highcpu machine with 8 CPUs.
-        pub const N1_HIGHCPU_8: MachineType = MachineType::new("N1_HIGHCPU_8");
-
-        /// Highcpu machine with 32 CPUs.
-        pub const N1_HIGHCPU_32: MachineType = MachineType::new("N1_HIGHCPU_32");
-
-        /// Highcpu e2 machine with 8 CPUs.
-        pub const E2_HIGHCPU_8: MachineType = MachineType::new("E2_HIGHCPU_8");
-
-        /// Highcpu e2 machine with 32 CPUs.
-        pub const E2_HIGHCPU_32: MachineType = MachineType::new("E2_HIGHCPU_32");
-
-        /// E2 machine with 1 CPU.
-        pub const E2_MEDIUM: MachineType = MachineType::new("E2_MEDIUM");
-    }
-
-    impl std::convert::From<std::string::String> for MachineType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MachineType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MachineType {
         fn default() -> Self {
-            machine_type::UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Specifies the behavior when there is an error in the substitution checks.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SubstitutionOption(std::borrow::Cow<'static, str>);
+    pub struct SubstitutionOption(i32);
 
     impl SubstitutionOption {
+        /// Fails the build if error in substitutions checks, like missing
+        /// a substitution in the template or in the map.
+        pub const MUST_MATCH: SubstitutionOption = SubstitutionOption::new(0);
+
+        /// Do not fail the build if error in substitutions checks.
+        pub const ALLOW_LOOSE: SubstitutionOption = SubstitutionOption::new(1);
+
         /// Creates a new SubstitutionOption instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MUST_MATCH"),
+                1 => std::borrow::Cow::Borrowed("ALLOW_LOOSE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MUST_MATCH" => std::option::Option::Some(Self::MUST_MATCH),
+                "ALLOW_LOOSE" => std::option::Option::Some(Self::ALLOW_LOOSE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [SubstitutionOption](SubstitutionOption)
-    pub mod substitution_option {
-        use super::SubstitutionOption;
-
-        /// Fails the build if error in substitutions checks, like missing
-        /// a substitution in the template or in the map.
-        pub const MUST_MATCH: SubstitutionOption = SubstitutionOption::new("MUST_MATCH");
-
-        /// Do not fail the build if error in substitutions checks.
-        pub const ALLOW_LOOSE: SubstitutionOption = SubstitutionOption::new("ALLOW_LOOSE");
-    }
-
-    impl std::convert::From<std::string::String> for SubstitutionOption {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SubstitutionOption {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SubstitutionOption {
         fn default() -> Self {
-            substitution_option::MUST_MATCH
+            Self::new(0)
         }
     }
 
     /// Specifies the behavior when writing build logs to Cloud Storage.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LogStreamingOption(std::borrow::Cow<'static, str>);
+    pub struct LogStreamingOption(i32);
 
     impl LogStreamingOption {
-        /// Creates a new LogStreamingOption instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [LogStreamingOption](LogStreamingOption)
-    pub mod log_streaming_option {
-        use super::LogStreamingOption;
-
         /// Service may automatically determine build log streaming behavior.
-        pub const STREAM_DEFAULT: LogStreamingOption = LogStreamingOption::new("STREAM_DEFAULT");
+        pub const STREAM_DEFAULT: LogStreamingOption = LogStreamingOption::new(0);
 
         /// Build logs should be streamed to Cloud Storage.
-        pub const STREAM_ON: LogStreamingOption = LogStreamingOption::new("STREAM_ON");
+        pub const STREAM_ON: LogStreamingOption = LogStreamingOption::new(1);
 
         /// Build logs should not be streamed to Cloud Storage; they will be
         /// written when the build is completed.
-        pub const STREAM_OFF: LogStreamingOption = LogStreamingOption::new("STREAM_OFF");
+        pub const STREAM_OFF: LogStreamingOption = LogStreamingOption::new(2);
+
+        /// Creates a new LogStreamingOption instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STREAM_DEFAULT"),
+                1 => std::borrow::Cow::Borrowed("STREAM_ON"),
+                2 => std::borrow::Cow::Borrowed("STREAM_OFF"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STREAM_DEFAULT" => std::option::Option::Some(Self::STREAM_DEFAULT),
+                "STREAM_ON" => std::option::Option::Some(Self::STREAM_ON),
+                "STREAM_OFF" => std::option::Option::Some(Self::STREAM_OFF),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for LogStreamingOption {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LogStreamingOption {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LogStreamingOption {
         fn default() -> Self {
-            log_streaming_option::STREAM_DEFAULT
+            Self::new(0)
         }
     }
 
     /// Specifies the logging mode.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LoggingMode(std::borrow::Cow<'static, str>);
+    pub struct LoggingMode(i32);
 
     impl LoggingMode {
-        /// Creates a new LoggingMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [LoggingMode](LoggingMode)
-    pub mod logging_mode {
-        use super::LoggingMode;
-
         /// The service determines the logging mode. The default is `LEGACY`. Do not
         /// rely on the default logging behavior as it may change in the future.
-        pub const LOGGING_UNSPECIFIED: LoggingMode = LoggingMode::new("LOGGING_UNSPECIFIED");
+        pub const LOGGING_UNSPECIFIED: LoggingMode = LoggingMode::new(0);
 
         /// Build logs are stored in Cloud Logging and Cloud Storage.
-        pub const LEGACY: LoggingMode = LoggingMode::new("LEGACY");
+        pub const LEGACY: LoggingMode = LoggingMode::new(1);
 
         /// Build logs are stored in Cloud Storage.
-        pub const GCS_ONLY: LoggingMode = LoggingMode::new("GCS_ONLY");
+        pub const GCS_ONLY: LoggingMode = LoggingMode::new(2);
 
         /// This option is the same as CLOUD_LOGGING_ONLY.
-        pub const STACKDRIVER_ONLY: LoggingMode = LoggingMode::new("STACKDRIVER_ONLY");
+        pub const STACKDRIVER_ONLY: LoggingMode = LoggingMode::new(3);
 
         /// Build logs are stored in Cloud Logging. Selecting this option will not
         /// allow [logs
         /// streaming](https://cloud.google.com/sdk/gcloud/reference/builds/log).
-        pub const CLOUD_LOGGING_ONLY: LoggingMode = LoggingMode::new("CLOUD_LOGGING_ONLY");
+        pub const CLOUD_LOGGING_ONLY: LoggingMode = LoggingMode::new(5);
 
         /// Turn off all logging. No build logs will be captured.
-        pub const NONE: LoggingMode = LoggingMode::new("NONE");
+        pub const NONE: LoggingMode = LoggingMode::new(4);
+
+        /// Creates a new LoggingMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LOGGING_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LEGACY"),
+                2 => std::borrow::Cow::Borrowed("GCS_ONLY"),
+                3 => std::borrow::Cow::Borrowed("STACKDRIVER_ONLY"),
+                4 => std::borrow::Cow::Borrowed("NONE"),
+                5 => std::borrow::Cow::Borrowed("CLOUD_LOGGING_ONLY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LOGGING_UNSPECIFIED" => std::option::Option::Some(Self::LOGGING_UNSPECIFIED),
+                "LEGACY" => std::option::Option::Some(Self::LEGACY),
+                "GCS_ONLY" => std::option::Option::Some(Self::GCS_ONLY),
+                "STACKDRIVER_ONLY" => std::option::Option::Some(Self::STACKDRIVER_ONLY),
+                "CLOUD_LOGGING_ONLY" => std::option::Option::Some(Self::CLOUD_LOGGING_ONLY),
+                "NONE" => std::option::Option::Some(Self::NONE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for LoggingMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LoggingMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LoggingMode {
         fn default() -> Self {
-            logging_mode::LOGGING_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Default Cloud Storage log bucket behavior options.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DefaultLogsBucketBehavior(std::borrow::Cow<'static, str>);
+    pub struct DefaultLogsBucketBehavior(i32);
 
     impl DefaultLogsBucketBehavior {
-        /// Creates a new DefaultLogsBucketBehavior instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DefaultLogsBucketBehavior](DefaultLogsBucketBehavior)
-    pub mod default_logs_bucket_behavior {
-        use super::DefaultLogsBucketBehavior;
-
         /// Unspecified.
         pub const DEFAULT_LOGS_BUCKET_BEHAVIOR_UNSPECIFIED: DefaultLogsBucketBehavior =
-            DefaultLogsBucketBehavior::new("DEFAULT_LOGS_BUCKET_BEHAVIOR_UNSPECIFIED");
+            DefaultLogsBucketBehavior::new(0);
 
         /// Bucket is located in user-owned project in the same region as the
         /// build. The builder service account must have access to create and write
         /// to Cloud Storage buckets in the build project.
         pub const REGIONAL_USER_OWNED_BUCKET: DefaultLogsBucketBehavior =
-            DefaultLogsBucketBehavior::new("REGIONAL_USER_OWNED_BUCKET");
+            DefaultLogsBucketBehavior::new(1);
 
         /// Bucket is located in a Google-owned project and is not regionalized.
-        pub const LEGACY_BUCKET: DefaultLogsBucketBehavior =
-            DefaultLogsBucketBehavior::new("LEGACY_BUCKET");
+        pub const LEGACY_BUCKET: DefaultLogsBucketBehavior = DefaultLogsBucketBehavior::new(2);
+
+        /// Creates a new DefaultLogsBucketBehavior instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DEFAULT_LOGS_BUCKET_BEHAVIOR_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REGIONAL_USER_OWNED_BUCKET"),
+                2 => std::borrow::Cow::Borrowed("LEGACY_BUCKET"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DEFAULT_LOGS_BUCKET_BEHAVIOR_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DEFAULT_LOGS_BUCKET_BEHAVIOR_UNSPECIFIED)
+                }
+                "REGIONAL_USER_OWNED_BUCKET" => {
+                    std::option::Option::Some(Self::REGIONAL_USER_OWNED_BUCKET)
+                }
+                "LEGACY_BUCKET" => std::option::Option::Some(Self::LEGACY_BUCKET),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DefaultLogsBucketBehavior {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DefaultLogsBucketBehavior {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DefaultLogsBucketBehavior {
         fn default() -> Self {
-            default_logs_bucket_behavior::DEFAULT_LOGS_BUCKET_BEHAVIOR_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7430,52 +7762,73 @@ pub mod worker_pool {
 
     /// State of the `WorkerPool`.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// State of the `WorkerPool` is unknown.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// `WorkerPool` is being created.
+        pub const CREATING: State = State::new(1);
+
+        /// `WorkerPool` is running.
+        pub const RUNNING: State = State::new(2);
+
+        /// `WorkerPool` is being deleted: cancelling builds and draining workers.
+        pub const DELETING: State = State::new(3);
+
+        /// `WorkerPool` is deleted.
+        pub const DELETED: State = State::new(4);
+
+        /// `WorkerPool` is being updated; new builds cannot be run.
+        pub const UPDATING: State = State::new(5);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                4 => std::borrow::Cow::Borrowed("DELETED"),
+                5 => std::borrow::Cow::Borrowed("UPDATING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                "DELETED" => std::option::Option::Some(Self::DELETED),
+                "UPDATING" => std::option::Option::Some(Self::UPDATING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// State of the `WorkerPool` is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// `WorkerPool` is being created.
-        pub const CREATING: State = State::new("CREATING");
-
-        /// `WorkerPool` is running.
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// `WorkerPool` is being deleted: cancelling builds and draining workers.
-        pub const DELETING: State = State::new("DELETING");
-
-        /// `WorkerPool` is deleted.
-        pub const DELETED: State = State::new("DELETED");
-
-        /// `WorkerPool` is being updated; new builds cannot be run.
-        pub const UPDATING: State = State::new("UPDATING");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -7695,46 +8048,62 @@ pub mod private_pool_v_1_config {
 
         /// Defines the egress option for the pool.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct EgressOption(std::borrow::Cow<'static, str>);
+        pub struct EgressOption(i32);
 
         impl EgressOption {
-            /// Creates a new EgressOption instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [EgressOption](EgressOption)
-        pub mod egress_option {
-            use super::EgressOption;
-
             /// If set, defaults to PUBLIC_EGRESS.
-            pub const EGRESS_OPTION_UNSPECIFIED: EgressOption =
-                EgressOption::new("EGRESS_OPTION_UNSPECIFIED");
+            pub const EGRESS_OPTION_UNSPECIFIED: EgressOption = EgressOption::new(0);
 
             /// If set, workers are created without any public address, which prevents
             /// network egress to public IPs unless a network proxy is configured.
-            pub const NO_PUBLIC_EGRESS: EgressOption = EgressOption::new("NO_PUBLIC_EGRESS");
+            pub const NO_PUBLIC_EGRESS: EgressOption = EgressOption::new(1);
 
             /// If set, workers are created with a public address which allows for
             /// public internet egress.
-            pub const PUBLIC_EGRESS: EgressOption = EgressOption::new("PUBLIC_EGRESS");
+            pub const PUBLIC_EGRESS: EgressOption = EgressOption::new(2);
+
+            /// Creates a new EgressOption instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("EGRESS_OPTION_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("NO_PUBLIC_EGRESS"),
+                    2 => std::borrow::Cow::Borrowed("PUBLIC_EGRESS"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "EGRESS_OPTION_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::EGRESS_OPTION_UNSPECIFIED)
+                    }
+                    "NO_PUBLIC_EGRESS" => std::option::Option::Some(Self::NO_PUBLIC_EGRESS),
+                    "PUBLIC_EGRESS" => std::option::Option::Some(Self::PUBLIC_EGRESS),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for EgressOption {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for EgressOption {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for EgressOption {
             fn default() -> Self {
-                egress_option::EGRESS_OPTION_UNSPECIFIED
+                Self::new(0)
             }
         }
     }

--- a/src/generated/devtools/cloudbuild/v1/src/transport.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::CloudBuild for CloudBuild {
                 reqwest::Method::POST,
                 format!("/v1/projects/{}/builds", req.project_id),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -73,7 +73,7 @@ impl crate::stubs::CloudBuild for CloudBuild {
                 reqwest::Method::GET,
                 format!("/v1/projects/{}/builds/{}", req.project_id, req.id),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -96,7 +96,7 @@ impl crate::stubs::CloudBuild for CloudBuild {
                 reqwest::Method::GET,
                 format!("/v1/projects/{}/builds", req.project_id),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -122,7 +122,7 @@ impl crate::stubs::CloudBuild for CloudBuild {
                 reqwest::Method::POST,
                 format!("/v1/projects/{}/builds/{}:cancel", req.project_id, req.id),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -142,7 +142,7 @@ impl crate::stubs::CloudBuild for CloudBuild {
                 reqwest::Method::POST,
                 format!("/v1/projects/{}/builds/{}:retry", req.project_id, req.id),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -159,7 +159,7 @@ impl crate::stubs::CloudBuild for CloudBuild {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:approve", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -179,7 +179,7 @@ impl crate::stubs::CloudBuild for CloudBuild {
                 reqwest::Method::POST,
                 format!("/v1/projects/{}/triggers", req.project_id),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -205,7 +205,7 @@ impl crate::stubs::CloudBuild for CloudBuild {
                     req.project_id, req.trigger_id
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -228,7 +228,7 @@ impl crate::stubs::CloudBuild for CloudBuild {
                 reqwest::Method::GET,
                 format!("/v1/projects/{}/triggers", req.project_id),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -256,7 +256,7 @@ impl crate::stubs::CloudBuild for CloudBuild {
                     req.project_id, req.trigger_id
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -282,7 +282,7 @@ impl crate::stubs::CloudBuild for CloudBuild {
                     req.project_id, req.trigger_id
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -317,7 +317,7 @@ impl crate::stubs::CloudBuild for CloudBuild {
                     req.project_id, req.trigger_id
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -341,7 +341,7 @@ impl crate::stubs::CloudBuild for CloudBuild {
                     req.project_id, req.trigger
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -363,7 +363,7 @@ impl crate::stubs::CloudBuild for CloudBuild {
                 reqwest::Method::POST,
                 format!("/v1/{}/workerPools", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -384,7 +384,7 @@ impl crate::stubs::CloudBuild for CloudBuild {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -403,7 +403,7 @@ impl crate::stubs::CloudBuild for CloudBuild {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -434,7 +434,7 @@ impl crate::stubs::CloudBuild for CloudBuild {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -467,7 +467,7 @@ impl crate::stubs::CloudBuild for CloudBuild {
                 reqwest::Method::GET,
                 format!("/v1/{}/workerPools", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -488,7 +488,7 @@ impl crate::stubs::CloudBuild for CloudBuild {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -507,7 +507,7 @@ impl crate::stubs::CloudBuild for CloudBuild {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/devtools/cloudbuild/v2/src/model.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/model.rs
@@ -611,50 +611,69 @@ pub mod installation_state {
 
     /// Stage of the installation process.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Stage(std::borrow::Cow<'static, str>);
+    pub struct Stage(i32);
 
     impl Stage {
-        /// Creates a new Stage instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Stage](Stage)
-    pub mod stage {
-        use super::Stage;
-
         /// No stage specified.
-        pub const STAGE_UNSPECIFIED: Stage = Stage::new("STAGE_UNSPECIFIED");
+        pub const STAGE_UNSPECIFIED: Stage = Stage::new(0);
 
         /// Only for GitHub Enterprise. An App creation has been requested.
         /// The user needs to confirm the creation in their GitHub enterprise host.
-        pub const PENDING_CREATE_APP: Stage = Stage::new("PENDING_CREATE_APP");
+        pub const PENDING_CREATE_APP: Stage = Stage::new(1);
 
         /// User needs to authorize the GitHub (or Enterprise) App via OAuth.
-        pub const PENDING_USER_OAUTH: Stage = Stage::new("PENDING_USER_OAUTH");
+        pub const PENDING_USER_OAUTH: Stage = Stage::new(2);
 
         /// User needs to follow the link to install the GitHub (or Enterprise) App.
-        pub const PENDING_INSTALL_APP: Stage = Stage::new("PENDING_INSTALL_APP");
+        pub const PENDING_INSTALL_APP: Stage = Stage::new(3);
 
         /// Installation process has been completed.
-        pub const COMPLETE: Stage = Stage::new("COMPLETE");
+        pub const COMPLETE: Stage = Stage::new(10);
+
+        /// Creates a new Stage instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STAGE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING_CREATE_APP"),
+                2 => std::borrow::Cow::Borrowed("PENDING_USER_OAUTH"),
+                3 => std::borrow::Cow::Borrowed("PENDING_INSTALL_APP"),
+                10 => std::borrow::Cow::Borrowed("COMPLETE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STAGE_UNSPECIFIED" => std::option::Option::Some(Self::STAGE_UNSPECIFIED),
+                "PENDING_CREATE_APP" => std::option::Option::Some(Self::PENDING_CREATE_APP),
+                "PENDING_USER_OAUTH" => std::option::Option::Some(Self::PENDING_USER_OAUTH),
+                "PENDING_INSTALL_APP" => std::option::Option::Some(Self::PENDING_INSTALL_APP),
+                "COMPLETE" => std::option::Option::Some(Self::COMPLETE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Stage {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Stage {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Stage {
         fn default() -> Self {
-            stage::STAGE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2381,43 +2400,58 @@ pub mod fetch_git_refs_request {
 
     /// Type of refs
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RefType(std::borrow::Cow<'static, str>);
+    pub struct RefType(i32);
 
     impl RefType {
+        /// No type specified.
+        pub const REF_TYPE_UNSPECIFIED: RefType = RefType::new(0);
+
+        /// To fetch tags.
+        pub const TAG: RefType = RefType::new(1);
+
+        /// To fetch branches.
+        pub const BRANCH: RefType = RefType::new(2);
+
         /// Creates a new RefType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("REF_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TAG"),
+                2 => std::borrow::Cow::Borrowed("BRANCH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "REF_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::REF_TYPE_UNSPECIFIED),
+                "TAG" => std::option::Option::Some(Self::TAG),
+                "BRANCH" => std::option::Option::Some(Self::BRANCH),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RefType](RefType)
-    pub mod ref_type {
-        use super::RefType;
-
-        /// No type specified.
-        pub const REF_TYPE_UNSPECIFIED: RefType = RefType::new("REF_TYPE_UNSPECIFIED");
-
-        /// To fetch tags.
-        pub const TAG: RefType = RefType::new("TAG");
-
-        /// To fetch branches.
-        pub const BRANCH: RefType = RefType::new("BRANCH");
-    }
-
-    impl std::convert::From<std::string::String> for RefType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RefType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RefType {
         fn default() -> Self {
-            ref_type::REF_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/devtools/cloudbuild/v2/src/transport.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::RepositoryManager for RepositoryManager {
                 reqwest::Method::POST,
                 format!("/v2/{}/connections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::RepositoryManager for RepositoryManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -94,7 +94,7 @@ impl crate::stubs::RepositoryManager for RepositoryManager {
                 reqwest::Method::GET,
                 format!("/v2/{}/connections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -124,7 +124,7 @@ impl crate::stubs::RepositoryManager for RepositoryManager {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -155,7 +155,7 @@ impl crate::stubs::RepositoryManager for RepositoryManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -179,7 +179,7 @@ impl crate::stubs::RepositoryManager for RepositoryManager {
                 reqwest::Method::POST,
                 format!("/v2/{}/repositories", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -202,7 +202,7 @@ impl crate::stubs::RepositoryManager for RepositoryManager {
                 reqwest::Method::POST,
                 format!("/v2/{}/repositories:batchCreate", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -219,7 +219,7 @@ impl crate::stubs::RepositoryManager for RepositoryManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -241,7 +241,7 @@ impl crate::stubs::RepositoryManager for RepositoryManager {
                 reqwest::Method::GET,
                 format!("/v2/{}/repositories", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -263,7 +263,7 @@ impl crate::stubs::RepositoryManager for RepositoryManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -287,7 +287,7 @@ impl crate::stubs::RepositoryManager for RepositoryManager {
                 reqwest::Method::POST,
                 format!("/v2/{}:accessReadWriteToken", req.repository),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -307,7 +307,7 @@ impl crate::stubs::RepositoryManager for RepositoryManager {
                 reqwest::Method::POST,
                 format!("/v2/{}:accessReadToken", req.repository),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -327,7 +327,7 @@ impl crate::stubs::RepositoryManager for RepositoryManager {
                 reqwest::Method::GET,
                 format!("/v2/{}:fetchLinkableRepositories", req.connection),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -351,7 +351,7 @@ impl crate::stubs::RepositoryManager for RepositoryManager {
                 reqwest::Method::GET,
                 format!("/v2/{}:fetchGitRefs", req.repository),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -374,7 +374,7 @@ impl crate::stubs::RepositoryManager for RepositoryManager {
                 reqwest::Method::POST,
                 format!("/v2/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -394,7 +394,7 @@ impl crate::stubs::RepositoryManager for RepositoryManager {
                 reqwest::Method::GET,
                 format!("/v2/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -426,7 +426,7 @@ impl crate::stubs::RepositoryManager for RepositoryManager {
                 reqwest::Method::POST,
                 format!("/v2/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -443,7 +443,7 @@ impl crate::stubs::RepositoryManager for RepositoryManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -462,7 +462,7 @@ impl crate::stubs::RepositoryManager for RepositoryManager {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/devtools/cloudprofiler/v2/src/model.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/model.rs
@@ -501,45 +501,30 @@ impl gax::paginator::PageableResponse for ListProfilesResponse {
 /// NOTE: the enumeration member names are used (in lowercase) as unique string
 /// identifiers of profile types, so they must not be renamed.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ProfileType(std::borrow::Cow<'static, str>);
+pub struct ProfileType(i32);
 
 impl ProfileType {
-    /// Creates a new ProfileType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ProfileType](ProfileType)
-pub mod profile_type {
-    use super::ProfileType;
-
     /// Unspecified profile type.
-    pub const PROFILE_TYPE_UNSPECIFIED: ProfileType = ProfileType::new("PROFILE_TYPE_UNSPECIFIED");
+    pub const PROFILE_TYPE_UNSPECIFIED: ProfileType = ProfileType::new(0);
 
     /// Thread CPU time sampling.
-    pub const CPU: ProfileType = ProfileType::new("CPU");
+    pub const CPU: ProfileType = ProfileType::new(1);
 
     /// Wallclock time sampling. More expensive as stops all threads.
-    pub const WALL: ProfileType = ProfileType::new("WALL");
+    pub const WALL: ProfileType = ProfileType::new(2);
 
     /// In-use heap profile. Represents a snapshot of the allocations that are
     /// live at the time of the profiling.
-    pub const HEAP: ProfileType = ProfileType::new("HEAP");
+    pub const HEAP: ProfileType = ProfileType::new(3);
 
     /// Single-shot collection of all thread stacks.
-    pub const THREADS: ProfileType = ProfileType::new("THREADS");
+    pub const THREADS: ProfileType = ProfileType::new(4);
 
     /// Synchronization contention profile.
-    pub const CONTENTION: ProfileType = ProfileType::new("CONTENTION");
+    pub const CONTENTION: ProfileType = ProfileType::new(5);
 
     /// Peak heap profile.
-    pub const PEAK_HEAP: ProfileType = ProfileType::new("PEAK_HEAP");
+    pub const PEAK_HEAP: ProfileType = ProfileType::new(6);
 
     /// Heap allocation profile. It represents the aggregation of all allocations
     /// made over the duration of the profile. All allocations are included,
@@ -547,17 +532,57 @@ pub mod profile_type {
     /// interval. The profile is in particular useful for garbage collecting
     /// languages to understand which parts of the code create most of the garbage
     /// collection pressure to see if those can be optimized.
-    pub const HEAP_ALLOC: ProfileType = ProfileType::new("HEAP_ALLOC");
+    pub const HEAP_ALLOC: ProfileType = ProfileType::new(7);
+
+    /// Creates a new ProfileType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("PROFILE_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("CPU"),
+            2 => std::borrow::Cow::Borrowed("WALL"),
+            3 => std::borrow::Cow::Borrowed("HEAP"),
+            4 => std::borrow::Cow::Borrowed("THREADS"),
+            5 => std::borrow::Cow::Borrowed("CONTENTION"),
+            6 => std::borrow::Cow::Borrowed("PEAK_HEAP"),
+            7 => std::borrow::Cow::Borrowed("HEAP_ALLOC"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "PROFILE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::PROFILE_TYPE_UNSPECIFIED),
+            "CPU" => std::option::Option::Some(Self::CPU),
+            "WALL" => std::option::Option::Some(Self::WALL),
+            "HEAP" => std::option::Option::Some(Self::HEAP),
+            "THREADS" => std::option::Option::Some(Self::THREADS),
+            "CONTENTION" => std::option::Option::Some(Self::CONTENTION),
+            "PEAK_HEAP" => std::option::Option::Some(Self::PEAK_HEAP),
+            "HEAP_ALLOC" => std::option::Option::Some(Self::HEAP_ALLOC),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ProfileType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ProfileType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ProfileType {
     fn default() -> Self {
-        profile_type::PROFILE_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/devtools/cloudprofiler/v2/src/transport.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::ProfilerService for ProfilerService {
                 reqwest::Method::POST,
                 format!("/v2/{}/profiles", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::ProfilerService for ProfilerService {
                 reqwest::Method::POST,
                 format!("/v2/{}/profiles:createOffline", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -100,7 +100,7 @@ impl crate::stubs::ProfilerService for ProfilerService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -152,7 +152,7 @@ impl crate::stubs::ExportService for ExportService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/profiles", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/devtools/cloudtrace/v2/src/model.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/model.rs
@@ -571,43 +571,58 @@ pub mod span {
 
             /// Indicates whether the message was sent or received.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct Type(std::borrow::Cow<'static, str>);
+            pub struct Type(i32);
 
             impl Type {
+                /// Unknown event type.
+                pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+                /// Indicates a sent message.
+                pub const SENT: Type = Type::new(1);
+
+                /// Indicates a received message.
+                pub const RECEIVED: Type = Type::new(2);
+
                 /// Creates a new Type instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
                 }
 
                 /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("SENT"),
+                        2 => std::borrow::Cow::Borrowed("RECEIVED"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                        "SENT" => std::option::Option::Some(Self::SENT),
+                        "RECEIVED" => std::option::Option::Some(Self::RECEIVED),
+                        _ => std::option::Option::None,
+                    }
                 }
             }
 
-            /// Useful constants to work with [Type](Type)
-            pub mod r#type {
-                use super::Type;
-
-                /// Unknown event type.
-                pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-                /// Indicates a sent message.
-                pub const SENT: Type = Type::new("SENT");
-
-                /// Indicates a received message.
-                pub const RECEIVED: Type = Type::new("RECEIVED");
-            }
-
-            impl std::convert::From<std::string::String> for Type {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for Type {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for Type {
                 fn default() -> Self {
-                    r#type::TYPE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -763,43 +778,58 @@ pub mod span {
         /// The relationship of the current span relative to the linked span: child,
         /// parent, or unspecified.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(std::borrow::Cow<'static, str>);
+        pub struct Type(i32);
 
         impl Type {
+            /// The relationship of the two spans is unknown.
+            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+            /// The linked span is a child of the current span.
+            pub const CHILD_LINKED_SPAN: Type = Type::new(1);
+
+            /// The linked span is a parent of the current span.
+            pub const PARENT_LINKED_SPAN: Type = Type::new(2);
+
             /// Creates a new Type instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("CHILD_LINKED_SPAN"),
+                    2 => std::borrow::Cow::Borrowed("PARENT_LINKED_SPAN"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                    "CHILD_LINKED_SPAN" => std::option::Option::Some(Self::CHILD_LINKED_SPAN),
+                    "PARENT_LINKED_SPAN" => std::option::Option::Some(Self::PARENT_LINKED_SPAN),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Type](Type)
-        pub mod r#type {
-            use super::Type;
-
-            /// The relationship of the two spans is unknown.
-            pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-            /// The linked span is a child of the current span.
-            pub const CHILD_LINKED_SPAN: Type = Type::new("CHILD_LINKED_SPAN");
-
-            /// The linked span is a parent of the current span.
-            pub const PARENT_LINKED_SPAN: Type = Type::new("PARENT_LINKED_SPAN");
-        }
-
-        impl std::convert::From<std::string::String> for Type {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                r#type::TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -852,61 +882,82 @@ pub mod span {
     /// Type of span. Can be used to specify additional relationships between spans
     /// in addition to a parent/child relationship.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SpanKind(std::borrow::Cow<'static, str>);
+    pub struct SpanKind(i32);
 
     impl SpanKind {
-        /// Creates a new SpanKind instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [SpanKind](SpanKind)
-    pub mod span_kind {
-        use super::SpanKind;
-
         /// Unspecified. Do NOT use as default.
         /// Implementations MAY assume SpanKind.INTERNAL to be default.
-        pub const SPAN_KIND_UNSPECIFIED: SpanKind = SpanKind::new("SPAN_KIND_UNSPECIFIED");
+        pub const SPAN_KIND_UNSPECIFIED: SpanKind = SpanKind::new(0);
 
         /// Indicates that the span is used internally. Default value.
-        pub const INTERNAL: SpanKind = SpanKind::new("INTERNAL");
+        pub const INTERNAL: SpanKind = SpanKind::new(1);
 
         /// Indicates that the span covers server-side handling of an RPC or other
         /// remote network request.
-        pub const SERVER: SpanKind = SpanKind::new("SERVER");
+        pub const SERVER: SpanKind = SpanKind::new(2);
 
         /// Indicates that the span covers the client-side wrapper around an RPC or
         /// other remote request.
-        pub const CLIENT: SpanKind = SpanKind::new("CLIENT");
+        pub const CLIENT: SpanKind = SpanKind::new(3);
 
         /// Indicates that the span describes producer sending a message to a broker.
         /// Unlike client and  server, there is no direct critical path latency
         /// relationship between producer and consumer spans (e.g. publishing a
         /// message to a pubsub service).
-        pub const PRODUCER: SpanKind = SpanKind::new("PRODUCER");
+        pub const PRODUCER: SpanKind = SpanKind::new(4);
 
         /// Indicates that the span describes consumer receiving a message from a
         /// broker. Unlike client and  server, there is no direct critical path
         /// latency relationship between producer and consumer spans (e.g. receiving
         /// a message from a pubsub service subscription).
-        pub const CONSUMER: SpanKind = SpanKind::new("CONSUMER");
+        pub const CONSUMER: SpanKind = SpanKind::new(5);
+
+        /// Creates a new SpanKind instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SPAN_KIND_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("INTERNAL"),
+                2 => std::borrow::Cow::Borrowed("SERVER"),
+                3 => std::borrow::Cow::Borrowed("CLIENT"),
+                4 => std::borrow::Cow::Borrowed("PRODUCER"),
+                5 => std::borrow::Cow::Borrowed("CONSUMER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SPAN_KIND_UNSPECIFIED" => std::option::Option::Some(Self::SPAN_KIND_UNSPECIFIED),
+                "INTERNAL" => std::option::Option::Some(Self::INTERNAL),
+                "SERVER" => std::option::Option::Some(Self::SERVER),
+                "CLIENT" => std::option::Option::Some(Self::CLIENT),
+                "PRODUCER" => std::option::Option::Some(Self::PRODUCER),
+                "CONSUMER" => std::option::Option::Some(Self::CONSUMER),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for SpanKind {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SpanKind {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SpanKind {
         fn default() -> Self {
-            span_kind::SPAN_KIND_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/devtools/cloudtrace/v2/src/transport.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::TraceService for TraceService {
                 reqwest::Method::POST,
                 format!("/v2/{}/traces:batchWrite", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -69,7 +69,7 @@ impl crate::stubs::TraceService for TraceService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/devtools/containeranalysis/v1/src/transport.rs
+++ b/src/generated/devtools/containeranalysis/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::ContainerAnalysis for ContainerAnalysis {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::ContainerAnalysis for ContainerAnalysis {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -92,7 +92,7 @@ impl crate::stubs::ContainerAnalysis for ContainerAnalysis {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -112,7 +112,7 @@ impl crate::stubs::ContainerAnalysis for ContainerAnalysis {
                 reqwest::Method::GET,
                 format!("/v1/{}/occurrences:vulnerabilitySummary", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/firestore/admin/v1/src/model.rs
+++ b/src/generated/firestore/admin/v1/src/model.rs
@@ -198,47 +198,64 @@ pub mod backup {
 
     /// Indicate the current state of the backup.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The pending backup is still being created. Operations on the
         /// backup will be rejected in this state.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The backup is complete and ready to use.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(2);
 
         /// The backup is not available at this moment.
-        pub const NOT_AVAILABLE: State = State::new("NOT_AVAILABLE");
+        pub const NOT_AVAILABLE: State = State::new(3);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                3 => std::borrow::Cow::Borrowed("NOT_AVAILABLE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "NOT_AVAILABLE" => std::option::Option::Some(Self::NOT_AVAILABLE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -990,80 +1007,80 @@ pub mod database {
     ///
     /// Mode changes are only allowed if the database is empty.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DatabaseType(std::borrow::Cow<'static, str>);
+    pub struct DatabaseType(i32);
 
     impl DatabaseType {
+        /// Not used.
+        pub const DATABASE_TYPE_UNSPECIFIED: DatabaseType = DatabaseType::new(0);
+
+        /// Firestore Native Mode
+        pub const FIRESTORE_NATIVE: DatabaseType = DatabaseType::new(1);
+
+        /// Firestore in Datastore Mode.
+        pub const DATASTORE_MODE: DatabaseType = DatabaseType::new(2);
+
         /// Creates a new DatabaseType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATABASE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FIRESTORE_NATIVE"),
+                2 => std::borrow::Cow::Borrowed("DATASTORE_MODE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATABASE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DATABASE_TYPE_UNSPECIFIED)
+                }
+                "FIRESTORE_NATIVE" => std::option::Option::Some(Self::FIRESTORE_NATIVE),
+                "DATASTORE_MODE" => std::option::Option::Some(Self::DATASTORE_MODE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DatabaseType](DatabaseType)
-    pub mod database_type {
-        use super::DatabaseType;
-
-        /// Not used.
-        pub const DATABASE_TYPE_UNSPECIFIED: DatabaseType =
-            DatabaseType::new("DATABASE_TYPE_UNSPECIFIED");
-
-        /// Firestore Native Mode
-        pub const FIRESTORE_NATIVE: DatabaseType = DatabaseType::new("FIRESTORE_NATIVE");
-
-        /// Firestore in Datastore Mode.
-        pub const DATASTORE_MODE: DatabaseType = DatabaseType::new("DATASTORE_MODE");
-    }
-
-    impl std::convert::From<std::string::String> for DatabaseType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DatabaseType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DatabaseType {
         fn default() -> Self {
-            database_type::DATABASE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The type of concurrency control mode for transactions.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConcurrencyMode(std::borrow::Cow<'static, str>);
+    pub struct ConcurrencyMode(i32);
 
     impl ConcurrencyMode {
-        /// Creates a new ConcurrencyMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ConcurrencyMode](ConcurrencyMode)
-    pub mod concurrency_mode {
-        use super::ConcurrencyMode;
-
         /// Not used.
-        pub const CONCURRENCY_MODE_UNSPECIFIED: ConcurrencyMode =
-            ConcurrencyMode::new("CONCURRENCY_MODE_UNSPECIFIED");
+        pub const CONCURRENCY_MODE_UNSPECIFIED: ConcurrencyMode = ConcurrencyMode::new(0);
 
         /// Use optimistic concurrency control by default. This mode is available
         /// for Cloud Firestore databases.
-        pub const OPTIMISTIC: ConcurrencyMode = ConcurrencyMode::new("OPTIMISTIC");
+        pub const OPTIMISTIC: ConcurrencyMode = ConcurrencyMode::new(1);
 
         /// Use pessimistic concurrency control by default. This mode is available
         /// for Cloud Firestore databases.
         ///
         /// This is the default setting for Cloud Firestore.
-        pub const PESSIMISTIC: ConcurrencyMode = ConcurrencyMode::new("PESSIMISTIC");
+        pub const PESSIMISTIC: ConcurrencyMode = ConcurrencyMode::new(2);
 
         /// Use optimistic concurrency control with entity groups by default.
         ///
@@ -1071,45 +1088,65 @@ pub mod database {
         ///
         /// This mode is also available for Cloud Firestore with Datastore Mode but
         /// is not recommended.
-        pub const OPTIMISTIC_WITH_ENTITY_GROUPS: ConcurrencyMode =
-            ConcurrencyMode::new("OPTIMISTIC_WITH_ENTITY_GROUPS");
+        pub const OPTIMISTIC_WITH_ENTITY_GROUPS: ConcurrencyMode = ConcurrencyMode::new(3);
+
+        /// Creates a new ConcurrencyMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CONCURRENCY_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("OPTIMISTIC"),
+                2 => std::borrow::Cow::Borrowed("PESSIMISTIC"),
+                3 => std::borrow::Cow::Borrowed("OPTIMISTIC_WITH_ENTITY_GROUPS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CONCURRENCY_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CONCURRENCY_MODE_UNSPECIFIED)
+                }
+                "OPTIMISTIC" => std::option::Option::Some(Self::OPTIMISTIC),
+                "PESSIMISTIC" => std::option::Option::Some(Self::PESSIMISTIC),
+                "OPTIMISTIC_WITH_ENTITY_GROUPS" => {
+                    std::option::Option::Some(Self::OPTIMISTIC_WITH_ENTITY_GROUPS)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ConcurrencyMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ConcurrencyMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ConcurrencyMode {
         fn default() -> Self {
-            concurrency_mode::CONCURRENCY_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Point In Time Recovery feature enablement.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PointInTimeRecoveryEnablement(std::borrow::Cow<'static, str>);
+    pub struct PointInTimeRecoveryEnablement(i32);
 
     impl PointInTimeRecoveryEnablement {
-        /// Creates a new PointInTimeRecoveryEnablement instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PointInTimeRecoveryEnablement](PointInTimeRecoveryEnablement)
-    pub mod point_in_time_recovery_enablement {
-        use super::PointInTimeRecoveryEnablement;
-
         /// Not used.
         pub const POINT_IN_TIME_RECOVERY_ENABLEMENT_UNSPECIFIED: PointInTimeRecoveryEnablement =
-            PointInTimeRecoveryEnablement::new("POINT_IN_TIME_RECOVERY_ENABLEMENT_UNSPECIFIED");
+            PointInTimeRecoveryEnablement::new(0);
 
         /// Reads are supported on selected versions of the data from within the past
         /// 7 days:
@@ -1120,117 +1157,189 @@ pub mod database {
         /// `version_retention_period` and `earliest_version_time` can be
         /// used to determine the supported versions.
         pub const POINT_IN_TIME_RECOVERY_ENABLED: PointInTimeRecoveryEnablement =
-            PointInTimeRecoveryEnablement::new("POINT_IN_TIME_RECOVERY_ENABLED");
+            PointInTimeRecoveryEnablement::new(1);
 
         /// Reads are supported on any version of the data from within the past 1
         /// hour.
         pub const POINT_IN_TIME_RECOVERY_DISABLED: PointInTimeRecoveryEnablement =
-            PointInTimeRecoveryEnablement::new("POINT_IN_TIME_RECOVERY_DISABLED");
+            PointInTimeRecoveryEnablement::new(2);
+
+        /// Creates a new PointInTimeRecoveryEnablement instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("POINT_IN_TIME_RECOVERY_ENABLEMENT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("POINT_IN_TIME_RECOVERY_ENABLED"),
+                2 => std::borrow::Cow::Borrowed("POINT_IN_TIME_RECOVERY_DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "POINT_IN_TIME_RECOVERY_ENABLEMENT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::POINT_IN_TIME_RECOVERY_ENABLEMENT_UNSPECIFIED)
+                }
+                "POINT_IN_TIME_RECOVERY_ENABLED" => {
+                    std::option::Option::Some(Self::POINT_IN_TIME_RECOVERY_ENABLED)
+                }
+                "POINT_IN_TIME_RECOVERY_DISABLED" => {
+                    std::option::Option::Some(Self::POINT_IN_TIME_RECOVERY_DISABLED)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PointInTimeRecoveryEnablement {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PointInTimeRecoveryEnablement {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PointInTimeRecoveryEnablement {
         fn default() -> Self {
-            point_in_time_recovery_enablement::POINT_IN_TIME_RECOVERY_ENABLEMENT_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The type of App Engine integration mode.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AppEngineIntegrationMode(std::borrow::Cow<'static, str>);
+    pub struct AppEngineIntegrationMode(i32);
 
     impl AppEngineIntegrationMode {
-        /// Creates a new AppEngineIntegrationMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [AppEngineIntegrationMode](AppEngineIntegrationMode)
-    pub mod app_engine_integration_mode {
-        use super::AppEngineIntegrationMode;
-
         /// Not used.
         pub const APP_ENGINE_INTEGRATION_MODE_UNSPECIFIED: AppEngineIntegrationMode =
-            AppEngineIntegrationMode::new("APP_ENGINE_INTEGRATION_MODE_UNSPECIFIED");
+            AppEngineIntegrationMode::new(0);
 
         /// If an App Engine application exists in the same region as this database,
         /// App Engine configuration will impact this database. This includes
         /// disabling of the application & database, as well as disabling writes to
         /// the database.
-        pub const ENABLED: AppEngineIntegrationMode = AppEngineIntegrationMode::new("ENABLED");
+        pub const ENABLED: AppEngineIntegrationMode = AppEngineIntegrationMode::new(1);
 
         /// App Engine has no effect on the ability of this database to serve
         /// requests.
         ///
         /// This is the default setting for databases created with the Firestore API.
-        pub const DISABLED: AppEngineIntegrationMode = AppEngineIntegrationMode::new("DISABLED");
+        pub const DISABLED: AppEngineIntegrationMode = AppEngineIntegrationMode::new(2);
+
+        /// Creates a new AppEngineIntegrationMode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("APP_ENGINE_INTEGRATION_MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENABLED"),
+                2 => std::borrow::Cow::Borrowed("DISABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "APP_ENGINE_INTEGRATION_MODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::APP_ENGINE_INTEGRATION_MODE_UNSPECIFIED)
+                }
+                "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for AppEngineIntegrationMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AppEngineIntegrationMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AppEngineIntegrationMode {
         fn default() -> Self {
-            app_engine_integration_mode::APP_ENGINE_INTEGRATION_MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The delete protection state of the database.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DeleteProtectionState(std::borrow::Cow<'static, str>);
+    pub struct DeleteProtectionState(i32);
 
     impl DeleteProtectionState {
+        /// The default value. Delete protection type is not specified
+        pub const DELETE_PROTECTION_STATE_UNSPECIFIED: DeleteProtectionState =
+            DeleteProtectionState::new(0);
+
+        /// Delete protection is disabled
+        pub const DELETE_PROTECTION_DISABLED: DeleteProtectionState = DeleteProtectionState::new(1);
+
+        /// Delete protection is enabled
+        pub const DELETE_PROTECTION_ENABLED: DeleteProtectionState = DeleteProtectionState::new(2);
+
         /// Creates a new DeleteProtectionState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DELETE_PROTECTION_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DELETE_PROTECTION_DISABLED"),
+                2 => std::borrow::Cow::Borrowed("DELETE_PROTECTION_ENABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DELETE_PROTECTION_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DELETE_PROTECTION_STATE_UNSPECIFIED)
+                }
+                "DELETE_PROTECTION_DISABLED" => {
+                    std::option::Option::Some(Self::DELETE_PROTECTION_DISABLED)
+                }
+                "DELETE_PROTECTION_ENABLED" => {
+                    std::option::Option::Some(Self::DELETE_PROTECTION_ENABLED)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DeleteProtectionState](DeleteProtectionState)
-    pub mod delete_protection_state {
-        use super::DeleteProtectionState;
-
-        /// The default value. Delete protection type is not specified
-        pub const DELETE_PROTECTION_STATE_UNSPECIFIED: DeleteProtectionState =
-            DeleteProtectionState::new("DELETE_PROTECTION_STATE_UNSPECIFIED");
-
-        /// Delete protection is disabled
-        pub const DELETE_PROTECTION_DISABLED: DeleteProtectionState =
-            DeleteProtectionState::new("DELETE_PROTECTION_DISABLED");
-
-        /// Delete protection is enabled
-        pub const DELETE_PROTECTION_ENABLED: DeleteProtectionState =
-            DeleteProtectionState::new("DELETE_PROTECTION_ENABLED");
-    }
-
-    impl std::convert::From<std::string::String> for DeleteProtectionState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DeleteProtectionState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DeleteProtectionState {
         fn default() -> Self {
-            delete_protection_state::DELETE_PROTECTION_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1449,53 +1558,70 @@ pub mod field {
 
         /// The state of applying the TTL configuration to all documents.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(std::borrow::Cow<'static, str>);
+        pub struct State(i32);
 
         impl State {
-            /// Creates a new State instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [State](State)
-        pub mod state {
-            use super::State;
-
             /// The state is unspecified or unknown.
-            pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+            pub const STATE_UNSPECIFIED: State = State::new(0);
 
             /// The TTL is being applied. There is an active long-running operation to
             /// track the change. Newly written documents will have TTLs applied as
             /// requested. Requested TTLs on existing documents are still being
             /// processed. When TTLs on all existing documents have been processed, the
             /// state will move to 'ACTIVE'.
-            pub const CREATING: State = State::new("CREATING");
+            pub const CREATING: State = State::new(1);
 
             /// The TTL is active for all documents.
-            pub const ACTIVE: State = State::new("ACTIVE");
+            pub const ACTIVE: State = State::new(2);
 
             /// The TTL configuration could not be enabled for all existing documents.
             /// Newly written documents will continue to have their TTL applied.
             /// The LRO returned when last attempting to enable TTL for this `Field`
             /// has failed, and may have more details.
-            pub const NEEDS_REPAIR: State = State::new("NEEDS_REPAIR");
+            pub const NEEDS_REPAIR: State = State::new(3);
+
+            /// Creates a new State instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("CREATING"),
+                    2 => std::borrow::Cow::Borrowed("ACTIVE"),
+                    3 => std::borrow::Cow::Borrowed("NEEDS_REPAIR"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                    "CREATING" => std::option::Option::Some(Self::CREATING),
+                    "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                    "NEEDS_REPAIR" => std::option::Option::Some(Self::NEEDS_REPAIR),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for State {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                state::STATE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -3482,83 +3608,112 @@ pub mod index {
 
         /// The supported orderings.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Order(std::borrow::Cow<'static, str>);
+        pub struct Order(i32);
 
         impl Order {
+            /// The ordering is unspecified. Not a valid option.
+            pub const ORDER_UNSPECIFIED: Order = Order::new(0);
+
+            /// The field is ordered by ascending field value.
+            pub const ASCENDING: Order = Order::new(1);
+
+            /// The field is ordered by descending field value.
+            pub const DESCENDING: Order = Order::new(2);
+
             /// Creates a new Order instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("ORDER_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("ASCENDING"),
+                    2 => std::borrow::Cow::Borrowed("DESCENDING"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "ORDER_UNSPECIFIED" => std::option::Option::Some(Self::ORDER_UNSPECIFIED),
+                    "ASCENDING" => std::option::Option::Some(Self::ASCENDING),
+                    "DESCENDING" => std::option::Option::Some(Self::DESCENDING),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Order](Order)
-        pub mod order {
-            use super::Order;
-
-            /// The ordering is unspecified. Not a valid option.
-            pub const ORDER_UNSPECIFIED: Order = Order::new("ORDER_UNSPECIFIED");
-
-            /// The field is ordered by ascending field value.
-            pub const ASCENDING: Order = Order::new("ASCENDING");
-
-            /// The field is ordered by descending field value.
-            pub const DESCENDING: Order = Order::new("DESCENDING");
-        }
-
-        impl std::convert::From<std::string::String> for Order {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Order {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Order {
             fn default() -> Self {
-                order::ORDER_UNSPECIFIED
+                Self::new(0)
             }
         }
 
         /// The supported array value configurations.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ArrayConfig(std::borrow::Cow<'static, str>);
+        pub struct ArrayConfig(i32);
 
         impl ArrayConfig {
+            /// The index does not support additional array queries.
+            pub const ARRAY_CONFIG_UNSPECIFIED: ArrayConfig = ArrayConfig::new(0);
+
+            /// The index supports array containment queries.
+            pub const CONTAINS: ArrayConfig = ArrayConfig::new(1);
+
             /// Creates a new ArrayConfig instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("ARRAY_CONFIG_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("CONTAINS"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "ARRAY_CONFIG_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::ARRAY_CONFIG_UNSPECIFIED)
+                    }
+                    "CONTAINS" => std::option::Option::Some(Self::CONTAINS),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [ArrayConfig](ArrayConfig)
-        pub mod array_config {
-            use super::ArrayConfig;
-
-            /// The index does not support additional array queries.
-            pub const ARRAY_CONFIG_UNSPECIFIED: ArrayConfig =
-                ArrayConfig::new("ARRAY_CONFIG_UNSPECIFIED");
-
-            /// The index supports array containment queries.
-            pub const CONTAINS: ArrayConfig = ArrayConfig::new("CONTAINS");
-        }
-
-        impl std::convert::From<std::string::String> for ArrayConfig {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for ArrayConfig {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for ArrayConfig {
             fn default() -> Self {
-                array_config::ARRAY_CONFIG_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -3581,92 +3736,124 @@ pub mod index {
     /// Query Scope defines the scope at which a query is run. This is specified on
     /// a StructuredQuery's `from` field.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct QueryScope(std::borrow::Cow<'static, str>);
+    pub struct QueryScope(i32);
 
     impl QueryScope {
-        /// Creates a new QueryScope instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [QueryScope](QueryScope)
-    pub mod query_scope {
-        use super::QueryScope;
-
         /// The query scope is unspecified. Not a valid option.
-        pub const QUERY_SCOPE_UNSPECIFIED: QueryScope = QueryScope::new("QUERY_SCOPE_UNSPECIFIED");
+        pub const QUERY_SCOPE_UNSPECIFIED: QueryScope = QueryScope::new(0);
 
         /// Indexes with a collection query scope specified allow queries
         /// against a collection that is the child of a specific document, specified
         /// at query time, and that has the collection ID specified by the index.
-        pub const COLLECTION: QueryScope = QueryScope::new("COLLECTION");
+        pub const COLLECTION: QueryScope = QueryScope::new(1);
 
         /// Indexes with a collection group query scope specified allow queries
         /// against all collections that has the collection ID specified by the
         /// index.
-        pub const COLLECTION_GROUP: QueryScope = QueryScope::new("COLLECTION_GROUP");
+        pub const COLLECTION_GROUP: QueryScope = QueryScope::new(2);
 
         /// Include all the collections's ancestor in the index. Only available for
         /// Datastore Mode databases.
-        pub const COLLECTION_RECURSIVE: QueryScope = QueryScope::new("COLLECTION_RECURSIVE");
+        pub const COLLECTION_RECURSIVE: QueryScope = QueryScope::new(3);
+
+        /// Creates a new QueryScope instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("QUERY_SCOPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("COLLECTION"),
+                2 => std::borrow::Cow::Borrowed("COLLECTION_GROUP"),
+                3 => std::borrow::Cow::Borrowed("COLLECTION_RECURSIVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "QUERY_SCOPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::QUERY_SCOPE_UNSPECIFIED)
+                }
+                "COLLECTION" => std::option::Option::Some(Self::COLLECTION),
+                "COLLECTION_GROUP" => std::option::Option::Some(Self::COLLECTION_GROUP),
+                "COLLECTION_RECURSIVE" => std::option::Option::Some(Self::COLLECTION_RECURSIVE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for QueryScope {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for QueryScope {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for QueryScope {
         fn default() -> Self {
-            query_scope::QUERY_SCOPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// API Scope defines the APIs (Firestore Native, or Firestore in
     /// Datastore Mode) that are supported for queries.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ApiScope(std::borrow::Cow<'static, str>);
+    pub struct ApiScope(i32);
 
     impl ApiScope {
+        /// The index can only be used by the Firestore Native query API.
+        /// This is the default.
+        pub const ANY_API: ApiScope = ApiScope::new(0);
+
+        /// The index can only be used by the Firestore in Datastore Mode query API.
+        pub const DATASTORE_MODE_API: ApiScope = ApiScope::new(1);
+
         /// Creates a new ApiScope instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ANY_API"),
+                1 => std::borrow::Cow::Borrowed("DATASTORE_MODE_API"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ANY_API" => std::option::Option::Some(Self::ANY_API),
+                "DATASTORE_MODE_API" => std::option::Option::Some(Self::DATASTORE_MODE_API),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ApiScope](ApiScope)
-    pub mod api_scope {
-        use super::ApiScope;
-
-        /// The index can only be used by the Firestore Native query API.
-        /// This is the default.
-        pub const ANY_API: ApiScope = ApiScope::new("ANY_API");
-
-        /// The index can only be used by the Firestore in Datastore Mode query API.
-        pub const DATASTORE_MODE_API: ApiScope = ApiScope::new("DATASTORE_MODE_API");
-    }
-
-    impl std::convert::From<std::string::String> for ApiScope {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ApiScope {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ApiScope {
         fn default() -> Self {
-            api_scope::ANY_API
+            Self::new(0)
         }
     }
 
@@ -3675,37 +3862,22 @@ pub mod index {
     /// to the `READY` state. If the index creation encounters a problem, the index
     /// will transition to the `NEEDS_REPAIR` state.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// The state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The index is being created.
         /// There is an active long-running operation for the index.
         /// The index is updated when writing a document.
         /// Some index data may exist.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The index is ready to be used.
         /// The index is updated when writing a document.
         /// The index is fully populated from all stored documents it applies to.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(2);
 
         /// The index was being created, but something went wrong.
         /// There is no active long-running operation for the index,
@@ -3715,18 +3887,50 @@ pub mod index {
         /// Use the google.longrunning.Operations API to determine why the operation
         /// that last attempted to create this index failed, then re-create the
         /// index.
-        pub const NEEDS_REPAIR: State = State::new("NEEDS_REPAIR");
+        pub const NEEDS_REPAIR: State = State::new(3);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                3 => std::borrow::Cow::Borrowed("NEEDS_REPAIR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "NEEDS_REPAIR" => std::option::Option::Some(Self::NEEDS_REPAIR),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4053,44 +4257,60 @@ pub mod field_operation_metadata {
 
         /// Specifies how the index is changing.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ChangeType(std::borrow::Cow<'static, str>);
+        pub struct ChangeType(i32);
 
         impl ChangeType {
+            /// The type of change is not specified or known.
+            pub const CHANGE_TYPE_UNSPECIFIED: ChangeType = ChangeType::new(0);
+
+            /// The single field index is being added.
+            pub const ADD: ChangeType = ChangeType::new(1);
+
+            /// The single field index is being removed.
+            pub const REMOVE: ChangeType = ChangeType::new(2);
+
             /// Creates a new ChangeType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("CHANGE_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("ADD"),
+                    2 => std::borrow::Cow::Borrowed("REMOVE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "CHANGE_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::CHANGE_TYPE_UNSPECIFIED)
+                    }
+                    "ADD" => std::option::Option::Some(Self::ADD),
+                    "REMOVE" => std::option::Option::Some(Self::REMOVE),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [ChangeType](ChangeType)
-        pub mod change_type {
-            use super::ChangeType;
-
-            /// The type of change is not specified or known.
-            pub const CHANGE_TYPE_UNSPECIFIED: ChangeType =
-                ChangeType::new("CHANGE_TYPE_UNSPECIFIED");
-
-            /// The single field index is being added.
-            pub const ADD: ChangeType = ChangeType::new("ADD");
-
-            /// The single field index is being removed.
-            pub const REMOVE: ChangeType = ChangeType::new("REMOVE");
-        }
-
-        impl std::convert::From<std::string::String> for ChangeType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for ChangeType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for ChangeType {
             fn default() -> Self {
-                change_type::CHANGE_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -4137,44 +4357,60 @@ pub mod field_operation_metadata {
 
         /// Specifies how the TTL config is changing.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ChangeType(std::borrow::Cow<'static, str>);
+        pub struct ChangeType(i32);
 
         impl ChangeType {
+            /// The type of change is not specified or known.
+            pub const CHANGE_TYPE_UNSPECIFIED: ChangeType = ChangeType::new(0);
+
+            /// The TTL config is being added.
+            pub const ADD: ChangeType = ChangeType::new(1);
+
+            /// The TTL config is being removed.
+            pub const REMOVE: ChangeType = ChangeType::new(2);
+
             /// Creates a new ChangeType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("CHANGE_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("ADD"),
+                    2 => std::borrow::Cow::Borrowed("REMOVE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "CHANGE_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::CHANGE_TYPE_UNSPECIFIED)
+                    }
+                    "ADD" => std::option::Option::Some(Self::ADD),
+                    "REMOVE" => std::option::Option::Some(Self::REMOVE),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [ChangeType](ChangeType)
-        pub mod change_type {
-            use super::ChangeType;
-
-            /// The type of change is not specified or known.
-            pub const CHANGE_TYPE_UNSPECIFIED: ChangeType =
-                ChangeType::new("CHANGE_TYPE_UNSPECIFIED");
-
-            /// The TTL config is being added.
-            pub const ADD: ChangeType = ChangeType::new("ADD");
-
-            /// The TTL config is being removed.
-            pub const REMOVE: ChangeType = ChangeType::new("REMOVE");
-        }
-
-        impl std::convert::From<std::string::String> for ChangeType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for ChangeType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for ChangeType {
             fn default() -> Self {
-                change_type::CHANGE_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -5017,60 +5253,86 @@ impl wkt::message::Message for WeeklyRecurrence {
 
 /// Describes the state of the operation.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OperationState(std::borrow::Cow<'static, str>);
+pub struct OperationState(i32);
 
 impl OperationState {
-    /// Creates a new OperationState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [OperationState](OperationState)
-pub mod operation_state {
-    use super::OperationState;
-
     /// Unspecified.
-    pub const OPERATION_STATE_UNSPECIFIED: OperationState =
-        OperationState::new("OPERATION_STATE_UNSPECIFIED");
+    pub const OPERATION_STATE_UNSPECIFIED: OperationState = OperationState::new(0);
 
     /// Request is being prepared for processing.
-    pub const INITIALIZING: OperationState = OperationState::new("INITIALIZING");
+    pub const INITIALIZING: OperationState = OperationState::new(1);
 
     /// Request is actively being processed.
-    pub const PROCESSING: OperationState = OperationState::new("PROCESSING");
+    pub const PROCESSING: OperationState = OperationState::new(2);
 
     /// Request is in the process of being cancelled after user called
     /// google.longrunning.Operations.CancelOperation on the operation.
-    pub const CANCELLING: OperationState = OperationState::new("CANCELLING");
+    pub const CANCELLING: OperationState = OperationState::new(3);
 
     /// Request has been processed and is in its finalization stage.
-    pub const FINALIZING: OperationState = OperationState::new("FINALIZING");
+    pub const FINALIZING: OperationState = OperationState::new(4);
 
     /// Request has completed successfully.
-    pub const SUCCESSFUL: OperationState = OperationState::new("SUCCESSFUL");
+    pub const SUCCESSFUL: OperationState = OperationState::new(5);
 
     /// Request has finished being processed, but encountered an error.
-    pub const FAILED: OperationState = OperationState::new("FAILED");
+    pub const FAILED: OperationState = OperationState::new(6);
 
     /// Request has finished being cancelled after user called
     /// google.longrunning.Operations.CancelOperation.
-    pub const CANCELLED: OperationState = OperationState::new("CANCELLED");
+    pub const CANCELLED: OperationState = OperationState::new(7);
+
+    /// Creates a new OperationState instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("OPERATION_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("INITIALIZING"),
+            2 => std::borrow::Cow::Borrowed("PROCESSING"),
+            3 => std::borrow::Cow::Borrowed("CANCELLING"),
+            4 => std::borrow::Cow::Borrowed("FINALIZING"),
+            5 => std::borrow::Cow::Borrowed("SUCCESSFUL"),
+            6 => std::borrow::Cow::Borrowed("FAILED"),
+            7 => std::borrow::Cow::Borrowed("CANCELLED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "OPERATION_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::OPERATION_STATE_UNSPECIFIED)
+            }
+            "INITIALIZING" => std::option::Option::Some(Self::INITIALIZING),
+            "PROCESSING" => std::option::Option::Some(Self::PROCESSING),
+            "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
+            "FINALIZING" => std::option::Option::Some(Self::FINALIZING),
+            "SUCCESSFUL" => std::option::Option::Some(Self::SUCCESSFUL),
+            "FAILED" => std::option::Option::Some(Self::FAILED),
+            "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for OperationState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for OperationState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for OperationState {
     fn default() -> Self {
-        operation_state::OPERATION_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/firestore/admin/v1/src/transport.rs
+++ b/src/generated/firestore/admin/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/indexes", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -66,7 +66,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/indexes", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -88,7 +88,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -107,7 +107,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -126,7 +126,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -154,7 +154,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -181,7 +181,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/fields", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -206,7 +206,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}:exportDocuments", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -226,7 +226,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}:importDocuments", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -246,7 +246,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}:bulkDeleteDocuments", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -266,7 +266,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}/databases", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -286,7 +286,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -308,7 +308,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
                 reqwest::Method::GET,
                 format!("/v1/{}/databases", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -337,7 +337,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -366,7 +366,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -386,7 +386,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -405,7 +405,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/backups", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -425,7 +425,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -447,7 +447,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}/databases:restore", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -467,7 +467,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}/backupSchedules", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -486,7 +486,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -508,7 +508,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
                 reqwest::Method::GET,
                 format!("/v1/{}/backupSchedules", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -536,7 +536,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -565,7 +565,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -584,7 +584,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -606,7 +606,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -625,7 +625,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -644,7 +644,7 @@ impl crate::stubs::FirestoreAdmin for FirestoreAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/grafeas/v1/src/model.rs
+++ b/src/generated/grafeas/v1/src/model.rs
@@ -1228,251 +1228,352 @@ pub mod cvs_sv_3 {
     use super::*;
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AttackVector(std::borrow::Cow<'static, str>);
+    pub struct AttackVector(i32);
 
     impl AttackVector {
+        pub const ATTACK_VECTOR_UNSPECIFIED: AttackVector = AttackVector::new(0);
+
+        pub const ATTACK_VECTOR_NETWORK: AttackVector = AttackVector::new(1);
+
+        pub const ATTACK_VECTOR_ADJACENT: AttackVector = AttackVector::new(2);
+
+        pub const ATTACK_VECTOR_LOCAL: AttackVector = AttackVector::new(3);
+
+        pub const ATTACK_VECTOR_PHYSICAL: AttackVector = AttackVector::new(4);
+
         /// Creates a new AttackVector instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_NETWORK"),
+                2 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_ADJACENT"),
+                3 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_LOCAL"),
+                4 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_PHYSICAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ATTACK_VECTOR_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ATTACK_VECTOR_UNSPECIFIED)
+                }
+                "ATTACK_VECTOR_NETWORK" => std::option::Option::Some(Self::ATTACK_VECTOR_NETWORK),
+                "ATTACK_VECTOR_ADJACENT" => std::option::Option::Some(Self::ATTACK_VECTOR_ADJACENT),
+                "ATTACK_VECTOR_LOCAL" => std::option::Option::Some(Self::ATTACK_VECTOR_LOCAL),
+                "ATTACK_VECTOR_PHYSICAL" => std::option::Option::Some(Self::ATTACK_VECTOR_PHYSICAL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AttackVector](AttackVector)
-    pub mod attack_vector {
-        use super::AttackVector;
-
-        pub const ATTACK_VECTOR_UNSPECIFIED: AttackVector =
-            AttackVector::new("ATTACK_VECTOR_UNSPECIFIED");
-
-        pub const ATTACK_VECTOR_NETWORK: AttackVector = AttackVector::new("ATTACK_VECTOR_NETWORK");
-
-        pub const ATTACK_VECTOR_ADJACENT: AttackVector =
-            AttackVector::new("ATTACK_VECTOR_ADJACENT");
-
-        pub const ATTACK_VECTOR_LOCAL: AttackVector = AttackVector::new("ATTACK_VECTOR_LOCAL");
-
-        pub const ATTACK_VECTOR_PHYSICAL: AttackVector =
-            AttackVector::new("ATTACK_VECTOR_PHYSICAL");
-    }
-
-    impl std::convert::From<std::string::String> for AttackVector {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AttackVector {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AttackVector {
         fn default() -> Self {
-            attack_vector::ATTACK_VECTOR_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AttackComplexity(std::borrow::Cow<'static, str>);
+    pub struct AttackComplexity(i32);
 
     impl AttackComplexity {
+        pub const ATTACK_COMPLEXITY_UNSPECIFIED: AttackComplexity = AttackComplexity::new(0);
+
+        pub const ATTACK_COMPLEXITY_LOW: AttackComplexity = AttackComplexity::new(1);
+
+        pub const ATTACK_COMPLEXITY_HIGH: AttackComplexity = AttackComplexity::new(2);
+
         /// Creates a new AttackComplexity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_LOW"),
+                2 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_HIGH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ATTACK_COMPLEXITY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ATTACK_COMPLEXITY_UNSPECIFIED)
+                }
+                "ATTACK_COMPLEXITY_LOW" => std::option::Option::Some(Self::ATTACK_COMPLEXITY_LOW),
+                "ATTACK_COMPLEXITY_HIGH" => std::option::Option::Some(Self::ATTACK_COMPLEXITY_HIGH),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AttackComplexity](AttackComplexity)
-    pub mod attack_complexity {
-        use super::AttackComplexity;
-
-        pub const ATTACK_COMPLEXITY_UNSPECIFIED: AttackComplexity =
-            AttackComplexity::new("ATTACK_COMPLEXITY_UNSPECIFIED");
-
-        pub const ATTACK_COMPLEXITY_LOW: AttackComplexity =
-            AttackComplexity::new("ATTACK_COMPLEXITY_LOW");
-
-        pub const ATTACK_COMPLEXITY_HIGH: AttackComplexity =
-            AttackComplexity::new("ATTACK_COMPLEXITY_HIGH");
-    }
-
-    impl std::convert::From<std::string::String> for AttackComplexity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AttackComplexity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AttackComplexity {
         fn default() -> Self {
-            attack_complexity::ATTACK_COMPLEXITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PrivilegesRequired(std::borrow::Cow<'static, str>);
+    pub struct PrivilegesRequired(i32);
 
     impl PrivilegesRequired {
+        pub const PRIVILEGES_REQUIRED_UNSPECIFIED: PrivilegesRequired = PrivilegesRequired::new(0);
+
+        pub const PRIVILEGES_REQUIRED_NONE: PrivilegesRequired = PrivilegesRequired::new(1);
+
+        pub const PRIVILEGES_REQUIRED_LOW: PrivilegesRequired = PrivilegesRequired::new(2);
+
+        pub const PRIVILEGES_REQUIRED_HIGH: PrivilegesRequired = PrivilegesRequired::new(3);
+
         /// Creates a new PrivilegesRequired instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_NONE"),
+                2 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_LOW"),
+                3 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_HIGH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PRIVILEGES_REQUIRED_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_UNSPECIFIED)
+                }
+                "PRIVILEGES_REQUIRED_NONE" => {
+                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_NONE)
+                }
+                "PRIVILEGES_REQUIRED_LOW" => {
+                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_LOW)
+                }
+                "PRIVILEGES_REQUIRED_HIGH" => {
+                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_HIGH)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [PrivilegesRequired](PrivilegesRequired)
-    pub mod privileges_required {
-        use super::PrivilegesRequired;
-
-        pub const PRIVILEGES_REQUIRED_UNSPECIFIED: PrivilegesRequired =
-            PrivilegesRequired::new("PRIVILEGES_REQUIRED_UNSPECIFIED");
-
-        pub const PRIVILEGES_REQUIRED_NONE: PrivilegesRequired =
-            PrivilegesRequired::new("PRIVILEGES_REQUIRED_NONE");
-
-        pub const PRIVILEGES_REQUIRED_LOW: PrivilegesRequired =
-            PrivilegesRequired::new("PRIVILEGES_REQUIRED_LOW");
-
-        pub const PRIVILEGES_REQUIRED_HIGH: PrivilegesRequired =
-            PrivilegesRequired::new("PRIVILEGES_REQUIRED_HIGH");
-    }
-
-    impl std::convert::From<std::string::String> for PrivilegesRequired {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PrivilegesRequired {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PrivilegesRequired {
         fn default() -> Self {
-            privileges_required::PRIVILEGES_REQUIRED_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct UserInteraction(std::borrow::Cow<'static, str>);
+    pub struct UserInteraction(i32);
 
     impl UserInteraction {
+        pub const USER_INTERACTION_UNSPECIFIED: UserInteraction = UserInteraction::new(0);
+
+        pub const USER_INTERACTION_NONE: UserInteraction = UserInteraction::new(1);
+
+        pub const USER_INTERACTION_REQUIRED: UserInteraction = UserInteraction::new(2);
+
         /// Creates a new UserInteraction instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("USER_INTERACTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("USER_INTERACTION_NONE"),
+                2 => std::borrow::Cow::Borrowed("USER_INTERACTION_REQUIRED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "USER_INTERACTION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::USER_INTERACTION_UNSPECIFIED)
+                }
+                "USER_INTERACTION_NONE" => std::option::Option::Some(Self::USER_INTERACTION_NONE),
+                "USER_INTERACTION_REQUIRED" => {
+                    std::option::Option::Some(Self::USER_INTERACTION_REQUIRED)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [UserInteraction](UserInteraction)
-    pub mod user_interaction {
-        use super::UserInteraction;
-
-        pub const USER_INTERACTION_UNSPECIFIED: UserInteraction =
-            UserInteraction::new("USER_INTERACTION_UNSPECIFIED");
-
-        pub const USER_INTERACTION_NONE: UserInteraction =
-            UserInteraction::new("USER_INTERACTION_NONE");
-
-        pub const USER_INTERACTION_REQUIRED: UserInteraction =
-            UserInteraction::new("USER_INTERACTION_REQUIRED");
-    }
-
-    impl std::convert::From<std::string::String> for UserInteraction {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for UserInteraction {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for UserInteraction {
         fn default() -> Self {
-            user_interaction::USER_INTERACTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Scope(std::borrow::Cow<'static, str>);
+    pub struct Scope(i32);
 
     impl Scope {
+        pub const SCOPE_UNSPECIFIED: Scope = Scope::new(0);
+
+        pub const SCOPE_UNCHANGED: Scope = Scope::new(1);
+
+        pub const SCOPE_CHANGED: Scope = Scope::new(2);
+
         /// Creates a new Scope instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SCOPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SCOPE_UNCHANGED"),
+                2 => std::borrow::Cow::Borrowed("SCOPE_CHANGED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SCOPE_UNSPECIFIED" => std::option::Option::Some(Self::SCOPE_UNSPECIFIED),
+                "SCOPE_UNCHANGED" => std::option::Option::Some(Self::SCOPE_UNCHANGED),
+                "SCOPE_CHANGED" => std::option::Option::Some(Self::SCOPE_CHANGED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Scope](Scope)
-    pub mod scope {
-        use super::Scope;
-
-        pub const SCOPE_UNSPECIFIED: Scope = Scope::new("SCOPE_UNSPECIFIED");
-
-        pub const SCOPE_UNCHANGED: Scope = Scope::new("SCOPE_UNCHANGED");
-
-        pub const SCOPE_CHANGED: Scope = Scope::new("SCOPE_CHANGED");
-    }
-
-    impl std::convert::From<std::string::String> for Scope {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Scope {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Scope {
         fn default() -> Self {
-            scope::SCOPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Impact(std::borrow::Cow<'static, str>);
+    pub struct Impact(i32);
 
     impl Impact {
+        pub const IMPACT_UNSPECIFIED: Impact = Impact::new(0);
+
+        pub const IMPACT_HIGH: Impact = Impact::new(1);
+
+        pub const IMPACT_LOW: Impact = Impact::new(2);
+
+        pub const IMPACT_NONE: Impact = Impact::new(3);
+
         /// Creates a new Impact instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("IMPACT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IMPACT_HIGH"),
+                2 => std::borrow::Cow::Borrowed("IMPACT_LOW"),
+                3 => std::borrow::Cow::Borrowed("IMPACT_NONE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "IMPACT_UNSPECIFIED" => std::option::Option::Some(Self::IMPACT_UNSPECIFIED),
+                "IMPACT_HIGH" => std::option::Option::Some(Self::IMPACT_HIGH),
+                "IMPACT_LOW" => std::option::Option::Some(Self::IMPACT_LOW),
+                "IMPACT_NONE" => std::option::Option::Some(Self::IMPACT_NONE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Impact](Impact)
-    pub mod impact {
-        use super::Impact;
-
-        pub const IMPACT_UNSPECIFIED: Impact = Impact::new("IMPACT_UNSPECIFIED");
-
-        pub const IMPACT_HIGH: Impact = Impact::new("IMPACT_HIGH");
-
-        pub const IMPACT_LOW: Impact = Impact::new("IMPACT_LOW");
-
-        pub const IMPACT_NONE: Impact = Impact::new("IMPACT_NONE");
-    }
-
-    impl std::convert::From<std::string::String> for Impact {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Impact {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Impact {
         fn default() -> Self {
-            impact::IMPACT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1631,301 +1732,427 @@ pub mod cvss {
     use super::*;
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AttackVector(std::borrow::Cow<'static, str>);
+    pub struct AttackVector(i32);
 
     impl AttackVector {
+        pub const ATTACK_VECTOR_UNSPECIFIED: AttackVector = AttackVector::new(0);
+
+        pub const ATTACK_VECTOR_NETWORK: AttackVector = AttackVector::new(1);
+
+        pub const ATTACK_VECTOR_ADJACENT: AttackVector = AttackVector::new(2);
+
+        pub const ATTACK_VECTOR_LOCAL: AttackVector = AttackVector::new(3);
+
+        pub const ATTACK_VECTOR_PHYSICAL: AttackVector = AttackVector::new(4);
+
         /// Creates a new AttackVector instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_NETWORK"),
+                2 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_ADJACENT"),
+                3 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_LOCAL"),
+                4 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_PHYSICAL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ATTACK_VECTOR_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ATTACK_VECTOR_UNSPECIFIED)
+                }
+                "ATTACK_VECTOR_NETWORK" => std::option::Option::Some(Self::ATTACK_VECTOR_NETWORK),
+                "ATTACK_VECTOR_ADJACENT" => std::option::Option::Some(Self::ATTACK_VECTOR_ADJACENT),
+                "ATTACK_VECTOR_LOCAL" => std::option::Option::Some(Self::ATTACK_VECTOR_LOCAL),
+                "ATTACK_VECTOR_PHYSICAL" => std::option::Option::Some(Self::ATTACK_VECTOR_PHYSICAL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AttackVector](AttackVector)
-    pub mod attack_vector {
-        use super::AttackVector;
-
-        pub const ATTACK_VECTOR_UNSPECIFIED: AttackVector =
-            AttackVector::new("ATTACK_VECTOR_UNSPECIFIED");
-
-        pub const ATTACK_VECTOR_NETWORK: AttackVector = AttackVector::new("ATTACK_VECTOR_NETWORK");
-
-        pub const ATTACK_VECTOR_ADJACENT: AttackVector =
-            AttackVector::new("ATTACK_VECTOR_ADJACENT");
-
-        pub const ATTACK_VECTOR_LOCAL: AttackVector = AttackVector::new("ATTACK_VECTOR_LOCAL");
-
-        pub const ATTACK_VECTOR_PHYSICAL: AttackVector =
-            AttackVector::new("ATTACK_VECTOR_PHYSICAL");
-    }
-
-    impl std::convert::From<std::string::String> for AttackVector {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AttackVector {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AttackVector {
         fn default() -> Self {
-            attack_vector::ATTACK_VECTOR_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AttackComplexity(std::borrow::Cow<'static, str>);
+    pub struct AttackComplexity(i32);
 
     impl AttackComplexity {
+        pub const ATTACK_COMPLEXITY_UNSPECIFIED: AttackComplexity = AttackComplexity::new(0);
+
+        pub const ATTACK_COMPLEXITY_LOW: AttackComplexity = AttackComplexity::new(1);
+
+        pub const ATTACK_COMPLEXITY_HIGH: AttackComplexity = AttackComplexity::new(2);
+
+        pub const ATTACK_COMPLEXITY_MEDIUM: AttackComplexity = AttackComplexity::new(3);
+
         /// Creates a new AttackComplexity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_LOW"),
+                2 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_HIGH"),
+                3 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_MEDIUM"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ATTACK_COMPLEXITY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ATTACK_COMPLEXITY_UNSPECIFIED)
+                }
+                "ATTACK_COMPLEXITY_LOW" => std::option::Option::Some(Self::ATTACK_COMPLEXITY_LOW),
+                "ATTACK_COMPLEXITY_HIGH" => std::option::Option::Some(Self::ATTACK_COMPLEXITY_HIGH),
+                "ATTACK_COMPLEXITY_MEDIUM" => {
+                    std::option::Option::Some(Self::ATTACK_COMPLEXITY_MEDIUM)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AttackComplexity](AttackComplexity)
-    pub mod attack_complexity {
-        use super::AttackComplexity;
-
-        pub const ATTACK_COMPLEXITY_UNSPECIFIED: AttackComplexity =
-            AttackComplexity::new("ATTACK_COMPLEXITY_UNSPECIFIED");
-
-        pub const ATTACK_COMPLEXITY_LOW: AttackComplexity =
-            AttackComplexity::new("ATTACK_COMPLEXITY_LOW");
-
-        pub const ATTACK_COMPLEXITY_HIGH: AttackComplexity =
-            AttackComplexity::new("ATTACK_COMPLEXITY_HIGH");
-
-        pub const ATTACK_COMPLEXITY_MEDIUM: AttackComplexity =
-            AttackComplexity::new("ATTACK_COMPLEXITY_MEDIUM");
-    }
-
-    impl std::convert::From<std::string::String> for AttackComplexity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AttackComplexity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AttackComplexity {
         fn default() -> Self {
-            attack_complexity::ATTACK_COMPLEXITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Authentication(std::borrow::Cow<'static, str>);
+    pub struct Authentication(i32);
 
     impl Authentication {
+        pub const AUTHENTICATION_UNSPECIFIED: Authentication = Authentication::new(0);
+
+        pub const AUTHENTICATION_MULTIPLE: Authentication = Authentication::new(1);
+
+        pub const AUTHENTICATION_SINGLE: Authentication = Authentication::new(2);
+
+        pub const AUTHENTICATION_NONE: Authentication = Authentication::new(3);
+
         /// Creates a new Authentication instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("AUTHENTICATION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AUTHENTICATION_MULTIPLE"),
+                2 => std::borrow::Cow::Borrowed("AUTHENTICATION_SINGLE"),
+                3 => std::borrow::Cow::Borrowed("AUTHENTICATION_NONE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "AUTHENTICATION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::AUTHENTICATION_UNSPECIFIED)
+                }
+                "AUTHENTICATION_MULTIPLE" => {
+                    std::option::Option::Some(Self::AUTHENTICATION_MULTIPLE)
+                }
+                "AUTHENTICATION_SINGLE" => std::option::Option::Some(Self::AUTHENTICATION_SINGLE),
+                "AUTHENTICATION_NONE" => std::option::Option::Some(Self::AUTHENTICATION_NONE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Authentication](Authentication)
-    pub mod authentication {
-        use super::Authentication;
-
-        pub const AUTHENTICATION_UNSPECIFIED: Authentication =
-            Authentication::new("AUTHENTICATION_UNSPECIFIED");
-
-        pub const AUTHENTICATION_MULTIPLE: Authentication =
-            Authentication::new("AUTHENTICATION_MULTIPLE");
-
-        pub const AUTHENTICATION_SINGLE: Authentication =
-            Authentication::new("AUTHENTICATION_SINGLE");
-
-        pub const AUTHENTICATION_NONE: Authentication = Authentication::new("AUTHENTICATION_NONE");
-    }
-
-    impl std::convert::From<std::string::String> for Authentication {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Authentication {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Authentication {
         fn default() -> Self {
-            authentication::AUTHENTICATION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PrivilegesRequired(std::borrow::Cow<'static, str>);
+    pub struct PrivilegesRequired(i32);
 
     impl PrivilegesRequired {
+        pub const PRIVILEGES_REQUIRED_UNSPECIFIED: PrivilegesRequired = PrivilegesRequired::new(0);
+
+        pub const PRIVILEGES_REQUIRED_NONE: PrivilegesRequired = PrivilegesRequired::new(1);
+
+        pub const PRIVILEGES_REQUIRED_LOW: PrivilegesRequired = PrivilegesRequired::new(2);
+
+        pub const PRIVILEGES_REQUIRED_HIGH: PrivilegesRequired = PrivilegesRequired::new(3);
+
         /// Creates a new PrivilegesRequired instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_NONE"),
+                2 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_LOW"),
+                3 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_HIGH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PRIVILEGES_REQUIRED_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_UNSPECIFIED)
+                }
+                "PRIVILEGES_REQUIRED_NONE" => {
+                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_NONE)
+                }
+                "PRIVILEGES_REQUIRED_LOW" => {
+                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_LOW)
+                }
+                "PRIVILEGES_REQUIRED_HIGH" => {
+                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_HIGH)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [PrivilegesRequired](PrivilegesRequired)
-    pub mod privileges_required {
-        use super::PrivilegesRequired;
-
-        pub const PRIVILEGES_REQUIRED_UNSPECIFIED: PrivilegesRequired =
-            PrivilegesRequired::new("PRIVILEGES_REQUIRED_UNSPECIFIED");
-
-        pub const PRIVILEGES_REQUIRED_NONE: PrivilegesRequired =
-            PrivilegesRequired::new("PRIVILEGES_REQUIRED_NONE");
-
-        pub const PRIVILEGES_REQUIRED_LOW: PrivilegesRequired =
-            PrivilegesRequired::new("PRIVILEGES_REQUIRED_LOW");
-
-        pub const PRIVILEGES_REQUIRED_HIGH: PrivilegesRequired =
-            PrivilegesRequired::new("PRIVILEGES_REQUIRED_HIGH");
-    }
-
-    impl std::convert::From<std::string::String> for PrivilegesRequired {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PrivilegesRequired {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PrivilegesRequired {
         fn default() -> Self {
-            privileges_required::PRIVILEGES_REQUIRED_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct UserInteraction(std::borrow::Cow<'static, str>);
+    pub struct UserInteraction(i32);
 
     impl UserInteraction {
+        pub const USER_INTERACTION_UNSPECIFIED: UserInteraction = UserInteraction::new(0);
+
+        pub const USER_INTERACTION_NONE: UserInteraction = UserInteraction::new(1);
+
+        pub const USER_INTERACTION_REQUIRED: UserInteraction = UserInteraction::new(2);
+
         /// Creates a new UserInteraction instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("USER_INTERACTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("USER_INTERACTION_NONE"),
+                2 => std::borrow::Cow::Borrowed("USER_INTERACTION_REQUIRED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "USER_INTERACTION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::USER_INTERACTION_UNSPECIFIED)
+                }
+                "USER_INTERACTION_NONE" => std::option::Option::Some(Self::USER_INTERACTION_NONE),
+                "USER_INTERACTION_REQUIRED" => {
+                    std::option::Option::Some(Self::USER_INTERACTION_REQUIRED)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [UserInteraction](UserInteraction)
-    pub mod user_interaction {
-        use super::UserInteraction;
-
-        pub const USER_INTERACTION_UNSPECIFIED: UserInteraction =
-            UserInteraction::new("USER_INTERACTION_UNSPECIFIED");
-
-        pub const USER_INTERACTION_NONE: UserInteraction =
-            UserInteraction::new("USER_INTERACTION_NONE");
-
-        pub const USER_INTERACTION_REQUIRED: UserInteraction =
-            UserInteraction::new("USER_INTERACTION_REQUIRED");
-    }
-
-    impl std::convert::From<std::string::String> for UserInteraction {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for UserInteraction {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for UserInteraction {
         fn default() -> Self {
-            user_interaction::USER_INTERACTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Scope(std::borrow::Cow<'static, str>);
+    pub struct Scope(i32);
 
     impl Scope {
+        pub const SCOPE_UNSPECIFIED: Scope = Scope::new(0);
+
+        pub const SCOPE_UNCHANGED: Scope = Scope::new(1);
+
+        pub const SCOPE_CHANGED: Scope = Scope::new(2);
+
         /// Creates a new Scope instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SCOPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SCOPE_UNCHANGED"),
+                2 => std::borrow::Cow::Borrowed("SCOPE_CHANGED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SCOPE_UNSPECIFIED" => std::option::Option::Some(Self::SCOPE_UNSPECIFIED),
+                "SCOPE_UNCHANGED" => std::option::Option::Some(Self::SCOPE_UNCHANGED),
+                "SCOPE_CHANGED" => std::option::Option::Some(Self::SCOPE_CHANGED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Scope](Scope)
-    pub mod scope {
-        use super::Scope;
-
-        pub const SCOPE_UNSPECIFIED: Scope = Scope::new("SCOPE_UNSPECIFIED");
-
-        pub const SCOPE_UNCHANGED: Scope = Scope::new("SCOPE_UNCHANGED");
-
-        pub const SCOPE_CHANGED: Scope = Scope::new("SCOPE_CHANGED");
-    }
-
-    impl std::convert::From<std::string::String> for Scope {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Scope {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Scope {
         fn default() -> Self {
-            scope::SCOPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Impact(std::borrow::Cow<'static, str>);
+    pub struct Impact(i32);
 
     impl Impact {
+        pub const IMPACT_UNSPECIFIED: Impact = Impact::new(0);
+
+        pub const IMPACT_HIGH: Impact = Impact::new(1);
+
+        pub const IMPACT_LOW: Impact = Impact::new(2);
+
+        pub const IMPACT_NONE: Impact = Impact::new(3);
+
+        pub const IMPACT_PARTIAL: Impact = Impact::new(4);
+
+        pub const IMPACT_COMPLETE: Impact = Impact::new(5);
+
         /// Creates a new Impact instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("IMPACT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IMPACT_HIGH"),
+                2 => std::borrow::Cow::Borrowed("IMPACT_LOW"),
+                3 => std::borrow::Cow::Borrowed("IMPACT_NONE"),
+                4 => std::borrow::Cow::Borrowed("IMPACT_PARTIAL"),
+                5 => std::borrow::Cow::Borrowed("IMPACT_COMPLETE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "IMPACT_UNSPECIFIED" => std::option::Option::Some(Self::IMPACT_UNSPECIFIED),
+                "IMPACT_HIGH" => std::option::Option::Some(Self::IMPACT_HIGH),
+                "IMPACT_LOW" => std::option::Option::Some(Self::IMPACT_LOW),
+                "IMPACT_NONE" => std::option::Option::Some(Self::IMPACT_NONE),
+                "IMPACT_PARTIAL" => std::option::Option::Some(Self::IMPACT_PARTIAL),
+                "IMPACT_COMPLETE" => std::option::Option::Some(Self::IMPACT_COMPLETE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Impact](Impact)
-    pub mod impact {
-        use super::Impact;
-
-        pub const IMPACT_UNSPECIFIED: Impact = Impact::new("IMPACT_UNSPECIFIED");
-
-        pub const IMPACT_HIGH: Impact = Impact::new("IMPACT_HIGH");
-
-        pub const IMPACT_LOW: Impact = Impact::new("IMPACT_LOW");
-
-        pub const IMPACT_NONE: Impact = Impact::new("IMPACT_NONE");
-
-        pub const IMPACT_PARTIAL: Impact = Impact::new("IMPACT_PARTIAL");
-
-        pub const IMPACT_COMPLETE: Impact = Impact::new("IMPACT_COMPLETE");
-    }
-
-    impl std::convert::From<std::string::String> for Impact {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Impact {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Impact {
         fn default() -> Self {
-            impact::IMPACT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2074,46 +2301,63 @@ pub mod deployment_occurrence {
 
     /// Types of platforms.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Platform(std::borrow::Cow<'static, str>);
+    pub struct Platform(i32);
 
     impl Platform {
+        /// Unknown.
+        pub const PLATFORM_UNSPECIFIED: Platform = Platform::new(0);
+
+        /// Google Container Engine.
+        pub const GKE: Platform = Platform::new(1);
+
+        /// Google App Engine: Flexible Environment.
+        pub const FLEX: Platform = Platform::new(2);
+
+        /// Custom user-defined platform.
+        pub const CUSTOM: Platform = Platform::new(3);
+
         /// Creates a new Platform instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PLATFORM_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GKE"),
+                2 => std::borrow::Cow::Borrowed("FLEX"),
+                3 => std::borrow::Cow::Borrowed("CUSTOM"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PLATFORM_UNSPECIFIED" => std::option::Option::Some(Self::PLATFORM_UNSPECIFIED),
+                "GKE" => std::option::Option::Some(Self::GKE),
+                "FLEX" => std::option::Option::Some(Self::FLEX),
+                "CUSTOM" => std::option::Option::Some(Self::CUSTOM),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Platform](Platform)
-    pub mod platform {
-        use super::Platform;
-
-        /// Unknown.
-        pub const PLATFORM_UNSPECIFIED: Platform = Platform::new("PLATFORM_UNSPECIFIED");
-
-        /// Google Container Engine.
-        pub const GKE: Platform = Platform::new("GKE");
-
-        /// Google App Engine: Flexible Environment.
-        pub const FLEX: Platform = Platform::new("FLEX");
-
-        /// Custom user-defined platform.
-        pub const CUSTOM: Platform = Platform::new("CUSTOM");
-    }
-
-    impl std::convert::From<std::string::String> for Platform {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Platform {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Platform {
         fn default() -> Self {
-            platform::PLATFORM_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2408,43 +2652,60 @@ pub mod discovery_occurrence {
 
         /// An enum indicating the progress of the SBOM generation.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SBOMState(std::borrow::Cow<'static, str>);
+        pub struct SBOMState(i32);
 
         impl SBOMState {
+            /// Default unknown state.
+            pub const SBOM_STATE_UNSPECIFIED: SBOMState = SBOMState::new(0);
+
+            /// SBOM scanning is pending.
+            pub const PENDING: SBOMState = SBOMState::new(1);
+
+            /// SBOM scanning has completed.
+            pub const COMPLETE: SBOMState = SBOMState::new(2);
+
             /// Creates a new SBOMState instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("SBOM_STATE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("PENDING"),
+                    2 => std::borrow::Cow::Borrowed("COMPLETE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "SBOM_STATE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::SBOM_STATE_UNSPECIFIED)
+                    }
+                    "PENDING" => std::option::Option::Some(Self::PENDING),
+                    "COMPLETE" => std::option::Option::Some(Self::COMPLETE),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [SBOMState](SBOMState)
-        pub mod sbom_state {
-            use super::SBOMState;
-
-            /// Default unknown state.
-            pub const SBOM_STATE_UNSPECIFIED: SBOMState = SBOMState::new("SBOM_STATE_UNSPECIFIED");
-
-            /// SBOM scanning is pending.
-            pub const PENDING: SBOMState = SBOMState::new("PENDING");
-
-            /// SBOM scanning has completed.
-            pub const COMPLETE: SBOMState = SBOMState::new("COMPLETE");
-        }
-
-        impl std::convert::From<std::string::String> for SBOMState {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for SBOMState {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for SBOMState {
             fn default() -> Self {
-                sbom_state::SBOM_STATE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -2508,148 +2769,203 @@ pub mod discovery_occurrence {
 
         /// An enum indicating the state of the attestation generation.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct VulnerabilityAttestationState(std::borrow::Cow<'static, str>);
+        pub struct VulnerabilityAttestationState(i32);
 
         impl VulnerabilityAttestationState {
-            /// Creates a new VulnerabilityAttestationState instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [VulnerabilityAttestationState](VulnerabilityAttestationState)
-        pub mod vulnerability_attestation_state {
-            use super::VulnerabilityAttestationState;
-
             /// Default unknown state.
             pub const VULNERABILITY_ATTESTATION_STATE_UNSPECIFIED: VulnerabilityAttestationState =
-                VulnerabilityAttestationState::new("VULNERABILITY_ATTESTATION_STATE_UNSPECIFIED");
+                VulnerabilityAttestationState::new(0);
 
             /// Attestation was successfully generated and stored.
             pub const SUCCESS: VulnerabilityAttestationState =
-                VulnerabilityAttestationState::new("SUCCESS");
+                VulnerabilityAttestationState::new(1);
 
             /// Attestation was unsuccessfully generated and stored.
             pub const FAILURE: VulnerabilityAttestationState =
-                VulnerabilityAttestationState::new("FAILURE");
+                VulnerabilityAttestationState::new(2);
+
+            /// Creates a new VulnerabilityAttestationState instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("VULNERABILITY_ATTESTATION_STATE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("SUCCESS"),
+                    2 => std::borrow::Cow::Borrowed("FAILURE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "VULNERABILITY_ATTESTATION_STATE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::VULNERABILITY_ATTESTATION_STATE_UNSPECIFIED)
+                    }
+                    "SUCCESS" => std::option::Option::Some(Self::SUCCESS),
+                    "FAILURE" => std::option::Option::Some(Self::FAILURE),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for VulnerabilityAttestationState {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for VulnerabilityAttestationState {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for VulnerabilityAttestationState {
             fn default() -> Self {
-                vulnerability_attestation_state::VULNERABILITY_ATTESTATION_STATE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// Whether the resource is continuously analyzed.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ContinuousAnalysis(std::borrow::Cow<'static, str>);
+    pub struct ContinuousAnalysis(i32);
 
     impl ContinuousAnalysis {
+        /// Unknown.
+        pub const CONTINUOUS_ANALYSIS_UNSPECIFIED: ContinuousAnalysis = ContinuousAnalysis::new(0);
+
+        /// The resource is continuously analyzed.
+        pub const ACTIVE: ContinuousAnalysis = ContinuousAnalysis::new(1);
+
+        /// The resource is ignored for continuous analysis.
+        pub const INACTIVE: ContinuousAnalysis = ContinuousAnalysis::new(2);
+
         /// Creates a new ContinuousAnalysis instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CONTINUOUS_ANALYSIS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACTIVE"),
+                2 => std::borrow::Cow::Borrowed("INACTIVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CONTINUOUS_ANALYSIS_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CONTINUOUS_ANALYSIS_UNSPECIFIED)
+                }
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ContinuousAnalysis](ContinuousAnalysis)
-    pub mod continuous_analysis {
-        use super::ContinuousAnalysis;
-
-        /// Unknown.
-        pub const CONTINUOUS_ANALYSIS_UNSPECIFIED: ContinuousAnalysis =
-            ContinuousAnalysis::new("CONTINUOUS_ANALYSIS_UNSPECIFIED");
-
-        /// The resource is continuously analyzed.
-        pub const ACTIVE: ContinuousAnalysis = ContinuousAnalysis::new("ACTIVE");
-
-        /// The resource is ignored for continuous analysis.
-        pub const INACTIVE: ContinuousAnalysis = ContinuousAnalysis::new("INACTIVE");
-    }
-
-    impl std::convert::From<std::string::String> for ContinuousAnalysis {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ContinuousAnalysis {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ContinuousAnalysis {
         fn default() -> Self {
-            continuous_analysis::CONTINUOUS_ANALYSIS_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Analysis status for a resource. Currently for initial analysis only (not
     /// updated in continuous analysis).
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AnalysisStatus(std::borrow::Cow<'static, str>);
+    pub struct AnalysisStatus(i32);
 
     impl AnalysisStatus {
-        /// Creates a new AnalysisStatus instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [AnalysisStatus](AnalysisStatus)
-    pub mod analysis_status {
-        use super::AnalysisStatus;
-
         /// Unknown.
-        pub const ANALYSIS_STATUS_UNSPECIFIED: AnalysisStatus =
-            AnalysisStatus::new("ANALYSIS_STATUS_UNSPECIFIED");
+        pub const ANALYSIS_STATUS_UNSPECIFIED: AnalysisStatus = AnalysisStatus::new(0);
 
         /// Resource is known but no action has been taken yet.
-        pub const PENDING: AnalysisStatus = AnalysisStatus::new("PENDING");
+        pub const PENDING: AnalysisStatus = AnalysisStatus::new(1);
 
         /// Resource is being analyzed.
-        pub const SCANNING: AnalysisStatus = AnalysisStatus::new("SCANNING");
+        pub const SCANNING: AnalysisStatus = AnalysisStatus::new(2);
 
         /// Analysis has finished successfully.
-        pub const FINISHED_SUCCESS: AnalysisStatus = AnalysisStatus::new("FINISHED_SUCCESS");
+        pub const FINISHED_SUCCESS: AnalysisStatus = AnalysisStatus::new(3);
 
         /// Analysis has completed.
-        pub const COMPLETE: AnalysisStatus = AnalysisStatus::new("COMPLETE");
+        pub const COMPLETE: AnalysisStatus = AnalysisStatus::new(3);
 
         /// Analysis has finished unsuccessfully, the analysis itself is in a bad
         /// state.
-        pub const FINISHED_FAILED: AnalysisStatus = AnalysisStatus::new("FINISHED_FAILED");
+        pub const FINISHED_FAILED: AnalysisStatus = AnalysisStatus::new(4);
 
         /// The resource is known not to be supported.
-        pub const FINISHED_UNSUPPORTED: AnalysisStatus =
-            AnalysisStatus::new("FINISHED_UNSUPPORTED");
+        pub const FINISHED_UNSUPPORTED: AnalysisStatus = AnalysisStatus::new(5);
+
+        /// Creates a new AnalysisStatus instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ANALYSIS_STATUS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("SCANNING"),
+                3 => std::borrow::Cow::Borrowed("COMPLETE"),
+                4 => std::borrow::Cow::Borrowed("FINISHED_FAILED"),
+                5 => std::borrow::Cow::Borrowed("FINISHED_UNSUPPORTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ANALYSIS_STATUS_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ANALYSIS_STATUS_UNSPECIFIED)
+                }
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "SCANNING" => std::option::Option::Some(Self::SCANNING),
+                "FINISHED_SUCCESS" => std::option::Option::Some(Self::FINISHED_SUCCESS),
+                "COMPLETE" => std::option::Option::Some(Self::COMPLETE),
+                "FINISHED_FAILED" => std::option::Option::Some(Self::FINISHED_FAILED),
+                "FINISHED_UNSUPPORTED" => std::option::Option::Some(Self::FINISHED_UNSUPPORTED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for AnalysisStatus {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AnalysisStatus {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AnalysisStatus {
         fn default() -> Self {
-            analysis_status::ANALYSIS_STATUS_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -6434,47 +6750,65 @@ pub mod version {
 
     /// Whether this is an ordinary package version or a sentinel MIN/MAX version.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VersionKind(std::borrow::Cow<'static, str>);
+    pub struct VersionKind(i32);
 
     impl VersionKind {
+        /// Unknown.
+        pub const VERSION_KIND_UNSPECIFIED: VersionKind = VersionKind::new(0);
+
+        /// A standard package version.
+        pub const NORMAL: VersionKind = VersionKind::new(1);
+
+        /// A special version representing negative infinity.
+        pub const MINIMUM: VersionKind = VersionKind::new(2);
+
+        /// A special version representing positive infinity.
+        pub const MAXIMUM: VersionKind = VersionKind::new(3);
+
         /// Creates a new VersionKind instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VERSION_KIND_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NORMAL"),
+                2 => std::borrow::Cow::Borrowed("MINIMUM"),
+                3 => std::borrow::Cow::Borrowed("MAXIMUM"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VERSION_KIND_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::VERSION_KIND_UNSPECIFIED)
+                }
+                "NORMAL" => std::option::Option::Some(Self::NORMAL),
+                "MINIMUM" => std::option::Option::Some(Self::MINIMUM),
+                "MAXIMUM" => std::option::Option::Some(Self::MAXIMUM),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [VersionKind](VersionKind)
-    pub mod version_kind {
-        use super::VersionKind;
-
-        /// Unknown.
-        pub const VERSION_KIND_UNSPECIFIED: VersionKind =
-            VersionKind::new("VERSION_KIND_UNSPECIFIED");
-
-        /// A standard package version.
-        pub const NORMAL: VersionKind = VersionKind::new("NORMAL");
-
-        /// A special version representing negative infinity.
-        pub const MINIMUM: VersionKind = VersionKind::new("MINIMUM");
-
-        /// A special version representing positive infinity.
-        pub const MAXIMUM: VersionKind = VersionKind::new("MAXIMUM");
-    }
-
-    impl std::convert::From<std::string::String> for VersionKind {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for VersionKind {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for VersionKind {
         fn default() -> Self {
-            version_kind::VERSION_KIND_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -7181,47 +7515,64 @@ pub mod alias_context {
 
     /// The type of an alias.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Kind(std::borrow::Cow<'static, str>);
+    pub struct Kind(i32);
 
     impl Kind {
-        /// Creates a new Kind instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Kind](Kind)
-    pub mod kind {
-        use super::Kind;
-
         /// Unknown.
-        pub const KIND_UNSPECIFIED: Kind = Kind::new("KIND_UNSPECIFIED");
+        pub const KIND_UNSPECIFIED: Kind = Kind::new(0);
 
         /// Git tag.
-        pub const FIXED: Kind = Kind::new("FIXED");
+        pub const FIXED: Kind = Kind::new(1);
 
         /// Git branch.
-        pub const MOVABLE: Kind = Kind::new("MOVABLE");
+        pub const MOVABLE: Kind = Kind::new(2);
 
         /// Used to specify non-standard aliases. For example, if a Git repo has a
         /// ref named "refs/foo/bar".
-        pub const OTHER: Kind = Kind::new("OTHER");
+        pub const OTHER: Kind = Kind::new(4);
+
+        /// Creates a new Kind instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("KIND_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FIXED"),
+                2 => std::borrow::Cow::Borrowed("MOVABLE"),
+                4 => std::borrow::Cow::Borrowed("OTHER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "KIND_UNSPECIFIED" => std::option::Option::Some(Self::KIND_UNSPECIFIED),
+                "FIXED" => std::option::Option::Some(Self::FIXED),
+                "MOVABLE" => std::option::Option::Some(Self::MOVABLE),
+                "OTHER" => std::option::Option::Some(Self::OTHER),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Kind {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Kind {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Kind {
         fn default() -> Self {
-            kind::KIND_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -9634,48 +9985,32 @@ pub mod vulnerability_assessment_note {
 
             /// Provides the type of justification.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct JustificationType(std::borrow::Cow<'static, str>);
+            pub struct JustificationType(i32);
 
             impl JustificationType {
-                /// Creates a new JustificationType instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [JustificationType](JustificationType)
-            pub mod justification_type {
-                use super::JustificationType;
-
                 /// JUSTIFICATION_TYPE_UNSPECIFIED.
                 pub const JUSTIFICATION_TYPE_UNSPECIFIED: JustificationType =
-                    JustificationType::new("JUSTIFICATION_TYPE_UNSPECIFIED");
+                    JustificationType::new(0);
 
                 /// The vulnerable component is not present in the product.
-                pub const COMPONENT_NOT_PRESENT: JustificationType =
-                    JustificationType::new("COMPONENT_NOT_PRESENT");
+                pub const COMPONENT_NOT_PRESENT: JustificationType = JustificationType::new(1);
 
                 /// The vulnerable code is not present. Typically this case
                 /// occurs when source code is configured or built in a way that excludes
                 /// the vulnerable code.
                 pub const VULNERABLE_CODE_NOT_PRESENT: JustificationType =
-                    JustificationType::new("VULNERABLE_CODE_NOT_PRESENT");
+                    JustificationType::new(2);
 
                 /// The vulnerable code can not be executed.
                 /// Typically this case occurs when the product includes the vulnerable
                 /// code but does not call or use the vulnerable code.
                 pub const VULNERABLE_CODE_NOT_IN_EXECUTE_PATH: JustificationType =
-                    JustificationType::new("VULNERABLE_CODE_NOT_IN_EXECUTE_PATH");
+                    JustificationType::new(3);
 
                 /// The vulnerable code cannot be controlled by an attacker to exploit
                 /// the vulnerability.
                 pub const VULNERABLE_CODE_CANNOT_BE_CONTROLLED_BY_ADVERSARY: JustificationType =
-                    JustificationType::new("VULNERABLE_CODE_CANNOT_BE_CONTROLLED_BY_ADVERSARY");
+                    JustificationType::new(4);
 
                 /// The product includes built-in protections or features that prevent
                 /// exploitation of the vulnerability. These built-in protections cannot
@@ -9683,18 +10018,70 @@ pub mod vulnerability_assessment_note {
                 /// the user. These mitigations completely prevent exploitation based on
                 /// known attack vectors.
                 pub const INLINE_MITIGATIONS_ALREADY_EXIST: JustificationType =
-                    JustificationType::new("INLINE_MITIGATIONS_ALREADY_EXIST");
+                    JustificationType::new(5);
+
+                /// Creates a new JustificationType instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("JUSTIFICATION_TYPE_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("COMPONENT_NOT_PRESENT"),
+                        2 => std::borrow::Cow::Borrowed("VULNERABLE_CODE_NOT_PRESENT"),
+                        3 => std::borrow::Cow::Borrowed("VULNERABLE_CODE_NOT_IN_EXECUTE_PATH"),
+                        4 => std::borrow::Cow::Borrowed(
+                            "VULNERABLE_CODE_CANNOT_BE_CONTROLLED_BY_ADVERSARY",
+                        ),
+                        5 => std::borrow::Cow::Borrowed("INLINE_MITIGATIONS_ALREADY_EXIST"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "JUSTIFICATION_TYPE_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::JUSTIFICATION_TYPE_UNSPECIFIED)
+                        }
+                        "COMPONENT_NOT_PRESENT" => {
+                            std::option::Option::Some(Self::COMPONENT_NOT_PRESENT)
+                        }
+                        "VULNERABLE_CODE_NOT_PRESENT" => {
+                            std::option::Option::Some(Self::VULNERABLE_CODE_NOT_PRESENT)
+                        }
+                        "VULNERABLE_CODE_NOT_IN_EXECUTE_PATH" => {
+                            std::option::Option::Some(Self::VULNERABLE_CODE_NOT_IN_EXECUTE_PATH)
+                        }
+                        "VULNERABLE_CODE_CANNOT_BE_CONTROLLED_BY_ADVERSARY" => {
+                            std::option::Option::Some(
+                                Self::VULNERABLE_CODE_CANNOT_BE_CONTROLLED_BY_ADVERSARY,
+                            )
+                        }
+                        "INLINE_MITIGATIONS_ALREADY_EXIST" => {
+                            std::option::Option::Some(Self::INLINE_MITIGATIONS_ALREADY_EXIST)
+                        }
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for JustificationType {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for JustificationType {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for JustificationType {
                 fn default() -> Self {
-                    justification_type::JUSTIFICATION_TYPE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
@@ -9760,103 +10147,144 @@ pub mod vulnerability_assessment_note {
 
             /// The type of remediation that can be applied.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct RemediationType(std::borrow::Cow<'static, str>);
+            pub struct RemediationType(i32);
 
             impl RemediationType {
+                /// No remediation type specified.
+                pub const REMEDIATION_TYPE_UNSPECIFIED: RemediationType = RemediationType::new(0);
+
+                /// A MITIGATION is available.
+                pub const MITIGATION: RemediationType = RemediationType::new(1);
+
+                /// No fix is planned.
+                pub const NO_FIX_PLANNED: RemediationType = RemediationType::new(2);
+
+                /// Not available.
+                pub const NONE_AVAILABLE: RemediationType = RemediationType::new(3);
+
+                /// A vendor fix is available.
+                pub const VENDOR_FIX: RemediationType = RemediationType::new(4);
+
+                /// A workaround is available.
+                pub const WORKAROUND: RemediationType = RemediationType::new(5);
+
                 /// Creates a new RemediationType instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
                 }
 
                 /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("REMEDIATION_TYPE_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("MITIGATION"),
+                        2 => std::borrow::Cow::Borrowed("NO_FIX_PLANNED"),
+                        3 => std::borrow::Cow::Borrowed("NONE_AVAILABLE"),
+                        4 => std::borrow::Cow::Borrowed("VENDOR_FIX"),
+                        5 => std::borrow::Cow::Borrowed("WORKAROUND"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "REMEDIATION_TYPE_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::REMEDIATION_TYPE_UNSPECIFIED)
+                        }
+                        "MITIGATION" => std::option::Option::Some(Self::MITIGATION),
+                        "NO_FIX_PLANNED" => std::option::Option::Some(Self::NO_FIX_PLANNED),
+                        "NONE_AVAILABLE" => std::option::Option::Some(Self::NONE_AVAILABLE),
+                        "VENDOR_FIX" => std::option::Option::Some(Self::VENDOR_FIX),
+                        "WORKAROUND" => std::option::Option::Some(Self::WORKAROUND),
+                        _ => std::option::Option::None,
+                    }
                 }
             }
 
-            /// Useful constants to work with [RemediationType](RemediationType)
-            pub mod remediation_type {
-                use super::RemediationType;
-
-                /// No remediation type specified.
-                pub const REMEDIATION_TYPE_UNSPECIFIED: RemediationType =
-                    RemediationType::new("REMEDIATION_TYPE_UNSPECIFIED");
-
-                /// A MITIGATION is available.
-                pub const MITIGATION: RemediationType = RemediationType::new("MITIGATION");
-
-                /// No fix is planned.
-                pub const NO_FIX_PLANNED: RemediationType = RemediationType::new("NO_FIX_PLANNED");
-
-                /// Not available.
-                pub const NONE_AVAILABLE: RemediationType = RemediationType::new("NONE_AVAILABLE");
-
-                /// A vendor fix is available.
-                pub const VENDOR_FIX: RemediationType = RemediationType::new("VENDOR_FIX");
-
-                /// A workaround is available.
-                pub const WORKAROUND: RemediationType = RemediationType::new("WORKAROUND");
-            }
-
-            impl std::convert::From<std::string::String> for RemediationType {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for RemediationType {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for RemediationType {
                 fn default() -> Self {
-                    remediation_type::REMEDIATION_TYPE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
 
         /// Provides the state of this Vulnerability assessment.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(std::borrow::Cow<'static, str>);
+        pub struct State(i32);
 
         impl State {
-            /// Creates a new State instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [State](State)
-        pub mod state {
-            use super::State;
-
             /// No state is specified.
-            pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+            pub const STATE_UNSPECIFIED: State = State::new(0);
 
             /// This product is known to be affected by this vulnerability.
-            pub const AFFECTED: State = State::new("AFFECTED");
+            pub const AFFECTED: State = State::new(1);
 
             /// This product is known to be not affected by this vulnerability.
-            pub const NOT_AFFECTED: State = State::new("NOT_AFFECTED");
+            pub const NOT_AFFECTED: State = State::new(2);
 
             /// This product contains a fix for this vulnerability.
-            pub const FIXED: State = State::new("FIXED");
+            pub const FIXED: State = State::new(3);
 
             /// It is not known yet whether these versions are or are not affected
             /// by the vulnerability. However, it is still under investigation.
-            pub const UNDER_INVESTIGATION: State = State::new("UNDER_INVESTIGATION");
+            pub const UNDER_INVESTIGATION: State = State::new(4);
+
+            /// Creates a new State instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("AFFECTED"),
+                    2 => std::borrow::Cow::Borrowed("NOT_AFFECTED"),
+                    3 => std::borrow::Cow::Borrowed("FIXED"),
+                    4 => std::borrow::Cow::Borrowed("UNDER_INVESTIGATION"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                    "AFFECTED" => std::option::Option::Some(Self::AFFECTED),
+                    "NOT_AFFECTED" => std::option::Option::Some(Self::NOT_AFFECTED),
+                    "FIXED" => std::option::Option::Some(Self::FIXED),
+                    "UNDER_INVESTIGATION" => std::option::Option::Some(Self::UNDER_INVESTIGATION),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for State {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                state::STATE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -10841,205 +11269,290 @@ pub mod vulnerability_occurrence {
 
 /// Kind represents the kinds of notes supported.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct NoteKind(std::borrow::Cow<'static, str>);
+pub struct NoteKind(i32);
 
 impl NoteKind {
+    /// Default value. This value is unused.
+    pub const NOTE_KIND_UNSPECIFIED: NoteKind = NoteKind::new(0);
+
+    /// The note and occurrence represent a package vulnerability.
+    pub const VULNERABILITY: NoteKind = NoteKind::new(1);
+
+    /// The note and occurrence assert build provenance.
+    pub const BUILD: NoteKind = NoteKind::new(2);
+
+    /// This represents an image basis relationship.
+    pub const IMAGE: NoteKind = NoteKind::new(3);
+
+    /// This represents a package installed via a package manager.
+    pub const PACKAGE: NoteKind = NoteKind::new(4);
+
+    /// The note and occurrence track deployment events.
+    pub const DEPLOYMENT: NoteKind = NoteKind::new(5);
+
+    /// The note and occurrence track the initial discovery status of a resource.
+    pub const DISCOVERY: NoteKind = NoteKind::new(6);
+
+    /// This represents a logical "role" that can attest to artifacts.
+    pub const ATTESTATION: NoteKind = NoteKind::new(7);
+
+    /// This represents an available package upgrade.
+    pub const UPGRADE: NoteKind = NoteKind::new(8);
+
+    /// This represents a Compliance Note
+    pub const COMPLIANCE: NoteKind = NoteKind::new(9);
+
+    /// This represents a DSSE attestation Note
+    pub const DSSE_ATTESTATION: NoteKind = NoteKind::new(10);
+
+    /// This represents a Vulnerability Assessment.
+    pub const VULNERABILITY_ASSESSMENT: NoteKind = NoteKind::new(11);
+
+    /// This represents an SBOM Reference.
+    pub const SBOM_REFERENCE: NoteKind = NoteKind::new(12);
+
     /// Creates a new NoteKind instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("NOTE_KIND_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("VULNERABILITY"),
+            2 => std::borrow::Cow::Borrowed("BUILD"),
+            3 => std::borrow::Cow::Borrowed("IMAGE"),
+            4 => std::borrow::Cow::Borrowed("PACKAGE"),
+            5 => std::borrow::Cow::Borrowed("DEPLOYMENT"),
+            6 => std::borrow::Cow::Borrowed("DISCOVERY"),
+            7 => std::borrow::Cow::Borrowed("ATTESTATION"),
+            8 => std::borrow::Cow::Borrowed("UPGRADE"),
+            9 => std::borrow::Cow::Borrowed("COMPLIANCE"),
+            10 => std::borrow::Cow::Borrowed("DSSE_ATTESTATION"),
+            11 => std::borrow::Cow::Borrowed("VULNERABILITY_ASSESSMENT"),
+            12 => std::borrow::Cow::Borrowed("SBOM_REFERENCE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "NOTE_KIND_UNSPECIFIED" => std::option::Option::Some(Self::NOTE_KIND_UNSPECIFIED),
+            "VULNERABILITY" => std::option::Option::Some(Self::VULNERABILITY),
+            "BUILD" => std::option::Option::Some(Self::BUILD),
+            "IMAGE" => std::option::Option::Some(Self::IMAGE),
+            "PACKAGE" => std::option::Option::Some(Self::PACKAGE),
+            "DEPLOYMENT" => std::option::Option::Some(Self::DEPLOYMENT),
+            "DISCOVERY" => std::option::Option::Some(Self::DISCOVERY),
+            "ATTESTATION" => std::option::Option::Some(Self::ATTESTATION),
+            "UPGRADE" => std::option::Option::Some(Self::UPGRADE),
+            "COMPLIANCE" => std::option::Option::Some(Self::COMPLIANCE),
+            "DSSE_ATTESTATION" => std::option::Option::Some(Self::DSSE_ATTESTATION),
+            "VULNERABILITY_ASSESSMENT" => std::option::Option::Some(Self::VULNERABILITY_ASSESSMENT),
+            "SBOM_REFERENCE" => std::option::Option::Some(Self::SBOM_REFERENCE),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [NoteKind](NoteKind)
-pub mod note_kind {
-    use super::NoteKind;
-
-    /// Default value. This value is unused.
-    pub const NOTE_KIND_UNSPECIFIED: NoteKind = NoteKind::new("NOTE_KIND_UNSPECIFIED");
-
-    /// The note and occurrence represent a package vulnerability.
-    pub const VULNERABILITY: NoteKind = NoteKind::new("VULNERABILITY");
-
-    /// The note and occurrence assert build provenance.
-    pub const BUILD: NoteKind = NoteKind::new("BUILD");
-
-    /// This represents an image basis relationship.
-    pub const IMAGE: NoteKind = NoteKind::new("IMAGE");
-
-    /// This represents a package installed via a package manager.
-    pub const PACKAGE: NoteKind = NoteKind::new("PACKAGE");
-
-    /// The note and occurrence track deployment events.
-    pub const DEPLOYMENT: NoteKind = NoteKind::new("DEPLOYMENT");
-
-    /// The note and occurrence track the initial discovery status of a resource.
-    pub const DISCOVERY: NoteKind = NoteKind::new("DISCOVERY");
-
-    /// This represents a logical "role" that can attest to artifacts.
-    pub const ATTESTATION: NoteKind = NoteKind::new("ATTESTATION");
-
-    /// This represents an available package upgrade.
-    pub const UPGRADE: NoteKind = NoteKind::new("UPGRADE");
-
-    /// This represents a Compliance Note
-    pub const COMPLIANCE: NoteKind = NoteKind::new("COMPLIANCE");
-
-    /// This represents a DSSE attestation Note
-    pub const DSSE_ATTESTATION: NoteKind = NoteKind::new("DSSE_ATTESTATION");
-
-    /// This represents a Vulnerability Assessment.
-    pub const VULNERABILITY_ASSESSMENT: NoteKind = NoteKind::new("VULNERABILITY_ASSESSMENT");
-
-    /// This represents an SBOM Reference.
-    pub const SBOM_REFERENCE: NoteKind = NoteKind::new("SBOM_REFERENCE");
-}
-
-impl std::convert::From<std::string::String> for NoteKind {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for NoteKind {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for NoteKind {
     fn default() -> Self {
-        note_kind::NOTE_KIND_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// CVSS Version.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct CVSSVersion(std::borrow::Cow<'static, str>);
+pub struct CVSSVersion(i32);
 
 impl CVSSVersion {
+    pub const CVSS_VERSION_UNSPECIFIED: CVSSVersion = CVSSVersion::new(0);
+
+    pub const CVSS_VERSION_2: CVSSVersion = CVSSVersion::new(1);
+
+    pub const CVSS_VERSION_3: CVSSVersion = CVSSVersion::new(2);
+
     /// Creates a new CVSSVersion instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("CVSS_VERSION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("CVSS_VERSION_2"),
+            2 => std::borrow::Cow::Borrowed("CVSS_VERSION_3"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "CVSS_VERSION_UNSPECIFIED" => std::option::Option::Some(Self::CVSS_VERSION_UNSPECIFIED),
+            "CVSS_VERSION_2" => std::option::Option::Some(Self::CVSS_VERSION_2),
+            "CVSS_VERSION_3" => std::option::Option::Some(Self::CVSS_VERSION_3),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [CVSSVersion](CVSSVersion)
-pub mod cvss_version {
-    use super::CVSSVersion;
-
-    pub const CVSS_VERSION_UNSPECIFIED: CVSSVersion = CVSSVersion::new("CVSS_VERSION_UNSPECIFIED");
-
-    pub const CVSS_VERSION_2: CVSSVersion = CVSSVersion::new("CVSS_VERSION_2");
-
-    pub const CVSS_VERSION_3: CVSSVersion = CVSSVersion::new("CVSS_VERSION_3");
-}
-
-impl std::convert::From<std::string::String> for CVSSVersion {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for CVSSVersion {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for CVSSVersion {
     fn default() -> Self {
-        cvss_version::CVSS_VERSION_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Instruction set architectures supported by various package managers.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Architecture(std::borrow::Cow<'static, str>);
+pub struct Architecture(i32);
 
 impl Architecture {
+    /// Unknown architecture.
+    pub const ARCHITECTURE_UNSPECIFIED: Architecture = Architecture::new(0);
+
+    /// X86 architecture.
+    pub const X86: Architecture = Architecture::new(1);
+
+    /// X64 architecture.
+    pub const X64: Architecture = Architecture::new(2);
+
     /// Creates a new Architecture instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ARCHITECTURE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("X86"),
+            2 => std::borrow::Cow::Borrowed("X64"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ARCHITECTURE_UNSPECIFIED" => std::option::Option::Some(Self::ARCHITECTURE_UNSPECIFIED),
+            "X86" => std::option::Option::Some(Self::X86),
+            "X64" => std::option::Option::Some(Self::X64),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [Architecture](Architecture)
-pub mod architecture {
-    use super::Architecture;
-
-    /// Unknown architecture.
-    pub const ARCHITECTURE_UNSPECIFIED: Architecture =
-        Architecture::new("ARCHITECTURE_UNSPECIFIED");
-
-    /// X86 architecture.
-    pub const X86: Architecture = Architecture::new("X86");
-
-    /// X64 architecture.
-    pub const X64: Architecture = Architecture::new("X64");
-}
-
-impl std::convert::From<std::string::String> for Architecture {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Architecture {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Architecture {
     fn default() -> Self {
-        architecture::ARCHITECTURE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Note provider assigned severity/impact ranking.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Severity(std::borrow::Cow<'static, str>);
+pub struct Severity(i32);
 
 impl Severity {
+    /// Unknown.
+    pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
+
+    /// Minimal severity.
+    pub const MINIMAL: Severity = Severity::new(1);
+
+    /// Low severity.
+    pub const LOW: Severity = Severity::new(2);
+
+    /// Medium severity.
+    pub const MEDIUM: Severity = Severity::new(3);
+
+    /// High severity.
+    pub const HIGH: Severity = Severity::new(4);
+
+    /// Critical severity.
+    pub const CRITICAL: Severity = Severity::new(5);
+
     /// Creates a new Severity instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("MINIMAL"),
+            2 => std::borrow::Cow::Borrowed("LOW"),
+            3 => std::borrow::Cow::Borrowed("MEDIUM"),
+            4 => std::borrow::Cow::Borrowed("HIGH"),
+            5 => std::borrow::Cow::Borrowed("CRITICAL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
+            "MINIMAL" => std::option::Option::Some(Self::MINIMAL),
+            "LOW" => std::option::Option::Some(Self::LOW),
+            "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
+            "HIGH" => std::option::Option::Some(Self::HIGH),
+            "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [Severity](Severity)
-pub mod severity {
-    use super::Severity;
-
-    /// Unknown.
-    pub const SEVERITY_UNSPECIFIED: Severity = Severity::new("SEVERITY_UNSPECIFIED");
-
-    /// Minimal severity.
-    pub const MINIMAL: Severity = Severity::new("MINIMAL");
-
-    /// Low severity.
-    pub const LOW: Severity = Severity::new("LOW");
-
-    /// Medium severity.
-    pub const MEDIUM: Severity = Severity::new("MEDIUM");
-
-    /// High severity.
-    pub const HIGH: Severity = Severity::new("HIGH");
-
-    /// Critical severity.
-    pub const CRITICAL: Severity = Severity::new("CRITICAL");
-}
-
-impl std::convert::From<std::string::String> for Severity {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Severity {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Severity {
     fn default() -> Self {
-        severity::SEVERITY_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/grafeas/v1/src/transport.rs
+++ b/src/generated/grafeas/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::Grafeas for Grafeas {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -71,7 +71,7 @@ impl crate::stubs::Grafeas for Grafeas {
                 reqwest::Method::GET,
                 format!("/v1/{}/occurrences", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -93,7 +93,7 @@ impl crate::stubs::Grafeas for Grafeas {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -115,7 +115,7 @@ impl crate::stubs::Grafeas for Grafeas {
                 reqwest::Method::POST,
                 format!("/v1/{}/occurrences", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -137,7 +137,7 @@ impl crate::stubs::Grafeas for Grafeas {
                 reqwest::Method::POST,
                 format!("/v1/{}/occurrences:batchCreate", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -154,7 +154,7 @@ impl crate::stubs::Grafeas for Grafeas {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -183,7 +183,7 @@ impl crate::stubs::Grafeas for Grafeas {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/notes", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -202,7 +202,7 @@ impl crate::stubs::Grafeas for Grafeas {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -221,7 +221,7 @@ impl crate::stubs::Grafeas for Grafeas {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/notes", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -243,7 +243,7 @@ impl crate::stubs::Grafeas for Grafeas {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -262,7 +262,7 @@ impl crate::stubs::Grafeas for Grafeas {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/notes", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -283,7 +283,7 @@ impl crate::stubs::Grafeas for Grafeas {
                 reqwest::Method::POST,
                 format!("/v1/{}/notes:batchCreate", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -300,7 +300,7 @@ impl crate::stubs::Grafeas for Grafeas {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -330,7 +330,7 @@ impl crate::stubs::Grafeas for Grafeas {
                 reqwest::Method::GET,
                 format!("/v1/{}/occurrences", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/iam/admin/v1/src/model.rs
+++ b/src/generated/iam/admin/v1/src/model.rs
@@ -759,44 +759,59 @@ pub mod list_service_account_keys_request {
     /// `KeyType` filters to selectively retrieve certain varieties
     /// of keys.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct KeyType(std::borrow::Cow<'static, str>);
+    pub struct KeyType(i32);
 
     impl KeyType {
+        /// Unspecified key type. The presence of this in the
+        /// message will immediately result in an error.
+        pub const KEY_TYPE_UNSPECIFIED: KeyType = KeyType::new(0);
+
+        /// User-managed keys (managed and rotated by the user).
+        pub const USER_MANAGED: KeyType = KeyType::new(1);
+
+        /// System-managed keys (managed and rotated by Google).
+        pub const SYSTEM_MANAGED: KeyType = KeyType::new(2);
+
         /// Creates a new KeyType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("KEY_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("USER_MANAGED"),
+                2 => std::borrow::Cow::Borrowed("SYSTEM_MANAGED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "KEY_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::KEY_TYPE_UNSPECIFIED),
+                "USER_MANAGED" => std::option::Option::Some(Self::USER_MANAGED),
+                "SYSTEM_MANAGED" => std::option::Option::Some(Self::SYSTEM_MANAGED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [KeyType](KeyType)
-    pub mod key_type {
-        use super::KeyType;
-
-        /// Unspecified key type. The presence of this in the
-        /// message will immediately result in an error.
-        pub const KEY_TYPE_UNSPECIFIED: KeyType = KeyType::new("KEY_TYPE_UNSPECIFIED");
-
-        /// User-managed keys (managed and rotated by the user).
-        pub const USER_MANAGED: KeyType = KeyType::new("USER_MANAGED");
-
-        /// System-managed keys (managed and rotated by Google).
-        pub const SYSTEM_MANAGED: KeyType = KeyType::new("SYSTEM_MANAGED");
-    }
-
-    impl std::convert::From<std::string::String> for KeyType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for KeyType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for KeyType {
         fn default() -> Self {
-            key_type::KEY_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1593,55 +1608,76 @@ pub mod role {
 
     /// A stage representing a role's lifecycle phase.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RoleLaunchStage(std::borrow::Cow<'static, str>);
+    pub struct RoleLaunchStage(i32);
 
     impl RoleLaunchStage {
-        /// Creates a new RoleLaunchStage instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RoleLaunchStage](RoleLaunchStage)
-    pub mod role_launch_stage {
-        use super::RoleLaunchStage;
-
         /// The user has indicated this role is currently in an Alpha phase. If this
         /// launch stage is selected, the `stage` field will not be included when
         /// requesting the definition for a given role.
-        pub const ALPHA: RoleLaunchStage = RoleLaunchStage::new("ALPHA");
+        pub const ALPHA: RoleLaunchStage = RoleLaunchStage::new(0);
 
         /// The user has indicated this role is currently in a Beta phase.
-        pub const BETA: RoleLaunchStage = RoleLaunchStage::new("BETA");
+        pub const BETA: RoleLaunchStage = RoleLaunchStage::new(1);
 
         /// The user has indicated this role is generally available.
-        pub const GA: RoleLaunchStage = RoleLaunchStage::new("GA");
+        pub const GA: RoleLaunchStage = RoleLaunchStage::new(2);
 
         /// The user has indicated this role is being deprecated.
-        pub const DEPRECATED: RoleLaunchStage = RoleLaunchStage::new("DEPRECATED");
+        pub const DEPRECATED: RoleLaunchStage = RoleLaunchStage::new(4);
 
         /// This role is disabled and will not contribute permissions to any
         /// principals it is granted to in policies.
-        pub const DISABLED: RoleLaunchStage = RoleLaunchStage::new("DISABLED");
+        pub const DISABLED: RoleLaunchStage = RoleLaunchStage::new(5);
 
         /// The user has indicated this role is currently in an EAP phase.
-        pub const EAP: RoleLaunchStage = RoleLaunchStage::new("EAP");
+        pub const EAP: RoleLaunchStage = RoleLaunchStage::new(6);
+
+        /// Creates a new RoleLaunchStage instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ALPHA"),
+                1 => std::borrow::Cow::Borrowed("BETA"),
+                2 => std::borrow::Cow::Borrowed("GA"),
+                4 => std::borrow::Cow::Borrowed("DEPRECATED"),
+                5 => std::borrow::Cow::Borrowed("DISABLED"),
+                6 => std::borrow::Cow::Borrowed("EAP"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ALPHA" => std::option::Option::Some(Self::ALPHA),
+                "BETA" => std::option::Option::Some(Self::BETA),
+                "GA" => std::option::Option::Some(Self::GA),
+                "DEPRECATED" => std::option::Option::Some(Self::DEPRECATED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "EAP" => std::option::Option::Some(Self::EAP),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RoleLaunchStage {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RoleLaunchStage {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RoleLaunchStage {
         fn default() -> Self {
-            role_launch_stage::ALPHA
+            Self::new(0)
         }
     }
 }
@@ -2386,89 +2422,120 @@ pub mod permission {
 
     /// A stage representing a permission's lifecycle phase.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PermissionLaunchStage(std::borrow::Cow<'static, str>);
+    pub struct PermissionLaunchStage(i32);
 
     impl PermissionLaunchStage {
+        /// The permission is currently in an alpha phase.
+        pub const ALPHA: PermissionLaunchStage = PermissionLaunchStage::new(0);
+
+        /// The permission is currently in a beta phase.
+        pub const BETA: PermissionLaunchStage = PermissionLaunchStage::new(1);
+
+        /// The permission is generally available.
+        pub const GA: PermissionLaunchStage = PermissionLaunchStage::new(2);
+
+        /// The permission is being deprecated.
+        pub const DEPRECATED: PermissionLaunchStage = PermissionLaunchStage::new(3);
+
         /// Creates a new PermissionLaunchStage instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ALPHA"),
+                1 => std::borrow::Cow::Borrowed("BETA"),
+                2 => std::borrow::Cow::Borrowed("GA"),
+                3 => std::borrow::Cow::Borrowed("DEPRECATED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ALPHA" => std::option::Option::Some(Self::ALPHA),
+                "BETA" => std::option::Option::Some(Self::BETA),
+                "GA" => std::option::Option::Some(Self::GA),
+                "DEPRECATED" => std::option::Option::Some(Self::DEPRECATED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [PermissionLaunchStage](PermissionLaunchStage)
-    pub mod permission_launch_stage {
-        use super::PermissionLaunchStage;
-
-        /// The permission is currently in an alpha phase.
-        pub const ALPHA: PermissionLaunchStage = PermissionLaunchStage::new("ALPHA");
-
-        /// The permission is currently in a beta phase.
-        pub const BETA: PermissionLaunchStage = PermissionLaunchStage::new("BETA");
-
-        /// The permission is generally available.
-        pub const GA: PermissionLaunchStage = PermissionLaunchStage::new("GA");
-
-        /// The permission is being deprecated.
-        pub const DEPRECATED: PermissionLaunchStage = PermissionLaunchStage::new("DEPRECATED");
-    }
-
-    impl std::convert::From<std::string::String> for PermissionLaunchStage {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PermissionLaunchStage {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PermissionLaunchStage {
         fn default() -> Self {
-            permission_launch_stage::ALPHA
+            Self::new(0)
         }
     }
 
     /// The state of the permission with regards to custom roles.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CustomRolesSupportLevel(std::borrow::Cow<'static, str>);
+    pub struct CustomRolesSupportLevel(i32);
 
     impl CustomRolesSupportLevel {
+        /// Default state. Permission is fully supported for custom role use.
+        pub const SUPPORTED: CustomRolesSupportLevel = CustomRolesSupportLevel::new(0);
+
+        /// Permission is being tested to check custom role compatibility.
+        pub const TESTING: CustomRolesSupportLevel = CustomRolesSupportLevel::new(1);
+
+        /// Permission is not supported for custom role use.
+        pub const NOT_SUPPORTED: CustomRolesSupportLevel = CustomRolesSupportLevel::new(2);
+
         /// Creates a new CustomRolesSupportLevel instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SUPPORTED"),
+                1 => std::borrow::Cow::Borrowed("TESTING"),
+                2 => std::borrow::Cow::Borrowed("NOT_SUPPORTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SUPPORTED" => std::option::Option::Some(Self::SUPPORTED),
+                "TESTING" => std::option::Option::Some(Self::TESTING),
+                "NOT_SUPPORTED" => std::option::Option::Some(Self::NOT_SUPPORTED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [CustomRolesSupportLevel](CustomRolesSupportLevel)
-    pub mod custom_roles_support_level {
-        use super::CustomRolesSupportLevel;
-
-        /// Default state. Permission is fully supported for custom role use.
-        pub const SUPPORTED: CustomRolesSupportLevel = CustomRolesSupportLevel::new("SUPPORTED");
-
-        /// Permission is being tested to check custom role compatibility.
-        pub const TESTING: CustomRolesSupportLevel = CustomRolesSupportLevel::new("TESTING");
-
-        /// Permission is not supported for custom role use.
-        pub const NOT_SUPPORTED: CustomRolesSupportLevel =
-            CustomRolesSupportLevel::new("NOT_SUPPORTED");
-    }
-
-    impl std::convert::From<std::string::String> for CustomRolesSupportLevel {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CustomRolesSupportLevel {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CustomRolesSupportLevel {
         fn default() -> Self {
-            custom_roles_support_level::SUPPORTED
+            Self::new(0)
         }
     }
 }
@@ -2897,71 +2964,69 @@ pub mod lint_result {
     /// Possible Level values of a validation unit corresponding to its domain
     /// of discourse.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Level(std::borrow::Cow<'static, str>);
+    pub struct Level(i32);
 
     impl Level {
-        /// Creates a new Level instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Level](Level)
-    pub mod level {
-        use super::Level;
-
         /// Level is unspecified.
-        pub const LEVEL_UNSPECIFIED: Level = Level::new("LEVEL_UNSPECIFIED");
+        pub const LEVEL_UNSPECIFIED: Level = Level::new(0);
 
         /// A validation unit which operates on an individual condition within a
         /// binding.
-        pub const CONDITION: Level = Level::new("CONDITION");
+        pub const CONDITION: Level = Level::new(3);
+
+        /// Creates a new Level instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LEVEL_UNSPECIFIED"),
+                3 => std::borrow::Cow::Borrowed("CONDITION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LEVEL_UNSPECIFIED" => std::option::Option::Some(Self::LEVEL_UNSPECIFIED),
+                "CONDITION" => std::option::Option::Some(Self::CONDITION),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Level {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Level {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Level {
         fn default() -> Self {
-            level::LEVEL_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Possible Severity values of an issued result.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(std::borrow::Cow<'static, str>);
+    pub struct Severity(i32);
 
     impl Severity {
-        /// Creates a new Severity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Severity](Severity)
-    pub mod severity {
-        use super::Severity;
-
         /// Severity is unspecified.
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new("SEVERITY_UNSPECIFIED");
+        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
 
         /// A validation unit returns an error only for critical issues. If an
         /// attempt is made to set the problematic policy without rectifying the
         /// critical issue, it causes the `setPolicy` operation to fail.
-        pub const ERROR: Severity = Severity::new("ERROR");
+        pub const ERROR: Severity = Severity::new(1);
 
         /// Any issue which is severe enough but does not cause an error.
         /// For example, suspicious constructs in the input object will not
@@ -2972,32 +3037,68 @@ pub mod lint_result {
         /// - Unsatisfiable condition: Expired timestamp in date/time condition.
         /// - Ineffective condition: Condition on a <principal, role> pair which is
         ///   granted unconditionally in another binding of the same policy.
-        pub const WARNING: Severity = Severity::new("WARNING");
+        pub const WARNING: Severity = Severity::new(2);
 
         /// Reserved for the issues that are not severe as `ERROR`/`WARNING`, but
         /// need special handling. For instance, messages about skipped validation
         /// units are issued as `NOTICE`.
-        pub const NOTICE: Severity = Severity::new("NOTICE");
+        pub const NOTICE: Severity = Severity::new(3);
 
         /// Any informative statement which is not severe enough to raise
         /// `ERROR`/`WARNING`/`NOTICE`, like auto-correction recommendations on the
         /// input content. Note that current version of the linter does not utilize
         /// `INFO`.
-        pub const INFO: Severity = Severity::new("INFO");
+        pub const INFO: Severity = Severity::new(4);
 
         /// Deprecated severity level.
-        pub const DEPRECATED: Severity = Severity::new("DEPRECATED");
+        pub const DEPRECATED: Severity = Severity::new(5);
+
+        /// Creates a new Severity instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ERROR"),
+                2 => std::borrow::Cow::Borrowed("WARNING"),
+                3 => std::borrow::Cow::Borrowed("NOTICE"),
+                4 => std::borrow::Cow::Borrowed("INFO"),
+                5 => std::borrow::Cow::Borrowed("DEPRECATED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "WARNING" => std::option::Option::Some(Self::WARNING),
+                "NOTICE" => std::option::Option::Some(Self::NOTICE),
+                "INFO" => std::option::Option::Some(Self::INFO),
+                "DEPRECATED" => std::option::Option::Some(Self::DEPRECATED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Severity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            severity::SEVERITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3039,222 +3140,287 @@ impl wkt::message::Message for LintPolicyResponse {
 
 /// Supported key algorithms.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ServiceAccountKeyAlgorithm(std::borrow::Cow<'static, str>);
+pub struct ServiceAccountKeyAlgorithm(i32);
 
 impl ServiceAccountKeyAlgorithm {
+    /// An unspecified key algorithm.
+    pub const KEY_ALG_UNSPECIFIED: ServiceAccountKeyAlgorithm = ServiceAccountKeyAlgorithm::new(0);
+
+    /// 1k RSA Key.
+    pub const KEY_ALG_RSA_1024: ServiceAccountKeyAlgorithm = ServiceAccountKeyAlgorithm::new(1);
+
+    /// 2k RSA Key.
+    pub const KEY_ALG_RSA_2048: ServiceAccountKeyAlgorithm = ServiceAccountKeyAlgorithm::new(2);
+
     /// Creates a new ServiceAccountKeyAlgorithm instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("KEY_ALG_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("KEY_ALG_RSA_1024"),
+            2 => std::borrow::Cow::Borrowed("KEY_ALG_RSA_2048"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "KEY_ALG_UNSPECIFIED" => std::option::Option::Some(Self::KEY_ALG_UNSPECIFIED),
+            "KEY_ALG_RSA_1024" => std::option::Option::Some(Self::KEY_ALG_RSA_1024),
+            "KEY_ALG_RSA_2048" => std::option::Option::Some(Self::KEY_ALG_RSA_2048),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [ServiceAccountKeyAlgorithm](ServiceAccountKeyAlgorithm)
-pub mod service_account_key_algorithm {
-    use super::ServiceAccountKeyAlgorithm;
-
-    /// An unspecified key algorithm.
-    pub const KEY_ALG_UNSPECIFIED: ServiceAccountKeyAlgorithm =
-        ServiceAccountKeyAlgorithm::new("KEY_ALG_UNSPECIFIED");
-
-    /// 1k RSA Key.
-    pub const KEY_ALG_RSA_1024: ServiceAccountKeyAlgorithm =
-        ServiceAccountKeyAlgorithm::new("KEY_ALG_RSA_1024");
-
-    /// 2k RSA Key.
-    pub const KEY_ALG_RSA_2048: ServiceAccountKeyAlgorithm =
-        ServiceAccountKeyAlgorithm::new("KEY_ALG_RSA_2048");
-}
-
-impl std::convert::From<std::string::String> for ServiceAccountKeyAlgorithm {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ServiceAccountKeyAlgorithm {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ServiceAccountKeyAlgorithm {
     fn default() -> Self {
-        service_account_key_algorithm::KEY_ALG_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Supported private key output formats.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ServiceAccountPrivateKeyType(std::borrow::Cow<'static, str>);
+pub struct ServiceAccountPrivateKeyType(i32);
 
 impl ServiceAccountPrivateKeyType {
-    /// Creates a new ServiceAccountPrivateKeyType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ServiceAccountPrivateKeyType](ServiceAccountPrivateKeyType)
-pub mod service_account_private_key_type {
-    use super::ServiceAccountPrivateKeyType;
-
     /// Unspecified. Equivalent to `TYPE_GOOGLE_CREDENTIALS_FILE`.
-    pub const TYPE_UNSPECIFIED: ServiceAccountPrivateKeyType =
-        ServiceAccountPrivateKeyType::new("TYPE_UNSPECIFIED");
+    pub const TYPE_UNSPECIFIED: ServiceAccountPrivateKeyType = ServiceAccountPrivateKeyType::new(0);
 
     /// PKCS12 format.
     /// The password for the PKCS12 file is `notasecret`.
     /// For more information, see <https://tools.ietf.org/html/rfc7292>.
-    pub const TYPE_PKCS12_FILE: ServiceAccountPrivateKeyType =
-        ServiceAccountPrivateKeyType::new("TYPE_PKCS12_FILE");
+    pub const TYPE_PKCS12_FILE: ServiceAccountPrivateKeyType = ServiceAccountPrivateKeyType::new(1);
 
     /// Google Credentials File format.
     pub const TYPE_GOOGLE_CREDENTIALS_FILE: ServiceAccountPrivateKeyType =
-        ServiceAccountPrivateKeyType::new("TYPE_GOOGLE_CREDENTIALS_FILE");
+        ServiceAccountPrivateKeyType::new(2);
+
+    /// Creates a new ServiceAccountPrivateKeyType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("TYPE_PKCS12_FILE"),
+            2 => std::borrow::Cow::Borrowed("TYPE_GOOGLE_CREDENTIALS_FILE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+            "TYPE_PKCS12_FILE" => std::option::Option::Some(Self::TYPE_PKCS12_FILE),
+            "TYPE_GOOGLE_CREDENTIALS_FILE" => {
+                std::option::Option::Some(Self::TYPE_GOOGLE_CREDENTIALS_FILE)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ServiceAccountPrivateKeyType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ServiceAccountPrivateKeyType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ServiceAccountPrivateKeyType {
     fn default() -> Self {
-        service_account_private_key_type::TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Supported public key output formats.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ServiceAccountPublicKeyType(std::borrow::Cow<'static, str>);
+pub struct ServiceAccountPublicKeyType(i32);
 
 impl ServiceAccountPublicKeyType {
-    /// Creates a new ServiceAccountPublicKeyType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ServiceAccountPublicKeyType](ServiceAccountPublicKeyType)
-pub mod service_account_public_key_type {
-    use super::ServiceAccountPublicKeyType;
-
     /// Do not return the public key.
-    pub const TYPE_NONE: ServiceAccountPublicKeyType =
-        ServiceAccountPublicKeyType::new("TYPE_NONE");
+    pub const TYPE_NONE: ServiceAccountPublicKeyType = ServiceAccountPublicKeyType::new(0);
 
     /// X509 PEM format.
-    pub const TYPE_X509_PEM_FILE: ServiceAccountPublicKeyType =
-        ServiceAccountPublicKeyType::new("TYPE_X509_PEM_FILE");
+    pub const TYPE_X509_PEM_FILE: ServiceAccountPublicKeyType = ServiceAccountPublicKeyType::new(1);
 
     /// Raw public key.
     pub const TYPE_RAW_PUBLIC_KEY: ServiceAccountPublicKeyType =
-        ServiceAccountPublicKeyType::new("TYPE_RAW_PUBLIC_KEY");
+        ServiceAccountPublicKeyType::new(2);
+
+    /// Creates a new ServiceAccountPublicKeyType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("TYPE_NONE"),
+            1 => std::borrow::Cow::Borrowed("TYPE_X509_PEM_FILE"),
+            2 => std::borrow::Cow::Borrowed("TYPE_RAW_PUBLIC_KEY"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "TYPE_NONE" => std::option::Option::Some(Self::TYPE_NONE),
+            "TYPE_X509_PEM_FILE" => std::option::Option::Some(Self::TYPE_X509_PEM_FILE),
+            "TYPE_RAW_PUBLIC_KEY" => std::option::Option::Some(Self::TYPE_RAW_PUBLIC_KEY),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ServiceAccountPublicKeyType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ServiceAccountPublicKeyType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ServiceAccountPublicKeyType {
     fn default() -> Self {
-        service_account_public_key_type::TYPE_NONE
+        Self::new(0)
     }
 }
 
 /// Service Account Key Origin.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ServiceAccountKeyOrigin(std::borrow::Cow<'static, str>);
+pub struct ServiceAccountKeyOrigin(i32);
 
 impl ServiceAccountKeyOrigin {
+    /// Unspecified key origin.
+    pub const ORIGIN_UNSPECIFIED: ServiceAccountKeyOrigin = ServiceAccountKeyOrigin::new(0);
+
+    /// Key is provided by user.
+    pub const USER_PROVIDED: ServiceAccountKeyOrigin = ServiceAccountKeyOrigin::new(1);
+
+    /// Key is provided by Google.
+    pub const GOOGLE_PROVIDED: ServiceAccountKeyOrigin = ServiceAccountKeyOrigin::new(2);
+
     /// Creates a new ServiceAccountKeyOrigin instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ORIGIN_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("USER_PROVIDED"),
+            2 => std::borrow::Cow::Borrowed("GOOGLE_PROVIDED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ORIGIN_UNSPECIFIED" => std::option::Option::Some(Self::ORIGIN_UNSPECIFIED),
+            "USER_PROVIDED" => std::option::Option::Some(Self::USER_PROVIDED),
+            "GOOGLE_PROVIDED" => std::option::Option::Some(Self::GOOGLE_PROVIDED),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [ServiceAccountKeyOrigin](ServiceAccountKeyOrigin)
-pub mod service_account_key_origin {
-    use super::ServiceAccountKeyOrigin;
-
-    /// Unspecified key origin.
-    pub const ORIGIN_UNSPECIFIED: ServiceAccountKeyOrigin =
-        ServiceAccountKeyOrigin::new("ORIGIN_UNSPECIFIED");
-
-    /// Key is provided by user.
-    pub const USER_PROVIDED: ServiceAccountKeyOrigin =
-        ServiceAccountKeyOrigin::new("USER_PROVIDED");
-
-    /// Key is provided by Google.
-    pub const GOOGLE_PROVIDED: ServiceAccountKeyOrigin =
-        ServiceAccountKeyOrigin::new("GOOGLE_PROVIDED");
-}
-
-impl std::convert::From<std::string::String> for ServiceAccountKeyOrigin {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ServiceAccountKeyOrigin {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ServiceAccountKeyOrigin {
     fn default() -> Self {
-        service_account_key_origin::ORIGIN_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// A view for Role objects.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RoleView(std::borrow::Cow<'static, str>);
+pub struct RoleView(i32);
 
 impl RoleView {
+    /// Omits the `included_permissions` field.
+    /// This is the default value.
+    pub const BASIC: RoleView = RoleView::new(0);
+
+    /// Returns all fields.
+    pub const FULL: RoleView = RoleView::new(1);
+
     /// Creates a new RoleView instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("BASIC"),
+            1 => std::borrow::Cow::Borrowed("FULL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "BASIC" => std::option::Option::Some(Self::BASIC),
+            "FULL" => std::option::Option::Some(Self::FULL),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [RoleView](RoleView)
-pub mod role_view {
-    use super::RoleView;
-
-    /// Omits the `included_permissions` field.
-    /// This is the default value.
-    pub const BASIC: RoleView = RoleView::new("BASIC");
-
-    /// Returns all fields.
-    pub const FULL: RoleView = RoleView::new("FULL");
-}
-
-impl std::convert::From<std::string::String> for RoleView {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for RoleView {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for RoleView {
     fn default() -> Self {
-        role_view::BASIC
+        Self::new(0)
     }
 }

--- a/src/generated/iam/admin/v1/src/transport.rs
+++ b/src/generated/iam/admin/v1/src/transport.rs
@@ -50,7 +50,7 @@ impl crate::stubs::Iam for Iam {
                 reqwest::Method::GET,
                 format!("/v1/{}/serviceAccounts", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -71,7 +71,7 @@ impl crate::stubs::Iam for Iam {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -93,7 +93,7 @@ impl crate::stubs::Iam for Iam {
                 reqwest::Method::POST,
                 format!("/v1/{}/serviceAccounts", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -110,7 +110,7 @@ impl crate::stubs::Iam for Iam {
         let builder = self
             .inner
             .builder(reqwest::Method::PUT, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -136,7 +136,7 @@ impl crate::stubs::Iam for Iam {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -153,7 +153,7 @@ impl crate::stubs::Iam for Iam {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -172,7 +172,7 @@ impl crate::stubs::Iam for Iam {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:undelete", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -189,7 +189,7 @@ impl crate::stubs::Iam for Iam {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:enable", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -206,7 +206,7 @@ impl crate::stubs::Iam for Iam {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:disable", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -223,7 +223,7 @@ impl crate::stubs::Iam for Iam {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/keys", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -245,7 +245,7 @@ impl crate::stubs::Iam for Iam {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -265,7 +265,7 @@ impl crate::stubs::Iam for Iam {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/keys", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -285,7 +285,7 @@ impl crate::stubs::Iam for Iam {
                 reqwest::Method::POST,
                 format!("/v1/{}/keys:upload", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -302,7 +302,7 @@ impl crate::stubs::Iam for Iam {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -321,7 +321,7 @@ impl crate::stubs::Iam for Iam {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:disable", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -338,7 +338,7 @@ impl crate::stubs::Iam for Iam {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:enable", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -355,7 +355,7 @@ impl crate::stubs::Iam for Iam {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:signBlob", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -372,7 +372,7 @@ impl crate::stubs::Iam for Iam {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:signJwt", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -392,7 +392,7 @@ impl crate::stubs::Iam for Iam {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -424,7 +424,7 @@ impl crate::stubs::Iam for Iam {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -444,7 +444,7 @@ impl crate::stubs::Iam for Iam {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -464,7 +464,7 @@ impl crate::stubs::Iam for Iam {
                 reqwest::Method::POST,
                 "/v1/roles:queryGrantableRoles".to_string(),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -481,7 +481,7 @@ impl crate::stubs::Iam for Iam {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v1/roles".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -505,7 +505,7 @@ impl crate::stubs::Iam for Iam {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -524,7 +524,7 @@ impl crate::stubs::Iam for Iam {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/roles", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -541,7 +541,7 @@ impl crate::stubs::Iam for Iam {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -568,7 +568,7 @@ impl crate::stubs::Iam for Iam {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -588,7 +588,7 @@ impl crate::stubs::Iam for Iam {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:undelete", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -608,7 +608,7 @@ impl crate::stubs::Iam for Iam {
                 reqwest::Method::POST,
                 "/v1/permissions:queryTestablePermissions".to_string(),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -628,7 +628,7 @@ impl crate::stubs::Iam for Iam {
                 reqwest::Method::POST,
                 "/v1/iamPolicies:queryAuditableServices".to_string(),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -648,7 +648,7 @@ impl crate::stubs::Iam for Iam {
                 reqwest::Method::POST,
                 "/v1/iamPolicies:lintPolicy".to_string(),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/iam/credentials/v1/src/transport.rs
+++ b/src/generated/iam/credentials/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::IAMCredentials for IAMCredentials {
                 reqwest::Method::POST,
                 format!("/v1/{}:generateAccessToken", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::IAMCredentials for IAMCredentials {
                 reqwest::Method::POST,
                 format!("/v1/{}:generateIdToken", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -89,7 +89,7 @@ impl crate::stubs::IAMCredentials for IAMCredentials {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:signBlob", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -106,7 +106,7 @@ impl crate::stubs::IAMCredentials for IAMCredentials {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:signJwt", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/iam/v1/src/model.rs
+++ b/src/generated/iam/v1/src/model.rs
@@ -737,46 +737,63 @@ pub mod audit_log_config {
     /// The list of valid permission types for which logging can be configured.
     /// Admin writes are always logged, and are not configurable.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LogType(std::borrow::Cow<'static, str>);
+    pub struct LogType(i32);
 
     impl LogType {
+        /// Default case. Should never be this.
+        pub const LOG_TYPE_UNSPECIFIED: LogType = LogType::new(0);
+
+        /// Admin reads. Example: CloudIAM getIamPolicy
+        pub const ADMIN_READ: LogType = LogType::new(1);
+
+        /// Data writes. Example: CloudSQL Users create
+        pub const DATA_WRITE: LogType = LogType::new(2);
+
+        /// Data reads. Example: CloudSQL Users list
+        pub const DATA_READ: LogType = LogType::new(3);
+
         /// Creates a new LogType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LOG_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ADMIN_READ"),
+                2 => std::borrow::Cow::Borrowed("DATA_WRITE"),
+                3 => std::borrow::Cow::Borrowed("DATA_READ"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LOG_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::LOG_TYPE_UNSPECIFIED),
+                "ADMIN_READ" => std::option::Option::Some(Self::ADMIN_READ),
+                "DATA_WRITE" => std::option::Option::Some(Self::DATA_WRITE),
+                "DATA_READ" => std::option::Option::Some(Self::DATA_READ),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [LogType](LogType)
-    pub mod log_type {
-        use super::LogType;
-
-        /// Default case. Should never be this.
-        pub const LOG_TYPE_UNSPECIFIED: LogType = LogType::new("LOG_TYPE_UNSPECIFIED");
-
-        /// Admin reads. Example: CloudIAM getIamPolicy
-        pub const ADMIN_READ: LogType = LogType::new("ADMIN_READ");
-
-        /// Data writes. Example: CloudSQL Users create
-        pub const DATA_WRITE: LogType = LogType::new("DATA_WRITE");
-
-        /// Data reads. Example: CloudSQL Users list
-        pub const DATA_READ: LogType = LogType::new("DATA_READ");
-    }
-
-    impl std::convert::From<std::string::String> for LogType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LogType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LogType {
         fn default() -> Self {
-            log_type::LOG_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -907,43 +924,58 @@ pub mod binding_delta {
 
     /// The type of action performed on a Binding in a policy.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(std::borrow::Cow<'static, str>);
+    pub struct Action(i32);
 
     impl Action {
+        /// Unspecified.
+        pub const ACTION_UNSPECIFIED: Action = Action::new(0);
+
+        /// Addition of a Binding.
+        pub const ADD: Action = Action::new(1);
+
+        /// Removal of a Binding.
+        pub const REMOVE: Action = Action::new(2);
+
         /// Creates a new Action instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ACTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ADD"),
+                2 => std::borrow::Cow::Borrowed("REMOVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ACTION_UNSPECIFIED" => std::option::Option::Some(Self::ACTION_UNSPECIFIED),
+                "ADD" => std::option::Option::Some(Self::ADD),
+                "REMOVE" => std::option::Option::Some(Self::REMOVE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Action](Action)
-    pub mod action {
-        use super::Action;
-
-        /// Unspecified.
-        pub const ACTION_UNSPECIFIED: Action = Action::new("ACTION_UNSPECIFIED");
-
-        /// Addition of a Binding.
-        pub const ADD: Action = Action::new("ADD");
-
-        /// Removal of a Binding.
-        pub const REMOVE: Action = Action::new("REMOVE");
-    }
-
-    impl std::convert::From<std::string::String> for Action {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            action::ACTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1025,43 +1057,58 @@ pub mod audit_config_delta {
 
     /// The type of action performed on an audit configuration in a policy.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(std::borrow::Cow<'static, str>);
+    pub struct Action(i32);
 
     impl Action {
+        /// Unspecified.
+        pub const ACTION_UNSPECIFIED: Action = Action::new(0);
+
+        /// Addition of an audit configuration.
+        pub const ADD: Action = Action::new(1);
+
+        /// Removal of an audit configuration.
+        pub const REMOVE: Action = Action::new(2);
+
         /// Creates a new Action instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ACTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ADD"),
+                2 => std::borrow::Cow::Borrowed("REMOVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ACTION_UNSPECIFIED" => std::option::Option::Some(Self::ACTION_UNSPECIFIED),
+                "ADD" => std::option::Option::Some(Self::ADD),
+                "REMOVE" => std::option::Option::Some(Self::REMOVE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Action](Action)
-    pub mod action {
-        use super::Action;
-
-        /// Unspecified.
-        pub const ACTION_UNSPECIFIED: Action = Action::new("ACTION_UNSPECIFIED");
-
-        /// Addition of an audit configuration.
-        pub const ADD: Action = Action::new("ADD");
-
-        /// Removal of an audit configuration.
-        pub const REMOVE: Action = Action::new("REMOVE");
-    }
-
-    impl std::convert::From<std::string::String> for Action {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            action::ACTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/iam/v1/src/transport.rs
+++ b/src/generated/iam/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::IAMPolicy for IAMPolicy {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::IAMPolicy for IAMPolicy {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -92,7 +92,7 @@ impl crate::stubs::IAMPolicy for IAMPolicy {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/iam/v2/src/transport.rs
+++ b/src/generated/iam/v2/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::Policies for Policies {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -70,7 +70,7 @@ impl crate::stubs::Policies for Policies {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -89,7 +89,7 @@ impl crate::stubs::Policies for Policies {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -116,7 +116,7 @@ impl crate::stubs::Policies for Policies {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -133,7 +133,7 @@ impl crate::stubs::Policies for Policies {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -153,7 +153,7 @@ impl crate::stubs::Policies for Policies {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/iam/v3/src/model.rs
+++ b/src/generated/iam/v3/src/model.rs
@@ -445,41 +445,57 @@ pub mod policy_binding {
 
     /// Different policy kinds supported in this binding.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PolicyKind(std::borrow::Cow<'static, str>);
+    pub struct PolicyKind(i32);
 
     impl PolicyKind {
+        /// Unspecified policy kind; Not a valid state
+        pub const POLICY_KIND_UNSPECIFIED: PolicyKind = PolicyKind::new(0);
+
+        /// Principal access boundary policy kind
+        pub const PRINCIPAL_ACCESS_BOUNDARY: PolicyKind = PolicyKind::new(1);
+
         /// Creates a new PolicyKind instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("POLICY_KIND_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PRINCIPAL_ACCESS_BOUNDARY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "POLICY_KIND_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::POLICY_KIND_UNSPECIFIED)
+                }
+                "PRINCIPAL_ACCESS_BOUNDARY" => {
+                    std::option::Option::Some(Self::PRINCIPAL_ACCESS_BOUNDARY)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [PolicyKind](PolicyKind)
-    pub mod policy_kind {
-        use super::PolicyKind;
-
-        /// Unspecified policy kind; Not a valid state
-        pub const POLICY_KIND_UNSPECIFIED: PolicyKind = PolicyKind::new("POLICY_KIND_UNSPECIFIED");
-
-        /// Principal access boundary policy kind
-        pub const PRINCIPAL_ACCESS_BOUNDARY: PolicyKind =
-            PolicyKind::new("PRINCIPAL_ACCESS_BOUNDARY");
-    }
-
-    impl std::convert::From<std::string::String> for PolicyKind {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PolicyKind {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PolicyKind {
         fn default() -> Self {
-            policy_kind::POLICY_KIND_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1734,40 +1750,53 @@ pub mod principal_access_boundary_policy_rule {
 
     /// An effect to describe the access relationship.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Effect(std::borrow::Cow<'static, str>);
+    pub struct Effect(i32);
 
     impl Effect {
+        /// Effect unspecified.
+        pub const EFFECT_UNSPECIFIED: Effect = Effect::new(0);
+
+        /// Allows access to the resources in this rule.
+        pub const ALLOW: Effect = Effect::new(1);
+
         /// Creates a new Effect instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EFFECT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALLOW"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EFFECT_UNSPECIFIED" => std::option::Option::Some(Self::EFFECT_UNSPECIFIED),
+                "ALLOW" => std::option::Option::Some(Self::ALLOW),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Effect](Effect)
-    pub mod effect {
-        use super::Effect;
-
-        /// Effect unspecified.
-        pub const EFFECT_UNSPECIFIED: Effect = Effect::new("EFFECT_UNSPECIFIED");
-
-        /// Allows access to the resources in this rule.
-        pub const ALLOW: Effect = Effect::new("ALLOW");
-    }
-
-    impl std::convert::From<std::string::String> for Effect {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Effect {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Effect {
         fn default() -> Self {
-            effect::EFFECT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/iam/v3/src/transport.rs
+++ b/src/generated/iam/v3/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::PolicyBindings for PolicyBindings {
                 reqwest::Method::POST,
                 format!("/v3/{}/policyBindings", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -73,7 +73,7 @@ impl crate::stubs::PolicyBindings for PolicyBindings {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -101,7 +101,7 @@ impl crate::stubs::PolicyBindings for PolicyBindings {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -131,7 +131,7 @@ impl crate::stubs::PolicyBindings for PolicyBindings {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -155,7 +155,7 @@ impl crate::stubs::PolicyBindings for PolicyBindings {
                 reqwest::Method::GET,
                 format!("/v3/{}/policyBindings", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -183,7 +183,7 @@ impl crate::stubs::PolicyBindings for PolicyBindings {
                     req.parent
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -205,7 +205,7 @@ impl crate::stubs::PolicyBindings for PolicyBindings {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -264,7 +264,7 @@ impl crate::stubs::PrincipalAccessBoundaryPolicies for PrincipalAccessBoundaryPo
                 reqwest::Method::POST,
                 format!("/v3/{}/principalAccessBoundaryPolicies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -288,7 +288,7 @@ impl crate::stubs::PrincipalAccessBoundaryPolicies for PrincipalAccessBoundaryPo
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -318,7 +318,7 @@ impl crate::stubs::PrincipalAccessBoundaryPolicies for PrincipalAccessBoundaryPo
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -348,7 +348,7 @@ impl crate::stubs::PrincipalAccessBoundaryPolicies for PrincipalAccessBoundaryPo
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -373,7 +373,7 @@ impl crate::stubs::PrincipalAccessBoundaryPolicies for PrincipalAccessBoundaryPo
                 reqwest::Method::GET,
                 format!("/v3/{}/principalAccessBoundaryPolicies", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -397,7 +397,7 @@ impl crate::stubs::PrincipalAccessBoundaryPolicies for PrincipalAccessBoundaryPo
                 reqwest::Method::GET,
                 format!("/v3/{}:searchPolicyBindings", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -418,7 +418,7 @@ impl crate::stubs::PrincipalAccessBoundaryPolicies for PrincipalAccessBoundaryPo
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/identity/accesscontextmanager/type/src/model.rs
+++ b/src/generated/identity/accesscontextmanager/type/src/model.rs
@@ -25,151 +25,205 @@ extern crate wkt;
 
 /// The encryption state of the device.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DeviceEncryptionStatus(std::borrow::Cow<'static, str>);
+pub struct DeviceEncryptionStatus(i32);
 
 impl DeviceEncryptionStatus {
+    /// The encryption status of the device is not specified or not known.
+    pub const ENCRYPTION_UNSPECIFIED: DeviceEncryptionStatus = DeviceEncryptionStatus::new(0);
+
+    /// The device does not support encryption.
+    pub const ENCRYPTION_UNSUPPORTED: DeviceEncryptionStatus = DeviceEncryptionStatus::new(1);
+
+    /// The device supports encryption, but is currently unencrypted.
+    pub const UNENCRYPTED: DeviceEncryptionStatus = DeviceEncryptionStatus::new(2);
+
+    /// The device is encrypted.
+    pub const ENCRYPTED: DeviceEncryptionStatus = DeviceEncryptionStatus::new(3);
+
     /// Creates a new DeviceEncryptionStatus instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ENCRYPTION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ENCRYPTION_UNSUPPORTED"),
+            2 => std::borrow::Cow::Borrowed("UNENCRYPTED"),
+            3 => std::borrow::Cow::Borrowed("ENCRYPTED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ENCRYPTION_UNSPECIFIED" => std::option::Option::Some(Self::ENCRYPTION_UNSPECIFIED),
+            "ENCRYPTION_UNSUPPORTED" => std::option::Option::Some(Self::ENCRYPTION_UNSUPPORTED),
+            "UNENCRYPTED" => std::option::Option::Some(Self::UNENCRYPTED),
+            "ENCRYPTED" => std::option::Option::Some(Self::ENCRYPTED),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [DeviceEncryptionStatus](DeviceEncryptionStatus)
-pub mod device_encryption_status {
-    use super::DeviceEncryptionStatus;
-
-    /// The encryption status of the device is not specified or not known.
-    pub const ENCRYPTION_UNSPECIFIED: DeviceEncryptionStatus =
-        DeviceEncryptionStatus::new("ENCRYPTION_UNSPECIFIED");
-
-    /// The device does not support encryption.
-    pub const ENCRYPTION_UNSUPPORTED: DeviceEncryptionStatus =
-        DeviceEncryptionStatus::new("ENCRYPTION_UNSUPPORTED");
-
-    /// The device supports encryption, but is currently unencrypted.
-    pub const UNENCRYPTED: DeviceEncryptionStatus = DeviceEncryptionStatus::new("UNENCRYPTED");
-
-    /// The device is encrypted.
-    pub const ENCRYPTED: DeviceEncryptionStatus = DeviceEncryptionStatus::new("ENCRYPTED");
-}
-
-impl std::convert::From<std::string::String> for DeviceEncryptionStatus {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DeviceEncryptionStatus {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DeviceEncryptionStatus {
     fn default() -> Self {
-        device_encryption_status::ENCRYPTION_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The operating system type of the device.
 /// Next id: 7
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OsType(std::borrow::Cow<'static, str>);
+pub struct OsType(i32);
 
 impl OsType {
+    /// The operating system of the device is not specified or not known.
+    pub const OS_UNSPECIFIED: OsType = OsType::new(0);
+
+    /// A desktop Mac operating system.
+    pub const DESKTOP_MAC: OsType = OsType::new(1);
+
+    /// A desktop Windows operating system.
+    pub const DESKTOP_WINDOWS: OsType = OsType::new(2);
+
+    /// A desktop Linux operating system.
+    pub const DESKTOP_LINUX: OsType = OsType::new(3);
+
+    /// A desktop ChromeOS operating system.
+    pub const DESKTOP_CHROME_OS: OsType = OsType::new(6);
+
+    /// An Android operating system.
+    pub const ANDROID: OsType = OsType::new(4);
+
+    /// An iOS operating system.
+    pub const IOS: OsType = OsType::new(5);
+
     /// Creates a new OsType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("OS_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("DESKTOP_MAC"),
+            2 => std::borrow::Cow::Borrowed("DESKTOP_WINDOWS"),
+            3 => std::borrow::Cow::Borrowed("DESKTOP_LINUX"),
+            4 => std::borrow::Cow::Borrowed("ANDROID"),
+            5 => std::borrow::Cow::Borrowed("IOS"),
+            6 => std::borrow::Cow::Borrowed("DESKTOP_CHROME_OS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "OS_UNSPECIFIED" => std::option::Option::Some(Self::OS_UNSPECIFIED),
+            "DESKTOP_MAC" => std::option::Option::Some(Self::DESKTOP_MAC),
+            "DESKTOP_WINDOWS" => std::option::Option::Some(Self::DESKTOP_WINDOWS),
+            "DESKTOP_LINUX" => std::option::Option::Some(Self::DESKTOP_LINUX),
+            "DESKTOP_CHROME_OS" => std::option::Option::Some(Self::DESKTOP_CHROME_OS),
+            "ANDROID" => std::option::Option::Some(Self::ANDROID),
+            "IOS" => std::option::Option::Some(Self::IOS),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [OsType](OsType)
-pub mod os_type {
-    use super::OsType;
-
-    /// The operating system of the device is not specified or not known.
-    pub const OS_UNSPECIFIED: OsType = OsType::new("OS_UNSPECIFIED");
-
-    /// A desktop Mac operating system.
-    pub const DESKTOP_MAC: OsType = OsType::new("DESKTOP_MAC");
-
-    /// A desktop Windows operating system.
-    pub const DESKTOP_WINDOWS: OsType = OsType::new("DESKTOP_WINDOWS");
-
-    /// A desktop Linux operating system.
-    pub const DESKTOP_LINUX: OsType = OsType::new("DESKTOP_LINUX");
-
-    /// A desktop ChromeOS operating system.
-    pub const DESKTOP_CHROME_OS: OsType = OsType::new("DESKTOP_CHROME_OS");
-
-    /// An Android operating system.
-    pub const ANDROID: OsType = OsType::new("ANDROID");
-
-    /// An iOS operating system.
-    pub const IOS: OsType = OsType::new("IOS");
-}
-
-impl std::convert::From<std::string::String> for OsType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for OsType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for OsType {
     fn default() -> Self {
-        os_type::OS_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The degree to which the device is managed by the Cloud organization.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DeviceManagementLevel(std::borrow::Cow<'static, str>);
+pub struct DeviceManagementLevel(i32);
 
 impl DeviceManagementLevel {
-    /// Creates a new DeviceManagementLevel instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [DeviceManagementLevel](DeviceManagementLevel)
-pub mod device_management_level {
-    use super::DeviceManagementLevel;
-
     /// The device's management level is not specified or not known.
-    pub const MANAGEMENT_UNSPECIFIED: DeviceManagementLevel =
-        DeviceManagementLevel::new("MANAGEMENT_UNSPECIFIED");
+    pub const MANAGEMENT_UNSPECIFIED: DeviceManagementLevel = DeviceManagementLevel::new(0);
 
     /// The device is not managed.
-    pub const NONE: DeviceManagementLevel = DeviceManagementLevel::new("NONE");
+    pub const NONE: DeviceManagementLevel = DeviceManagementLevel::new(1);
 
     /// Basic management is enabled, which is generally limited to monitoring and
     /// wiping the corporate account.
-    pub const BASIC: DeviceManagementLevel = DeviceManagementLevel::new("BASIC");
+    pub const BASIC: DeviceManagementLevel = DeviceManagementLevel::new(2);
 
     /// Complete device management. This includes more thorough monitoring and the
     /// ability to directly manage the device (such as remote wiping). This can be
     /// enabled through the Android Enterprise Platform.
-    pub const COMPLETE: DeviceManagementLevel = DeviceManagementLevel::new("COMPLETE");
+    pub const COMPLETE: DeviceManagementLevel = DeviceManagementLevel::new(3);
+
+    /// Creates a new DeviceManagementLevel instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("MANAGEMENT_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("NONE"),
+            2 => std::borrow::Cow::Borrowed("BASIC"),
+            3 => std::borrow::Cow::Borrowed("COMPLETE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "MANAGEMENT_UNSPECIFIED" => std::option::Option::Some(Self::MANAGEMENT_UNSPECIFIED),
+            "NONE" => std::option::Option::Some(Self::NONE),
+            "BASIC" => std::option::Option::Some(Self::BASIC),
+            "COMPLETE" => std::option::Option::Some(Self::COMPLETE),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for DeviceManagementLevel {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DeviceManagementLevel {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DeviceManagementLevel {
     fn default() -> Self {
-        device_management_level::MANAGEMENT_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/identity/accesscontextmanager/v1/src/model.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/model.rs
@@ -1685,40 +1685,53 @@ pub mod basic_level {
     /// Options for how the `conditions` list should be combined to determine if
     /// this `AccessLevel` is applied. Default is AND.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConditionCombiningFunction(std::borrow::Cow<'static, str>);
+    pub struct ConditionCombiningFunction(i32);
 
     impl ConditionCombiningFunction {
+        /// All `Conditions` must be true for the `BasicLevel` to be true.
+        pub const AND: ConditionCombiningFunction = ConditionCombiningFunction::new(0);
+
+        /// If at least one `Condition` is true, then the `BasicLevel` is true.
+        pub const OR: ConditionCombiningFunction = ConditionCombiningFunction::new(1);
+
         /// Creates a new ConditionCombiningFunction instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("AND"),
+                1 => std::borrow::Cow::Borrowed("OR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "AND" => std::option::Option::Some(Self::AND),
+                "OR" => std::option::Option::Some(Self::OR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ConditionCombiningFunction](ConditionCombiningFunction)
-    pub mod condition_combining_function {
-        use super::ConditionCombiningFunction;
-
-        /// All `Conditions` must be true for the `BasicLevel` to be true.
-        pub const AND: ConditionCombiningFunction = ConditionCombiningFunction::new("AND");
-
-        /// If at least one `Condition` is true, then the `BasicLevel` is true.
-        pub const OR: ConditionCombiningFunction = ConditionCombiningFunction::new("OR");
-    }
-
-    impl std::convert::From<std::string::String> for ConditionCombiningFunction {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ConditionCombiningFunction {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ConditionCombiningFunction {
         fn default() -> Self {
-            condition_combining_function::AND
+            Self::new(0)
         }
     }
 }
@@ -2415,42 +2428,53 @@ pub mod service_perimeter {
     /// with many independent perimeters that need to share some data with a common
     /// perimeter, but should not be able to share data among themselves.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PerimeterType(std::borrow::Cow<'static, str>);
+    pub struct PerimeterType(i32);
 
     impl PerimeterType {
+        /// Regular Perimeter.
+        pub const PERIMETER_TYPE_REGULAR: PerimeterType = PerimeterType::new(0);
+
+        /// Perimeter Bridge.
+        pub const PERIMETER_TYPE_BRIDGE: PerimeterType = PerimeterType::new(1);
+
         /// Creates a new PerimeterType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PERIMETER_TYPE_REGULAR"),
+                1 => std::borrow::Cow::Borrowed("PERIMETER_TYPE_BRIDGE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PERIMETER_TYPE_REGULAR" => std::option::Option::Some(Self::PERIMETER_TYPE_REGULAR),
+                "PERIMETER_TYPE_BRIDGE" => std::option::Option::Some(Self::PERIMETER_TYPE_BRIDGE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [PerimeterType](PerimeterType)
-    pub mod perimeter_type {
-        use super::PerimeterType;
-
-        /// Regular Perimeter.
-        pub const PERIMETER_TYPE_REGULAR: PerimeterType =
-            PerimeterType::new("PERIMETER_TYPE_REGULAR");
-
-        /// Perimeter Bridge.
-        pub const PERIMETER_TYPE_BRIDGE: PerimeterType =
-            PerimeterType::new("PERIMETER_TYPE_BRIDGE");
-    }
-
-    impl std::convert::From<std::string::String> for PerimeterType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PerimeterType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PerimeterType {
         fn default() -> Self {
-            perimeter_type::PERIMETER_TYPE_REGULAR
+            Self::new(0)
         }
     }
 }
@@ -3424,91 +3448,124 @@ pub mod service_perimeter_config {
     /// [google.identity.accesscontextmanager.v1.ServicePerimeterConfig.EgressFrom]
     /// rules.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IdentityType(std::borrow::Cow<'static, str>);
+    pub struct IdentityType(i32);
 
     impl IdentityType {
+        /// No blanket identity group specified.
+        pub const IDENTITY_TYPE_UNSPECIFIED: IdentityType = IdentityType::new(0);
+
+        /// Authorize access from all identities outside the perimeter.
+        pub const ANY_IDENTITY: IdentityType = IdentityType::new(1);
+
+        /// Authorize access from all human users outside the perimeter.
+        pub const ANY_USER_ACCOUNT: IdentityType = IdentityType::new(2);
+
+        /// Authorize access from all service accounts outside the perimeter.
+        pub const ANY_SERVICE_ACCOUNT: IdentityType = IdentityType::new(3);
+
         /// Creates a new IdentityType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("IDENTITY_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ANY_IDENTITY"),
+                2 => std::borrow::Cow::Borrowed("ANY_USER_ACCOUNT"),
+                3 => std::borrow::Cow::Borrowed("ANY_SERVICE_ACCOUNT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "IDENTITY_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::IDENTITY_TYPE_UNSPECIFIED)
+                }
+                "ANY_IDENTITY" => std::option::Option::Some(Self::ANY_IDENTITY),
+                "ANY_USER_ACCOUNT" => std::option::Option::Some(Self::ANY_USER_ACCOUNT),
+                "ANY_SERVICE_ACCOUNT" => std::option::Option::Some(Self::ANY_SERVICE_ACCOUNT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [IdentityType](IdentityType)
-    pub mod identity_type {
-        use super::IdentityType;
-
-        /// No blanket identity group specified.
-        pub const IDENTITY_TYPE_UNSPECIFIED: IdentityType =
-            IdentityType::new("IDENTITY_TYPE_UNSPECIFIED");
-
-        /// Authorize access from all identities outside the perimeter.
-        pub const ANY_IDENTITY: IdentityType = IdentityType::new("ANY_IDENTITY");
-
-        /// Authorize access from all human users outside the perimeter.
-        pub const ANY_USER_ACCOUNT: IdentityType = IdentityType::new("ANY_USER_ACCOUNT");
-
-        /// Authorize access from all service accounts outside the perimeter.
-        pub const ANY_SERVICE_ACCOUNT: IdentityType = IdentityType::new("ANY_SERVICE_ACCOUNT");
-    }
-
-    impl std::convert::From<std::string::String> for IdentityType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for IdentityType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for IdentityType {
         fn default() -> Self {
-            identity_type::IDENTITY_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
 
 /// The format used in an `AccessLevel`.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LevelFormat(std::borrow::Cow<'static, str>);
+pub struct LevelFormat(i32);
 
 impl LevelFormat {
-    /// Creates a new LevelFormat instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [LevelFormat](LevelFormat)
-pub mod level_format {
-    use super::LevelFormat;
-
     /// The format was not specified.
-    pub const LEVEL_FORMAT_UNSPECIFIED: LevelFormat = LevelFormat::new("LEVEL_FORMAT_UNSPECIFIED");
+    pub const LEVEL_FORMAT_UNSPECIFIED: LevelFormat = LevelFormat::new(0);
 
     /// Uses the format the resource was defined in. BasicLevels are returned as
     /// BasicLevels, CustomLevels are returned as CustomLevels.
-    pub const AS_DEFINED: LevelFormat = LevelFormat::new("AS_DEFINED");
+    pub const AS_DEFINED: LevelFormat = LevelFormat::new(1);
 
     /// Use Cloud Common Expression Language when returning the resource.  Both
     /// BasicLevels and CustomLevels are returned as CustomLevels.
-    pub const CEL: LevelFormat = LevelFormat::new("CEL");
+    pub const CEL: LevelFormat = LevelFormat::new(2);
+
+    /// Creates a new LevelFormat instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("LEVEL_FORMAT_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("AS_DEFINED"),
+            2 => std::borrow::Cow::Borrowed("CEL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "LEVEL_FORMAT_UNSPECIFIED" => std::option::Option::Some(Self::LEVEL_FORMAT_UNSPECIFIED),
+            "AS_DEFINED" => std::option::Option::Some(Self::AS_DEFINED),
+            "CEL" => std::option::Option::Some(Self::CEL),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for LevelFormat {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for LevelFormat {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for LevelFormat {
     fn default() -> Self {
-        level_format::LEVEL_FORMAT_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/identity/accesscontextmanager/v1/src/transport.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v1/accessPolicies".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -71,7 +71,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -90,7 +90,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, "/v1/accessPolicies".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -116,7 +116,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -143,7 +143,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -165,7 +165,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/accessLevels", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -187,7 +187,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -210,7 +210,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/accessLevels", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -238,7 +238,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -267,7 +267,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -289,7 +289,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/accessLevels:replaceAll", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -309,7 +309,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/servicePerimeters", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -330,7 +330,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -352,7 +352,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/servicePerimeters", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -380,7 +380,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -409,7 +409,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -431,7 +431,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/servicePerimeters:replaceAll", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -451,7 +451,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/servicePerimeters:commit", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -471,7 +471,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
                 reqwest::Method::GET,
                 format!("/v1/{}/gcpUserAccessBindings", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -492,7 +492,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -514,7 +514,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
                 reqwest::Method::POST,
                 format!("/v1/{}/gcpUserAccessBindings", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -542,7 +542,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -571,7 +571,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -593,7 +593,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -613,7 +613,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -633,7 +633,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -650,7 +650,7 @@ impl crate::stubs::AccessContextManager for AccessContextManager {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/logging/type/src/model.rs
+++ b/src/generated/logging/type/src/model.rs
@@ -232,61 +232,88 @@ impl wkt::message::Message for HttpRequest {
 /// FINER, and FINEST levels to `LogSeverity.DEBUG`. You can preserve the
 /// original severity level in the log entry payload if you wish.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LogSeverity(std::borrow::Cow<'static, str>);
+pub struct LogSeverity(i32);
 
 impl LogSeverity {
-    /// Creates a new LogSeverity instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [LogSeverity](LogSeverity)
-pub mod log_severity {
-    use super::LogSeverity;
-
     /// (0) The log entry has no assigned severity level.
-    pub const DEFAULT: LogSeverity = LogSeverity::new("DEFAULT");
+    pub const DEFAULT: LogSeverity = LogSeverity::new(0);
 
     /// (100) Debug or trace information.
-    pub const DEBUG: LogSeverity = LogSeverity::new("DEBUG");
+    pub const DEBUG: LogSeverity = LogSeverity::new(100);
 
     /// (200) Routine information, such as ongoing status or performance.
-    pub const INFO: LogSeverity = LogSeverity::new("INFO");
+    pub const INFO: LogSeverity = LogSeverity::new(200);
 
     /// (300) Normal but significant events, such as start up, shut down, or
     /// a configuration change.
-    pub const NOTICE: LogSeverity = LogSeverity::new("NOTICE");
+    pub const NOTICE: LogSeverity = LogSeverity::new(300);
 
     /// (400) Warning events might cause problems.
-    pub const WARNING: LogSeverity = LogSeverity::new("WARNING");
+    pub const WARNING: LogSeverity = LogSeverity::new(400);
 
     /// (500) Error events are likely to cause problems.
-    pub const ERROR: LogSeverity = LogSeverity::new("ERROR");
+    pub const ERROR: LogSeverity = LogSeverity::new(500);
 
     /// (600) Critical events cause more severe problems or outages.
-    pub const CRITICAL: LogSeverity = LogSeverity::new("CRITICAL");
+    pub const CRITICAL: LogSeverity = LogSeverity::new(600);
 
     /// (700) A person must take an action immediately.
-    pub const ALERT: LogSeverity = LogSeverity::new("ALERT");
+    pub const ALERT: LogSeverity = LogSeverity::new(700);
 
     /// (800) One or more systems are unusable.
-    pub const EMERGENCY: LogSeverity = LogSeverity::new("EMERGENCY");
+    pub const EMERGENCY: LogSeverity = LogSeverity::new(800);
+
+    /// Creates a new LogSeverity instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DEFAULT"),
+            100 => std::borrow::Cow::Borrowed("DEBUG"),
+            200 => std::borrow::Cow::Borrowed("INFO"),
+            300 => std::borrow::Cow::Borrowed("NOTICE"),
+            400 => std::borrow::Cow::Borrowed("WARNING"),
+            500 => std::borrow::Cow::Borrowed("ERROR"),
+            600 => std::borrow::Cow::Borrowed("CRITICAL"),
+            700 => std::borrow::Cow::Borrowed("ALERT"),
+            800 => std::borrow::Cow::Borrowed("EMERGENCY"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
+            "DEBUG" => std::option::Option::Some(Self::DEBUG),
+            "INFO" => std::option::Option::Some(Self::INFO),
+            "NOTICE" => std::option::Option::Some(Self::NOTICE),
+            "WARNING" => std::option::Option::Some(Self::WARNING),
+            "ERROR" => std::option::Option::Some(Self::ERROR),
+            "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
+            "ALERT" => std::option::Option::Some(Self::ALERT),
+            "EMERGENCY" => std::option::Option::Some(Self::EMERGENCY),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for LogSeverity {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for LogSeverity {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for LogSeverity {
     fn default() -> Self {
-        log_severity::DEFAULT
+        Self::new(0)
     }
 }

--- a/src/generated/logging/v2/src/model.rs
+++ b/src/generated/logging/v2/src/model.rs
@@ -1480,47 +1480,62 @@ pub mod tail_log_entries_response {
 
         /// An indicator of why entries were omitted.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Reason(std::borrow::Cow<'static, str>);
+        pub struct Reason(i32);
 
         impl Reason {
-            /// Creates a new Reason instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [Reason](Reason)
-        pub mod reason {
-            use super::Reason;
-
             /// Unexpected default.
-            pub const REASON_UNSPECIFIED: Reason = Reason::new("REASON_UNSPECIFIED");
+            pub const REASON_UNSPECIFIED: Reason = Reason::new(0);
 
             /// Indicates suppression occurred due to relevant entries being
             /// received in excess of rate limits. For quotas and limits, see
             /// [Logging API quotas and
             /// limits](https://cloud.google.com/logging/quotas#api-limits).
-            pub const RATE_LIMIT: Reason = Reason::new("RATE_LIMIT");
+            pub const RATE_LIMIT: Reason = Reason::new(1);
 
             /// Indicates suppression occurred due to the client not consuming
             /// responses quickly enough.
-            pub const NOT_CONSUMED: Reason = Reason::new("NOT_CONSUMED");
+            pub const NOT_CONSUMED: Reason = Reason::new(2);
+
+            /// Creates a new Reason instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("REASON_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("RATE_LIMIT"),
+                    2 => std::borrow::Cow::Borrowed("NOT_CONSUMED"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "REASON_UNSPECIFIED" => std::option::Option::Some(Self::REASON_UNSPECIFIED),
+                    "RATE_LIMIT" => std::option::Option::Some(Self::RATE_LIMIT),
+                    "NOT_CONSUMED" => std::option::Option::Some(Self::NOT_CONSUMED),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for Reason {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Reason {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Reason {
             fn default() -> Self {
-                reason::REASON_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -2128,44 +2143,60 @@ pub mod log_sink {
 
     /// Deprecated. This is unused.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VersionFormat(std::borrow::Cow<'static, str>);
+    pub struct VersionFormat(i32);
 
     impl VersionFormat {
+        /// An unspecified format version that will default to V2.
+        pub const VERSION_FORMAT_UNSPECIFIED: VersionFormat = VersionFormat::new(0);
+
+        /// `LogEntry` version 2 format.
+        pub const V2: VersionFormat = VersionFormat::new(1);
+
+        /// `LogEntry` version 1 format.
+        pub const V1: VersionFormat = VersionFormat::new(2);
+
         /// Creates a new VersionFormat instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VERSION_FORMAT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("V2"),
+                2 => std::borrow::Cow::Borrowed("V1"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VERSION_FORMAT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::VERSION_FORMAT_UNSPECIFIED)
+                }
+                "V2" => std::option::Option::Some(Self::V2),
+                "V1" => std::option::Option::Some(Self::V1),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [VersionFormat](VersionFormat)
-    pub mod version_format {
-        use super::VersionFormat;
-
-        /// An unspecified format version that will default to V2.
-        pub const VERSION_FORMAT_UNSPECIFIED: VersionFormat =
-            VersionFormat::new("VERSION_FORMAT_UNSPECIFIED");
-
-        /// `LogEntry` version 2 format.
-        pub const V2: VersionFormat = VersionFormat::new("V2");
-
-        /// `LogEntry` version 1 format.
-        pub const V1: VersionFormat = VersionFormat::new("V1");
-    }
-
-    impl std::convert::From<std::string::String> for VersionFormat {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for VersionFormat {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for VersionFormat {
         fn default() -> Self {
-            version_format::VERSION_FORMAT_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -5437,40 +5468,53 @@ pub mod log_metric {
 
     /// Logging API version.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ApiVersion(std::borrow::Cow<'static, str>);
+    pub struct ApiVersion(i32);
 
     impl ApiVersion {
+        /// Logging API v2.
+        pub const V2: ApiVersion = ApiVersion::new(0);
+
+        /// Logging API v1.
+        pub const V1: ApiVersion = ApiVersion::new(1);
+
         /// Creates a new ApiVersion instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("V2"),
+                1 => std::borrow::Cow::Borrowed("V1"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "V2" => std::option::Option::Some(Self::V2),
+                "V1" => std::option::Option::Some(Self::V1),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ApiVersion](ApiVersion)
-    pub mod api_version {
-        use super::ApiVersion;
-
-        /// Logging API v2.
-        pub const V2: ApiVersion = ApiVersion::new("V2");
-
-        /// Logging API v1.
-        pub const V1: ApiVersion = ApiVersion::new("V1");
-    }
-
-    impl std::convert::From<std::string::String> for ApiVersion {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ApiVersion {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ApiVersion {
         fn default() -> Self {
-            api_version::V2
+            Self::new(0)
         }
     }
 }
@@ -5762,160 +5806,223 @@ impl wkt::message::Message for DeleteLogMetricRequest {
 /// the current state of the operation can be queried even before the
 /// operation is finished and the final result is available.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OperationState(std::borrow::Cow<'static, str>);
+pub struct OperationState(i32);
 
 impl OperationState {
+    /// Should not be used.
+    pub const OPERATION_STATE_UNSPECIFIED: OperationState = OperationState::new(0);
+
+    /// The operation is scheduled.
+    pub const OPERATION_STATE_SCHEDULED: OperationState = OperationState::new(1);
+
+    /// Waiting for necessary permissions.
+    pub const OPERATION_STATE_WAITING_FOR_PERMISSIONS: OperationState = OperationState::new(2);
+
+    /// The operation is running.
+    pub const OPERATION_STATE_RUNNING: OperationState = OperationState::new(3);
+
+    /// The operation was completed successfully.
+    pub const OPERATION_STATE_SUCCEEDED: OperationState = OperationState::new(4);
+
+    /// The operation failed.
+    pub const OPERATION_STATE_FAILED: OperationState = OperationState::new(5);
+
+    /// The operation was cancelled by the user.
+    pub const OPERATION_STATE_CANCELLED: OperationState = OperationState::new(6);
+
     /// Creates a new OperationState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("OPERATION_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("OPERATION_STATE_SCHEDULED"),
+            2 => std::borrow::Cow::Borrowed("OPERATION_STATE_WAITING_FOR_PERMISSIONS"),
+            3 => std::borrow::Cow::Borrowed("OPERATION_STATE_RUNNING"),
+            4 => std::borrow::Cow::Borrowed("OPERATION_STATE_SUCCEEDED"),
+            5 => std::borrow::Cow::Borrowed("OPERATION_STATE_FAILED"),
+            6 => std::borrow::Cow::Borrowed("OPERATION_STATE_CANCELLED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "OPERATION_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::OPERATION_STATE_UNSPECIFIED)
+            }
+            "OPERATION_STATE_SCHEDULED" => {
+                std::option::Option::Some(Self::OPERATION_STATE_SCHEDULED)
+            }
+            "OPERATION_STATE_WAITING_FOR_PERMISSIONS" => {
+                std::option::Option::Some(Self::OPERATION_STATE_WAITING_FOR_PERMISSIONS)
+            }
+            "OPERATION_STATE_RUNNING" => std::option::Option::Some(Self::OPERATION_STATE_RUNNING),
+            "OPERATION_STATE_SUCCEEDED" => {
+                std::option::Option::Some(Self::OPERATION_STATE_SUCCEEDED)
+            }
+            "OPERATION_STATE_FAILED" => std::option::Option::Some(Self::OPERATION_STATE_FAILED),
+            "OPERATION_STATE_CANCELLED" => {
+                std::option::Option::Some(Self::OPERATION_STATE_CANCELLED)
+            }
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [OperationState](OperationState)
-pub mod operation_state {
-    use super::OperationState;
-
-    /// Should not be used.
-    pub const OPERATION_STATE_UNSPECIFIED: OperationState =
-        OperationState::new("OPERATION_STATE_UNSPECIFIED");
-
-    /// The operation is scheduled.
-    pub const OPERATION_STATE_SCHEDULED: OperationState =
-        OperationState::new("OPERATION_STATE_SCHEDULED");
-
-    /// Waiting for necessary permissions.
-    pub const OPERATION_STATE_WAITING_FOR_PERMISSIONS: OperationState =
-        OperationState::new("OPERATION_STATE_WAITING_FOR_PERMISSIONS");
-
-    /// The operation is running.
-    pub const OPERATION_STATE_RUNNING: OperationState =
-        OperationState::new("OPERATION_STATE_RUNNING");
-
-    /// The operation was completed successfully.
-    pub const OPERATION_STATE_SUCCEEDED: OperationState =
-        OperationState::new("OPERATION_STATE_SUCCEEDED");
-
-    /// The operation failed.
-    pub const OPERATION_STATE_FAILED: OperationState =
-        OperationState::new("OPERATION_STATE_FAILED");
-
-    /// The operation was cancelled by the user.
-    pub const OPERATION_STATE_CANCELLED: OperationState =
-        OperationState::new("OPERATION_STATE_CANCELLED");
-}
-
-impl std::convert::From<std::string::String> for OperationState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for OperationState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for OperationState {
     fn default() -> Self {
-        operation_state::OPERATION_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// LogBucket lifecycle states.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LifecycleState(std::borrow::Cow<'static, str>);
+pub struct LifecycleState(i32);
 
 impl LifecycleState {
-    /// Creates a new LifecycleState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [LifecycleState](LifecycleState)
-pub mod lifecycle_state {
-    use super::LifecycleState;
-
     /// Unspecified state. This is only used/useful for distinguishing unset
     /// values.
-    pub const LIFECYCLE_STATE_UNSPECIFIED: LifecycleState =
-        LifecycleState::new("LIFECYCLE_STATE_UNSPECIFIED");
+    pub const LIFECYCLE_STATE_UNSPECIFIED: LifecycleState = LifecycleState::new(0);
 
     /// The normal and active state.
-    pub const ACTIVE: LifecycleState = LifecycleState::new("ACTIVE");
+    pub const ACTIVE: LifecycleState = LifecycleState::new(1);
 
     /// The resource has been marked for deletion by the user. For some resources
     /// (e.g. buckets), this can be reversed by an un-delete operation.
-    pub const DELETE_REQUESTED: LifecycleState = LifecycleState::new("DELETE_REQUESTED");
+    pub const DELETE_REQUESTED: LifecycleState = LifecycleState::new(2);
 
     /// The resource has been marked for an update by the user. It will remain in
     /// this state until the update is complete.
-    pub const UPDATING: LifecycleState = LifecycleState::new("UPDATING");
+    pub const UPDATING: LifecycleState = LifecycleState::new(3);
 
     /// The resource has been marked for creation by the user. It will remain in
     /// this state until the creation is complete.
-    pub const CREATING: LifecycleState = LifecycleState::new("CREATING");
+    pub const CREATING: LifecycleState = LifecycleState::new(4);
 
     /// The resource is in an INTERNAL error state.
-    pub const FAILED: LifecycleState = LifecycleState::new("FAILED");
+    pub const FAILED: LifecycleState = LifecycleState::new(5);
+
+    /// Creates a new LifecycleState instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("LIFECYCLE_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ACTIVE"),
+            2 => std::borrow::Cow::Borrowed("DELETE_REQUESTED"),
+            3 => std::borrow::Cow::Borrowed("UPDATING"),
+            4 => std::borrow::Cow::Borrowed("CREATING"),
+            5 => std::borrow::Cow::Borrowed("FAILED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "LIFECYCLE_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::LIFECYCLE_STATE_UNSPECIFIED)
+            }
+            "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+            "DELETE_REQUESTED" => std::option::Option::Some(Self::DELETE_REQUESTED),
+            "UPDATING" => std::option::Option::Some(Self::UPDATING),
+            "CREATING" => std::option::Option::Some(Self::CREATING),
+            "FAILED" => std::option::Option::Some(Self::FAILED),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for LifecycleState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for LifecycleState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for LifecycleState {
     fn default() -> Self {
-        lifecycle_state::LIFECYCLE_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// IndexType is used for custom indexing. It describes the type of an indexed
 /// field.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct IndexType(std::borrow::Cow<'static, str>);
+pub struct IndexType(i32);
 
 impl IndexType {
+    /// The index's type is unspecified.
+    pub const INDEX_TYPE_UNSPECIFIED: IndexType = IndexType::new(0);
+
+    /// The index is a string-type index.
+    pub const INDEX_TYPE_STRING: IndexType = IndexType::new(1);
+
+    /// The index is a integer-type index.
+    pub const INDEX_TYPE_INTEGER: IndexType = IndexType::new(2);
+
     /// Creates a new IndexType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("INDEX_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("INDEX_TYPE_STRING"),
+            2 => std::borrow::Cow::Borrowed("INDEX_TYPE_INTEGER"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "INDEX_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::INDEX_TYPE_UNSPECIFIED),
+            "INDEX_TYPE_STRING" => std::option::Option::Some(Self::INDEX_TYPE_STRING),
+            "INDEX_TYPE_INTEGER" => std::option::Option::Some(Self::INDEX_TYPE_INTEGER),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [IndexType](IndexType)
-pub mod index_type {
-    use super::IndexType;
-
-    /// The index's type is unspecified.
-    pub const INDEX_TYPE_UNSPECIFIED: IndexType = IndexType::new("INDEX_TYPE_UNSPECIFIED");
-
-    /// The index is a string-type index.
-    pub const INDEX_TYPE_STRING: IndexType = IndexType::new("INDEX_TYPE_STRING");
-
-    /// The index is a integer-type index.
-    pub const INDEX_TYPE_INTEGER: IndexType = IndexType::new("INDEX_TYPE_INTEGER");
-}
-
-impl std::convert::From<std::string::String> for IndexType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for IndexType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for IndexType {
     fn default() -> Self {
-        index_type::INDEX_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/logging/v2/src/transport.rs
+++ b/src/generated/logging/v2/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::LoggingServiceV2 for LoggingServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.log_name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -68,7 +68,7 @@ impl crate::stubs::LoggingServiceV2 for LoggingServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, "/v2/entries:write".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -85,7 +85,7 @@ impl crate::stubs::LoggingServiceV2 for LoggingServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, "/v2/entries:list".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -105,7 +105,7 @@ impl crate::stubs::LoggingServiceV2 for LoggingServiceV2 {
                 reqwest::Method::GET,
                 "/v2/monitoredResourceDescriptors".to_string(),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -126,7 +126,7 @@ impl crate::stubs::LoggingServiceV2 for LoggingServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/logs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -151,7 +151,7 @@ impl crate::stubs::LoggingServiceV2 for LoggingServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -173,7 +173,7 @@ impl crate::stubs::LoggingServiceV2 for LoggingServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -192,7 +192,7 @@ impl crate::stubs::LoggingServiceV2 for LoggingServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -232,7 +232,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/buckets", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -253,7 +253,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -275,7 +275,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
                 reqwest::Method::POST,
                 format!("/v2/{}/buckets:createAsync", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -296,7 +296,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
                 reqwest::Method::POST,
                 format!("/v2/{}:updateAsync", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -323,7 +323,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}/buckets", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -341,7 +341,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -368,7 +368,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -387,7 +387,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:undelete", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -404,7 +404,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/views", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -425,7 +425,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -444,7 +444,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}/views", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -462,7 +462,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -489,7 +489,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -508,7 +508,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/sinks", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -529,7 +529,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.sink_name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -548,7 +548,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}/sinks", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -566,7 +566,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::PUT, format!("/v2/{}", req.sink_name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -594,7 +594,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.sink_name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -613,7 +613,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}/links", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -631,7 +631,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -650,7 +650,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/links", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -671,7 +671,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -693,7 +693,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
                 reqwest::Method::GET,
                 format!("/v2/{}/exclusions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -714,7 +714,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -736,7 +736,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
                 reqwest::Method::POST,
                 format!("/v2/{}/exclusions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -755,7 +755,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -784,7 +784,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -806,7 +806,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
                 reqwest::Method::GET,
                 format!("/v2/{}/cmekSettings", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -828,7 +828,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
                 reqwest::Method::PATCH,
                 format!("/v2/{}/cmekSettings", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -857,7 +857,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/settings", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -876,7 +876,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v2/{}/settings", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -905,7 +905,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, "/v2/entries:copy".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -922,7 +922,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -944,7 +944,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -963,7 +963,7 @@ impl crate::stubs::ConfigServiceV2 for ConfigServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1017,7 +1017,7 @@ impl crate::stubs::MetricsServiceV2 for MetricsServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/metrics", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1038,7 +1038,7 @@ impl crate::stubs::MetricsServiceV2 for MetricsServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.metric_name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1057,7 +1057,7 @@ impl crate::stubs::MetricsServiceV2 for MetricsServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}/metrics", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1074,7 +1074,7 @@ impl crate::stubs::MetricsServiceV2 for MetricsServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::PUT, format!("/v2/{}", req.metric_name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1091,7 +1091,7 @@ impl crate::stubs::MetricsServiceV2 for MetricsServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.metric_name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1110,7 +1110,7 @@ impl crate::stubs::MetricsServiceV2 for MetricsServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1132,7 +1132,7 @@ impl crate::stubs::MetricsServiceV2 for MetricsServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1151,7 +1151,7 @@ impl crate::stubs::MetricsServiceV2 for MetricsServiceV2 {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/longrunning/src/transport.rs
+++ b/src/generated/longrunning/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::Operations for Operations {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -71,7 +71,7 @@ impl crate::stubs::Operations for Operations {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -90,7 +90,7 @@ impl crate::stubs::Operations for Operations {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -109,7 +109,7 @@ impl crate::stubs::Operations for Operations {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/monitoring/dashboard/v1/src/model.rs
+++ b/src/generated/monitoring/dashboard/v1/src/model.rs
@@ -259,28 +259,13 @@ pub mod aggregation {
     /// `value_type` in the original time series is `BOOLEAN`, but the `value_type`
     /// in the aligned result is `INT64`.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Aligner(std::borrow::Cow<'static, str>);
+    pub struct Aligner(i32);
 
     impl Aligner {
-        /// Creates a new Aligner instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Aligner](Aligner)
-    pub mod aligner {
-        use super::Aligner;
-
         /// No alignment. Raw data is returned. Not valid if cross-series reduction
         /// is requested. The `value_type` of the result is the same as the
         /// `value_type` of the input.
-        pub const ALIGN_NONE: Aligner = Aligner::new("ALIGN_NONE");
+        pub const ALIGN_NONE: Aligner = Aligner::new(0);
 
         /// Align and convert to
         /// [DELTA][google.api.MetricDescriptor.MetricKind.DELTA].
@@ -292,7 +277,7 @@ pub mod aggregation {
         /// with no data, then the aligned value for such a period is created by
         /// interpolation. The `value_type`  of the aligned result is the same as
         /// the `value_type` of the input.
-        pub const ALIGN_DELTA: Aligner = Aligner::new("ALIGN_DELTA");
+        pub const ALIGN_DELTA: Aligner = Aligner::new(1);
 
         /// Align and convert to a rate. The result is computed as
         /// `rate = (y1 - y0)/(t1 - t0)`, or "delta over time".
@@ -307,70 +292,70 @@ pub mod aggregation {
         ///
         /// If, by "rate", you mean "percentage change", see the
         /// `ALIGN_PERCENT_CHANGE` aligner instead.
-        pub const ALIGN_RATE: Aligner = Aligner::new("ALIGN_RATE");
+        pub const ALIGN_RATE: Aligner = Aligner::new(2);
 
         /// Align by interpolating between adjacent points around the alignment
         /// period boundary. This aligner is valid for `GAUGE` metrics with
         /// numeric values. The `value_type` of the aligned result is the same as the
         /// `value_type` of the input.
-        pub const ALIGN_INTERPOLATE: Aligner = Aligner::new("ALIGN_INTERPOLATE");
+        pub const ALIGN_INTERPOLATE: Aligner = Aligner::new(3);
 
         /// Align by moving the most recent data point before the end of the
         /// alignment period to the boundary at the end of the alignment
         /// period. This aligner is valid for `GAUGE` metrics. The `value_type` of
         /// the aligned result is the same as the `value_type` of the input.
-        pub const ALIGN_NEXT_OLDER: Aligner = Aligner::new("ALIGN_NEXT_OLDER");
+        pub const ALIGN_NEXT_OLDER: Aligner = Aligner::new(4);
 
         /// Align the time series by returning the minimum value in each alignment
         /// period. This aligner is valid for `GAUGE` and `DELTA` metrics with
         /// numeric values. The `value_type` of the aligned result is the same as
         /// the `value_type` of the input.
-        pub const ALIGN_MIN: Aligner = Aligner::new("ALIGN_MIN");
+        pub const ALIGN_MIN: Aligner = Aligner::new(10);
 
         /// Align the time series by returning the maximum value in each alignment
         /// period. This aligner is valid for `GAUGE` and `DELTA` metrics with
         /// numeric values. The `value_type` of the aligned result is the same as
         /// the `value_type` of the input.
-        pub const ALIGN_MAX: Aligner = Aligner::new("ALIGN_MAX");
+        pub const ALIGN_MAX: Aligner = Aligner::new(11);
 
         /// Align the time series by returning the mean value in each alignment
         /// period. This aligner is valid for `GAUGE` and `DELTA` metrics with
         /// numeric values. The `value_type` of the aligned result is `DOUBLE`.
-        pub const ALIGN_MEAN: Aligner = Aligner::new("ALIGN_MEAN");
+        pub const ALIGN_MEAN: Aligner = Aligner::new(12);
 
         /// Align the time series by returning the number of values in each alignment
         /// period. This aligner is valid for `GAUGE` and `DELTA` metrics with
         /// numeric or Boolean values. The `value_type` of the aligned result is
         /// `INT64`.
-        pub const ALIGN_COUNT: Aligner = Aligner::new("ALIGN_COUNT");
+        pub const ALIGN_COUNT: Aligner = Aligner::new(13);
 
         /// Align the time series by returning the sum of the values in each
         /// alignment period. This aligner is valid for `GAUGE` and `DELTA`
         /// metrics with numeric and distribution values. The `value_type` of the
         /// aligned result is the same as the `value_type` of the input.
-        pub const ALIGN_SUM: Aligner = Aligner::new("ALIGN_SUM");
+        pub const ALIGN_SUM: Aligner = Aligner::new(14);
 
         /// Align the time series by returning the standard deviation of the values
         /// in each alignment period. This aligner is valid for `GAUGE` and
         /// `DELTA` metrics with numeric values. The `value_type` of the output is
         /// `DOUBLE`.
-        pub const ALIGN_STDDEV: Aligner = Aligner::new("ALIGN_STDDEV");
+        pub const ALIGN_STDDEV: Aligner = Aligner::new(15);
 
         /// Align the time series by returning the number of `True` values in
         /// each alignment period. This aligner is valid for `GAUGE` metrics with
         /// Boolean values. The `value_type` of the output is `INT64`.
-        pub const ALIGN_COUNT_TRUE: Aligner = Aligner::new("ALIGN_COUNT_TRUE");
+        pub const ALIGN_COUNT_TRUE: Aligner = Aligner::new(16);
 
         /// Align the time series by returning the number of `False` values in
         /// each alignment period. This aligner is valid for `GAUGE` metrics with
         /// Boolean values. The `value_type` of the output is `INT64`.
-        pub const ALIGN_COUNT_FALSE: Aligner = Aligner::new("ALIGN_COUNT_FALSE");
+        pub const ALIGN_COUNT_FALSE: Aligner = Aligner::new(24);
 
         /// Align the time series by returning the ratio of the number of `True`
         /// values to the total number of values in each alignment period. This
         /// aligner is valid for `GAUGE` metrics with Boolean values. The output
         /// value is in the range [0.0, 1.0] and has `value_type` `DOUBLE`.
-        pub const ALIGN_FRACTION_TRUE: Aligner = Aligner::new("ALIGN_FRACTION_TRUE");
+        pub const ALIGN_FRACTION_TRUE: Aligner = Aligner::new(17);
 
         /// Align the time series by using [percentile
         /// aggregation](https://en.wikipedia.org/wiki/Percentile). The resulting
@@ -378,7 +363,7 @@ pub mod aggregation {
         /// points in the period. This aligner is valid for `GAUGE` and `DELTA`
         /// metrics with distribution values. The output is a `GAUGE` metric with
         /// `value_type` `DOUBLE`.
-        pub const ALIGN_PERCENTILE_99: Aligner = Aligner::new("ALIGN_PERCENTILE_99");
+        pub const ALIGN_PERCENTILE_99: Aligner = Aligner::new(18);
 
         /// Align the time series by using [percentile
         /// aggregation](https://en.wikipedia.org/wiki/Percentile). The resulting
@@ -386,7 +371,7 @@ pub mod aggregation {
         /// points in the period. This aligner is valid for `GAUGE` and `DELTA`
         /// metrics with distribution values. The output is a `GAUGE` metric with
         /// `value_type` `DOUBLE`.
-        pub const ALIGN_PERCENTILE_95: Aligner = Aligner::new("ALIGN_PERCENTILE_95");
+        pub const ALIGN_PERCENTILE_95: Aligner = Aligner::new(19);
 
         /// Align the time series by using [percentile
         /// aggregation](https://en.wikipedia.org/wiki/Percentile). The resulting
@@ -394,7 +379,7 @@ pub mod aggregation {
         /// points in the period. This aligner is valid for `GAUGE` and `DELTA`
         /// metrics with distribution values. The output is a `GAUGE` metric with
         /// `value_type` `DOUBLE`.
-        pub const ALIGN_PERCENTILE_50: Aligner = Aligner::new("ALIGN_PERCENTILE_50");
+        pub const ALIGN_PERCENTILE_50: Aligner = Aligner::new(20);
 
         /// Align the time series by using [percentile
         /// aggregation](https://en.wikipedia.org/wiki/Percentile). The resulting
@@ -402,7 +387,7 @@ pub mod aggregation {
         /// points in the period. This aligner is valid for `GAUGE` and `DELTA`
         /// metrics with distribution values. The output is a `GAUGE` metric with
         /// `value_type` `DOUBLE`.
-        pub const ALIGN_PERCENTILE_05: Aligner = Aligner::new("ALIGN_PERCENTILE_05");
+        pub const ALIGN_PERCENTILE_05: Aligner = Aligner::new(21);
 
         /// Align and convert to a percentage change. This aligner is valid for
         /// `GAUGE` and `DELTA` metrics with numeric values. This alignment returns
@@ -420,18 +405,80 @@ pub mod aggregation {
         /// metrics are accepted by this alignment, special care should be taken that
         /// the values for the metric will always be positive. The output is a
         /// `GAUGE` metric with `value_type` `DOUBLE`.
-        pub const ALIGN_PERCENT_CHANGE: Aligner = Aligner::new("ALIGN_PERCENT_CHANGE");
+        pub const ALIGN_PERCENT_CHANGE: Aligner = Aligner::new(23);
+
+        /// Creates a new Aligner instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ALIGN_NONE"),
+                1 => std::borrow::Cow::Borrowed("ALIGN_DELTA"),
+                2 => std::borrow::Cow::Borrowed("ALIGN_RATE"),
+                3 => std::borrow::Cow::Borrowed("ALIGN_INTERPOLATE"),
+                4 => std::borrow::Cow::Borrowed("ALIGN_NEXT_OLDER"),
+                10 => std::borrow::Cow::Borrowed("ALIGN_MIN"),
+                11 => std::borrow::Cow::Borrowed("ALIGN_MAX"),
+                12 => std::borrow::Cow::Borrowed("ALIGN_MEAN"),
+                13 => std::borrow::Cow::Borrowed("ALIGN_COUNT"),
+                14 => std::borrow::Cow::Borrowed("ALIGN_SUM"),
+                15 => std::borrow::Cow::Borrowed("ALIGN_STDDEV"),
+                16 => std::borrow::Cow::Borrowed("ALIGN_COUNT_TRUE"),
+                17 => std::borrow::Cow::Borrowed("ALIGN_FRACTION_TRUE"),
+                18 => std::borrow::Cow::Borrowed("ALIGN_PERCENTILE_99"),
+                19 => std::borrow::Cow::Borrowed("ALIGN_PERCENTILE_95"),
+                20 => std::borrow::Cow::Borrowed("ALIGN_PERCENTILE_50"),
+                21 => std::borrow::Cow::Borrowed("ALIGN_PERCENTILE_05"),
+                23 => std::borrow::Cow::Borrowed("ALIGN_PERCENT_CHANGE"),
+                24 => std::borrow::Cow::Borrowed("ALIGN_COUNT_FALSE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ALIGN_NONE" => std::option::Option::Some(Self::ALIGN_NONE),
+                "ALIGN_DELTA" => std::option::Option::Some(Self::ALIGN_DELTA),
+                "ALIGN_RATE" => std::option::Option::Some(Self::ALIGN_RATE),
+                "ALIGN_INTERPOLATE" => std::option::Option::Some(Self::ALIGN_INTERPOLATE),
+                "ALIGN_NEXT_OLDER" => std::option::Option::Some(Self::ALIGN_NEXT_OLDER),
+                "ALIGN_MIN" => std::option::Option::Some(Self::ALIGN_MIN),
+                "ALIGN_MAX" => std::option::Option::Some(Self::ALIGN_MAX),
+                "ALIGN_MEAN" => std::option::Option::Some(Self::ALIGN_MEAN),
+                "ALIGN_COUNT" => std::option::Option::Some(Self::ALIGN_COUNT),
+                "ALIGN_SUM" => std::option::Option::Some(Self::ALIGN_SUM),
+                "ALIGN_STDDEV" => std::option::Option::Some(Self::ALIGN_STDDEV),
+                "ALIGN_COUNT_TRUE" => std::option::Option::Some(Self::ALIGN_COUNT_TRUE),
+                "ALIGN_COUNT_FALSE" => std::option::Option::Some(Self::ALIGN_COUNT_FALSE),
+                "ALIGN_FRACTION_TRUE" => std::option::Option::Some(Self::ALIGN_FRACTION_TRUE),
+                "ALIGN_PERCENTILE_99" => std::option::Option::Some(Self::ALIGN_PERCENTILE_99),
+                "ALIGN_PERCENTILE_95" => std::option::Option::Some(Self::ALIGN_PERCENTILE_95),
+                "ALIGN_PERCENTILE_50" => std::option::Option::Some(Self::ALIGN_PERCENTILE_50),
+                "ALIGN_PERCENTILE_05" => std::option::Option::Some(Self::ALIGN_PERCENTILE_05),
+                "ALIGN_PERCENT_CHANGE" => std::option::Option::Some(Self::ALIGN_PERCENT_CHANGE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Aligner {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Aligner {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Aligner {
         fn default() -> Self {
-            aligner::ALIGN_NONE
+            Self::new(0)
         }
     }
 
@@ -440,27 +487,12 @@ pub mod aggregation {
     /// in the resulting series is a function of all the already aligned values in
     /// the input time series.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Reducer(std::borrow::Cow<'static, str>);
+    pub struct Reducer(i32);
 
     impl Reducer {
-        /// Creates a new Reducer instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Reducer](Reducer)
-    pub mod reducer {
-        use super::Reducer;
-
         /// No cross-time series reduction. The output of the `Aligner` is
         /// returned.
-        pub const REDUCE_NONE: Reducer = Reducer::new("REDUCE_NONE");
+        pub const REDUCE_NONE: Reducer = Reducer::new(0);
 
         /// Reduce by computing the mean value across time series for each
         /// alignment period. This reducer is valid for
@@ -468,95 +500,147 @@ pub mod aggregation {
         /// [GAUGE][google.api.MetricDescriptor.MetricKind.GAUGE] metrics with
         /// numeric or distribution values. The `value_type` of the output is
         /// [DOUBLE][google.api.MetricDescriptor.ValueType.DOUBLE].
-        pub const REDUCE_MEAN: Reducer = Reducer::new("REDUCE_MEAN");
+        pub const REDUCE_MEAN: Reducer = Reducer::new(1);
 
         /// Reduce by computing the minimum value across time series for each
         /// alignment period. This reducer is valid for `DELTA` and `GAUGE` metrics
         /// with numeric values. The `value_type` of the output is the same as the
         /// `value_type` of the input.
-        pub const REDUCE_MIN: Reducer = Reducer::new("REDUCE_MIN");
+        pub const REDUCE_MIN: Reducer = Reducer::new(2);
 
         /// Reduce by computing the maximum value across time series for each
         /// alignment period. This reducer is valid for `DELTA` and `GAUGE` metrics
         /// with numeric values. The `value_type` of the output is the same as the
         /// `value_type` of the input.
-        pub const REDUCE_MAX: Reducer = Reducer::new("REDUCE_MAX");
+        pub const REDUCE_MAX: Reducer = Reducer::new(3);
 
         /// Reduce by computing the sum across time series for each
         /// alignment period. This reducer is valid for `DELTA` and `GAUGE` metrics
         /// with numeric and distribution values. The `value_type` of the output is
         /// the same as the `value_type` of the input.
-        pub const REDUCE_SUM: Reducer = Reducer::new("REDUCE_SUM");
+        pub const REDUCE_SUM: Reducer = Reducer::new(4);
 
         /// Reduce by computing the standard deviation across time series
         /// for each alignment period. This reducer is valid for `DELTA` and
         /// `GAUGE` metrics with numeric or distribution values. The `value_type`
         /// of the output is `DOUBLE`.
-        pub const REDUCE_STDDEV: Reducer = Reducer::new("REDUCE_STDDEV");
+        pub const REDUCE_STDDEV: Reducer = Reducer::new(5);
 
         /// Reduce by computing the number of data points across time series
         /// for each alignment period. This reducer is valid for `DELTA` and
         /// `GAUGE` metrics of numeric, Boolean, distribution, and string
         /// `value_type`. The `value_type` of the output is `INT64`.
-        pub const REDUCE_COUNT: Reducer = Reducer::new("REDUCE_COUNT");
+        pub const REDUCE_COUNT: Reducer = Reducer::new(6);
 
         /// Reduce by computing the number of `True`-valued data points across time
         /// series for each alignment period. This reducer is valid for `DELTA` and
         /// `GAUGE` metrics of Boolean `value_type`. The `value_type` of the output
         /// is `INT64`.
-        pub const REDUCE_COUNT_TRUE: Reducer = Reducer::new("REDUCE_COUNT_TRUE");
+        pub const REDUCE_COUNT_TRUE: Reducer = Reducer::new(7);
 
         /// Reduce by computing the number of `False`-valued data points across time
         /// series for each alignment period. This reducer is valid for `DELTA` and
         /// `GAUGE` metrics of Boolean `value_type`. The `value_type` of the output
         /// is `INT64`.
-        pub const REDUCE_COUNT_FALSE: Reducer = Reducer::new("REDUCE_COUNT_FALSE");
+        pub const REDUCE_COUNT_FALSE: Reducer = Reducer::new(15);
 
         /// Reduce by computing the ratio of the number of `True`-valued data points
         /// to the total number of data points for each alignment period. This
         /// reducer is valid for `DELTA` and `GAUGE` metrics of Boolean `value_type`.
         /// The output value is in the range [0.0, 1.0] and has `value_type`
         /// `DOUBLE`.
-        pub const REDUCE_FRACTION_TRUE: Reducer = Reducer::new("REDUCE_FRACTION_TRUE");
+        pub const REDUCE_FRACTION_TRUE: Reducer = Reducer::new(8);
 
         /// Reduce by computing the [99th
         /// percentile](https://en.wikipedia.org/wiki/Percentile) of data points
         /// across time series for each alignment period. This reducer is valid for
         /// `GAUGE` and `DELTA` metrics of numeric and distribution type. The value
         /// of the output is `DOUBLE`.
-        pub const REDUCE_PERCENTILE_99: Reducer = Reducer::new("REDUCE_PERCENTILE_99");
+        pub const REDUCE_PERCENTILE_99: Reducer = Reducer::new(9);
 
         /// Reduce by computing the [95th
         /// percentile](https://en.wikipedia.org/wiki/Percentile) of data points
         /// across time series for each alignment period. This reducer is valid for
         /// `GAUGE` and `DELTA` metrics of numeric and distribution type. The value
         /// of the output is `DOUBLE`.
-        pub const REDUCE_PERCENTILE_95: Reducer = Reducer::new("REDUCE_PERCENTILE_95");
+        pub const REDUCE_PERCENTILE_95: Reducer = Reducer::new(10);
 
         /// Reduce by computing the [50th
         /// percentile](https://en.wikipedia.org/wiki/Percentile) of data points
         /// across time series for each alignment period. This reducer is valid for
         /// `GAUGE` and `DELTA` metrics of numeric and distribution type. The value
         /// of the output is `DOUBLE`.
-        pub const REDUCE_PERCENTILE_50: Reducer = Reducer::new("REDUCE_PERCENTILE_50");
+        pub const REDUCE_PERCENTILE_50: Reducer = Reducer::new(11);
 
         /// Reduce by computing the [5th
         /// percentile](https://en.wikipedia.org/wiki/Percentile) of data points
         /// across time series for each alignment period. This reducer is valid for
         /// `GAUGE` and `DELTA` metrics of numeric and distribution type. The value
         /// of the output is `DOUBLE`.
-        pub const REDUCE_PERCENTILE_05: Reducer = Reducer::new("REDUCE_PERCENTILE_05");
+        pub const REDUCE_PERCENTILE_05: Reducer = Reducer::new(12);
+
+        /// Creates a new Reducer instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("REDUCE_NONE"),
+                1 => std::borrow::Cow::Borrowed("REDUCE_MEAN"),
+                2 => std::borrow::Cow::Borrowed("REDUCE_MIN"),
+                3 => std::borrow::Cow::Borrowed("REDUCE_MAX"),
+                4 => std::borrow::Cow::Borrowed("REDUCE_SUM"),
+                5 => std::borrow::Cow::Borrowed("REDUCE_STDDEV"),
+                6 => std::borrow::Cow::Borrowed("REDUCE_COUNT"),
+                7 => std::borrow::Cow::Borrowed("REDUCE_COUNT_TRUE"),
+                8 => std::borrow::Cow::Borrowed("REDUCE_FRACTION_TRUE"),
+                9 => std::borrow::Cow::Borrowed("REDUCE_PERCENTILE_99"),
+                10 => std::borrow::Cow::Borrowed("REDUCE_PERCENTILE_95"),
+                11 => std::borrow::Cow::Borrowed("REDUCE_PERCENTILE_50"),
+                12 => std::borrow::Cow::Borrowed("REDUCE_PERCENTILE_05"),
+                15 => std::borrow::Cow::Borrowed("REDUCE_COUNT_FALSE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "REDUCE_NONE" => std::option::Option::Some(Self::REDUCE_NONE),
+                "REDUCE_MEAN" => std::option::Option::Some(Self::REDUCE_MEAN),
+                "REDUCE_MIN" => std::option::Option::Some(Self::REDUCE_MIN),
+                "REDUCE_MAX" => std::option::Option::Some(Self::REDUCE_MAX),
+                "REDUCE_SUM" => std::option::Option::Some(Self::REDUCE_SUM),
+                "REDUCE_STDDEV" => std::option::Option::Some(Self::REDUCE_STDDEV),
+                "REDUCE_COUNT" => std::option::Option::Some(Self::REDUCE_COUNT),
+                "REDUCE_COUNT_TRUE" => std::option::Option::Some(Self::REDUCE_COUNT_TRUE),
+                "REDUCE_COUNT_FALSE" => std::option::Option::Some(Self::REDUCE_COUNT_FALSE),
+                "REDUCE_FRACTION_TRUE" => std::option::Option::Some(Self::REDUCE_FRACTION_TRUE),
+                "REDUCE_PERCENTILE_99" => std::option::Option::Some(Self::REDUCE_PERCENTILE_99),
+                "REDUCE_PERCENTILE_95" => std::option::Option::Some(Self::REDUCE_PERCENTILE_95),
+                "REDUCE_PERCENTILE_50" => std::option::Option::Some(Self::REDUCE_PERCENTILE_50),
+                "REDUCE_PERCENTILE_05" => std::option::Option::Some(Self::REDUCE_PERCENTILE_05),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Reducer {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Reducer {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Reducer {
         fn default() -> Self {
-            reducer::REDUCE_NONE
+            Self::new(0)
         }
     }
 }
@@ -645,96 +729,132 @@ pub mod pick_time_series_filter {
 
     /// The value reducers that can be applied to a `PickTimeSeriesFilter`.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Method(std::borrow::Cow<'static, str>);
+    pub struct Method(i32);
 
     impl Method {
+        /// Not allowed. You must specify a different `Method` if you specify a
+        /// `PickTimeSeriesFilter`.
+        pub const METHOD_UNSPECIFIED: Method = Method::new(0);
+
+        /// Select the mean of all values.
+        pub const METHOD_MEAN: Method = Method::new(1);
+
+        /// Select the maximum value.
+        pub const METHOD_MAX: Method = Method::new(2);
+
+        /// Select the minimum value.
+        pub const METHOD_MIN: Method = Method::new(3);
+
+        /// Compute the sum of all values.
+        pub const METHOD_SUM: Method = Method::new(4);
+
+        /// Select the most recent value.
+        pub const METHOD_LATEST: Method = Method::new(5);
+
         /// Creates a new Method instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("METHOD_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("METHOD_MEAN"),
+                2 => std::borrow::Cow::Borrowed("METHOD_MAX"),
+                3 => std::borrow::Cow::Borrowed("METHOD_MIN"),
+                4 => std::borrow::Cow::Borrowed("METHOD_SUM"),
+                5 => std::borrow::Cow::Borrowed("METHOD_LATEST"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "METHOD_UNSPECIFIED" => std::option::Option::Some(Self::METHOD_UNSPECIFIED),
+                "METHOD_MEAN" => std::option::Option::Some(Self::METHOD_MEAN),
+                "METHOD_MAX" => std::option::Option::Some(Self::METHOD_MAX),
+                "METHOD_MIN" => std::option::Option::Some(Self::METHOD_MIN),
+                "METHOD_SUM" => std::option::Option::Some(Self::METHOD_SUM),
+                "METHOD_LATEST" => std::option::Option::Some(Self::METHOD_LATEST),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Method](Method)
-    pub mod method {
-        use super::Method;
-
-        /// Not allowed. You must specify a different `Method` if you specify a
-        /// `PickTimeSeriesFilter`.
-        pub const METHOD_UNSPECIFIED: Method = Method::new("METHOD_UNSPECIFIED");
-
-        /// Select the mean of all values.
-        pub const METHOD_MEAN: Method = Method::new("METHOD_MEAN");
-
-        /// Select the maximum value.
-        pub const METHOD_MAX: Method = Method::new("METHOD_MAX");
-
-        /// Select the minimum value.
-        pub const METHOD_MIN: Method = Method::new("METHOD_MIN");
-
-        /// Compute the sum of all values.
-        pub const METHOD_SUM: Method = Method::new("METHOD_SUM");
-
-        /// Select the most recent value.
-        pub const METHOD_LATEST: Method = Method::new("METHOD_LATEST");
-    }
-
-    impl std::convert::From<std::string::String> for Method {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Method {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Method {
         fn default() -> Self {
-            method::METHOD_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Describes the ranking directions.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Direction(std::borrow::Cow<'static, str>);
+    pub struct Direction(i32);
 
     impl Direction {
+        /// Not allowed. You must specify a different `Direction` if you specify a
+        /// `PickTimeSeriesFilter`.
+        pub const DIRECTION_UNSPECIFIED: Direction = Direction::new(0);
+
+        /// Pass the highest `num_time_series` ranking inputs.
+        pub const TOP: Direction = Direction::new(1);
+
+        /// Pass the lowest `num_time_series` ranking inputs.
+        pub const BOTTOM: Direction = Direction::new(2);
+
         /// Creates a new Direction instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DIRECTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TOP"),
+                2 => std::borrow::Cow::Borrowed("BOTTOM"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DIRECTION_UNSPECIFIED" => std::option::Option::Some(Self::DIRECTION_UNSPECIFIED),
+                "TOP" => std::option::Option::Some(Self::TOP),
+                "BOTTOM" => std::option::Option::Some(Self::BOTTOM),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Direction](Direction)
-    pub mod direction {
-        use super::Direction;
-
-        /// Not allowed. You must specify a different `Direction` if you specify a
-        /// `PickTimeSeriesFilter`.
-        pub const DIRECTION_UNSPECIFIED: Direction = Direction::new("DIRECTION_UNSPECIFIED");
-
-        /// Pass the highest `num_time_series` ranking inputs.
-        pub const TOP: Direction = Direction::new("TOP");
-
-        /// Pass the lowest `num_time_series` ranking inputs.
-        pub const BOTTOM: Direction = Direction::new("BOTTOM");
-    }
-
-    impl std::convert::From<std::string::String> for Direction {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Direction {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Direction {
         fn default() -> Self {
-            direction::DIRECTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -794,40 +914,53 @@ pub mod statistical_time_series_filter {
 
     /// The filter methods that can be applied to a stream.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Method(std::borrow::Cow<'static, str>);
+    pub struct Method(i32);
 
     impl Method {
+        /// Not allowed in well-formed requests.
+        pub const METHOD_UNSPECIFIED: Method = Method::new(0);
+
+        /// Compute the outlier score of each stream.
+        pub const METHOD_CLUSTER_OUTLIER: Method = Method::new(1);
+
         /// Creates a new Method instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("METHOD_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("METHOD_CLUSTER_OUTLIER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "METHOD_UNSPECIFIED" => std::option::Option::Some(Self::METHOD_UNSPECIFIED),
+                "METHOD_CLUSTER_OUTLIER" => std::option::Option::Some(Self::METHOD_CLUSTER_OUTLIER),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Method](Method)
-    pub mod method {
-        use super::Method;
-
-        /// Not allowed in well-formed requests.
-        pub const METHOD_UNSPECIFIED: Method = Method::new("METHOD_UNSPECIFIED");
-
-        /// Compute the outlier score of each stream.
-        pub const METHOD_CLUSTER_OUTLIER: Method = Method::new("METHOD_CLUSTER_OUTLIER");
-    }
-
-    impl std::convert::From<std::string::String> for Method {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Method {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Method {
         fn default() -> Self {
-            method::METHOD_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1168,52 +1301,75 @@ pub mod dashboard_filter {
 
     /// The type for the dashboard filter
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FilterType(std::borrow::Cow<'static, str>);
+    pub struct FilterType(i32);
 
     impl FilterType {
+        /// Filter type is unspecified. This is not valid in a well-formed request.
+        pub const FILTER_TYPE_UNSPECIFIED: FilterType = FilterType::new(0);
+
+        /// Filter on a resource label value
+        pub const RESOURCE_LABEL: FilterType = FilterType::new(1);
+
+        /// Filter on a metrics label value
+        pub const METRIC_LABEL: FilterType = FilterType::new(2);
+
+        /// Filter on a user metadata label value
+        pub const USER_METADATA_LABEL: FilterType = FilterType::new(3);
+
+        /// Filter on a system metadata label value
+        pub const SYSTEM_METADATA_LABEL: FilterType = FilterType::new(4);
+
+        /// Filter on a group id
+        pub const GROUP: FilterType = FilterType::new(5);
+
         /// Creates a new FilterType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FILTER_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RESOURCE_LABEL"),
+                2 => std::borrow::Cow::Borrowed("METRIC_LABEL"),
+                3 => std::borrow::Cow::Borrowed("USER_METADATA_LABEL"),
+                4 => std::borrow::Cow::Borrowed("SYSTEM_METADATA_LABEL"),
+                5 => std::borrow::Cow::Borrowed("GROUP"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FILTER_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::FILTER_TYPE_UNSPECIFIED)
+                }
+                "RESOURCE_LABEL" => std::option::Option::Some(Self::RESOURCE_LABEL),
+                "METRIC_LABEL" => std::option::Option::Some(Self::METRIC_LABEL),
+                "USER_METADATA_LABEL" => std::option::Option::Some(Self::USER_METADATA_LABEL),
+                "SYSTEM_METADATA_LABEL" => std::option::Option::Some(Self::SYSTEM_METADATA_LABEL),
+                "GROUP" => std::option::Option::Some(Self::GROUP),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [FilterType](FilterType)
-    pub mod filter_type {
-        use super::FilterType;
-
-        /// Filter type is unspecified. This is not valid in a well-formed request.
-        pub const FILTER_TYPE_UNSPECIFIED: FilterType = FilterType::new("FILTER_TYPE_UNSPECIFIED");
-
-        /// Filter on a resource label value
-        pub const RESOURCE_LABEL: FilterType = FilterType::new("RESOURCE_LABEL");
-
-        /// Filter on a metrics label value
-        pub const METRIC_LABEL: FilterType = FilterType::new("METRIC_LABEL");
-
-        /// Filter on a user metadata label value
-        pub const USER_METADATA_LABEL: FilterType = FilterType::new("USER_METADATA_LABEL");
-
-        /// Filter on a system metadata label value
-        pub const SYSTEM_METADATA_LABEL: FilterType = FilterType::new("SYSTEM_METADATA_LABEL");
-
-        /// Filter on a group id
-        pub const GROUP: FilterType = FilterType::new("GROUP");
-    }
-
-    impl std::convert::From<std::string::String> for FilterType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for FilterType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for FilterType {
         fn default() -> Self {
-            filter_type::FILTER_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -2709,130 +2865,177 @@ pub mod threshold {
     /// the threshold. Comments on each color provide UX guidance on how users can
     /// be expected to interpret a given state color.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Color(std::borrow::Cow<'static, str>);
+    pub struct Color(i32);
 
     impl Color {
+        /// Color is unspecified. Not allowed in well-formed requests.
+        pub const COLOR_UNSPECIFIED: Color = Color::new(0);
+
+        /// Crossing the threshold is "concerning" behavior.
+        pub const YELLOW: Color = Color::new(4);
+
+        /// Crossing the threshold is "emergency" behavior.
+        pub const RED: Color = Color::new(6);
+
         /// Creates a new Color instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COLOR_UNSPECIFIED"),
+                4 => std::borrow::Cow::Borrowed("YELLOW"),
+                6 => std::borrow::Cow::Borrowed("RED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COLOR_UNSPECIFIED" => std::option::Option::Some(Self::COLOR_UNSPECIFIED),
+                "YELLOW" => std::option::Option::Some(Self::YELLOW),
+                "RED" => std::option::Option::Some(Self::RED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Color](Color)
-    pub mod color {
-        use super::Color;
-
-        /// Color is unspecified. Not allowed in well-formed requests.
-        pub const COLOR_UNSPECIFIED: Color = Color::new("COLOR_UNSPECIFIED");
-
-        /// Crossing the threshold is "concerning" behavior.
-        pub const YELLOW: Color = Color::new("YELLOW");
-
-        /// Crossing the threshold is "emergency" behavior.
-        pub const RED: Color = Color::new("RED");
-    }
-
-    impl std::convert::From<std::string::String> for Color {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Color {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Color {
         fn default() -> Self {
-            color::COLOR_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Whether the threshold is considered crossed by an actual value above or
     /// below its threshold value.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Direction(std::borrow::Cow<'static, str>);
+    pub struct Direction(i32);
 
     impl Direction {
-        /// Creates a new Direction instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Direction](Direction)
-    pub mod direction {
-        use super::Direction;
-
         /// Not allowed in well-formed requests.
-        pub const DIRECTION_UNSPECIFIED: Direction = Direction::new("DIRECTION_UNSPECIFIED");
+        pub const DIRECTION_UNSPECIFIED: Direction = Direction::new(0);
 
         /// The threshold will be considered crossed if the actual value is above
         /// the threshold value.
-        pub const ABOVE: Direction = Direction::new("ABOVE");
+        pub const ABOVE: Direction = Direction::new(1);
 
         /// The threshold will be considered crossed if the actual value is below
         /// the threshold value.
-        pub const BELOW: Direction = Direction::new("BELOW");
+        pub const BELOW: Direction = Direction::new(2);
+
+        /// Creates a new Direction instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DIRECTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ABOVE"),
+                2 => std::borrow::Cow::Borrowed("BELOW"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DIRECTION_UNSPECIFIED" => std::option::Option::Some(Self::DIRECTION_UNSPECIFIED),
+                "ABOVE" => std::option::Option::Some(Self::ABOVE),
+                "BELOW" => std::option::Option::Some(Self::BELOW),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Direction {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Direction {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Direction {
         fn default() -> Self {
-            direction::DIRECTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// An axis identifier.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TargetAxis(std::borrow::Cow<'static, str>);
+    pub struct TargetAxis(i32);
 
     impl TargetAxis {
+        /// The target axis was not specified. Defaults to Y1.
+        pub const TARGET_AXIS_UNSPECIFIED: TargetAxis = TargetAxis::new(0);
+
+        /// The y_axis (the right axis of chart).
+        pub const Y1: TargetAxis = TargetAxis::new(1);
+
+        /// The y2_axis (the left axis of chart).
+        pub const Y2: TargetAxis = TargetAxis::new(2);
+
         /// Creates a new TargetAxis instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TARGET_AXIS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("Y1"),
+                2 => std::borrow::Cow::Borrowed("Y2"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TARGET_AXIS_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::TARGET_AXIS_UNSPECIFIED)
+                }
+                "Y1" => std::option::Option::Some(Self::Y1),
+                "Y2" => std::option::Option::Some(Self::Y2),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [TargetAxis](TargetAxis)
-    pub mod target_axis {
-        use super::TargetAxis;
-
-        /// The target axis was not specified. Defaults to Y1.
-        pub const TARGET_AXIS_UNSPECIFIED: TargetAxis = TargetAxis::new("TARGET_AXIS_UNSPECIFIED");
-
-        /// The y_axis (the right axis of chart).
-        pub const Y1: TargetAxis = TargetAxis::new("Y1");
-
-        /// The y2_axis (the left axis of chart).
-        pub const Y2: TargetAxis = TargetAxis::new("Y2");
-    }
-
-    impl std::convert::From<std::string::String> for TargetAxis {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TargetAxis {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TargetAxis {
         fn default() -> Self {
-            target_axis::TARGET_AXIS_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2971,44 +3174,60 @@ pub mod pie_chart {
 
     /// Types for the pie chart.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PieChartType(std::borrow::Cow<'static, str>);
+    pub struct PieChartType(i32);
 
     impl PieChartType {
+        /// The zero value. No type specified. Do not use.
+        pub const PIE_CHART_TYPE_UNSPECIFIED: PieChartType = PieChartType::new(0);
+
+        /// A Pie type PieChart.
+        pub const PIE: PieChartType = PieChartType::new(1);
+
+        /// Similar to PIE, but the DONUT type PieChart has a hole in the middle.
+        pub const DONUT: PieChartType = PieChartType::new(2);
+
         /// Creates a new PieChartType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PIE_CHART_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PIE"),
+                2 => std::borrow::Cow::Borrowed("DONUT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PIE_CHART_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PIE_CHART_TYPE_UNSPECIFIED)
+                }
+                "PIE" => std::option::Option::Some(Self::PIE),
+                "DONUT" => std::option::Option::Some(Self::DONUT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [PieChartType](PieChartType)
-    pub mod pie_chart_type {
-        use super::PieChartType;
-
-        /// The zero value. No type specified. Do not use.
-        pub const PIE_CHART_TYPE_UNSPECIFIED: PieChartType =
-            PieChartType::new("PIE_CHART_TYPE_UNSPECIFIED");
-
-        /// A Pie type PieChart.
-        pub const PIE: PieChartType = PieChartType::new("PIE");
-
-        /// Similar to PIE, but the DONUT type PieChart has a hole in the middle.
-        pub const DONUT: PieChartType = PieChartType::new("DONUT");
-    }
-
-    impl std::convert::From<std::string::String> for PieChartType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PieChartType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PieChartType {
         fn default() -> Self {
-            pie_chart_type::PIE_CHART_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3569,44 +3788,61 @@ pub mod time_series_table {
 
     /// Enum for metric metric_visualization
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MetricVisualization(std::borrow::Cow<'static, str>);
+    pub struct MetricVisualization(i32);
 
     impl MetricVisualization {
+        /// Unspecified state
+        pub const METRIC_VISUALIZATION_UNSPECIFIED: MetricVisualization =
+            MetricVisualization::new(0);
+
+        /// Default text rendering
+        pub const NUMBER: MetricVisualization = MetricVisualization::new(1);
+
+        /// Horizontal bar rendering
+        pub const BAR: MetricVisualization = MetricVisualization::new(2);
+
         /// Creates a new MetricVisualization instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("METRIC_VISUALIZATION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NUMBER"),
+                2 => std::borrow::Cow::Borrowed("BAR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "METRIC_VISUALIZATION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::METRIC_VISUALIZATION_UNSPECIFIED)
+                }
+                "NUMBER" => std::option::Option::Some(Self::NUMBER),
+                "BAR" => std::option::Option::Some(Self::BAR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [MetricVisualization](MetricVisualization)
-    pub mod metric_visualization {
-        use super::MetricVisualization;
-
-        /// Unspecified state
-        pub const METRIC_VISUALIZATION_UNSPECIFIED: MetricVisualization =
-            MetricVisualization::new("METRIC_VISUALIZATION_UNSPECIFIED");
-
-        /// Default text rendering
-        pub const NUMBER: MetricVisualization = MetricVisualization::new("NUMBER");
-
-        /// Horizontal bar rendering
-        pub const BAR: MetricVisualization = MetricVisualization::new("BAR");
-    }
-
-    impl std::convert::From<std::string::String> for MetricVisualization {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MetricVisualization {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MetricVisualization {
         fn default() -> Self {
-            metric_visualization::METRIC_VISUALIZATION_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3818,313 +4054,446 @@ pub mod text {
 
         /// The horizontal alignment of both the title and content on a text widget
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct HorizontalAlignment(std::borrow::Cow<'static, str>);
+        pub struct HorizontalAlignment(i32);
 
         impl HorizontalAlignment {
+            /// No horizontal alignment specified, will default to H_LEFT
+            pub const HORIZONTAL_ALIGNMENT_UNSPECIFIED: HorizontalAlignment =
+                HorizontalAlignment::new(0);
+
+            /// Left-align
+            pub const H_LEFT: HorizontalAlignment = HorizontalAlignment::new(1);
+
+            /// Center-align
+            pub const H_CENTER: HorizontalAlignment = HorizontalAlignment::new(2);
+
+            /// Right-align
+            pub const H_RIGHT: HorizontalAlignment = HorizontalAlignment::new(3);
+
             /// Creates a new HorizontalAlignment instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("HORIZONTAL_ALIGNMENT_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("H_LEFT"),
+                    2 => std::borrow::Cow::Borrowed("H_CENTER"),
+                    3 => std::borrow::Cow::Borrowed("H_RIGHT"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "HORIZONTAL_ALIGNMENT_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::HORIZONTAL_ALIGNMENT_UNSPECIFIED)
+                    }
+                    "H_LEFT" => std::option::Option::Some(Self::H_LEFT),
+                    "H_CENTER" => std::option::Option::Some(Self::H_CENTER),
+                    "H_RIGHT" => std::option::Option::Some(Self::H_RIGHT),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [HorizontalAlignment](HorizontalAlignment)
-        pub mod horizontal_alignment {
-            use super::HorizontalAlignment;
-
-            /// No horizontal alignment specified, will default to H_LEFT
-            pub const HORIZONTAL_ALIGNMENT_UNSPECIFIED: HorizontalAlignment =
-                HorizontalAlignment::new("HORIZONTAL_ALIGNMENT_UNSPECIFIED");
-
-            /// Left-align
-            pub const H_LEFT: HorizontalAlignment = HorizontalAlignment::new("H_LEFT");
-
-            /// Center-align
-            pub const H_CENTER: HorizontalAlignment = HorizontalAlignment::new("H_CENTER");
-
-            /// Right-align
-            pub const H_RIGHT: HorizontalAlignment = HorizontalAlignment::new("H_RIGHT");
-        }
-
-        impl std::convert::From<std::string::String> for HorizontalAlignment {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for HorizontalAlignment {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for HorizontalAlignment {
             fn default() -> Self {
-                horizontal_alignment::HORIZONTAL_ALIGNMENT_UNSPECIFIED
+                Self::new(0)
             }
         }
 
         /// The vertical alignment of both the title and content on a text widget
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct VerticalAlignment(std::borrow::Cow<'static, str>);
+        pub struct VerticalAlignment(i32);
 
         impl VerticalAlignment {
+            /// No vertical alignment specified, will default to V_TOP
+            pub const VERTICAL_ALIGNMENT_UNSPECIFIED: VerticalAlignment = VerticalAlignment::new(0);
+
+            /// Top-align
+            pub const V_TOP: VerticalAlignment = VerticalAlignment::new(1);
+
+            /// Center-align
+            pub const V_CENTER: VerticalAlignment = VerticalAlignment::new(2);
+
+            /// Bottom-align
+            pub const V_BOTTOM: VerticalAlignment = VerticalAlignment::new(3);
+
             /// Creates a new VerticalAlignment instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("VERTICAL_ALIGNMENT_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("V_TOP"),
+                    2 => std::borrow::Cow::Borrowed("V_CENTER"),
+                    3 => std::borrow::Cow::Borrowed("V_BOTTOM"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "VERTICAL_ALIGNMENT_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::VERTICAL_ALIGNMENT_UNSPECIFIED)
+                    }
+                    "V_TOP" => std::option::Option::Some(Self::V_TOP),
+                    "V_CENTER" => std::option::Option::Some(Self::V_CENTER),
+                    "V_BOTTOM" => std::option::Option::Some(Self::V_BOTTOM),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [VerticalAlignment](VerticalAlignment)
-        pub mod vertical_alignment {
-            use super::VerticalAlignment;
-
-            /// No vertical alignment specified, will default to V_TOP
-            pub const VERTICAL_ALIGNMENT_UNSPECIFIED: VerticalAlignment =
-                VerticalAlignment::new("VERTICAL_ALIGNMENT_UNSPECIFIED");
-
-            /// Top-align
-            pub const V_TOP: VerticalAlignment = VerticalAlignment::new("V_TOP");
-
-            /// Center-align
-            pub const V_CENTER: VerticalAlignment = VerticalAlignment::new("V_CENTER");
-
-            /// Bottom-align
-            pub const V_BOTTOM: VerticalAlignment = VerticalAlignment::new("V_BOTTOM");
-        }
-
-        impl std::convert::From<std::string::String> for VerticalAlignment {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for VerticalAlignment {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for VerticalAlignment {
             fn default() -> Self {
-                vertical_alignment::VERTICAL_ALIGNMENT_UNSPECIFIED
+                Self::new(0)
             }
         }
 
         /// Specifies padding size around a text widget
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct PaddingSize(std::borrow::Cow<'static, str>);
+        pub struct PaddingSize(i32);
 
         impl PaddingSize {
+            /// No padding size specified, will default to P_EXTRA_SMALL
+            pub const PADDING_SIZE_UNSPECIFIED: PaddingSize = PaddingSize::new(0);
+
+            /// Extra small padding
+            pub const P_EXTRA_SMALL: PaddingSize = PaddingSize::new(1);
+
+            /// Small padding
+            pub const P_SMALL: PaddingSize = PaddingSize::new(2);
+
+            /// Medium padding
+            pub const P_MEDIUM: PaddingSize = PaddingSize::new(3);
+
+            /// Large padding
+            pub const P_LARGE: PaddingSize = PaddingSize::new(4);
+
+            /// Extra large padding
+            pub const P_EXTRA_LARGE: PaddingSize = PaddingSize::new(5);
+
             /// Creates a new PaddingSize instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("PADDING_SIZE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("P_EXTRA_SMALL"),
+                    2 => std::borrow::Cow::Borrowed("P_SMALL"),
+                    3 => std::borrow::Cow::Borrowed("P_MEDIUM"),
+                    4 => std::borrow::Cow::Borrowed("P_LARGE"),
+                    5 => std::borrow::Cow::Borrowed("P_EXTRA_LARGE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "PADDING_SIZE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::PADDING_SIZE_UNSPECIFIED)
+                    }
+                    "P_EXTRA_SMALL" => std::option::Option::Some(Self::P_EXTRA_SMALL),
+                    "P_SMALL" => std::option::Option::Some(Self::P_SMALL),
+                    "P_MEDIUM" => std::option::Option::Some(Self::P_MEDIUM),
+                    "P_LARGE" => std::option::Option::Some(Self::P_LARGE),
+                    "P_EXTRA_LARGE" => std::option::Option::Some(Self::P_EXTRA_LARGE),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [PaddingSize](PaddingSize)
-        pub mod padding_size {
-            use super::PaddingSize;
-
-            /// No padding size specified, will default to P_EXTRA_SMALL
-            pub const PADDING_SIZE_UNSPECIFIED: PaddingSize =
-                PaddingSize::new("PADDING_SIZE_UNSPECIFIED");
-
-            /// Extra small padding
-            pub const P_EXTRA_SMALL: PaddingSize = PaddingSize::new("P_EXTRA_SMALL");
-
-            /// Small padding
-            pub const P_SMALL: PaddingSize = PaddingSize::new("P_SMALL");
-
-            /// Medium padding
-            pub const P_MEDIUM: PaddingSize = PaddingSize::new("P_MEDIUM");
-
-            /// Large padding
-            pub const P_LARGE: PaddingSize = PaddingSize::new("P_LARGE");
-
-            /// Extra large padding
-            pub const P_EXTRA_LARGE: PaddingSize = PaddingSize::new("P_EXTRA_LARGE");
-        }
-
-        impl std::convert::From<std::string::String> for PaddingSize {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for PaddingSize {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for PaddingSize {
             fn default() -> Self {
-                padding_size::PADDING_SIZE_UNSPECIFIED
+                Self::new(0)
             }
         }
 
         /// Specifies a font size for the title and content of a text widget
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct FontSize(std::borrow::Cow<'static, str>);
+        pub struct FontSize(i32);
 
         impl FontSize {
+            /// No font size specified, will default to FS_LARGE
+            pub const FONT_SIZE_UNSPECIFIED: FontSize = FontSize::new(0);
+
+            /// Extra small font size
+            pub const FS_EXTRA_SMALL: FontSize = FontSize::new(1);
+
+            /// Small font size
+            pub const FS_SMALL: FontSize = FontSize::new(2);
+
+            /// Medium font size
+            pub const FS_MEDIUM: FontSize = FontSize::new(3);
+
+            /// Large font size
+            pub const FS_LARGE: FontSize = FontSize::new(4);
+
+            /// Extra large font size
+            pub const FS_EXTRA_LARGE: FontSize = FontSize::new(5);
+
             /// Creates a new FontSize instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("FONT_SIZE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("FS_EXTRA_SMALL"),
+                    2 => std::borrow::Cow::Borrowed("FS_SMALL"),
+                    3 => std::borrow::Cow::Borrowed("FS_MEDIUM"),
+                    4 => std::borrow::Cow::Borrowed("FS_LARGE"),
+                    5 => std::borrow::Cow::Borrowed("FS_EXTRA_LARGE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "FONT_SIZE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::FONT_SIZE_UNSPECIFIED)
+                    }
+                    "FS_EXTRA_SMALL" => std::option::Option::Some(Self::FS_EXTRA_SMALL),
+                    "FS_SMALL" => std::option::Option::Some(Self::FS_SMALL),
+                    "FS_MEDIUM" => std::option::Option::Some(Self::FS_MEDIUM),
+                    "FS_LARGE" => std::option::Option::Some(Self::FS_LARGE),
+                    "FS_EXTRA_LARGE" => std::option::Option::Some(Self::FS_EXTRA_LARGE),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [FontSize](FontSize)
-        pub mod font_size {
-            use super::FontSize;
-
-            /// No font size specified, will default to FS_LARGE
-            pub const FONT_SIZE_UNSPECIFIED: FontSize = FontSize::new("FONT_SIZE_UNSPECIFIED");
-
-            /// Extra small font size
-            pub const FS_EXTRA_SMALL: FontSize = FontSize::new("FS_EXTRA_SMALL");
-
-            /// Small font size
-            pub const FS_SMALL: FontSize = FontSize::new("FS_SMALL");
-
-            /// Medium font size
-            pub const FS_MEDIUM: FontSize = FontSize::new("FS_MEDIUM");
-
-            /// Large font size
-            pub const FS_LARGE: FontSize = FontSize::new("FS_LARGE");
-
-            /// Extra large font size
-            pub const FS_EXTRA_LARGE: FontSize = FontSize::new("FS_EXTRA_LARGE");
-        }
-
-        impl std::convert::From<std::string::String> for FontSize {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for FontSize {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for FontSize {
             fn default() -> Self {
-                font_size::FONT_SIZE_UNSPECIFIED
+                Self::new(0)
             }
         }
 
         /// Specifies where a visual pointer is placed on a text widget (also
         /// sometimes called a "tail")
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct PointerLocation(std::borrow::Cow<'static, str>);
+        pub struct PointerLocation(i32);
 
         impl PointerLocation {
+            /// No visual pointer
+            pub const POINTER_LOCATION_UNSPECIFIED: PointerLocation = PointerLocation::new(0);
+
+            /// Placed in the middle of the top of the widget
+            pub const PL_TOP: PointerLocation = PointerLocation::new(1);
+
+            /// Placed in the middle of the right side of the widget
+            pub const PL_RIGHT: PointerLocation = PointerLocation::new(2);
+
+            /// Placed in the middle of the bottom of the widget
+            pub const PL_BOTTOM: PointerLocation = PointerLocation::new(3);
+
+            /// Placed in the middle of the left side of the widget
+            pub const PL_LEFT: PointerLocation = PointerLocation::new(4);
+
+            /// Placed on the left side of the top of the widget
+            pub const PL_TOP_LEFT: PointerLocation = PointerLocation::new(5);
+
+            /// Placed on the right side of the top of the widget
+            pub const PL_TOP_RIGHT: PointerLocation = PointerLocation::new(6);
+
+            /// Placed on the top of the right side of the widget
+            pub const PL_RIGHT_TOP: PointerLocation = PointerLocation::new(7);
+
+            /// Placed on the bottom of the right side of the widget
+            pub const PL_RIGHT_BOTTOM: PointerLocation = PointerLocation::new(8);
+
+            /// Placed on the right side of the bottom of the widget
+            pub const PL_BOTTOM_RIGHT: PointerLocation = PointerLocation::new(9);
+
+            /// Placed on the left side of the bottom of the widget
+            pub const PL_BOTTOM_LEFT: PointerLocation = PointerLocation::new(10);
+
+            /// Placed on the bottom of the left side of the widget
+            pub const PL_LEFT_BOTTOM: PointerLocation = PointerLocation::new(11);
+
+            /// Placed on the top of the left side of the widget
+            pub const PL_LEFT_TOP: PointerLocation = PointerLocation::new(12);
+
             /// Creates a new PointerLocation instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("POINTER_LOCATION_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("PL_TOP"),
+                    2 => std::borrow::Cow::Borrowed("PL_RIGHT"),
+                    3 => std::borrow::Cow::Borrowed("PL_BOTTOM"),
+                    4 => std::borrow::Cow::Borrowed("PL_LEFT"),
+                    5 => std::borrow::Cow::Borrowed("PL_TOP_LEFT"),
+                    6 => std::borrow::Cow::Borrowed("PL_TOP_RIGHT"),
+                    7 => std::borrow::Cow::Borrowed("PL_RIGHT_TOP"),
+                    8 => std::borrow::Cow::Borrowed("PL_RIGHT_BOTTOM"),
+                    9 => std::borrow::Cow::Borrowed("PL_BOTTOM_RIGHT"),
+                    10 => std::borrow::Cow::Borrowed("PL_BOTTOM_LEFT"),
+                    11 => std::borrow::Cow::Borrowed("PL_LEFT_BOTTOM"),
+                    12 => std::borrow::Cow::Borrowed("PL_LEFT_TOP"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "POINTER_LOCATION_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::POINTER_LOCATION_UNSPECIFIED)
+                    }
+                    "PL_TOP" => std::option::Option::Some(Self::PL_TOP),
+                    "PL_RIGHT" => std::option::Option::Some(Self::PL_RIGHT),
+                    "PL_BOTTOM" => std::option::Option::Some(Self::PL_BOTTOM),
+                    "PL_LEFT" => std::option::Option::Some(Self::PL_LEFT),
+                    "PL_TOP_LEFT" => std::option::Option::Some(Self::PL_TOP_LEFT),
+                    "PL_TOP_RIGHT" => std::option::Option::Some(Self::PL_TOP_RIGHT),
+                    "PL_RIGHT_TOP" => std::option::Option::Some(Self::PL_RIGHT_TOP),
+                    "PL_RIGHT_BOTTOM" => std::option::Option::Some(Self::PL_RIGHT_BOTTOM),
+                    "PL_BOTTOM_RIGHT" => std::option::Option::Some(Self::PL_BOTTOM_RIGHT),
+                    "PL_BOTTOM_LEFT" => std::option::Option::Some(Self::PL_BOTTOM_LEFT),
+                    "PL_LEFT_BOTTOM" => std::option::Option::Some(Self::PL_LEFT_BOTTOM),
+                    "PL_LEFT_TOP" => std::option::Option::Some(Self::PL_LEFT_TOP),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [PointerLocation](PointerLocation)
-        pub mod pointer_location {
-            use super::PointerLocation;
-
-            /// No visual pointer
-            pub const POINTER_LOCATION_UNSPECIFIED: PointerLocation =
-                PointerLocation::new("POINTER_LOCATION_UNSPECIFIED");
-
-            /// Placed in the middle of the top of the widget
-            pub const PL_TOP: PointerLocation = PointerLocation::new("PL_TOP");
-
-            /// Placed in the middle of the right side of the widget
-            pub const PL_RIGHT: PointerLocation = PointerLocation::new("PL_RIGHT");
-
-            /// Placed in the middle of the bottom of the widget
-            pub const PL_BOTTOM: PointerLocation = PointerLocation::new("PL_BOTTOM");
-
-            /// Placed in the middle of the left side of the widget
-            pub const PL_LEFT: PointerLocation = PointerLocation::new("PL_LEFT");
-
-            /// Placed on the left side of the top of the widget
-            pub const PL_TOP_LEFT: PointerLocation = PointerLocation::new("PL_TOP_LEFT");
-
-            /// Placed on the right side of the top of the widget
-            pub const PL_TOP_RIGHT: PointerLocation = PointerLocation::new("PL_TOP_RIGHT");
-
-            /// Placed on the top of the right side of the widget
-            pub const PL_RIGHT_TOP: PointerLocation = PointerLocation::new("PL_RIGHT_TOP");
-
-            /// Placed on the bottom of the right side of the widget
-            pub const PL_RIGHT_BOTTOM: PointerLocation = PointerLocation::new("PL_RIGHT_BOTTOM");
-
-            /// Placed on the right side of the bottom of the widget
-            pub const PL_BOTTOM_RIGHT: PointerLocation = PointerLocation::new("PL_BOTTOM_RIGHT");
-
-            /// Placed on the left side of the bottom of the widget
-            pub const PL_BOTTOM_LEFT: PointerLocation = PointerLocation::new("PL_BOTTOM_LEFT");
-
-            /// Placed on the bottom of the left side of the widget
-            pub const PL_LEFT_BOTTOM: PointerLocation = PointerLocation::new("PL_LEFT_BOTTOM");
-
-            /// Placed on the top of the left side of the widget
-            pub const PL_LEFT_TOP: PointerLocation = PointerLocation::new("PL_LEFT_TOP");
-        }
-
-        impl std::convert::From<std::string::String> for PointerLocation {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for PointerLocation {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for PointerLocation {
             fn default() -> Self {
-                pointer_location::POINTER_LOCATION_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// The format type of the text content.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Format(std::borrow::Cow<'static, str>);
+    pub struct Format(i32);
 
     impl Format {
+        /// Format is unspecified. Defaults to MARKDOWN.
+        pub const FORMAT_UNSPECIFIED: Format = Format::new(0);
+
+        /// The text contains Markdown formatting.
+        pub const MARKDOWN: Format = Format::new(1);
+
+        /// The text contains no special formatting.
+        pub const RAW: Format = Format::new(2);
+
         /// Creates a new Format instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FORMAT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MARKDOWN"),
+                2 => std::borrow::Cow::Borrowed("RAW"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FORMAT_UNSPECIFIED" => std::option::Option::Some(Self::FORMAT_UNSPECIFIED),
+                "MARKDOWN" => std::option::Option::Some(Self::MARKDOWN),
+                "RAW" => std::option::Option::Some(Self::RAW),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Format](Format)
-    pub mod format {
-        use super::Format;
-
-        /// Format is unspecified. Defaults to MARKDOWN.
-        pub const FORMAT_UNSPECIFIED: Format = Format::new("FORMAT_UNSPECIFIED");
-
-        /// The text contains Markdown formatting.
-        pub const MARKDOWN: Format = Format::new("MARKDOWN");
-
-        /// The text contains no special formatting.
-        pub const RAW: Format = Format::new("RAW");
-    }
-
-    impl std::convert::From<std::string::String> for Format {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Format {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Format {
         fn default() -> Self {
-            format::FORMAT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4795,101 +5164,138 @@ pub mod xy_chart {
 
         /// The types of plotting strategies for data sets.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct PlotType(std::borrow::Cow<'static, str>);
+        pub struct PlotType(i32);
 
         impl PlotType {
-            /// Creates a new PlotType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [PlotType](PlotType)
-        pub mod plot_type {
-            use super::PlotType;
-
             /// Plot type is unspecified. The view will default to `LINE`.
-            pub const PLOT_TYPE_UNSPECIFIED: PlotType = PlotType::new("PLOT_TYPE_UNSPECIFIED");
+            pub const PLOT_TYPE_UNSPECIFIED: PlotType = PlotType::new(0);
 
             /// The data is plotted as a set of lines (one line per series).
-            pub const LINE: PlotType = PlotType::new("LINE");
+            pub const LINE: PlotType = PlotType::new(1);
 
             /// The data is plotted as a set of filled areas (one area per series),
             /// with the areas stacked vertically (the base of each area is the top of
             /// its predecessor, and the base of the first area is the x-axis). Since
             /// the areas do not overlap, each is filled with a different opaque color.
-            pub const STACKED_AREA: PlotType = PlotType::new("STACKED_AREA");
+            pub const STACKED_AREA: PlotType = PlotType::new(2);
 
             /// The data is plotted as a set of rectangular boxes (one box per series),
             /// with the boxes stacked vertically (the base of each box is the top of
             /// its predecessor, and the base of the first box is the x-axis). Since
             /// the boxes do not overlap, each is filled with a different opaque color.
-            pub const STACKED_BAR: PlotType = PlotType::new("STACKED_BAR");
+            pub const STACKED_BAR: PlotType = PlotType::new(3);
 
             /// The data is plotted as a heatmap. The series being plotted must have a
             /// `DISTRIBUTION` value type. The value of each bucket in the distribution
             /// is displayed as a color. This type is not currently available in the
             /// Stackdriver Monitoring application.
-            pub const HEATMAP: PlotType = PlotType::new("HEATMAP");
+            pub const HEATMAP: PlotType = PlotType::new(4);
+
+            /// Creates a new PlotType instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("PLOT_TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("LINE"),
+                    2 => std::borrow::Cow::Borrowed("STACKED_AREA"),
+                    3 => std::borrow::Cow::Borrowed("STACKED_BAR"),
+                    4 => std::borrow::Cow::Borrowed("HEATMAP"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "PLOT_TYPE_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::PLOT_TYPE_UNSPECIFIED)
+                    }
+                    "LINE" => std::option::Option::Some(Self::LINE),
+                    "STACKED_AREA" => std::option::Option::Some(Self::STACKED_AREA),
+                    "STACKED_BAR" => std::option::Option::Some(Self::STACKED_BAR),
+                    "HEATMAP" => std::option::Option::Some(Self::HEATMAP),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for PlotType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for PlotType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for PlotType {
             fn default() -> Self {
-                plot_type::PLOT_TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
 
         /// An axis identifier.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct TargetAxis(std::borrow::Cow<'static, str>);
+        pub struct TargetAxis(i32);
 
         impl TargetAxis {
+            /// The target axis was not specified. Defaults to Y1.
+            pub const TARGET_AXIS_UNSPECIFIED: TargetAxis = TargetAxis::new(0);
+
+            /// The y_axis (the right axis of chart).
+            pub const Y1: TargetAxis = TargetAxis::new(1);
+
+            /// The y2_axis (the left axis of chart).
+            pub const Y2: TargetAxis = TargetAxis::new(2);
+
             /// Creates a new TargetAxis instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("TARGET_AXIS_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("Y1"),
+                    2 => std::borrow::Cow::Borrowed("Y2"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "TARGET_AXIS_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::TARGET_AXIS_UNSPECIFIED)
+                    }
+                    "Y1" => std::option::Option::Some(Self::Y1),
+                    "Y2" => std::option::Option::Some(Self::Y2),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [TargetAxis](TargetAxis)
-        pub mod target_axis {
-            use super::TargetAxis;
-
-            /// The target axis was not specified. Defaults to Y1.
-            pub const TARGET_AXIS_UNSPECIFIED: TargetAxis =
-                TargetAxis::new("TARGET_AXIS_UNSPECIFIED");
-
-            /// The y_axis (the right axis of chart).
-            pub const Y1: TargetAxis = TargetAxis::new("Y1");
-
-            /// The y2_axis (the left axis of chart).
-            pub const Y2: TargetAxis = TargetAxis::new("Y2");
-        }
-
-        impl std::convert::From<std::string::String> for TargetAxis {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for TargetAxis {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for TargetAxis {
             fn default() -> Self {
-                target_axis::TARGET_AXIS_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -4942,43 +5348,58 @@ pub mod xy_chart {
 
         /// Types of scales used in axes.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Scale(std::borrow::Cow<'static, str>);
+        pub struct Scale(i32);
 
         impl Scale {
+            /// Scale is unspecified. The view will default to `LINEAR`.
+            pub const SCALE_UNSPECIFIED: Scale = Scale::new(0);
+
+            /// Linear scale.
+            pub const LINEAR: Scale = Scale::new(1);
+
+            /// Logarithmic scale (base 10).
+            pub const LOG10: Scale = Scale::new(2);
+
             /// Creates a new Scale instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("SCALE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("LINEAR"),
+                    2 => std::borrow::Cow::Borrowed("LOG10"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "SCALE_UNSPECIFIED" => std::option::Option::Some(Self::SCALE_UNSPECIFIED),
+                    "LINEAR" => std::option::Option::Some(Self::LINEAR),
+                    "LOG10" => std::option::Option::Some(Self::LOG10),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Scale](Scale)
-        pub mod scale {
-            use super::Scale;
-
-            /// Scale is unspecified. The view will default to `LINEAR`.
-            pub const SCALE_UNSPECIFIED: Scale = Scale::new("SCALE_UNSPECIFIED");
-
-            /// Linear scale.
-            pub const LINEAR: Scale = Scale::new("LINEAR");
-
-            /// Logarithmic scale (base 10).
-            pub const LOG10: Scale = Scale::new("LOG10");
-        }
-
-        impl std::convert::From<std::string::String> for Scale {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Scale {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Scale {
             fn default() -> Self {
-                scale::SCALE_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -5022,92 +5443,125 @@ pub mod chart_options {
 
     /// Chart mode options.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(std::borrow::Cow<'static, str>);
+    pub struct Mode(i32);
 
     impl Mode {
-        /// Creates a new Mode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Mode](Mode)
-    pub mod mode {
-        use super::Mode;
-
         /// Mode is unspecified. The view will default to `COLOR`.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new("MODE_UNSPECIFIED");
+        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
 
         /// The chart distinguishes data series using different color. Line
         /// colors may get reused when there are many lines in the chart.
-        pub const COLOR: Mode = Mode::new("COLOR");
+        pub const COLOR: Mode = Mode::new(1);
 
         /// The chart uses the Stackdriver x-ray mode, in which each
         /// data set is plotted using the same semi-transparent color.
-        pub const X_RAY: Mode = Mode::new("X_RAY");
+        pub const X_RAY: Mode = Mode::new(2);
 
         /// The chart displays statistics such as average, median, 95th percentile,
         /// and more.
-        pub const STATS: Mode = Mode::new("STATS");
+        pub const STATS: Mode = Mode::new(3);
+
+        /// Creates a new Mode instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("COLOR"),
+                2 => std::borrow::Cow::Borrowed("X_RAY"),
+                3 => std::borrow::Cow::Borrowed("STATS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
+                "COLOR" => std::option::Option::Some(Self::COLOR),
+                "X_RAY" => std::option::Option::Some(Self::X_RAY),
+                "STATS" => std::option::Option::Some(Self::STATS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Mode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            mode::MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
 
 /// Defines the possible types of spark chart supported by the `Scorecard`.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SparkChartType(std::borrow::Cow<'static, str>);
+pub struct SparkChartType(i32);
 
 impl SparkChartType {
+    /// Not allowed in well-formed requests.
+    pub const SPARK_CHART_TYPE_UNSPECIFIED: SparkChartType = SparkChartType::new(0);
+
+    /// The sparkline will be rendered as a small line chart.
+    pub const SPARK_LINE: SparkChartType = SparkChartType::new(1);
+
+    /// The sparkbar will be rendered as a small bar chart.
+    pub const SPARK_BAR: SparkChartType = SparkChartType::new(2);
+
     /// Creates a new SparkChartType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SPARK_CHART_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SPARK_LINE"),
+            2 => std::borrow::Cow::Borrowed("SPARK_BAR"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SPARK_CHART_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::SPARK_CHART_TYPE_UNSPECIFIED)
+            }
+            "SPARK_LINE" => std::option::Option::Some(Self::SPARK_LINE),
+            "SPARK_BAR" => std::option::Option::Some(Self::SPARK_BAR),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [SparkChartType](SparkChartType)
-pub mod spark_chart_type {
-    use super::SparkChartType;
-
-    /// Not allowed in well-formed requests.
-    pub const SPARK_CHART_TYPE_UNSPECIFIED: SparkChartType =
-        SparkChartType::new("SPARK_CHART_TYPE_UNSPECIFIED");
-
-    /// The sparkline will be rendered as a small line chart.
-    pub const SPARK_LINE: SparkChartType = SparkChartType::new("SPARK_LINE");
-
-    /// The sparkbar will be rendered as a small bar chart.
-    pub const SPARK_BAR: SparkChartType = SparkChartType::new("SPARK_BAR");
-}
-
-impl std::convert::From<std::string::String> for SparkChartType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for SparkChartType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for SparkChartType {
     fn default() -> Self {
-        spark_chart_type::SPARK_CHART_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/monitoring/dashboard/v1/src/transport.rs
+++ b/src/generated/monitoring/dashboard/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::DashboardsService for DashboardsService {
                 reqwest::Method::POST,
                 format!("/v1/{}/dashboards", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::DashboardsService for DashboardsService {
                 reqwest::Method::GET,
                 format!("/v1/{}/dashboards", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -96,7 +96,7 @@ impl crate::stubs::DashboardsService for DashboardsService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -115,7 +115,7 @@ impl crate::stubs::DashboardsService for DashboardsService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -143,7 +143,7 @@ impl crate::stubs::DashboardsService for DashboardsService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/monitoring/metricsscope/v1/src/model.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/model.rs
@@ -407,49 +407,68 @@ pub mod operation_metadata {
 
     /// Batch operation states.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
+        /// Invalid.
+        pub const STATE_UNSPECIFIED: State = State::new(0);
+
+        /// Request has been received.
+        pub const CREATED: State = State::new(1);
+
+        /// Request is actively being processed.
+        pub const RUNNING: State = State::new(2);
+
+        /// The batch processing is done.
+        pub const DONE: State = State::new(3);
+
+        /// The batch processing was cancelled.
+        pub const CANCELLED: State = State::new(4);
+
         /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATED"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("DONE"),
+                4 => std::borrow::Cow::Borrowed("CANCELLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATED" => std::option::Option::Some(Self::CREATED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "DONE" => std::option::Option::Some(Self::DONE),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
-        /// Invalid.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
-
-        /// Request has been received.
-        pub const CREATED: State = State::new("CREATED");
-
-        /// Request is actively being processed.
-        pub const RUNNING: State = State::new("RUNNING");
-
-        /// The batch processing is done.
-        pub const DONE: State = State::new("DONE");
-
-        /// The batch processing was cancelled.
-        pub const CANCELLED: State = State::new("CANCELLED");
-    }
-
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/monitoring/metricsscope/v1/src/transport.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/transport.rs
@@ -49,7 +49,7 @@ impl crate::stubs::MetricsScopes for MetricsScopes {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::MetricsScopes for MetricsScopes {
                 "/v1/locations/global/metricsScopes:listMetricsScopesByMonitoredProject"
                     .to_string(),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -98,7 +98,7 @@ impl crate::stubs::MetricsScopes for MetricsScopes {
                 reqwest::Method::POST,
                 format!("/v1/{}/projects", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -117,7 +117,7 @@ impl crate::stubs::MetricsScopes for MetricsScopes {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -136,7 +136,7 @@ impl crate::stubs::MetricsScopes for MetricsScopes {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/monitoring/v3/src/model.rs
+++ b/src/generated/monitoring/v3/src/model.rs
@@ -2110,53 +2110,78 @@ pub mod alert_policy {
         /// are evaluated when data stops arriving.
         /// This control doesn't affect metric-absence policies.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct EvaluationMissingData(std::borrow::Cow<'static, str>);
+        pub struct EvaluationMissingData(i32);
 
         impl EvaluationMissingData {
-            /// Creates a new EvaluationMissingData instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [EvaluationMissingData](EvaluationMissingData)
-        pub mod evaluation_missing_data {
-            use super::EvaluationMissingData;
-
             /// An unspecified evaluation missing data option.  Equivalent to
             /// EVALUATION_MISSING_DATA_NO_OP.
             pub const EVALUATION_MISSING_DATA_UNSPECIFIED: EvaluationMissingData =
-                EvaluationMissingData::new("EVALUATION_MISSING_DATA_UNSPECIFIED");
+                EvaluationMissingData::new(0);
 
             /// If there is no data to evaluate the condition, then evaluate the
             /// condition as false.
             pub const EVALUATION_MISSING_DATA_INACTIVE: EvaluationMissingData =
-                EvaluationMissingData::new("EVALUATION_MISSING_DATA_INACTIVE");
+                EvaluationMissingData::new(1);
 
             /// If there is no data to evaluate the condition, then evaluate the
             /// condition as true.
             pub const EVALUATION_MISSING_DATA_ACTIVE: EvaluationMissingData =
-                EvaluationMissingData::new("EVALUATION_MISSING_DATA_ACTIVE");
+                EvaluationMissingData::new(2);
 
             /// Do not evaluate the condition to any value if there is no data.
             pub const EVALUATION_MISSING_DATA_NO_OP: EvaluationMissingData =
-                EvaluationMissingData::new("EVALUATION_MISSING_DATA_NO_OP");
+                EvaluationMissingData::new(3);
+
+            /// Creates a new EvaluationMissingData instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("EVALUATION_MISSING_DATA_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("EVALUATION_MISSING_DATA_INACTIVE"),
+                    2 => std::borrow::Cow::Borrowed("EVALUATION_MISSING_DATA_ACTIVE"),
+                    3 => std::borrow::Cow::Borrowed("EVALUATION_MISSING_DATA_NO_OP"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "EVALUATION_MISSING_DATA_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::EVALUATION_MISSING_DATA_UNSPECIFIED)
+                    }
+                    "EVALUATION_MISSING_DATA_INACTIVE" => {
+                        std::option::Option::Some(Self::EVALUATION_MISSING_DATA_INACTIVE)
+                    }
+                    "EVALUATION_MISSING_DATA_ACTIVE" => {
+                        std::option::Option::Some(Self::EVALUATION_MISSING_DATA_ACTIVE)
+                    }
+                    "EVALUATION_MISSING_DATA_NO_OP" => {
+                        std::option::Option::Some(Self::EVALUATION_MISSING_DATA_NO_OP)
+                    }
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for EvaluationMissingData {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for EvaluationMissingData {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for EvaluationMissingData {
             fn default() -> Self {
-                evaluation_missing_data::EVALUATION_MISSING_DATA_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -2386,147 +2411,198 @@ pub mod alert_policy {
 
         /// Control when notifications will be sent out.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct NotificationPrompt(std::borrow::Cow<'static, str>);
+        pub struct NotificationPrompt(i32);
 
         impl NotificationPrompt {
+            /// No strategy specified. Treated as error.
+            pub const NOTIFICATION_PROMPT_UNSPECIFIED: NotificationPrompt =
+                NotificationPrompt::new(0);
+
+            /// Notify when an incident is opened.
+            pub const OPENED: NotificationPrompt = NotificationPrompt::new(1);
+
+            /// Notify when an incident is closed.
+            pub const CLOSED: NotificationPrompt = NotificationPrompt::new(3);
+
             /// Creates a new NotificationPrompt instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("NOTIFICATION_PROMPT_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("OPENED"),
+                    3 => std::borrow::Cow::Borrowed("CLOSED"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "NOTIFICATION_PROMPT_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::NOTIFICATION_PROMPT_UNSPECIFIED)
+                    }
+                    "OPENED" => std::option::Option::Some(Self::OPENED),
+                    "CLOSED" => std::option::Option::Some(Self::CLOSED),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [NotificationPrompt](NotificationPrompt)
-        pub mod notification_prompt {
-            use super::NotificationPrompt;
-
-            /// No strategy specified. Treated as error.
-            pub const NOTIFICATION_PROMPT_UNSPECIFIED: NotificationPrompt =
-                NotificationPrompt::new("NOTIFICATION_PROMPT_UNSPECIFIED");
-
-            /// Notify when an incident is opened.
-            pub const OPENED: NotificationPrompt = NotificationPrompt::new("OPENED");
-
-            /// Notify when an incident is closed.
-            pub const CLOSED: NotificationPrompt = NotificationPrompt::new("CLOSED");
-        }
-
-        impl std::convert::From<std::string::String> for NotificationPrompt {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for NotificationPrompt {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for NotificationPrompt {
             fn default() -> Self {
-                notification_prompt::NOTIFICATION_PROMPT_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// Operators for combining conditions.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConditionCombinerType(std::borrow::Cow<'static, str>);
+    pub struct ConditionCombinerType(i32);
 
     impl ConditionCombinerType {
-        /// Creates a new ConditionCombinerType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ConditionCombinerType](ConditionCombinerType)
-    pub mod condition_combiner_type {
-        use super::ConditionCombinerType;
-
         /// An unspecified combiner.
-        pub const COMBINE_UNSPECIFIED: ConditionCombinerType =
-            ConditionCombinerType::new("COMBINE_UNSPECIFIED");
+        pub const COMBINE_UNSPECIFIED: ConditionCombinerType = ConditionCombinerType::new(0);
 
         /// Combine conditions using the logical `AND` operator. An
         /// incident is created only if all the conditions are met
         /// simultaneously. This combiner is satisfied if all conditions are
         /// met, even if they are met on completely different resources.
-        pub const AND: ConditionCombinerType = ConditionCombinerType::new("AND");
+        pub const AND: ConditionCombinerType = ConditionCombinerType::new(1);
 
         /// Combine conditions using the logical `OR` operator. An incident
         /// is created if any of the listed conditions is met.
-        pub const OR: ConditionCombinerType = ConditionCombinerType::new("OR");
+        pub const OR: ConditionCombinerType = ConditionCombinerType::new(2);
 
         /// Combine conditions using logical `AND` operator, but unlike the regular
         /// `AND` option, an incident is created only if all conditions are met
         /// simultaneously on at least one resource.
-        pub const AND_WITH_MATCHING_RESOURCE: ConditionCombinerType =
-            ConditionCombinerType::new("AND_WITH_MATCHING_RESOURCE");
+        pub const AND_WITH_MATCHING_RESOURCE: ConditionCombinerType = ConditionCombinerType::new(3);
+
+        /// Creates a new ConditionCombinerType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COMBINE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AND"),
+                2 => std::borrow::Cow::Borrowed("OR"),
+                3 => std::borrow::Cow::Borrowed("AND_WITH_MATCHING_RESOURCE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COMBINE_UNSPECIFIED" => std::option::Option::Some(Self::COMBINE_UNSPECIFIED),
+                "AND" => std::option::Option::Some(Self::AND),
+                "OR" => std::option::Option::Some(Self::OR),
+                "AND_WITH_MATCHING_RESOURCE" => {
+                    std::option::Option::Some(Self::AND_WITH_MATCHING_RESOURCE)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ConditionCombinerType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ConditionCombinerType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ConditionCombinerType {
         fn default() -> Self {
-            condition_combiner_type::COMBINE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// An enumeration of possible severity level for an alerting policy.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(std::borrow::Cow<'static, str>);
+    pub struct Severity(i32);
 
     impl Severity {
-        /// Creates a new Severity instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Severity](Severity)
-    pub mod severity {
-        use super::Severity;
-
         /// No severity is specified. This is the default value.
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new("SEVERITY_UNSPECIFIED");
+        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
 
         /// This is the highest severity level. Use this if the problem could
         /// cause significant damage or downtime.
-        pub const CRITICAL: Severity = Severity::new("CRITICAL");
+        pub const CRITICAL: Severity = Severity::new(1);
 
         /// This is the medium severity level. Use this if the problem could
         /// cause minor damage or downtime.
-        pub const ERROR: Severity = Severity::new("ERROR");
+        pub const ERROR: Severity = Severity::new(2);
 
         /// This is the lowest severity level. Use this if the problem is not causing
         /// any damage or downtime, but could potentially lead to a problem in the
         /// future.
-        pub const WARNING: Severity = Severity::new("WARNING");
+        pub const WARNING: Severity = Severity::new(3);
+
+        /// Creates a new Severity instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CRITICAL"),
+                2 => std::borrow::Cow::Borrowed("ERROR"),
+                3 => std::borrow::Cow::Borrowed("WARNING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
+                "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                "WARNING" => std::option::Option::Some(Self::WARNING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Severity {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            severity::SEVERITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3324,28 +3400,13 @@ pub mod aggregation {
     /// `value_type` in the original time series is `BOOLEAN`, but the `value_type`
     /// in the aligned result is `INT64`.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Aligner(std::borrow::Cow<'static, str>);
+    pub struct Aligner(i32);
 
     impl Aligner {
-        /// Creates a new Aligner instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Aligner](Aligner)
-    pub mod aligner {
-        use super::Aligner;
-
         /// No alignment. Raw data is returned. Not valid if cross-series reduction
         /// is requested. The `value_type` of the result is the same as the
         /// `value_type` of the input.
-        pub const ALIGN_NONE: Aligner = Aligner::new("ALIGN_NONE");
+        pub const ALIGN_NONE: Aligner = Aligner::new(0);
 
         /// Align and convert to
         /// [DELTA][google.api.MetricDescriptor.MetricKind.DELTA].
@@ -3360,7 +3421,7 @@ pub mod aggregation {
         ///
         /// [google.api.MetricDescriptor.MetricKind.CUMULATIVE]: api::model::metric_descriptor::metric_kind::CUMULATIVE
         /// [google.api.MetricDescriptor.MetricKind.DELTA]: api::model::metric_descriptor::metric_kind::DELTA
-        pub const ALIGN_DELTA: Aligner = Aligner::new("ALIGN_DELTA");
+        pub const ALIGN_DELTA: Aligner = Aligner::new(1);
 
         /// Align and convert to a rate. The result is computed as
         /// `rate = (y1 - y0)/(t1 - t0)`, or "delta over time".
@@ -3375,70 +3436,70 @@ pub mod aggregation {
         ///
         /// If, by "rate", you mean "percentage change", see the
         /// `ALIGN_PERCENT_CHANGE` aligner instead.
-        pub const ALIGN_RATE: Aligner = Aligner::new("ALIGN_RATE");
+        pub const ALIGN_RATE: Aligner = Aligner::new(2);
 
         /// Align by interpolating between adjacent points around the alignment
         /// period boundary. This aligner is valid for `GAUGE` metrics with
         /// numeric values. The `value_type` of the aligned result is the same as the
         /// `value_type` of the input.
-        pub const ALIGN_INTERPOLATE: Aligner = Aligner::new("ALIGN_INTERPOLATE");
+        pub const ALIGN_INTERPOLATE: Aligner = Aligner::new(3);
 
         /// Align by moving the most recent data point before the end of the
         /// alignment period to the boundary at the end of the alignment
         /// period. This aligner is valid for `GAUGE` metrics. The `value_type` of
         /// the aligned result is the same as the `value_type` of the input.
-        pub const ALIGN_NEXT_OLDER: Aligner = Aligner::new("ALIGN_NEXT_OLDER");
+        pub const ALIGN_NEXT_OLDER: Aligner = Aligner::new(4);
 
         /// Align the time series by returning the minimum value in each alignment
         /// period. This aligner is valid for `GAUGE` and `DELTA` metrics with
         /// numeric values. The `value_type` of the aligned result is the same as
         /// the `value_type` of the input.
-        pub const ALIGN_MIN: Aligner = Aligner::new("ALIGN_MIN");
+        pub const ALIGN_MIN: Aligner = Aligner::new(10);
 
         /// Align the time series by returning the maximum value in each alignment
         /// period. This aligner is valid for `GAUGE` and `DELTA` metrics with
         /// numeric values. The `value_type` of the aligned result is the same as
         /// the `value_type` of the input.
-        pub const ALIGN_MAX: Aligner = Aligner::new("ALIGN_MAX");
+        pub const ALIGN_MAX: Aligner = Aligner::new(11);
 
         /// Align the time series by returning the mean value in each alignment
         /// period. This aligner is valid for `GAUGE` and `DELTA` metrics with
         /// numeric values. The `value_type` of the aligned result is `DOUBLE`.
-        pub const ALIGN_MEAN: Aligner = Aligner::new("ALIGN_MEAN");
+        pub const ALIGN_MEAN: Aligner = Aligner::new(12);
 
         /// Align the time series by returning the number of values in each alignment
         /// period. This aligner is valid for `GAUGE` and `DELTA` metrics with
         /// numeric or Boolean values. The `value_type` of the aligned result is
         /// `INT64`.
-        pub const ALIGN_COUNT: Aligner = Aligner::new("ALIGN_COUNT");
+        pub const ALIGN_COUNT: Aligner = Aligner::new(13);
 
         /// Align the time series by returning the sum of the values in each
         /// alignment period. This aligner is valid for `GAUGE` and `DELTA`
         /// metrics with numeric and distribution values. The `value_type` of the
         /// aligned result is the same as the `value_type` of the input.
-        pub const ALIGN_SUM: Aligner = Aligner::new("ALIGN_SUM");
+        pub const ALIGN_SUM: Aligner = Aligner::new(14);
 
         /// Align the time series by returning the standard deviation of the values
         /// in each alignment period. This aligner is valid for `GAUGE` and
         /// `DELTA` metrics with numeric values. The `value_type` of the output is
         /// `DOUBLE`.
-        pub const ALIGN_STDDEV: Aligner = Aligner::new("ALIGN_STDDEV");
+        pub const ALIGN_STDDEV: Aligner = Aligner::new(15);
 
         /// Align the time series by returning the number of `True` values in
         /// each alignment period. This aligner is valid for `GAUGE` metrics with
         /// Boolean values. The `value_type` of the output is `INT64`.
-        pub const ALIGN_COUNT_TRUE: Aligner = Aligner::new("ALIGN_COUNT_TRUE");
+        pub const ALIGN_COUNT_TRUE: Aligner = Aligner::new(16);
 
         /// Align the time series by returning the number of `False` values in
         /// each alignment period. This aligner is valid for `GAUGE` metrics with
         /// Boolean values. The `value_type` of the output is `INT64`.
-        pub const ALIGN_COUNT_FALSE: Aligner = Aligner::new("ALIGN_COUNT_FALSE");
+        pub const ALIGN_COUNT_FALSE: Aligner = Aligner::new(24);
 
         /// Align the time series by returning the ratio of the number of `True`
         /// values to the total number of values in each alignment period. This
         /// aligner is valid for `GAUGE` metrics with Boolean values. The output
         /// value is in the range [0.0, 1.0] and has `value_type` `DOUBLE`.
-        pub const ALIGN_FRACTION_TRUE: Aligner = Aligner::new("ALIGN_FRACTION_TRUE");
+        pub const ALIGN_FRACTION_TRUE: Aligner = Aligner::new(17);
 
         /// Align the time series by using [percentile
         /// aggregation](https://en.wikipedia.org/wiki/Percentile). The resulting
@@ -3446,7 +3507,7 @@ pub mod aggregation {
         /// points in the period. This aligner is valid for `GAUGE` and `DELTA`
         /// metrics with distribution values. The output is a `GAUGE` metric with
         /// `value_type` `DOUBLE`.
-        pub const ALIGN_PERCENTILE_99: Aligner = Aligner::new("ALIGN_PERCENTILE_99");
+        pub const ALIGN_PERCENTILE_99: Aligner = Aligner::new(18);
 
         /// Align the time series by using [percentile
         /// aggregation](https://en.wikipedia.org/wiki/Percentile). The resulting
@@ -3454,7 +3515,7 @@ pub mod aggregation {
         /// points in the period. This aligner is valid for `GAUGE` and `DELTA`
         /// metrics with distribution values. The output is a `GAUGE` metric with
         /// `value_type` `DOUBLE`.
-        pub const ALIGN_PERCENTILE_95: Aligner = Aligner::new("ALIGN_PERCENTILE_95");
+        pub const ALIGN_PERCENTILE_95: Aligner = Aligner::new(19);
 
         /// Align the time series by using [percentile
         /// aggregation](https://en.wikipedia.org/wiki/Percentile). The resulting
@@ -3462,7 +3523,7 @@ pub mod aggregation {
         /// points in the period. This aligner is valid for `GAUGE` and `DELTA`
         /// metrics with distribution values. The output is a `GAUGE` metric with
         /// `value_type` `DOUBLE`.
-        pub const ALIGN_PERCENTILE_50: Aligner = Aligner::new("ALIGN_PERCENTILE_50");
+        pub const ALIGN_PERCENTILE_50: Aligner = Aligner::new(20);
 
         /// Align the time series by using [percentile
         /// aggregation](https://en.wikipedia.org/wiki/Percentile). The resulting
@@ -3470,7 +3531,7 @@ pub mod aggregation {
         /// points in the period. This aligner is valid for `GAUGE` and `DELTA`
         /// metrics with distribution values. The output is a `GAUGE` metric with
         /// `value_type` `DOUBLE`.
-        pub const ALIGN_PERCENTILE_05: Aligner = Aligner::new("ALIGN_PERCENTILE_05");
+        pub const ALIGN_PERCENTILE_05: Aligner = Aligner::new(21);
 
         /// Align and convert to a percentage change. This aligner is valid for
         /// `GAUGE` and `DELTA` metrics with numeric values. This alignment returns
@@ -3488,18 +3549,80 @@ pub mod aggregation {
         /// metrics are accepted by this alignment, special care should be taken that
         /// the values for the metric will always be positive. The output is a
         /// `GAUGE` metric with `value_type` `DOUBLE`.
-        pub const ALIGN_PERCENT_CHANGE: Aligner = Aligner::new("ALIGN_PERCENT_CHANGE");
+        pub const ALIGN_PERCENT_CHANGE: Aligner = Aligner::new(23);
+
+        /// Creates a new Aligner instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ALIGN_NONE"),
+                1 => std::borrow::Cow::Borrowed("ALIGN_DELTA"),
+                2 => std::borrow::Cow::Borrowed("ALIGN_RATE"),
+                3 => std::borrow::Cow::Borrowed("ALIGN_INTERPOLATE"),
+                4 => std::borrow::Cow::Borrowed("ALIGN_NEXT_OLDER"),
+                10 => std::borrow::Cow::Borrowed("ALIGN_MIN"),
+                11 => std::borrow::Cow::Borrowed("ALIGN_MAX"),
+                12 => std::borrow::Cow::Borrowed("ALIGN_MEAN"),
+                13 => std::borrow::Cow::Borrowed("ALIGN_COUNT"),
+                14 => std::borrow::Cow::Borrowed("ALIGN_SUM"),
+                15 => std::borrow::Cow::Borrowed("ALIGN_STDDEV"),
+                16 => std::borrow::Cow::Borrowed("ALIGN_COUNT_TRUE"),
+                17 => std::borrow::Cow::Borrowed("ALIGN_FRACTION_TRUE"),
+                18 => std::borrow::Cow::Borrowed("ALIGN_PERCENTILE_99"),
+                19 => std::borrow::Cow::Borrowed("ALIGN_PERCENTILE_95"),
+                20 => std::borrow::Cow::Borrowed("ALIGN_PERCENTILE_50"),
+                21 => std::borrow::Cow::Borrowed("ALIGN_PERCENTILE_05"),
+                23 => std::borrow::Cow::Borrowed("ALIGN_PERCENT_CHANGE"),
+                24 => std::borrow::Cow::Borrowed("ALIGN_COUNT_FALSE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ALIGN_NONE" => std::option::Option::Some(Self::ALIGN_NONE),
+                "ALIGN_DELTA" => std::option::Option::Some(Self::ALIGN_DELTA),
+                "ALIGN_RATE" => std::option::Option::Some(Self::ALIGN_RATE),
+                "ALIGN_INTERPOLATE" => std::option::Option::Some(Self::ALIGN_INTERPOLATE),
+                "ALIGN_NEXT_OLDER" => std::option::Option::Some(Self::ALIGN_NEXT_OLDER),
+                "ALIGN_MIN" => std::option::Option::Some(Self::ALIGN_MIN),
+                "ALIGN_MAX" => std::option::Option::Some(Self::ALIGN_MAX),
+                "ALIGN_MEAN" => std::option::Option::Some(Self::ALIGN_MEAN),
+                "ALIGN_COUNT" => std::option::Option::Some(Self::ALIGN_COUNT),
+                "ALIGN_SUM" => std::option::Option::Some(Self::ALIGN_SUM),
+                "ALIGN_STDDEV" => std::option::Option::Some(Self::ALIGN_STDDEV),
+                "ALIGN_COUNT_TRUE" => std::option::Option::Some(Self::ALIGN_COUNT_TRUE),
+                "ALIGN_COUNT_FALSE" => std::option::Option::Some(Self::ALIGN_COUNT_FALSE),
+                "ALIGN_FRACTION_TRUE" => std::option::Option::Some(Self::ALIGN_FRACTION_TRUE),
+                "ALIGN_PERCENTILE_99" => std::option::Option::Some(Self::ALIGN_PERCENTILE_99),
+                "ALIGN_PERCENTILE_95" => std::option::Option::Some(Self::ALIGN_PERCENTILE_95),
+                "ALIGN_PERCENTILE_50" => std::option::Option::Some(Self::ALIGN_PERCENTILE_50),
+                "ALIGN_PERCENTILE_05" => std::option::Option::Some(Self::ALIGN_PERCENTILE_05),
+                "ALIGN_PERCENT_CHANGE" => std::option::Option::Some(Self::ALIGN_PERCENT_CHANGE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Aligner {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Aligner {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Aligner {
         fn default() -> Self {
-            aligner::ALIGN_NONE
+            Self::new(0)
         }
     }
 
@@ -3508,27 +3631,12 @@ pub mod aggregation {
     /// in the resulting series is a function of all the already aligned values in
     /// the input time series.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Reducer(std::borrow::Cow<'static, str>);
+    pub struct Reducer(i32);
 
     impl Reducer {
-        /// Creates a new Reducer instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Reducer](Reducer)
-    pub mod reducer {
-        use super::Reducer;
-
         /// No cross-time series reduction. The output of the `Aligner` is
         /// returned.
-        pub const REDUCE_NONE: Reducer = Reducer::new("REDUCE_NONE");
+        pub const REDUCE_NONE: Reducer = Reducer::new(0);
 
         /// Reduce by computing the mean value across time series for each
         /// alignment period. This reducer is valid for
@@ -3540,95 +3648,147 @@ pub mod aggregation {
         /// [google.api.MetricDescriptor.MetricKind.DELTA]: api::model::metric_descriptor::metric_kind::DELTA
         /// [google.api.MetricDescriptor.MetricKind.GAUGE]: api::model::metric_descriptor::metric_kind::GAUGE
         /// [google.api.MetricDescriptor.ValueType.DOUBLE]: api::model::metric_descriptor::value_type::DOUBLE
-        pub const REDUCE_MEAN: Reducer = Reducer::new("REDUCE_MEAN");
+        pub const REDUCE_MEAN: Reducer = Reducer::new(1);
 
         /// Reduce by computing the minimum value across time series for each
         /// alignment period. This reducer is valid for `DELTA` and `GAUGE` metrics
         /// with numeric values. The `value_type` of the output is the same as the
         /// `value_type` of the input.
-        pub const REDUCE_MIN: Reducer = Reducer::new("REDUCE_MIN");
+        pub const REDUCE_MIN: Reducer = Reducer::new(2);
 
         /// Reduce by computing the maximum value across time series for each
         /// alignment period. This reducer is valid for `DELTA` and `GAUGE` metrics
         /// with numeric values. The `value_type` of the output is the same as the
         /// `value_type` of the input.
-        pub const REDUCE_MAX: Reducer = Reducer::new("REDUCE_MAX");
+        pub const REDUCE_MAX: Reducer = Reducer::new(3);
 
         /// Reduce by computing the sum across time series for each
         /// alignment period. This reducer is valid for `DELTA` and `GAUGE` metrics
         /// with numeric and distribution values. The `value_type` of the output is
         /// the same as the `value_type` of the input.
-        pub const REDUCE_SUM: Reducer = Reducer::new("REDUCE_SUM");
+        pub const REDUCE_SUM: Reducer = Reducer::new(4);
 
         /// Reduce by computing the standard deviation across time series
         /// for each alignment period. This reducer is valid for `DELTA` and
         /// `GAUGE` metrics with numeric or distribution values. The `value_type`
         /// of the output is `DOUBLE`.
-        pub const REDUCE_STDDEV: Reducer = Reducer::new("REDUCE_STDDEV");
+        pub const REDUCE_STDDEV: Reducer = Reducer::new(5);
 
         /// Reduce by computing the number of data points across time series
         /// for each alignment period. This reducer is valid for `DELTA` and
         /// `GAUGE` metrics of numeric, Boolean, distribution, and string
         /// `value_type`. The `value_type` of the output is `INT64`.
-        pub const REDUCE_COUNT: Reducer = Reducer::new("REDUCE_COUNT");
+        pub const REDUCE_COUNT: Reducer = Reducer::new(6);
 
         /// Reduce by computing the number of `True`-valued data points across time
         /// series for each alignment period. This reducer is valid for `DELTA` and
         /// `GAUGE` metrics of Boolean `value_type`. The `value_type` of the output
         /// is `INT64`.
-        pub const REDUCE_COUNT_TRUE: Reducer = Reducer::new("REDUCE_COUNT_TRUE");
+        pub const REDUCE_COUNT_TRUE: Reducer = Reducer::new(7);
 
         /// Reduce by computing the number of `False`-valued data points across time
         /// series for each alignment period. This reducer is valid for `DELTA` and
         /// `GAUGE` metrics of Boolean `value_type`. The `value_type` of the output
         /// is `INT64`.
-        pub const REDUCE_COUNT_FALSE: Reducer = Reducer::new("REDUCE_COUNT_FALSE");
+        pub const REDUCE_COUNT_FALSE: Reducer = Reducer::new(15);
 
         /// Reduce by computing the ratio of the number of `True`-valued data points
         /// to the total number of data points for each alignment period. This
         /// reducer is valid for `DELTA` and `GAUGE` metrics of Boolean `value_type`.
         /// The output value is in the range [0.0, 1.0] and has `value_type`
         /// `DOUBLE`.
-        pub const REDUCE_FRACTION_TRUE: Reducer = Reducer::new("REDUCE_FRACTION_TRUE");
+        pub const REDUCE_FRACTION_TRUE: Reducer = Reducer::new(8);
 
         /// Reduce by computing the [99th
         /// percentile](https://en.wikipedia.org/wiki/Percentile) of data points
         /// across time series for each alignment period. This reducer is valid for
         /// `GAUGE` and `DELTA` metrics of numeric and distribution type. The value
         /// of the output is `DOUBLE`.
-        pub const REDUCE_PERCENTILE_99: Reducer = Reducer::new("REDUCE_PERCENTILE_99");
+        pub const REDUCE_PERCENTILE_99: Reducer = Reducer::new(9);
 
         /// Reduce by computing the [95th
         /// percentile](https://en.wikipedia.org/wiki/Percentile) of data points
         /// across time series for each alignment period. This reducer is valid for
         /// `GAUGE` and `DELTA` metrics of numeric and distribution type. The value
         /// of the output is `DOUBLE`.
-        pub const REDUCE_PERCENTILE_95: Reducer = Reducer::new("REDUCE_PERCENTILE_95");
+        pub const REDUCE_PERCENTILE_95: Reducer = Reducer::new(10);
 
         /// Reduce by computing the [50th
         /// percentile](https://en.wikipedia.org/wiki/Percentile) of data points
         /// across time series for each alignment period. This reducer is valid for
         /// `GAUGE` and `DELTA` metrics of numeric and distribution type. The value
         /// of the output is `DOUBLE`.
-        pub const REDUCE_PERCENTILE_50: Reducer = Reducer::new("REDUCE_PERCENTILE_50");
+        pub const REDUCE_PERCENTILE_50: Reducer = Reducer::new(11);
 
         /// Reduce by computing the [5th
         /// percentile](https://en.wikipedia.org/wiki/Percentile) of data points
         /// across time series for each alignment period. This reducer is valid for
         /// `GAUGE` and `DELTA` metrics of numeric and distribution type. The value
         /// of the output is `DOUBLE`.
-        pub const REDUCE_PERCENTILE_05: Reducer = Reducer::new("REDUCE_PERCENTILE_05");
+        pub const REDUCE_PERCENTILE_05: Reducer = Reducer::new(12);
+
+        /// Creates a new Reducer instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("REDUCE_NONE"),
+                1 => std::borrow::Cow::Borrowed("REDUCE_MEAN"),
+                2 => std::borrow::Cow::Borrowed("REDUCE_MIN"),
+                3 => std::borrow::Cow::Borrowed("REDUCE_MAX"),
+                4 => std::borrow::Cow::Borrowed("REDUCE_SUM"),
+                5 => std::borrow::Cow::Borrowed("REDUCE_STDDEV"),
+                6 => std::borrow::Cow::Borrowed("REDUCE_COUNT"),
+                7 => std::borrow::Cow::Borrowed("REDUCE_COUNT_TRUE"),
+                8 => std::borrow::Cow::Borrowed("REDUCE_FRACTION_TRUE"),
+                9 => std::borrow::Cow::Borrowed("REDUCE_PERCENTILE_99"),
+                10 => std::borrow::Cow::Borrowed("REDUCE_PERCENTILE_95"),
+                11 => std::borrow::Cow::Borrowed("REDUCE_PERCENTILE_50"),
+                12 => std::borrow::Cow::Borrowed("REDUCE_PERCENTILE_05"),
+                15 => std::borrow::Cow::Borrowed("REDUCE_COUNT_FALSE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "REDUCE_NONE" => std::option::Option::Some(Self::REDUCE_NONE),
+                "REDUCE_MEAN" => std::option::Option::Some(Self::REDUCE_MEAN),
+                "REDUCE_MIN" => std::option::Option::Some(Self::REDUCE_MIN),
+                "REDUCE_MAX" => std::option::Option::Some(Self::REDUCE_MAX),
+                "REDUCE_SUM" => std::option::Option::Some(Self::REDUCE_SUM),
+                "REDUCE_STDDEV" => std::option::Option::Some(Self::REDUCE_STDDEV),
+                "REDUCE_COUNT" => std::option::Option::Some(Self::REDUCE_COUNT),
+                "REDUCE_COUNT_TRUE" => std::option::Option::Some(Self::REDUCE_COUNT_TRUE),
+                "REDUCE_COUNT_FALSE" => std::option::Option::Some(Self::REDUCE_COUNT_FALSE),
+                "REDUCE_FRACTION_TRUE" => std::option::Option::Some(Self::REDUCE_FRACTION_TRUE),
+                "REDUCE_PERCENTILE_99" => std::option::Option::Some(Self::REDUCE_PERCENTILE_99),
+                "REDUCE_PERCENTILE_95" => std::option::Option::Some(Self::REDUCE_PERCENTILE_95),
+                "REDUCE_PERCENTILE_50" => std::option::Option::Some(Self::REDUCE_PERCENTILE_50),
+                "REDUCE_PERCENTILE_05" => std::option::Option::Some(Self::REDUCE_PERCENTILE_05),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Reducer {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Reducer {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Reducer {
         fn default() -> Self {
-            reducer::REDUCE_NONE
+            Self::new(0)
         }
     }
 }
@@ -5766,42 +5926,55 @@ pub mod list_time_series_request {
 
     /// Controls which fields are returned by `ListTimeSeries*`.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TimeSeriesView(std::borrow::Cow<'static, str>);
+    pub struct TimeSeriesView(i32);
 
     impl TimeSeriesView {
-        /// Creates a new TimeSeriesView instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [TimeSeriesView](TimeSeriesView)
-    pub mod time_series_view {
-        use super::TimeSeriesView;
-
         /// Returns the identity of the metric(s), the time series,
         /// and the time series data.
-        pub const FULL: TimeSeriesView = TimeSeriesView::new("FULL");
+        pub const FULL: TimeSeriesView = TimeSeriesView::new(0);
 
         /// Returns the identity of the metric and the time series resource,
         /// but not the time series data.
-        pub const HEADERS: TimeSeriesView = TimeSeriesView::new("HEADERS");
+        pub const HEADERS: TimeSeriesView = TimeSeriesView::new(1);
+
+        /// Creates a new TimeSeriesView instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FULL"),
+                1 => std::borrow::Cow::Borrowed("HEADERS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FULL" => std::option::Option::Some(Self::FULL),
+                "HEADERS" => std::option::Option::Some(Self::HEADERS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for TimeSeriesView {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TimeSeriesView {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TimeSeriesView {
         fn default() -> Self {
-            time_series_view::FULL
+            Self::new(0)
         }
     }
 }
@@ -6691,51 +6864,67 @@ pub mod notification_channel {
     /// [google.monitoring.v3.NotificationChannelService.CreateNotificationChannel]: crate::client::NotificationChannelService::create_notification_channel
     /// [google.monitoring.v3.NotificationChannelService.UpdateNotificationChannel]: crate::client::NotificationChannelService::update_notification_channel
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VerificationStatus(std::borrow::Cow<'static, str>);
+    pub struct VerificationStatus(i32);
 
     impl VerificationStatus {
-        /// Creates a new VerificationStatus instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [VerificationStatus](VerificationStatus)
-    pub mod verification_status {
-        use super::VerificationStatus;
-
         /// Sentinel value used to indicate that the state is unknown, omitted, or
         /// is not applicable (as in the case of channels that neither support
         /// nor require verification in order to function).
-        pub const VERIFICATION_STATUS_UNSPECIFIED: VerificationStatus =
-            VerificationStatus::new("VERIFICATION_STATUS_UNSPECIFIED");
+        pub const VERIFICATION_STATUS_UNSPECIFIED: VerificationStatus = VerificationStatus::new(0);
 
         /// The channel has yet to be verified and requires verification to function.
         /// Note that this state also applies to the case where the verification
         /// process has been initiated by sending a verification code but where
         /// the verification code has not been submitted to complete the process.
-        pub const UNVERIFIED: VerificationStatus = VerificationStatus::new("UNVERIFIED");
+        pub const UNVERIFIED: VerificationStatus = VerificationStatus::new(1);
 
         /// It has been proven that notifications can be received on this
         /// notification channel and that someone on the project has access
         /// to messages that are delivered to that channel.
-        pub const VERIFIED: VerificationStatus = VerificationStatus::new("VERIFIED");
+        pub const VERIFIED: VerificationStatus = VerificationStatus::new(2);
+
+        /// Creates a new VerificationStatus instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VERIFICATION_STATUS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("UNVERIFIED"),
+                2 => std::borrow::Cow::Borrowed("VERIFIED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VERIFICATION_STATUS_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::VERIFICATION_STATUS_UNSPECIFIED)
+                }
+                "UNVERIFIED" => std::option::Option::Some(Self::UNVERIFIED),
+                "VERIFIED" => std::option::Option::Some(Self::VERIFIED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for VerificationStatus {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for VerificationStatus {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for VerificationStatus {
         fn default() -> Self {
-            verification_status::VERIFICATION_STATUS_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -8706,48 +8895,63 @@ pub mod service_level_objective {
     /// `ServiceLevelObjective` is returned from `GetServiceLevelObjective`,
     /// `ListServiceLevelObjectives`, and `ListServiceLevelObjectiveVersions` RPCs.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct View(std::borrow::Cow<'static, str>);
+    pub struct View(i32);
 
     impl View {
-        /// Creates a new View instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [View](View)
-    pub mod view {
-        use super::View;
-
         /// Same as FULL.
-        pub const VIEW_UNSPECIFIED: View = View::new("VIEW_UNSPECIFIED");
+        pub const VIEW_UNSPECIFIED: View = View::new(0);
 
         /// Return the embedded `ServiceLevelIndicator` in the form in which it was
         /// defined. If it was defined using a `BasicSli`, return that `BasicSli`.
-        pub const FULL: View = View::new("FULL");
+        pub const FULL: View = View::new(2);
 
         /// For `ServiceLevelIndicator`s using `BasicSli` articulation, instead
         /// return the `ServiceLevelIndicator` with its mode of computation fully
         /// spelled out as a `RequestBasedSli`. For `ServiceLevelIndicator`s using
         /// `RequestBasedSli` or `WindowsBasedSli`, return the
         /// `ServiceLevelIndicator` as it was provided.
-        pub const EXPLICIT: View = View::new("EXPLICIT");
+        pub const EXPLICIT: View = View::new(1);
+
+        /// Creates a new View instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("VIEW_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("EXPLICIT"),
+                2 => std::borrow::Cow::Borrowed("FULL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "VIEW_UNSPECIFIED" => std::option::Option::Some(Self::VIEW_UNSPECIFIED),
+                "FULL" => std::option::Option::Some(Self::FULL),
+                "EXPLICIT" => std::option::Option::Some(Self::EXPLICIT),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for View {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for View {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for View {
         fn default() -> Self {
-            view::VIEW_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -11077,33 +11281,18 @@ pub mod internal_checker {
 
     /// Operational states for an internal checker.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// An internal checker should never be in the unspecified state.
-        pub const UNSPECIFIED: State = State::new("UNSPECIFIED");
+        pub const UNSPECIFIED: State = State::new(0);
 
         /// The checker is being created, provisioned, and configured. A checker in
         /// this state can be returned by `ListInternalCheckers` or
         /// `GetInternalChecker`, as well as by examining the [long running
         /// Operation](https://cloud.google.com/apis/design/design_patterns#long_running_operations)
         /// that created it.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The checker is running and available for use. A checker in this state
         /// can be returned by `ListInternalCheckers` or `GetInternalChecker` as
@@ -11112,18 +11301,48 @@ pub mod internal_checker {
         /// that created it.
         /// If a checker is being torn down, it is neither visible nor usable, so
         /// there is no "deleting" or "down" state.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -12167,56 +12386,80 @@ pub mod uptime_check_config {
 
             /// An HTTP status code class.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct StatusClass(std::borrow::Cow<'static, str>);
+            pub struct StatusClass(i32);
 
             impl StatusClass {
+                /// Default value that matches no status codes.
+                pub const STATUS_CLASS_UNSPECIFIED: StatusClass = StatusClass::new(0);
+
+                /// The class of status codes between 100 and 199.
+                pub const STATUS_CLASS_1XX: StatusClass = StatusClass::new(100);
+
+                /// The class of status codes between 200 and 299.
+                pub const STATUS_CLASS_2XX: StatusClass = StatusClass::new(200);
+
+                /// The class of status codes between 300 and 399.
+                pub const STATUS_CLASS_3XX: StatusClass = StatusClass::new(300);
+
+                /// The class of status codes between 400 and 499.
+                pub const STATUS_CLASS_4XX: StatusClass = StatusClass::new(400);
+
+                /// The class of status codes between 500 and 599.
+                pub const STATUS_CLASS_5XX: StatusClass = StatusClass::new(500);
+
+                /// The class of all status codes.
+                pub const STATUS_CLASS_ANY: StatusClass = StatusClass::new(1000);
+
                 /// Creates a new StatusClass instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
                 }
 
                 /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("STATUS_CLASS_UNSPECIFIED"),
+                        100 => std::borrow::Cow::Borrowed("STATUS_CLASS_1XX"),
+                        200 => std::borrow::Cow::Borrowed("STATUS_CLASS_2XX"),
+                        300 => std::borrow::Cow::Borrowed("STATUS_CLASS_3XX"),
+                        400 => std::borrow::Cow::Borrowed("STATUS_CLASS_4XX"),
+                        500 => std::borrow::Cow::Borrowed("STATUS_CLASS_5XX"),
+                        1000 => std::borrow::Cow::Borrowed("STATUS_CLASS_ANY"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "STATUS_CLASS_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::STATUS_CLASS_UNSPECIFIED)
+                        }
+                        "STATUS_CLASS_1XX" => std::option::Option::Some(Self::STATUS_CLASS_1XX),
+                        "STATUS_CLASS_2XX" => std::option::Option::Some(Self::STATUS_CLASS_2XX),
+                        "STATUS_CLASS_3XX" => std::option::Option::Some(Self::STATUS_CLASS_3XX),
+                        "STATUS_CLASS_4XX" => std::option::Option::Some(Self::STATUS_CLASS_4XX),
+                        "STATUS_CLASS_5XX" => std::option::Option::Some(Self::STATUS_CLASS_5XX),
+                        "STATUS_CLASS_ANY" => std::option::Option::Some(Self::STATUS_CLASS_ANY),
+                        _ => std::option::Option::None,
+                    }
                 }
             }
 
-            /// Useful constants to work with [StatusClass](StatusClass)
-            pub mod status_class {
-                use super::StatusClass;
-
-                /// Default value that matches no status codes.
-                pub const STATUS_CLASS_UNSPECIFIED: StatusClass =
-                    StatusClass::new("STATUS_CLASS_UNSPECIFIED");
-
-                /// The class of status codes between 100 and 199.
-                pub const STATUS_CLASS_1XX: StatusClass = StatusClass::new("STATUS_CLASS_1XX");
-
-                /// The class of status codes between 200 and 299.
-                pub const STATUS_CLASS_2XX: StatusClass = StatusClass::new("STATUS_CLASS_2XX");
-
-                /// The class of status codes between 300 and 399.
-                pub const STATUS_CLASS_3XX: StatusClass = StatusClass::new("STATUS_CLASS_3XX");
-
-                /// The class of status codes between 400 and 499.
-                pub const STATUS_CLASS_4XX: StatusClass = StatusClass::new("STATUS_CLASS_4XX");
-
-                /// The class of status codes between 500 and 599.
-                pub const STATUS_CLASS_5XX: StatusClass = StatusClass::new("STATUS_CLASS_5XX");
-
-                /// The class of all status codes.
-                pub const STATUS_CLASS_ANY: StatusClass = StatusClass::new("STATUS_CLASS_ANY");
-            }
-
-            impl std::convert::From<std::string::String> for StatusClass {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for StatusClass {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for StatusClass {
                 fn default() -> Self {
-                    status_class::STATUS_CLASS_UNSPECIFIED
+                    Self::new(0)
                 }
             }
 
@@ -12274,132 +12517,179 @@ pub mod uptime_check_config {
 
             /// Type of authentication.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct ServiceAgentAuthenticationType(std::borrow::Cow<'static, str>);
+            pub struct ServiceAgentAuthenticationType(i32);
 
             impl ServiceAgentAuthenticationType {
-                /// Creates a new ServiceAgentAuthenticationType instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [ServiceAgentAuthenticationType](ServiceAgentAuthenticationType)
-            pub mod service_agent_authentication_type {
-                use super::ServiceAgentAuthenticationType;
-
                 /// Default value, will result in OIDC Authentication.
                 pub const SERVICE_AGENT_AUTHENTICATION_TYPE_UNSPECIFIED:
-                    ServiceAgentAuthenticationType = ServiceAgentAuthenticationType::new(
-                    "SERVICE_AGENT_AUTHENTICATION_TYPE_UNSPECIFIED",
-                );
+                    ServiceAgentAuthenticationType = ServiceAgentAuthenticationType::new(0);
 
                 /// OIDC Authentication
                 pub const OIDC_TOKEN: ServiceAgentAuthenticationType =
-                    ServiceAgentAuthenticationType::new("OIDC_TOKEN");
+                    ServiceAgentAuthenticationType::new(1);
+
+                /// Creates a new ServiceAgentAuthenticationType instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed(
+                            "SERVICE_AGENT_AUTHENTICATION_TYPE_UNSPECIFIED",
+                        ),
+                        1 => std::borrow::Cow::Borrowed("OIDC_TOKEN"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "SERVICE_AGENT_AUTHENTICATION_TYPE_UNSPECIFIED" => {
+                            std::option::Option::Some(
+                                Self::SERVICE_AGENT_AUTHENTICATION_TYPE_UNSPECIFIED,
+                            )
+                        }
+                        "OIDC_TOKEN" => std::option::Option::Some(Self::OIDC_TOKEN),
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for ServiceAgentAuthenticationType {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for ServiceAgentAuthenticationType {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for ServiceAgentAuthenticationType {
                 fn default() -> Self {
-                    service_agent_authentication_type::SERVICE_AGENT_AUTHENTICATION_TYPE_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
 
         /// The HTTP request method options.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct RequestMethod(std::borrow::Cow<'static, str>);
+        pub struct RequestMethod(i32);
 
         impl RequestMethod {
+            /// No request method specified.
+            pub const METHOD_UNSPECIFIED: RequestMethod = RequestMethod::new(0);
+
+            /// GET request.
+            pub const GET: RequestMethod = RequestMethod::new(1);
+
+            /// POST request.
+            pub const POST: RequestMethod = RequestMethod::new(2);
+
             /// Creates a new RequestMethod instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("METHOD_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("GET"),
+                    2 => std::borrow::Cow::Borrowed("POST"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "METHOD_UNSPECIFIED" => std::option::Option::Some(Self::METHOD_UNSPECIFIED),
+                    "GET" => std::option::Option::Some(Self::GET),
+                    "POST" => std::option::Option::Some(Self::POST),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [RequestMethod](RequestMethod)
-        pub mod request_method {
-            use super::RequestMethod;
-
-            /// No request method specified.
-            pub const METHOD_UNSPECIFIED: RequestMethod = RequestMethod::new("METHOD_UNSPECIFIED");
-
-            /// GET request.
-            pub const GET: RequestMethod = RequestMethod::new("GET");
-
-            /// POST request.
-            pub const POST: RequestMethod = RequestMethod::new("POST");
-        }
-
-        impl std::convert::From<std::string::String> for RequestMethod {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for RequestMethod {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for RequestMethod {
             fn default() -> Self {
-                request_method::METHOD_UNSPECIFIED
+                Self::new(0)
             }
         }
 
         /// Header options corresponding to the content type of a HTTP request body.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ContentType(std::borrow::Cow<'static, str>);
+        pub struct ContentType(i32);
 
         impl ContentType {
-            /// Creates a new ContentType instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [ContentType](ContentType)
-        pub mod content_type {
-            use super::ContentType;
-
             /// No content type specified.
-            pub const TYPE_UNSPECIFIED: ContentType = ContentType::new("TYPE_UNSPECIFIED");
+            pub const TYPE_UNSPECIFIED: ContentType = ContentType::new(0);
 
             /// `body` is in URL-encoded form. Equivalent to setting the `Content-Type`
             /// to `application/x-www-form-urlencoded` in the HTTP request.
-            pub const URL_ENCODED: ContentType = ContentType::new("URL_ENCODED");
+            pub const URL_ENCODED: ContentType = ContentType::new(1);
 
             /// `body` is in `custom_content_type` form. Equivalent to setting the
             /// `Content-Type` to the contents of `custom_content_type` in the HTTP
             /// request.
-            pub const USER_PROVIDED: ContentType = ContentType::new("USER_PROVIDED");
+            pub const USER_PROVIDED: ContentType = ContentType::new(2);
+
+            /// Creates a new ContentType instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("URL_ENCODED"),
+                    2 => std::borrow::Cow::Borrowed("USER_PROVIDED"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                    "URL_ENCODED" => std::option::Option::Some(Self::URL_ENCODED),
+                    "USER_PROVIDED" => std::option::Option::Some(Self::USER_PROVIDED),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for ContentType {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for ContentType {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for ContentType {
             fn default() -> Self {
-                content_type::TYPE_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -12636,127 +12926,163 @@ pub mod uptime_check_config {
 
             /// Options to perform JSONPath content matching.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct JsonPathMatcherOption(std::borrow::Cow<'static, str>);
+            pub struct JsonPathMatcherOption(i32);
 
             impl JsonPathMatcherOption {
-                /// Creates a new JsonPathMatcherOption instance.
-                pub const fn new(v: &'static str) -> Self {
-                    Self(std::borrow::Cow::Borrowed(v))
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> &str {
-                    &self.0
-                }
-            }
-
-            /// Useful constants to work with [JsonPathMatcherOption](JsonPathMatcherOption)
-            pub mod json_path_matcher_option {
-                use super::JsonPathMatcherOption;
-
                 /// No JSONPath matcher type specified (not valid).
                 pub const JSON_PATH_MATCHER_OPTION_UNSPECIFIED: JsonPathMatcherOption =
-                    JsonPathMatcherOption::new("JSON_PATH_MATCHER_OPTION_UNSPECIFIED");
+                    JsonPathMatcherOption::new(0);
 
                 /// Selects 'exact string' matching. The match succeeds if the content at
                 /// the `json_path` within the output is exactly the same as the
                 /// `content` string.
-                pub const EXACT_MATCH: JsonPathMatcherOption =
-                    JsonPathMatcherOption::new("EXACT_MATCH");
+                pub const EXACT_MATCH: JsonPathMatcherOption = JsonPathMatcherOption::new(1);
 
                 /// Selects regular-expression matching. The match succeeds if the
                 /// content at the `json_path` within the output matches the regular
                 /// expression specified in the `content` string.
-                pub const REGEX_MATCH: JsonPathMatcherOption =
-                    JsonPathMatcherOption::new("REGEX_MATCH");
+                pub const REGEX_MATCH: JsonPathMatcherOption = JsonPathMatcherOption::new(2);
+
+                /// Creates a new JsonPathMatcherOption instance.
+                pub(crate) const fn new(value: i32) -> Self {
+                    Self(value)
+                }
+
+                /// Gets the enum value.
+                pub fn value(&self) -> i32 {
+                    self.0
+                }
+
+                /// Gets the enum value as a string.
+                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                    match self.0 {
+                        0 => std::borrow::Cow::Borrowed("JSON_PATH_MATCHER_OPTION_UNSPECIFIED"),
+                        1 => std::borrow::Cow::Borrowed("EXACT_MATCH"),
+                        2 => std::borrow::Cow::Borrowed("REGEX_MATCH"),
+                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    }
+                }
+
+                /// Creates an enum value from the value name.
+                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                    match name {
+                        "JSON_PATH_MATCHER_OPTION_UNSPECIFIED" => {
+                            std::option::Option::Some(Self::JSON_PATH_MATCHER_OPTION_UNSPECIFIED)
+                        }
+                        "EXACT_MATCH" => std::option::Option::Some(Self::EXACT_MATCH),
+                        "REGEX_MATCH" => std::option::Option::Some(Self::REGEX_MATCH),
+                        _ => std::option::Option::None,
+                    }
+                }
             }
 
-            impl std::convert::From<std::string::String> for JsonPathMatcherOption {
-                fn from(value: std::string::String) -> Self {
-                    Self(std::borrow::Cow::Owned(value))
+            impl std::convert::From<i32> for JsonPathMatcherOption {
+                fn from(value: i32) -> Self {
+                    Self::new(value)
                 }
             }
 
             impl std::default::Default for JsonPathMatcherOption {
                 fn default() -> Self {
-                    json_path_matcher_option::JSON_PATH_MATCHER_OPTION_UNSPECIFIED
+                    Self::new(0)
                 }
             }
         }
 
         /// Options to perform content matching.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ContentMatcherOption(std::borrow::Cow<'static, str>);
+        pub struct ContentMatcherOption(i32);
 
         impl ContentMatcherOption {
-            /// Creates a new ContentMatcherOption instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [ContentMatcherOption](ContentMatcherOption)
-        pub mod content_matcher_option {
-            use super::ContentMatcherOption;
-
             /// No content matcher type specified (maintained for backward
             /// compatibility, but deprecated for future use).
             /// Treated as `CONTAINS_STRING`.
             pub const CONTENT_MATCHER_OPTION_UNSPECIFIED: ContentMatcherOption =
-                ContentMatcherOption::new("CONTENT_MATCHER_OPTION_UNSPECIFIED");
+                ContentMatcherOption::new(0);
 
             /// Selects substring matching. The match succeeds if the output contains
             /// the `content` string.  This is the default value for checks without
             /// a `matcher` option, or where the value of `matcher` is
             /// `CONTENT_MATCHER_OPTION_UNSPECIFIED`.
-            pub const CONTAINS_STRING: ContentMatcherOption =
-                ContentMatcherOption::new("CONTAINS_STRING");
+            pub const CONTAINS_STRING: ContentMatcherOption = ContentMatcherOption::new(1);
 
             /// Selects negation of substring matching. The match succeeds if the
             /// output does _NOT_ contain the `content` string.
-            pub const NOT_CONTAINS_STRING: ContentMatcherOption =
-                ContentMatcherOption::new("NOT_CONTAINS_STRING");
+            pub const NOT_CONTAINS_STRING: ContentMatcherOption = ContentMatcherOption::new(2);
 
             /// Selects regular-expression matching. The match succeeds if the output
             /// matches the regular expression specified in the `content` string.
             /// Regex matching is only supported for HTTP/HTTPS checks.
-            pub const MATCHES_REGEX: ContentMatcherOption =
-                ContentMatcherOption::new("MATCHES_REGEX");
+            pub const MATCHES_REGEX: ContentMatcherOption = ContentMatcherOption::new(3);
 
             /// Selects negation of regular-expression matching. The match succeeds if
             /// the output does _NOT_ match the regular expression specified in the
             /// `content` string. Regex matching is only supported for HTTP/HTTPS
             /// checks.
-            pub const NOT_MATCHES_REGEX: ContentMatcherOption =
-                ContentMatcherOption::new("NOT_MATCHES_REGEX");
+            pub const NOT_MATCHES_REGEX: ContentMatcherOption = ContentMatcherOption::new(4);
 
             /// Selects JSONPath matching. See `JsonPathMatcher` for details on when
             /// the match succeeds. JSONPath matching is only supported for HTTP/HTTPS
             /// checks.
-            pub const MATCHES_JSON_PATH: ContentMatcherOption =
-                ContentMatcherOption::new("MATCHES_JSON_PATH");
+            pub const MATCHES_JSON_PATH: ContentMatcherOption = ContentMatcherOption::new(5);
 
             /// Selects JSONPath matching. See `JsonPathMatcher` for details on when
             /// the match succeeds. Succeeds when output does _NOT_ match as specified.
             /// JSONPath is only supported for HTTP/HTTPS checks.
-            pub const NOT_MATCHES_JSON_PATH: ContentMatcherOption =
-                ContentMatcherOption::new("NOT_MATCHES_JSON_PATH");
+            pub const NOT_MATCHES_JSON_PATH: ContentMatcherOption = ContentMatcherOption::new(6);
+
+            /// Creates a new ContentMatcherOption instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("CONTENT_MATCHER_OPTION_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("CONTAINS_STRING"),
+                    2 => std::borrow::Cow::Borrowed("NOT_CONTAINS_STRING"),
+                    3 => std::borrow::Cow::Borrowed("MATCHES_REGEX"),
+                    4 => std::borrow::Cow::Borrowed("NOT_MATCHES_REGEX"),
+                    5 => std::borrow::Cow::Borrowed("MATCHES_JSON_PATH"),
+                    6 => std::borrow::Cow::Borrowed("NOT_MATCHES_JSON_PATH"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "CONTENT_MATCHER_OPTION_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::CONTENT_MATCHER_OPTION_UNSPECIFIED)
+                    }
+                    "CONTAINS_STRING" => std::option::Option::Some(Self::CONTAINS_STRING),
+                    "NOT_CONTAINS_STRING" => std::option::Option::Some(Self::NOT_CONTAINS_STRING),
+                    "MATCHES_REGEX" => std::option::Option::Some(Self::MATCHES_REGEX),
+                    "NOT_MATCHES_REGEX" => std::option::Option::Some(Self::NOT_MATCHES_REGEX),
+                    "MATCHES_JSON_PATH" => std::option::Option::Some(Self::MATCHES_JSON_PATH),
+                    "NOT_MATCHES_JSON_PATH" => {
+                        std::option::Option::Some(Self::NOT_MATCHES_JSON_PATH)
+                    }
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for ContentMatcherOption {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for ContentMatcherOption {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for ContentMatcherOption {
             fn default() -> Self {
-                content_matcher_option::CONTENT_MATCHER_OPTION_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -12778,49 +13104,65 @@ pub mod uptime_check_config {
 
     /// What kind of checkers are available to be used by the check.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CheckerType(std::borrow::Cow<'static, str>);
+    pub struct CheckerType(i32);
 
     impl CheckerType {
-        /// Creates a new CheckerType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CheckerType](CheckerType)
-    pub mod checker_type {
-        use super::CheckerType;
-
         /// The default checker type. Currently converted to `STATIC_IP_CHECKERS`
         /// on creation, the default conversion behavior may change in the future.
-        pub const CHECKER_TYPE_UNSPECIFIED: CheckerType =
-            CheckerType::new("CHECKER_TYPE_UNSPECIFIED");
+        pub const CHECKER_TYPE_UNSPECIFIED: CheckerType = CheckerType::new(0);
 
         /// `STATIC_IP_CHECKERS` are used for uptime checks that perform egress
         /// across the public internet. `STATIC_IP_CHECKERS` use the static IP
         /// addresses returned by `ListUptimeCheckIps`.
-        pub const STATIC_IP_CHECKERS: CheckerType = CheckerType::new("STATIC_IP_CHECKERS");
+        pub const STATIC_IP_CHECKERS: CheckerType = CheckerType::new(1);
 
         /// `VPC_CHECKERS` are used for uptime checks that perform egress using
         /// Service Directory and private network access. When using `VPC_CHECKERS`,
         /// the monitored resource type must be `servicedirectory_service`.
-        pub const VPC_CHECKERS: CheckerType = CheckerType::new("VPC_CHECKERS");
+        pub const VPC_CHECKERS: CheckerType = CheckerType::new(3);
+
+        /// Creates a new CheckerType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CHECKER_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STATIC_IP_CHECKERS"),
+                3 => std::borrow::Cow::Borrowed("VPC_CHECKERS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CHECKER_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CHECKER_TYPE_UNSPECIFIED)
+                }
+                "STATIC_IP_CHECKERS" => std::option::Option::Some(Self::STATIC_IP_CHECKERS),
+                "VPC_CHECKERS" => std::option::Option::Some(Self::VPC_CHECKERS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CheckerType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CheckerType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CheckerType {
         fn default() -> Self {
-            checker_type::CHECKER_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -13349,56 +13691,78 @@ impl gax::paginator::PageableResponse for ListUptimeCheckIpsResponse {
 /// Specifies an ordering relationship on two arguments, called `left` and
 /// `right`.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ComparisonType(std::borrow::Cow<'static, str>);
+pub struct ComparisonType(i32);
 
 impl ComparisonType {
+    /// No ordering relationship is specified.
+    pub const COMPARISON_UNSPECIFIED: ComparisonType = ComparisonType::new(0);
+
+    /// True if the left argument is greater than the right argument.
+    pub const COMPARISON_GT: ComparisonType = ComparisonType::new(1);
+
+    /// True if the left argument is greater than or equal to the right argument.
+    pub const COMPARISON_GE: ComparisonType = ComparisonType::new(2);
+
+    /// True if the left argument is less than the right argument.
+    pub const COMPARISON_LT: ComparisonType = ComparisonType::new(3);
+
+    /// True if the left argument is less than or equal to the right argument.
+    pub const COMPARISON_LE: ComparisonType = ComparisonType::new(4);
+
+    /// True if the left argument is equal to the right argument.
+    pub const COMPARISON_EQ: ComparisonType = ComparisonType::new(5);
+
+    /// True if the left argument is not equal to the right argument.
+    pub const COMPARISON_NE: ComparisonType = ComparisonType::new(6);
+
     /// Creates a new ComparisonType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("COMPARISON_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("COMPARISON_GT"),
+            2 => std::borrow::Cow::Borrowed("COMPARISON_GE"),
+            3 => std::borrow::Cow::Borrowed("COMPARISON_LT"),
+            4 => std::borrow::Cow::Borrowed("COMPARISON_LE"),
+            5 => std::borrow::Cow::Borrowed("COMPARISON_EQ"),
+            6 => std::borrow::Cow::Borrowed("COMPARISON_NE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "COMPARISON_UNSPECIFIED" => std::option::Option::Some(Self::COMPARISON_UNSPECIFIED),
+            "COMPARISON_GT" => std::option::Option::Some(Self::COMPARISON_GT),
+            "COMPARISON_GE" => std::option::Option::Some(Self::COMPARISON_GE),
+            "COMPARISON_LT" => std::option::Option::Some(Self::COMPARISON_LT),
+            "COMPARISON_LE" => std::option::Option::Some(Self::COMPARISON_LE),
+            "COMPARISON_EQ" => std::option::Option::Some(Self::COMPARISON_EQ),
+            "COMPARISON_NE" => std::option::Option::Some(Self::COMPARISON_NE),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [ComparisonType](ComparisonType)
-pub mod comparison_type {
-    use super::ComparisonType;
-
-    /// No ordering relationship is specified.
-    pub const COMPARISON_UNSPECIFIED: ComparisonType =
-        ComparisonType::new("COMPARISON_UNSPECIFIED");
-
-    /// True if the left argument is greater than the right argument.
-    pub const COMPARISON_GT: ComparisonType = ComparisonType::new("COMPARISON_GT");
-
-    /// True if the left argument is greater than or equal to the right argument.
-    pub const COMPARISON_GE: ComparisonType = ComparisonType::new("COMPARISON_GE");
-
-    /// True if the left argument is less than the right argument.
-    pub const COMPARISON_LT: ComparisonType = ComparisonType::new("COMPARISON_LT");
-
-    /// True if the left argument is less than or equal to the right argument.
-    pub const COMPARISON_LE: ComparisonType = ComparisonType::new("COMPARISON_LE");
-
-    /// True if the left argument is equal to the right argument.
-    pub const COMPARISON_EQ: ComparisonType = ComparisonType::new("COMPARISON_EQ");
-
-    /// True if the left argument is not equal to the right argument.
-    pub const COMPARISON_NE: ComparisonType = ComparisonType::new("COMPARISON_NE");
-}
-
-impl std::convert::From<std::string::String> for ComparisonType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ComparisonType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ComparisonType {
     fn default() -> Self {
-        comparison_type::COMPARISON_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -13407,115 +13771,155 @@ impl std::default::Default for ComparisonType {
 /// documentation](https://cloud.google.com/monitoring/workspaces/tiers) for more
 /// details.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ServiceTier(std::borrow::Cow<'static, str>);
+pub struct ServiceTier(i32);
 
 impl ServiceTier {
-    /// Creates a new ServiceTier instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ServiceTier](ServiceTier)
-pub mod service_tier {
-    use super::ServiceTier;
-
     /// An invalid sentinel value, used to indicate that a tier has not
     /// been provided explicitly.
-    pub const SERVICE_TIER_UNSPECIFIED: ServiceTier = ServiceTier::new("SERVICE_TIER_UNSPECIFIED");
+    pub const SERVICE_TIER_UNSPECIFIED: ServiceTier = ServiceTier::new(0);
 
     /// The Cloud Monitoring Basic tier, a free tier of service that provides basic
     /// features, a moderate allotment of logs, and access to built-in metrics.
     /// A number of features are not available in this tier. For more details,
     /// see [the service tiers
     /// documentation](https://cloud.google.com/monitoring/workspaces/tiers).
-    pub const SERVICE_TIER_BASIC: ServiceTier = ServiceTier::new("SERVICE_TIER_BASIC");
+    pub const SERVICE_TIER_BASIC: ServiceTier = ServiceTier::new(1);
 
     /// The Cloud Monitoring Premium tier, a higher, more expensive tier of service
     /// that provides access to all Cloud Monitoring features, lets you use Cloud
     /// Monitoring with AWS accounts, and has a larger allotments for logs and
     /// metrics. For more details, see [the service tiers
     /// documentation](https://cloud.google.com/monitoring/workspaces/tiers).
-    pub const SERVICE_TIER_PREMIUM: ServiceTier = ServiceTier::new("SERVICE_TIER_PREMIUM");
+    pub const SERVICE_TIER_PREMIUM: ServiceTier = ServiceTier::new(2);
+
+    /// Creates a new ServiceTier instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SERVICE_TIER_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SERVICE_TIER_BASIC"),
+            2 => std::borrow::Cow::Borrowed("SERVICE_TIER_PREMIUM"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SERVICE_TIER_UNSPECIFIED" => std::option::Option::Some(Self::SERVICE_TIER_UNSPECIFIED),
+            "SERVICE_TIER_BASIC" => std::option::Option::Some(Self::SERVICE_TIER_BASIC),
+            "SERVICE_TIER_PREMIUM" => std::option::Option::Some(Self::SERVICE_TIER_PREMIUM),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ServiceTier {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ServiceTier {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ServiceTier {
     fn default() -> Self {
-        service_tier::SERVICE_TIER_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// The regions from which an Uptime check can be run.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct UptimeCheckRegion(std::borrow::Cow<'static, str>);
+pub struct UptimeCheckRegion(i32);
 
 impl UptimeCheckRegion {
-    /// Creates a new UptimeCheckRegion instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [UptimeCheckRegion](UptimeCheckRegion)
-pub mod uptime_check_region {
-    use super::UptimeCheckRegion;
-
     /// Default value if no region is specified. Will result in Uptime checks
     /// running from all regions.
-    pub const REGION_UNSPECIFIED: UptimeCheckRegion = UptimeCheckRegion::new("REGION_UNSPECIFIED");
+    pub const REGION_UNSPECIFIED: UptimeCheckRegion = UptimeCheckRegion::new(0);
 
     /// Allows checks to run from locations within the United States of America.
-    pub const USA: UptimeCheckRegion = UptimeCheckRegion::new("USA");
+    pub const USA: UptimeCheckRegion = UptimeCheckRegion::new(1);
 
     /// Allows checks to run from locations within the continent of Europe.
-    pub const EUROPE: UptimeCheckRegion = UptimeCheckRegion::new("EUROPE");
+    pub const EUROPE: UptimeCheckRegion = UptimeCheckRegion::new(2);
 
     /// Allows checks to run from locations within the continent of South
     /// America.
-    pub const SOUTH_AMERICA: UptimeCheckRegion = UptimeCheckRegion::new("SOUTH_AMERICA");
+    pub const SOUTH_AMERICA: UptimeCheckRegion = UptimeCheckRegion::new(3);
 
     /// Allows checks to run from locations within the Asia Pacific area (ex:
     /// Singapore).
-    pub const ASIA_PACIFIC: UptimeCheckRegion = UptimeCheckRegion::new("ASIA_PACIFIC");
+    pub const ASIA_PACIFIC: UptimeCheckRegion = UptimeCheckRegion::new(4);
 
     /// Allows checks to run from locations within the western United States of
     /// America
-    pub const USA_OREGON: UptimeCheckRegion = UptimeCheckRegion::new("USA_OREGON");
+    pub const USA_OREGON: UptimeCheckRegion = UptimeCheckRegion::new(5);
 
     /// Allows checks to run from locations within the central United States of
     /// America
-    pub const USA_IOWA: UptimeCheckRegion = UptimeCheckRegion::new("USA_IOWA");
+    pub const USA_IOWA: UptimeCheckRegion = UptimeCheckRegion::new(6);
 
     /// Allows checks to run from locations within the eastern United States of
     /// America
-    pub const USA_VIRGINIA: UptimeCheckRegion = UptimeCheckRegion::new("USA_VIRGINIA");
+    pub const USA_VIRGINIA: UptimeCheckRegion = UptimeCheckRegion::new(7);
+
+    /// Creates a new UptimeCheckRegion instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("REGION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("USA"),
+            2 => std::borrow::Cow::Borrowed("EUROPE"),
+            3 => std::borrow::Cow::Borrowed("SOUTH_AMERICA"),
+            4 => std::borrow::Cow::Borrowed("ASIA_PACIFIC"),
+            5 => std::borrow::Cow::Borrowed("USA_OREGON"),
+            6 => std::borrow::Cow::Borrowed("USA_IOWA"),
+            7 => std::borrow::Cow::Borrowed("USA_VIRGINIA"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "REGION_UNSPECIFIED" => std::option::Option::Some(Self::REGION_UNSPECIFIED),
+            "USA" => std::option::Option::Some(Self::USA),
+            "EUROPE" => std::option::Option::Some(Self::EUROPE),
+            "SOUTH_AMERICA" => std::option::Option::Some(Self::SOUTH_AMERICA),
+            "ASIA_PACIFIC" => std::option::Option::Some(Self::ASIA_PACIFIC),
+            "USA_OREGON" => std::option::Option::Some(Self::USA_OREGON),
+            "USA_IOWA" => std::option::Option::Some(Self::USA_IOWA),
+            "USA_VIRGINIA" => std::option::Option::Some(Self::USA_VIRGINIA),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for UptimeCheckRegion {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for UptimeCheckRegion {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for UptimeCheckRegion {
     fn default() -> Self {
-        uptime_check_region::REGION_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -13525,45 +13929,60 @@ impl std::default::Default for UptimeCheckRegion {
 /// The resource types `gae_app` and `uptime_url` are not valid here because
 /// group checks on App Engine modules and URLs are not allowed.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct GroupResourceType(std::borrow::Cow<'static, str>);
+pub struct GroupResourceType(i32);
 
 impl GroupResourceType {
-    /// Creates a new GroupResourceType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [GroupResourceType](GroupResourceType)
-pub mod group_resource_type {
-    use super::GroupResourceType;
-
     /// Default value (not valid).
-    pub const RESOURCE_TYPE_UNSPECIFIED: GroupResourceType =
-        GroupResourceType::new("RESOURCE_TYPE_UNSPECIFIED");
+    pub const RESOURCE_TYPE_UNSPECIFIED: GroupResourceType = GroupResourceType::new(0);
 
     /// A group of instances from Google Cloud Platform (GCP) or
     /// Amazon Web Services (AWS).
-    pub const INSTANCE: GroupResourceType = GroupResourceType::new("INSTANCE");
+    pub const INSTANCE: GroupResourceType = GroupResourceType::new(1);
 
     /// A group of Amazon ELB load balancers.
-    pub const AWS_ELB_LOAD_BALANCER: GroupResourceType =
-        GroupResourceType::new("AWS_ELB_LOAD_BALANCER");
+    pub const AWS_ELB_LOAD_BALANCER: GroupResourceType = GroupResourceType::new(2);
+
+    /// Creates a new GroupResourceType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("RESOURCE_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("INSTANCE"),
+            2 => std::borrow::Cow::Borrowed("AWS_ELB_LOAD_BALANCER"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "RESOURCE_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::RESOURCE_TYPE_UNSPECIFIED)
+            }
+            "INSTANCE" => std::option::Option::Some(Self::INSTANCE),
+            "AWS_ELB_LOAD_BALANCER" => std::option::Option::Some(Self::AWS_ELB_LOAD_BALANCER),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for GroupResourceType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for GroupResourceType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for GroupResourceType {
     fn default() -> Self {
-        group_resource_type::RESOURCE_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/monitoring/v3/src/transport.rs
+++ b/src/generated/monitoring/v3/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::AlertPolicyService for AlertPolicyService {
                 reqwest::Method::GET,
                 format!("/v3/{}/alertPolicies", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -75,7 +75,7 @@ impl crate::stubs::AlertPolicyService for AlertPolicyService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -97,7 +97,7 @@ impl crate::stubs::AlertPolicyService for AlertPolicyService {
                 reqwest::Method::POST,
                 format!("/v3/{}/alertPolicies", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -116,7 +116,7 @@ impl crate::stubs::AlertPolicyService for AlertPolicyService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -144,7 +144,7 @@ impl crate::stubs::AlertPolicyService for AlertPolicyService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -196,7 +196,7 @@ impl crate::stubs::GroupService for GroupService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/groups", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -235,7 +235,7 @@ impl crate::stubs::GroupService for GroupService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -254,7 +254,7 @@ impl crate::stubs::GroupService for GroupService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}/groups", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -281,7 +281,7 @@ impl crate::stubs::GroupService for GroupService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -299,7 +299,7 @@ impl crate::stubs::GroupService for GroupService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -319,7 +319,7 @@ impl crate::stubs::GroupService for GroupService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/members", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -377,7 +377,7 @@ impl crate::stubs::MetricService for MetricService {
                 reqwest::Method::GET,
                 format!("/v3/{}/monitoredResourceDescriptors", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -399,7 +399,7 @@ impl crate::stubs::MetricService for MetricService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -421,7 +421,7 @@ impl crate::stubs::MetricService for MetricService {
                 reqwest::Method::GET,
                 format!("/v3/{}/metricDescriptors", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -444,7 +444,7 @@ impl crate::stubs::MetricService for MetricService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -466,7 +466,7 @@ impl crate::stubs::MetricService for MetricService {
                 reqwest::Method::POST,
                 format!("/v3/{}/metricDescriptors", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -485,7 +485,7 @@ impl crate::stubs::MetricService for MetricService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -504,7 +504,7 @@ impl crate::stubs::MetricService for MetricService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/timeSeries", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -561,7 +561,7 @@ impl crate::stubs::MetricService for MetricService {
                 reqwest::Method::POST,
                 format!("/v3/{}/timeSeries", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -581,7 +581,7 @@ impl crate::stubs::MetricService for MetricService {
                 reqwest::Method::POST,
                 format!("/v3/{}/timeSeries:createService", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -624,7 +624,7 @@ impl crate::stubs::NotificationChannelService for NotificationChannelService {
                 reqwest::Method::GET,
                 format!("/v3/{}/notificationChannelDescriptors", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -645,7 +645,7 @@ impl crate::stubs::NotificationChannelService for NotificationChannelService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -667,7 +667,7 @@ impl crate::stubs::NotificationChannelService for NotificationChannelService {
                 reqwest::Method::GET,
                 format!("/v3/{}/notificationChannels", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -690,7 +690,7 @@ impl crate::stubs::NotificationChannelService for NotificationChannelService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -712,7 +712,7 @@ impl crate::stubs::NotificationChannelService for NotificationChannelService {
                 reqwest::Method::POST,
                 format!("/v3/{}/notificationChannels", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -740,7 +740,7 @@ impl crate::stubs::NotificationChannelService for NotificationChannelService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -769,7 +769,7 @@ impl crate::stubs::NotificationChannelService for NotificationChannelService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -792,7 +792,7 @@ impl crate::stubs::NotificationChannelService for NotificationChannelService {
                 reqwest::Method::POST,
                 format!("/v3/{}:sendVerificationCode", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -812,7 +812,7 @@ impl crate::stubs::NotificationChannelService for NotificationChannelService {
                 reqwest::Method::POST,
                 format!("/v3/{}:getVerificationCode", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -829,7 +829,7 @@ impl crate::stubs::NotificationChannelService for NotificationChannelService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}:verify", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -872,7 +872,7 @@ impl crate::stubs::QueryService for QueryService {
                 reqwest::Method::POST,
                 format!("/v3/{}/timeSeries:query", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -915,7 +915,7 @@ impl crate::stubs::ServiceMonitoringService for ServiceMonitoringService {
                 reqwest::Method::POST,
                 format!("/v3/{}/services", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -935,7 +935,7 @@ impl crate::stubs::ServiceMonitoringService for ServiceMonitoringService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -954,7 +954,7 @@ impl crate::stubs::ServiceMonitoringService for ServiceMonitoringService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/services", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -985,7 +985,7 @@ impl crate::stubs::ServiceMonitoringService for ServiceMonitoringService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1014,7 +1014,7 @@ impl crate::stubs::ServiceMonitoringService for ServiceMonitoringService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1036,7 +1036,7 @@ impl crate::stubs::ServiceMonitoringService for ServiceMonitoringService {
                 reqwest::Method::POST,
                 format!("/v3/{}/serviceLevelObjectives", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1057,7 +1057,7 @@ impl crate::stubs::ServiceMonitoringService for ServiceMonitoringService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1080,7 +1080,7 @@ impl crate::stubs::ServiceMonitoringService for ServiceMonitoringService {
                 reqwest::Method::GET,
                 format!("/v3/{}/serviceLevelObjectives", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1112,7 +1112,7 @@ impl crate::stubs::ServiceMonitoringService for ServiceMonitoringService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1141,7 +1141,7 @@ impl crate::stubs::ServiceMonitoringService for ServiceMonitoringService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1183,7 +1183,7 @@ impl crate::stubs::SnoozeService for SnoozeService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v3/{}/snoozes", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1200,7 +1200,7 @@ impl crate::stubs::SnoozeService for SnoozeService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}/snoozes", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1222,7 +1222,7 @@ impl crate::stubs::SnoozeService for SnoozeService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1250,7 +1250,7 @@ impl crate::stubs::SnoozeService for SnoozeService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1303,7 +1303,7 @@ impl crate::stubs::UptimeCheckService for UptimeCheckService {
                 reqwest::Method::GET,
                 format!("/v3/{}/uptimeCheckConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1325,7 +1325,7 @@ impl crate::stubs::UptimeCheckService for UptimeCheckService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1347,7 +1347,7 @@ impl crate::stubs::UptimeCheckService for UptimeCheckService {
                 reqwest::Method::POST,
                 format!("/v3/{}/uptimeCheckConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1375,7 +1375,7 @@ impl crate::stubs::UptimeCheckService for UptimeCheckService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1404,7 +1404,7 @@ impl crate::stubs::UptimeCheckService for UptimeCheckService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1423,7 +1423,7 @@ impl crate::stubs::UptimeCheckService for UptimeCheckService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v3/uptimeCheckIps".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/openapi-validation/src/transport.rs
+++ b/src/generated/openapi-validation/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                 reqwest::Method::GET,
                 format!("/v1/projects/{}/locations", req.project),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -86,7 +86,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                 reqwest::Method::GET,
                 format!("/v1/projects/{}/locations/{}", req.project, req.location),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -108,7 +108,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                 reqwest::Method::GET,
                 format!("/v1/projects/{}/secrets", req.project),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -142,7 +142,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                 reqwest::Method::POST,
                 format!("/v1/projects/{}/secrets", req.project),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -168,7 +168,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.location
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -205,7 +205,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.location
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -231,7 +231,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.secret
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -254,7 +254,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.location, req.secret
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -274,7 +274,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                 reqwest::Method::GET,
                 format!("/v1/projects/{}/secrets/{}", req.project, req.secret),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -296,7 +296,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                 reqwest::Method::DELETE,
                 format!("/v1/projects/{}/secrets/{}", req.project, req.secret),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -322,7 +322,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                 reqwest::Method::PATCH,
                 format!("/v1/projects/{}/secrets/{}", req.project, req.secret),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -353,7 +353,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.location, req.secret
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -378,7 +378,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.location, req.secret
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -407,7 +407,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.location, req.secret
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -438,7 +438,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.secret
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -475,7 +475,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.location, req.secret
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -512,7 +512,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.secret, req.version
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -537,7 +537,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.location, req.secret, req.version
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -562,7 +562,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.secret, req.version
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -587,7 +587,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.location, req.secret, req.version
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -612,7 +612,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.secret, req.version
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -635,7 +635,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.location, req.secret, req.version
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -658,7 +658,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.secret, req.version
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -681,7 +681,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.location, req.secret, req.version
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -704,7 +704,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.secret, req.version
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -727,7 +727,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.location, req.secret, req.version
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -750,7 +750,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.secret
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -773,7 +773,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.location, req.secret
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -796,7 +796,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.secret
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -827,7 +827,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.location, req.secret
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -858,7 +858,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.secret
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -881,7 +881,7 @@ impl crate::stubs::SecretManagerService for SecretManagerService {
                     req.project, req.location, req.secret
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/oslogin/common/src/model.rs
+++ b/src/generated/oslogin/common/src/model.rs
@@ -217,44 +217,60 @@ impl wkt::message::Message for SshPublicKey {
 
 /// The operating system options for account entries.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OperatingSystemType(std::borrow::Cow<'static, str>);
+pub struct OperatingSystemType(i32);
 
 impl OperatingSystemType {
+    /// The operating system type associated with the user account information is
+    /// unspecified.
+    pub const OPERATING_SYSTEM_TYPE_UNSPECIFIED: OperatingSystemType = OperatingSystemType::new(0);
+
+    /// Linux user account information.
+    pub const LINUX: OperatingSystemType = OperatingSystemType::new(1);
+
+    /// Windows user account information.
+    pub const WINDOWS: OperatingSystemType = OperatingSystemType::new(2);
+
     /// Creates a new OperatingSystemType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("OPERATING_SYSTEM_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("LINUX"),
+            2 => std::borrow::Cow::Borrowed("WINDOWS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "OPERATING_SYSTEM_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::OPERATING_SYSTEM_TYPE_UNSPECIFIED)
+            }
+            "LINUX" => std::option::Option::Some(Self::LINUX),
+            "WINDOWS" => std::option::Option::Some(Self::WINDOWS),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [OperatingSystemType](OperatingSystemType)
-pub mod operating_system_type {
-    use super::OperatingSystemType;
-
-    /// The operating system type associated with the user account information is
-    /// unspecified.
-    pub const OPERATING_SYSTEM_TYPE_UNSPECIFIED: OperatingSystemType =
-        OperatingSystemType::new("OPERATING_SYSTEM_TYPE_UNSPECIFIED");
-
-    /// Linux user account information.
-    pub const LINUX: OperatingSystemType = OperatingSystemType::new("LINUX");
-
-    /// Windows user account information.
-    pub const WINDOWS: OperatingSystemType = OperatingSystemType::new("WINDOWS");
-}
-
-impl std::convert::From<std::string::String> for OperatingSystemType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for OperatingSystemType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for OperatingSystemType {
     fn default() -> Self {
-        operating_system_type::OPERATING_SYSTEM_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/privacy/dlp/v2/src/model.rs
+++ b/src/generated/privacy/dlp/v2/src/model.rs
@@ -915,88 +915,133 @@ pub mod byte_content_item {
     /// [Supported file
     /// types](https://cloud.google.com/sensitive-data-protection/docs/supported-file-types).
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BytesType(std::borrow::Cow<'static, str>);
+    pub struct BytesType(i32);
 
     impl BytesType {
+        /// Unused
+        pub const BYTES_TYPE_UNSPECIFIED: BytesType = BytesType::new(0);
+
+        /// Any image type.
+        pub const IMAGE: BytesType = BytesType::new(6);
+
+        /// jpeg
+        pub const IMAGE_JPEG: BytesType = BytesType::new(1);
+
+        /// bmp
+        pub const IMAGE_BMP: BytesType = BytesType::new(2);
+
+        /// png
+        pub const IMAGE_PNG: BytesType = BytesType::new(3);
+
+        /// svg
+        pub const IMAGE_SVG: BytesType = BytesType::new(4);
+
+        /// plain text
+        pub const TEXT_UTF8: BytesType = BytesType::new(5);
+
+        /// docx, docm, dotx, dotm
+        pub const WORD_DOCUMENT: BytesType = BytesType::new(7);
+
+        /// pdf
+        pub const PDF: BytesType = BytesType::new(8);
+
+        /// pptx, pptm, potx, potm, pot
+        pub const POWERPOINT_DOCUMENT: BytesType = BytesType::new(9);
+
+        /// xlsx, xlsm, xltx, xltm
+        pub const EXCEL_DOCUMENT: BytesType = BytesType::new(10);
+
+        /// avro
+        pub const AVRO: BytesType = BytesType::new(11);
+
+        /// csv
+        pub const CSV: BytesType = BytesType::new(12);
+
+        /// tsv
+        pub const TSV: BytesType = BytesType::new(13);
+
+        /// Audio file types. Only used for profiling.
+        pub const AUDIO: BytesType = BytesType::new(15);
+
+        /// Video file types. Only used for profiling.
+        pub const VIDEO: BytesType = BytesType::new(16);
+
+        /// Executable file types. Only used for profiling.
+        pub const EXECUTABLE: BytesType = BytesType::new(17);
+
+        /// AI model file types. Only used for profiling.
+        pub const AI_MODEL: BytesType = BytesType::new(18);
+
         /// Creates a new BytesType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("BYTES_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IMAGE_JPEG"),
+                2 => std::borrow::Cow::Borrowed("IMAGE_BMP"),
+                3 => std::borrow::Cow::Borrowed("IMAGE_PNG"),
+                4 => std::borrow::Cow::Borrowed("IMAGE_SVG"),
+                5 => std::borrow::Cow::Borrowed("TEXT_UTF8"),
+                6 => std::borrow::Cow::Borrowed("IMAGE"),
+                7 => std::borrow::Cow::Borrowed("WORD_DOCUMENT"),
+                8 => std::borrow::Cow::Borrowed("PDF"),
+                9 => std::borrow::Cow::Borrowed("POWERPOINT_DOCUMENT"),
+                10 => std::borrow::Cow::Borrowed("EXCEL_DOCUMENT"),
+                11 => std::borrow::Cow::Borrowed("AVRO"),
+                12 => std::borrow::Cow::Borrowed("CSV"),
+                13 => std::borrow::Cow::Borrowed("TSV"),
+                15 => std::borrow::Cow::Borrowed("AUDIO"),
+                16 => std::borrow::Cow::Borrowed("VIDEO"),
+                17 => std::borrow::Cow::Borrowed("EXECUTABLE"),
+                18 => std::borrow::Cow::Borrowed("AI_MODEL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "BYTES_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::BYTES_TYPE_UNSPECIFIED),
+                "IMAGE" => std::option::Option::Some(Self::IMAGE),
+                "IMAGE_JPEG" => std::option::Option::Some(Self::IMAGE_JPEG),
+                "IMAGE_BMP" => std::option::Option::Some(Self::IMAGE_BMP),
+                "IMAGE_PNG" => std::option::Option::Some(Self::IMAGE_PNG),
+                "IMAGE_SVG" => std::option::Option::Some(Self::IMAGE_SVG),
+                "TEXT_UTF8" => std::option::Option::Some(Self::TEXT_UTF8),
+                "WORD_DOCUMENT" => std::option::Option::Some(Self::WORD_DOCUMENT),
+                "PDF" => std::option::Option::Some(Self::PDF),
+                "POWERPOINT_DOCUMENT" => std::option::Option::Some(Self::POWERPOINT_DOCUMENT),
+                "EXCEL_DOCUMENT" => std::option::Option::Some(Self::EXCEL_DOCUMENT),
+                "AVRO" => std::option::Option::Some(Self::AVRO),
+                "CSV" => std::option::Option::Some(Self::CSV),
+                "TSV" => std::option::Option::Some(Self::TSV),
+                "AUDIO" => std::option::Option::Some(Self::AUDIO),
+                "VIDEO" => std::option::Option::Some(Self::VIDEO),
+                "EXECUTABLE" => std::option::Option::Some(Self::EXECUTABLE),
+                "AI_MODEL" => std::option::Option::Some(Self::AI_MODEL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [BytesType](BytesType)
-    pub mod bytes_type {
-        use super::BytesType;
-
-        /// Unused
-        pub const BYTES_TYPE_UNSPECIFIED: BytesType = BytesType::new("BYTES_TYPE_UNSPECIFIED");
-
-        /// Any image type.
-        pub const IMAGE: BytesType = BytesType::new("IMAGE");
-
-        /// jpeg
-        pub const IMAGE_JPEG: BytesType = BytesType::new("IMAGE_JPEG");
-
-        /// bmp
-        pub const IMAGE_BMP: BytesType = BytesType::new("IMAGE_BMP");
-
-        /// png
-        pub const IMAGE_PNG: BytesType = BytesType::new("IMAGE_PNG");
-
-        /// svg
-        pub const IMAGE_SVG: BytesType = BytesType::new("IMAGE_SVG");
-
-        /// plain text
-        pub const TEXT_UTF8: BytesType = BytesType::new("TEXT_UTF8");
-
-        /// docx, docm, dotx, dotm
-        pub const WORD_DOCUMENT: BytesType = BytesType::new("WORD_DOCUMENT");
-
-        /// pdf
-        pub const PDF: BytesType = BytesType::new("PDF");
-
-        /// pptx, pptm, potx, potm, pot
-        pub const POWERPOINT_DOCUMENT: BytesType = BytesType::new("POWERPOINT_DOCUMENT");
-
-        /// xlsx, xlsm, xltx, xltm
-        pub const EXCEL_DOCUMENT: BytesType = BytesType::new("EXCEL_DOCUMENT");
-
-        /// avro
-        pub const AVRO: BytesType = BytesType::new("AVRO");
-
-        /// csv
-        pub const CSV: BytesType = BytesType::new("CSV");
-
-        /// tsv
-        pub const TSV: BytesType = BytesType::new("TSV");
-
-        /// Audio file types. Only used for profiling.
-        pub const AUDIO: BytesType = BytesType::new("AUDIO");
-
-        /// Video file types. Only used for profiling.
-        pub const VIDEO: BytesType = BytesType::new("VIDEO");
-
-        /// Executable file types. Only used for profiling.
-        pub const EXECUTABLE: BytesType = BytesType::new("EXECUTABLE");
-
-        /// AI model file types. Only used for profiling.
-        pub const AI_MODEL: BytesType = BytesType::new("AI_MODEL");
-    }
-
-    impl std::convert::From<std::string::String> for BytesType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for BytesType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for BytesType {
         fn default() -> Self {
-            bytes_type::BYTES_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3225,54 +3270,76 @@ pub mod output_storage_config {
     /// Predefined schemas for storing findings.
     /// Only for use with external storage.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OutputSchema(std::borrow::Cow<'static, str>);
+    pub struct OutputSchema(i32);
 
     impl OutputSchema {
-        /// Creates a new OutputSchema instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [OutputSchema](OutputSchema)
-    pub mod output_schema {
-        use super::OutputSchema;
-
         /// Unused.
-        pub const OUTPUT_SCHEMA_UNSPECIFIED: OutputSchema =
-            OutputSchema::new("OUTPUT_SCHEMA_UNSPECIFIED");
+        pub const OUTPUT_SCHEMA_UNSPECIFIED: OutputSchema = OutputSchema::new(0);
 
         /// Basic schema including only `info_type`, `quote`, `certainty`, and
         /// `timestamp`.
-        pub const BASIC_COLUMNS: OutputSchema = OutputSchema::new("BASIC_COLUMNS");
+        pub const BASIC_COLUMNS: OutputSchema = OutputSchema::new(1);
 
         /// Schema tailored to findings from scanning Cloud Storage.
-        pub const GCS_COLUMNS: OutputSchema = OutputSchema::new("GCS_COLUMNS");
+        pub const GCS_COLUMNS: OutputSchema = OutputSchema::new(2);
 
         /// Schema tailored to findings from scanning Google Datastore.
-        pub const DATASTORE_COLUMNS: OutputSchema = OutputSchema::new("DATASTORE_COLUMNS");
+        pub const DATASTORE_COLUMNS: OutputSchema = OutputSchema::new(3);
 
         /// Schema tailored to findings from scanning Google BigQuery.
-        pub const BIG_QUERY_COLUMNS: OutputSchema = OutputSchema::new("BIG_QUERY_COLUMNS");
+        pub const BIG_QUERY_COLUMNS: OutputSchema = OutputSchema::new(4);
 
         /// Schema containing all columns.
-        pub const ALL_COLUMNS: OutputSchema = OutputSchema::new("ALL_COLUMNS");
+        pub const ALL_COLUMNS: OutputSchema = OutputSchema::new(5);
+
+        /// Creates a new OutputSchema instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("OUTPUT_SCHEMA_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("BASIC_COLUMNS"),
+                2 => std::borrow::Cow::Borrowed("GCS_COLUMNS"),
+                3 => std::borrow::Cow::Borrowed("DATASTORE_COLUMNS"),
+                4 => std::borrow::Cow::Borrowed("BIG_QUERY_COLUMNS"),
+                5 => std::borrow::Cow::Borrowed("ALL_COLUMNS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "OUTPUT_SCHEMA_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::OUTPUT_SCHEMA_UNSPECIFIED)
+                }
+                "BASIC_COLUMNS" => std::option::Option::Some(Self::BASIC_COLUMNS),
+                "GCS_COLUMNS" => std::option::Option::Some(Self::GCS_COLUMNS),
+                "DATASTORE_COLUMNS" => std::option::Option::Some(Self::DATASTORE_COLUMNS),
+                "BIG_QUERY_COLUMNS" => std::option::Option::Some(Self::BIG_QUERY_COLUMNS),
+                "ALL_COLUMNS" => std::option::Option::Some(Self::ALL_COLUMNS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for OutputSchema {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for OutputSchema {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for OutputSchema {
         fn default() -> Self {
-            output_schema::OUTPUT_SCHEMA_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -4265,303 +4332,454 @@ pub mod info_type_category {
     /// Enum of the current locations.
     /// We might add more locations in the future.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LocationCategory(std::borrow::Cow<'static, str>);
+    pub struct LocationCategory(i32);
 
     impl LocationCategory {
-        /// Creates a new LocationCategory instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [LocationCategory](LocationCategory)
-    pub mod location_category {
-        use super::LocationCategory;
-
         /// Unused location
-        pub const LOCATION_UNSPECIFIED: LocationCategory =
-            LocationCategory::new("LOCATION_UNSPECIFIED");
+        pub const LOCATION_UNSPECIFIED: LocationCategory = LocationCategory::new(0);
 
         /// The infoType is not issued by or tied to a specific region, but is used
         /// almost everywhere.
-        pub const GLOBAL: LocationCategory = LocationCategory::new("GLOBAL");
+        pub const GLOBAL: LocationCategory = LocationCategory::new(1);
 
         /// The infoType is typically used in Argentina.
-        pub const ARGENTINA: LocationCategory = LocationCategory::new("ARGENTINA");
+        pub const ARGENTINA: LocationCategory = LocationCategory::new(2);
 
         /// The infoType is typically used in Armenia.
-        pub const ARMENIA: LocationCategory = LocationCategory::new("ARMENIA");
+        pub const ARMENIA: LocationCategory = LocationCategory::new(51);
 
         /// The infoType is typically used in Australia.
-        pub const AUSTRALIA: LocationCategory = LocationCategory::new("AUSTRALIA");
+        pub const AUSTRALIA: LocationCategory = LocationCategory::new(3);
 
         /// The infoType is typically used in Azerbaijan.
-        pub const AZERBAIJAN: LocationCategory = LocationCategory::new("AZERBAIJAN");
+        pub const AZERBAIJAN: LocationCategory = LocationCategory::new(48);
 
         /// The infoType is typically used in Belarus.
-        pub const BELARUS: LocationCategory = LocationCategory::new("BELARUS");
+        pub const BELARUS: LocationCategory = LocationCategory::new(50);
 
         /// The infoType is typically used in Belgium.
-        pub const BELGIUM: LocationCategory = LocationCategory::new("BELGIUM");
+        pub const BELGIUM: LocationCategory = LocationCategory::new(4);
 
         /// The infoType is typically used in Brazil.
-        pub const BRAZIL: LocationCategory = LocationCategory::new("BRAZIL");
+        pub const BRAZIL: LocationCategory = LocationCategory::new(5);
 
         /// The infoType is typically used in Canada.
-        pub const CANADA: LocationCategory = LocationCategory::new("CANADA");
+        pub const CANADA: LocationCategory = LocationCategory::new(6);
 
         /// The infoType is typically used in Chile.
-        pub const CHILE: LocationCategory = LocationCategory::new("CHILE");
+        pub const CHILE: LocationCategory = LocationCategory::new(7);
 
         /// The infoType is typically used in China.
-        pub const CHINA: LocationCategory = LocationCategory::new("CHINA");
+        pub const CHINA: LocationCategory = LocationCategory::new(8);
 
         /// The infoType is typically used in Colombia.
-        pub const COLOMBIA: LocationCategory = LocationCategory::new("COLOMBIA");
+        pub const COLOMBIA: LocationCategory = LocationCategory::new(9);
 
         /// The infoType is typically used in Croatia.
-        pub const CROATIA: LocationCategory = LocationCategory::new("CROATIA");
+        pub const CROATIA: LocationCategory = LocationCategory::new(42);
 
         /// The infoType is typically used in Denmark.
-        pub const DENMARK: LocationCategory = LocationCategory::new("DENMARK");
+        pub const DENMARK: LocationCategory = LocationCategory::new(10);
 
         /// The infoType is typically used in France.
-        pub const FRANCE: LocationCategory = LocationCategory::new("FRANCE");
+        pub const FRANCE: LocationCategory = LocationCategory::new(11);
 
         /// The infoType is typically used in Finland.
-        pub const FINLAND: LocationCategory = LocationCategory::new("FINLAND");
+        pub const FINLAND: LocationCategory = LocationCategory::new(12);
 
         /// The infoType is typically used in Germany.
-        pub const GERMANY: LocationCategory = LocationCategory::new("GERMANY");
+        pub const GERMANY: LocationCategory = LocationCategory::new(13);
 
         /// The infoType is typically used in Hong Kong.
-        pub const HONG_KONG: LocationCategory = LocationCategory::new("HONG_KONG");
+        pub const HONG_KONG: LocationCategory = LocationCategory::new(14);
 
         /// The infoType is typically used in India.
-        pub const INDIA: LocationCategory = LocationCategory::new("INDIA");
+        pub const INDIA: LocationCategory = LocationCategory::new(15);
 
         /// The infoType is typically used in Indonesia.
-        pub const INDONESIA: LocationCategory = LocationCategory::new("INDONESIA");
+        pub const INDONESIA: LocationCategory = LocationCategory::new(16);
 
         /// The infoType is typically used in Ireland.
-        pub const IRELAND: LocationCategory = LocationCategory::new("IRELAND");
+        pub const IRELAND: LocationCategory = LocationCategory::new(17);
 
         /// The infoType is typically used in Israel.
-        pub const ISRAEL: LocationCategory = LocationCategory::new("ISRAEL");
+        pub const ISRAEL: LocationCategory = LocationCategory::new(18);
 
         /// The infoType is typically used in Italy.
-        pub const ITALY: LocationCategory = LocationCategory::new("ITALY");
+        pub const ITALY: LocationCategory = LocationCategory::new(19);
 
         /// The infoType is typically used in Japan.
-        pub const JAPAN: LocationCategory = LocationCategory::new("JAPAN");
+        pub const JAPAN: LocationCategory = LocationCategory::new(20);
 
         /// The infoType is typically used in Kazakhstan.
-        pub const KAZAKHSTAN: LocationCategory = LocationCategory::new("KAZAKHSTAN");
+        pub const KAZAKHSTAN: LocationCategory = LocationCategory::new(47);
 
         /// The infoType is typically used in Korea.
-        pub const KOREA: LocationCategory = LocationCategory::new("KOREA");
+        pub const KOREA: LocationCategory = LocationCategory::new(21);
 
         /// The infoType is typically used in Mexico.
-        pub const MEXICO: LocationCategory = LocationCategory::new("MEXICO");
+        pub const MEXICO: LocationCategory = LocationCategory::new(22);
 
         /// The infoType is typically used in the Netherlands.
-        pub const THE_NETHERLANDS: LocationCategory = LocationCategory::new("THE_NETHERLANDS");
+        pub const THE_NETHERLANDS: LocationCategory = LocationCategory::new(23);
 
         /// The infoType is typically used in New Zealand.
-        pub const NEW_ZEALAND: LocationCategory = LocationCategory::new("NEW_ZEALAND");
+        pub const NEW_ZEALAND: LocationCategory = LocationCategory::new(41);
 
         /// The infoType is typically used in Norway.
-        pub const NORWAY: LocationCategory = LocationCategory::new("NORWAY");
+        pub const NORWAY: LocationCategory = LocationCategory::new(24);
 
         /// The infoType is typically used in Paraguay.
-        pub const PARAGUAY: LocationCategory = LocationCategory::new("PARAGUAY");
+        pub const PARAGUAY: LocationCategory = LocationCategory::new(25);
 
         /// The infoType is typically used in Peru.
-        pub const PERU: LocationCategory = LocationCategory::new("PERU");
+        pub const PERU: LocationCategory = LocationCategory::new(26);
 
         /// The infoType is typically used in Poland.
-        pub const POLAND: LocationCategory = LocationCategory::new("POLAND");
+        pub const POLAND: LocationCategory = LocationCategory::new(27);
 
         /// The infoType is typically used in Portugal.
-        pub const PORTUGAL: LocationCategory = LocationCategory::new("PORTUGAL");
+        pub const PORTUGAL: LocationCategory = LocationCategory::new(28);
 
         /// The infoType is typically used in Russia.
-        pub const RUSSIA: LocationCategory = LocationCategory::new("RUSSIA");
+        pub const RUSSIA: LocationCategory = LocationCategory::new(44);
 
         /// The infoType is typically used in Singapore.
-        pub const SINGAPORE: LocationCategory = LocationCategory::new("SINGAPORE");
+        pub const SINGAPORE: LocationCategory = LocationCategory::new(29);
 
         /// The infoType is typically used in South Africa.
-        pub const SOUTH_AFRICA: LocationCategory = LocationCategory::new("SOUTH_AFRICA");
+        pub const SOUTH_AFRICA: LocationCategory = LocationCategory::new(30);
 
         /// The infoType is typically used in Spain.
-        pub const SPAIN: LocationCategory = LocationCategory::new("SPAIN");
+        pub const SPAIN: LocationCategory = LocationCategory::new(31);
 
         /// The infoType is typically used in Sweden.
-        pub const SWEDEN: LocationCategory = LocationCategory::new("SWEDEN");
+        pub const SWEDEN: LocationCategory = LocationCategory::new(32);
 
         /// The infoType is typically used in Switzerland.
-        pub const SWITZERLAND: LocationCategory = LocationCategory::new("SWITZERLAND");
+        pub const SWITZERLAND: LocationCategory = LocationCategory::new(43);
 
         /// The infoType is typically used in Taiwan.
-        pub const TAIWAN: LocationCategory = LocationCategory::new("TAIWAN");
+        pub const TAIWAN: LocationCategory = LocationCategory::new(33);
 
         /// The infoType is typically used in Thailand.
-        pub const THAILAND: LocationCategory = LocationCategory::new("THAILAND");
+        pub const THAILAND: LocationCategory = LocationCategory::new(34);
 
         /// The infoType is typically used in Turkey.
-        pub const TURKEY: LocationCategory = LocationCategory::new("TURKEY");
+        pub const TURKEY: LocationCategory = LocationCategory::new(35);
 
         /// The infoType is typically used in Ukraine.
-        pub const UKRAINE: LocationCategory = LocationCategory::new("UKRAINE");
+        pub const UKRAINE: LocationCategory = LocationCategory::new(45);
 
         /// The infoType is typically used in the United Kingdom.
-        pub const UNITED_KINGDOM: LocationCategory = LocationCategory::new("UNITED_KINGDOM");
+        pub const UNITED_KINGDOM: LocationCategory = LocationCategory::new(36);
 
         /// The infoType is typically used in the United States.
-        pub const UNITED_STATES: LocationCategory = LocationCategory::new("UNITED_STATES");
+        pub const UNITED_STATES: LocationCategory = LocationCategory::new(37);
 
         /// The infoType is typically used in Uruguay.
-        pub const URUGUAY: LocationCategory = LocationCategory::new("URUGUAY");
+        pub const URUGUAY: LocationCategory = LocationCategory::new(38);
 
         /// The infoType is typically used in Uzbekistan.
-        pub const UZBEKISTAN: LocationCategory = LocationCategory::new("UZBEKISTAN");
+        pub const UZBEKISTAN: LocationCategory = LocationCategory::new(46);
 
         /// The infoType is typically used in Venezuela.
-        pub const VENEZUELA: LocationCategory = LocationCategory::new("VENEZUELA");
+        pub const VENEZUELA: LocationCategory = LocationCategory::new(39);
 
         /// The infoType is typically used in Google internally.
-        pub const INTERNAL: LocationCategory = LocationCategory::new("INTERNAL");
+        pub const INTERNAL: LocationCategory = LocationCategory::new(40);
+
+        /// Creates a new LocationCategory instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LOCATION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GLOBAL"),
+                2 => std::borrow::Cow::Borrowed("ARGENTINA"),
+                3 => std::borrow::Cow::Borrowed("AUSTRALIA"),
+                4 => std::borrow::Cow::Borrowed("BELGIUM"),
+                5 => std::borrow::Cow::Borrowed("BRAZIL"),
+                6 => std::borrow::Cow::Borrowed("CANADA"),
+                7 => std::borrow::Cow::Borrowed("CHILE"),
+                8 => std::borrow::Cow::Borrowed("CHINA"),
+                9 => std::borrow::Cow::Borrowed("COLOMBIA"),
+                10 => std::borrow::Cow::Borrowed("DENMARK"),
+                11 => std::borrow::Cow::Borrowed("FRANCE"),
+                12 => std::borrow::Cow::Borrowed("FINLAND"),
+                13 => std::borrow::Cow::Borrowed("GERMANY"),
+                14 => std::borrow::Cow::Borrowed("HONG_KONG"),
+                15 => std::borrow::Cow::Borrowed("INDIA"),
+                16 => std::borrow::Cow::Borrowed("INDONESIA"),
+                17 => std::borrow::Cow::Borrowed("IRELAND"),
+                18 => std::borrow::Cow::Borrowed("ISRAEL"),
+                19 => std::borrow::Cow::Borrowed("ITALY"),
+                20 => std::borrow::Cow::Borrowed("JAPAN"),
+                21 => std::borrow::Cow::Borrowed("KOREA"),
+                22 => std::borrow::Cow::Borrowed("MEXICO"),
+                23 => std::borrow::Cow::Borrowed("THE_NETHERLANDS"),
+                24 => std::borrow::Cow::Borrowed("NORWAY"),
+                25 => std::borrow::Cow::Borrowed("PARAGUAY"),
+                26 => std::borrow::Cow::Borrowed("PERU"),
+                27 => std::borrow::Cow::Borrowed("POLAND"),
+                28 => std::borrow::Cow::Borrowed("PORTUGAL"),
+                29 => std::borrow::Cow::Borrowed("SINGAPORE"),
+                30 => std::borrow::Cow::Borrowed("SOUTH_AFRICA"),
+                31 => std::borrow::Cow::Borrowed("SPAIN"),
+                32 => std::borrow::Cow::Borrowed("SWEDEN"),
+                33 => std::borrow::Cow::Borrowed("TAIWAN"),
+                34 => std::borrow::Cow::Borrowed("THAILAND"),
+                35 => std::borrow::Cow::Borrowed("TURKEY"),
+                36 => std::borrow::Cow::Borrowed("UNITED_KINGDOM"),
+                37 => std::borrow::Cow::Borrowed("UNITED_STATES"),
+                38 => std::borrow::Cow::Borrowed("URUGUAY"),
+                39 => std::borrow::Cow::Borrowed("VENEZUELA"),
+                40 => std::borrow::Cow::Borrowed("INTERNAL"),
+                41 => std::borrow::Cow::Borrowed("NEW_ZEALAND"),
+                42 => std::borrow::Cow::Borrowed("CROATIA"),
+                43 => std::borrow::Cow::Borrowed("SWITZERLAND"),
+                44 => std::borrow::Cow::Borrowed("RUSSIA"),
+                45 => std::borrow::Cow::Borrowed("UKRAINE"),
+                46 => std::borrow::Cow::Borrowed("UZBEKISTAN"),
+                47 => std::borrow::Cow::Borrowed("KAZAKHSTAN"),
+                48 => std::borrow::Cow::Borrowed("AZERBAIJAN"),
+                50 => std::borrow::Cow::Borrowed("BELARUS"),
+                51 => std::borrow::Cow::Borrowed("ARMENIA"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LOCATION_UNSPECIFIED" => std::option::Option::Some(Self::LOCATION_UNSPECIFIED),
+                "GLOBAL" => std::option::Option::Some(Self::GLOBAL),
+                "ARGENTINA" => std::option::Option::Some(Self::ARGENTINA),
+                "ARMENIA" => std::option::Option::Some(Self::ARMENIA),
+                "AUSTRALIA" => std::option::Option::Some(Self::AUSTRALIA),
+                "AZERBAIJAN" => std::option::Option::Some(Self::AZERBAIJAN),
+                "BELARUS" => std::option::Option::Some(Self::BELARUS),
+                "BELGIUM" => std::option::Option::Some(Self::BELGIUM),
+                "BRAZIL" => std::option::Option::Some(Self::BRAZIL),
+                "CANADA" => std::option::Option::Some(Self::CANADA),
+                "CHILE" => std::option::Option::Some(Self::CHILE),
+                "CHINA" => std::option::Option::Some(Self::CHINA),
+                "COLOMBIA" => std::option::Option::Some(Self::COLOMBIA),
+                "CROATIA" => std::option::Option::Some(Self::CROATIA),
+                "DENMARK" => std::option::Option::Some(Self::DENMARK),
+                "FRANCE" => std::option::Option::Some(Self::FRANCE),
+                "FINLAND" => std::option::Option::Some(Self::FINLAND),
+                "GERMANY" => std::option::Option::Some(Self::GERMANY),
+                "HONG_KONG" => std::option::Option::Some(Self::HONG_KONG),
+                "INDIA" => std::option::Option::Some(Self::INDIA),
+                "INDONESIA" => std::option::Option::Some(Self::INDONESIA),
+                "IRELAND" => std::option::Option::Some(Self::IRELAND),
+                "ISRAEL" => std::option::Option::Some(Self::ISRAEL),
+                "ITALY" => std::option::Option::Some(Self::ITALY),
+                "JAPAN" => std::option::Option::Some(Self::JAPAN),
+                "KAZAKHSTAN" => std::option::Option::Some(Self::KAZAKHSTAN),
+                "KOREA" => std::option::Option::Some(Self::KOREA),
+                "MEXICO" => std::option::Option::Some(Self::MEXICO),
+                "THE_NETHERLANDS" => std::option::Option::Some(Self::THE_NETHERLANDS),
+                "NEW_ZEALAND" => std::option::Option::Some(Self::NEW_ZEALAND),
+                "NORWAY" => std::option::Option::Some(Self::NORWAY),
+                "PARAGUAY" => std::option::Option::Some(Self::PARAGUAY),
+                "PERU" => std::option::Option::Some(Self::PERU),
+                "POLAND" => std::option::Option::Some(Self::POLAND),
+                "PORTUGAL" => std::option::Option::Some(Self::PORTUGAL),
+                "RUSSIA" => std::option::Option::Some(Self::RUSSIA),
+                "SINGAPORE" => std::option::Option::Some(Self::SINGAPORE),
+                "SOUTH_AFRICA" => std::option::Option::Some(Self::SOUTH_AFRICA),
+                "SPAIN" => std::option::Option::Some(Self::SPAIN),
+                "SWEDEN" => std::option::Option::Some(Self::SWEDEN),
+                "SWITZERLAND" => std::option::Option::Some(Self::SWITZERLAND),
+                "TAIWAN" => std::option::Option::Some(Self::TAIWAN),
+                "THAILAND" => std::option::Option::Some(Self::THAILAND),
+                "TURKEY" => std::option::Option::Some(Self::TURKEY),
+                "UKRAINE" => std::option::Option::Some(Self::UKRAINE),
+                "UNITED_KINGDOM" => std::option::Option::Some(Self::UNITED_KINGDOM),
+                "UNITED_STATES" => std::option::Option::Some(Self::UNITED_STATES),
+                "URUGUAY" => std::option::Option::Some(Self::URUGUAY),
+                "UZBEKISTAN" => std::option::Option::Some(Self::UZBEKISTAN),
+                "VENEZUELA" => std::option::Option::Some(Self::VENEZUELA),
+                "INTERNAL" => std::option::Option::Some(Self::INTERNAL),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for LocationCategory {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LocationCategory {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LocationCategory {
         fn default() -> Self {
-            location_category::LOCATION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Enum of the current industries in the category.
     /// We might add more industries in the future.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IndustryCategory(std::borrow::Cow<'static, str>);
+    pub struct IndustryCategory(i32);
 
     impl IndustryCategory {
+        /// Unused industry
+        pub const INDUSTRY_UNSPECIFIED: IndustryCategory = IndustryCategory::new(0);
+
+        /// The infoType is typically used in the finance industry.
+        pub const FINANCE: IndustryCategory = IndustryCategory::new(1);
+
+        /// The infoType is typically used in the health industry.
+        pub const HEALTH: IndustryCategory = IndustryCategory::new(2);
+
+        /// The infoType is typically used in the telecommunications industry.
+        pub const TELECOMMUNICATIONS: IndustryCategory = IndustryCategory::new(3);
+
         /// Creates a new IndustryCategory instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("INDUSTRY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FINANCE"),
+                2 => std::borrow::Cow::Borrowed("HEALTH"),
+                3 => std::borrow::Cow::Borrowed("TELECOMMUNICATIONS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "INDUSTRY_UNSPECIFIED" => std::option::Option::Some(Self::INDUSTRY_UNSPECIFIED),
+                "FINANCE" => std::option::Option::Some(Self::FINANCE),
+                "HEALTH" => std::option::Option::Some(Self::HEALTH),
+                "TELECOMMUNICATIONS" => std::option::Option::Some(Self::TELECOMMUNICATIONS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [IndustryCategory](IndustryCategory)
-    pub mod industry_category {
-        use super::IndustryCategory;
-
-        /// Unused industry
-        pub const INDUSTRY_UNSPECIFIED: IndustryCategory =
-            IndustryCategory::new("INDUSTRY_UNSPECIFIED");
-
-        /// The infoType is typically used in the finance industry.
-        pub const FINANCE: IndustryCategory = IndustryCategory::new("FINANCE");
-
-        /// The infoType is typically used in the health industry.
-        pub const HEALTH: IndustryCategory = IndustryCategory::new("HEALTH");
-
-        /// The infoType is typically used in the telecommunications industry.
-        pub const TELECOMMUNICATIONS: IndustryCategory =
-            IndustryCategory::new("TELECOMMUNICATIONS");
-    }
-
-    impl std::convert::From<std::string::String> for IndustryCategory {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for IndustryCategory {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for IndustryCategory {
         fn default() -> Self {
-            industry_category::INDUSTRY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Enum of the current types in the category.
     /// We might add more types in the future.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TypeCategory(std::borrow::Cow<'static, str>);
+    pub struct TypeCategory(i32);
 
     impl TypeCategory {
-        /// Creates a new TypeCategory instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [TypeCategory](TypeCategory)
-    pub mod type_category {
-        use super::TypeCategory;
-
         /// Unused type
-        pub const TYPE_UNSPECIFIED: TypeCategory = TypeCategory::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: TypeCategory = TypeCategory::new(0);
 
         /// Personally identifiable information, for example, a
         /// name or phone number
-        pub const PII: TypeCategory = TypeCategory::new("PII");
+        pub const PII: TypeCategory = TypeCategory::new(1);
 
         /// Personally identifiable information that is especially sensitive, for
         /// example, a passport number.
-        pub const SPII: TypeCategory = TypeCategory::new("SPII");
+        pub const SPII: TypeCategory = TypeCategory::new(2);
 
         /// Attributes that can partially identify someone, especially in
         /// combination with other attributes, like age, height, and gender.
-        pub const DEMOGRAPHIC: TypeCategory = TypeCategory::new("DEMOGRAPHIC");
+        pub const DEMOGRAPHIC: TypeCategory = TypeCategory::new(3);
 
         /// Confidential or secret information, for example, a password.
-        pub const CREDENTIAL: TypeCategory = TypeCategory::new("CREDENTIAL");
+        pub const CREDENTIAL: TypeCategory = TypeCategory::new(4);
 
         /// An identification document issued by a government.
-        pub const GOVERNMENT_ID: TypeCategory = TypeCategory::new("GOVERNMENT_ID");
+        pub const GOVERNMENT_ID: TypeCategory = TypeCategory::new(5);
 
         /// A document, for example, a resume or source code.
-        pub const DOCUMENT: TypeCategory = TypeCategory::new("DOCUMENT");
+        pub const DOCUMENT: TypeCategory = TypeCategory::new(6);
 
         /// Information that is not sensitive on its own, but provides details about
         /// the circumstances surrounding an entity or an event.
-        pub const CONTEXTUAL_INFORMATION: TypeCategory =
-            TypeCategory::new("CONTEXTUAL_INFORMATION");
+        pub const CONTEXTUAL_INFORMATION: TypeCategory = TypeCategory::new(7);
 
         /// Category for `CustomInfoType` types.
-        pub const CUSTOM: TypeCategory = TypeCategory::new("CUSTOM");
+        pub const CUSTOM: TypeCategory = TypeCategory::new(8);
+
+        /// Creates a new TypeCategory instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PII"),
+                2 => std::borrow::Cow::Borrowed("SPII"),
+                3 => std::borrow::Cow::Borrowed("DEMOGRAPHIC"),
+                4 => std::borrow::Cow::Borrowed("CREDENTIAL"),
+                5 => std::borrow::Cow::Borrowed("GOVERNMENT_ID"),
+                6 => std::borrow::Cow::Borrowed("DOCUMENT"),
+                7 => std::borrow::Cow::Borrowed("CONTEXTUAL_INFORMATION"),
+                8 => std::borrow::Cow::Borrowed("CUSTOM"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "PII" => std::option::Option::Some(Self::PII),
+                "SPII" => std::option::Option::Some(Self::SPII),
+                "DEMOGRAPHIC" => std::option::Option::Some(Self::DEMOGRAPHIC),
+                "CREDENTIAL" => std::option::Option::Some(Self::CREDENTIAL),
+                "GOVERNMENT_ID" => std::option::Option::Some(Self::GOVERNMENT_ID),
+                "DOCUMENT" => std::option::Option::Some(Self::DOCUMENT),
+                "CONTEXTUAL_INFORMATION" => std::option::Option::Some(Self::CONTEXTUAL_INFORMATION),
+                "CUSTOM" => std::option::Option::Some(Self::CUSTOM),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for TypeCategory {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TypeCategory {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TypeCategory {
         fn default() -> Self {
-            type_category::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -8862,55 +9080,78 @@ pub mod time_part_config {
 
     /// Components that make up time.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TimePart(std::borrow::Cow<'static, str>);
+    pub struct TimePart(i32);
 
     impl TimePart {
+        /// Unused
+        pub const TIME_PART_UNSPECIFIED: TimePart = TimePart::new(0);
+
+        /// [0-9999]
+        pub const YEAR: TimePart = TimePart::new(1);
+
+        /// [1-12]
+        pub const MONTH: TimePart = TimePart::new(2);
+
+        /// [1-31]
+        pub const DAY_OF_MONTH: TimePart = TimePart::new(3);
+
+        /// [1-7]
+        pub const DAY_OF_WEEK: TimePart = TimePart::new(4);
+
+        /// [1-53]
+        pub const WEEK_OF_YEAR: TimePart = TimePart::new(5);
+
+        /// [0-23]
+        pub const HOUR_OF_DAY: TimePart = TimePart::new(6);
+
         /// Creates a new TimePart instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TIME_PART_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("YEAR"),
+                2 => std::borrow::Cow::Borrowed("MONTH"),
+                3 => std::borrow::Cow::Borrowed("DAY_OF_MONTH"),
+                4 => std::borrow::Cow::Borrowed("DAY_OF_WEEK"),
+                5 => std::borrow::Cow::Borrowed("WEEK_OF_YEAR"),
+                6 => std::borrow::Cow::Borrowed("HOUR_OF_DAY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TIME_PART_UNSPECIFIED" => std::option::Option::Some(Self::TIME_PART_UNSPECIFIED),
+                "YEAR" => std::option::Option::Some(Self::YEAR),
+                "MONTH" => std::option::Option::Some(Self::MONTH),
+                "DAY_OF_MONTH" => std::option::Option::Some(Self::DAY_OF_MONTH),
+                "DAY_OF_WEEK" => std::option::Option::Some(Self::DAY_OF_WEEK),
+                "WEEK_OF_YEAR" => std::option::Option::Some(Self::WEEK_OF_YEAR),
+                "HOUR_OF_DAY" => std::option::Option::Some(Self::HOUR_OF_DAY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [TimePart](TimePart)
-    pub mod time_part {
-        use super::TimePart;
-
-        /// Unused
-        pub const TIME_PART_UNSPECIFIED: TimePart = TimePart::new("TIME_PART_UNSPECIFIED");
-
-        /// [0-9999]
-        pub const YEAR: TimePart = TimePart::new("YEAR");
-
-        /// [1-12]
-        pub const MONTH: TimePart = TimePart::new("MONTH");
-
-        /// [1-31]
-        pub const DAY_OF_MONTH: TimePart = TimePart::new("DAY_OF_MONTH");
-
-        /// [1-7]
-        pub const DAY_OF_WEEK: TimePart = TimePart::new("DAY_OF_WEEK");
-
-        /// [1-53]
-        pub const WEEK_OF_YEAR: TimePart = TimePart::new("WEEK_OF_YEAR");
-
-        /// [0-23]
-        pub const HOUR_OF_DAY: TimePart = TimePart::new("HOUR_OF_DAY");
-    }
-
-    impl std::convert::From<std::string::String> for TimePart {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TimePart {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TimePart {
         fn default() -> Self {
-            time_part::TIME_PART_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -9324,55 +9565,76 @@ pub mod chars_to_ignore {
 
     /// Convenience enum for indicating common characters to not transform.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CommonCharsToIgnore(std::borrow::Cow<'static, str>);
+    pub struct CommonCharsToIgnore(i32);
 
     impl CommonCharsToIgnore {
+        /// Unused.
+        pub const COMMON_CHARS_TO_IGNORE_UNSPECIFIED: CommonCharsToIgnore =
+            CommonCharsToIgnore::new(0);
+
+        /// 0-9
+        pub const NUMERIC: CommonCharsToIgnore = CommonCharsToIgnore::new(1);
+
+        /// A-Z
+        pub const ALPHA_UPPER_CASE: CommonCharsToIgnore = CommonCharsToIgnore::new(2);
+
+        /// a-z
+        pub const ALPHA_LOWER_CASE: CommonCharsToIgnore = CommonCharsToIgnore::new(3);
+
+        /// US Punctuation, one of !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
+        pub const PUNCTUATION: CommonCharsToIgnore = CommonCharsToIgnore::new(4);
+
+        /// Whitespace character, one of [ \t\n\x0B\f\r]
+        pub const WHITESPACE: CommonCharsToIgnore = CommonCharsToIgnore::new(5);
+
         /// Creates a new CommonCharsToIgnore instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COMMON_CHARS_TO_IGNORE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NUMERIC"),
+                2 => std::borrow::Cow::Borrowed("ALPHA_UPPER_CASE"),
+                3 => std::borrow::Cow::Borrowed("ALPHA_LOWER_CASE"),
+                4 => std::borrow::Cow::Borrowed("PUNCTUATION"),
+                5 => std::borrow::Cow::Borrowed("WHITESPACE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COMMON_CHARS_TO_IGNORE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::COMMON_CHARS_TO_IGNORE_UNSPECIFIED)
+                }
+                "NUMERIC" => std::option::Option::Some(Self::NUMERIC),
+                "ALPHA_UPPER_CASE" => std::option::Option::Some(Self::ALPHA_UPPER_CASE),
+                "ALPHA_LOWER_CASE" => std::option::Option::Some(Self::ALPHA_LOWER_CASE),
+                "PUNCTUATION" => std::option::Option::Some(Self::PUNCTUATION),
+                "WHITESPACE" => std::option::Option::Some(Self::WHITESPACE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [CommonCharsToIgnore](CommonCharsToIgnore)
-    pub mod common_chars_to_ignore {
-        use super::CommonCharsToIgnore;
-
-        /// Unused.
-        pub const COMMON_CHARS_TO_IGNORE_UNSPECIFIED: CommonCharsToIgnore =
-            CommonCharsToIgnore::new("COMMON_CHARS_TO_IGNORE_UNSPECIFIED");
-
-        /// 0-9
-        pub const NUMERIC: CommonCharsToIgnore = CommonCharsToIgnore::new("NUMERIC");
-
-        /// A-Z
-        pub const ALPHA_UPPER_CASE: CommonCharsToIgnore =
-            CommonCharsToIgnore::new("ALPHA_UPPER_CASE");
-
-        /// a-z
-        pub const ALPHA_LOWER_CASE: CommonCharsToIgnore =
-            CommonCharsToIgnore::new("ALPHA_LOWER_CASE");
-
-        /// US Punctuation, one of !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
-        pub const PUNCTUATION: CommonCharsToIgnore = CommonCharsToIgnore::new("PUNCTUATION");
-
-        /// Whitespace character, one of [ \t\n\x0B\f\r]
-        pub const WHITESPACE: CommonCharsToIgnore = CommonCharsToIgnore::new("WHITESPACE");
-    }
-
-    impl std::convert::From<std::string::String> for CommonCharsToIgnore {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CommonCharsToIgnore {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CommonCharsToIgnore {
         fn default() -> Self {
-            common_chars_to_ignore::COMMON_CHARS_TO_IGNORE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -9900,53 +10162,74 @@ pub mod crypto_replace_ffx_fpe_config {
     /// natively supports. In the algorithm, the alphabet is selected using
     /// the "radix". Therefore each corresponds to a particular radix.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FfxCommonNativeAlphabet(std::borrow::Cow<'static, str>);
+    pub struct FfxCommonNativeAlphabet(i32);
 
     impl FfxCommonNativeAlphabet {
-        /// Creates a new FfxCommonNativeAlphabet instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [FfxCommonNativeAlphabet](FfxCommonNativeAlphabet)
-    pub mod ffx_common_native_alphabet {
-        use super::FfxCommonNativeAlphabet;
-
         /// Unused.
         pub const FFX_COMMON_NATIVE_ALPHABET_UNSPECIFIED: FfxCommonNativeAlphabet =
-            FfxCommonNativeAlphabet::new("FFX_COMMON_NATIVE_ALPHABET_UNSPECIFIED");
+            FfxCommonNativeAlphabet::new(0);
 
         /// `[0-9]` (radix of 10)
-        pub const NUMERIC: FfxCommonNativeAlphabet = FfxCommonNativeAlphabet::new("NUMERIC");
+        pub const NUMERIC: FfxCommonNativeAlphabet = FfxCommonNativeAlphabet::new(1);
 
         /// `[0-9A-F]` (radix of 16)
-        pub const HEXADECIMAL: FfxCommonNativeAlphabet =
-            FfxCommonNativeAlphabet::new("HEXADECIMAL");
+        pub const HEXADECIMAL: FfxCommonNativeAlphabet = FfxCommonNativeAlphabet::new(2);
 
         /// `[0-9A-Z]` (radix of 36)
         pub const UPPER_CASE_ALPHA_NUMERIC: FfxCommonNativeAlphabet =
-            FfxCommonNativeAlphabet::new("UPPER_CASE_ALPHA_NUMERIC");
+            FfxCommonNativeAlphabet::new(3);
 
         /// `[0-9A-Za-z]` (radix of 62)
-        pub const ALPHA_NUMERIC: FfxCommonNativeAlphabet =
-            FfxCommonNativeAlphabet::new("ALPHA_NUMERIC");
+        pub const ALPHA_NUMERIC: FfxCommonNativeAlphabet = FfxCommonNativeAlphabet::new(4);
+
+        /// Creates a new FfxCommonNativeAlphabet instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FFX_COMMON_NATIVE_ALPHABET_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NUMERIC"),
+                2 => std::borrow::Cow::Borrowed("HEXADECIMAL"),
+                3 => std::borrow::Cow::Borrowed("UPPER_CASE_ALPHA_NUMERIC"),
+                4 => std::borrow::Cow::Borrowed("ALPHA_NUMERIC"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FFX_COMMON_NATIVE_ALPHABET_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::FFX_COMMON_NATIVE_ALPHABET_UNSPECIFIED)
+                }
+                "NUMERIC" => std::option::Option::Some(Self::NUMERIC),
+                "HEXADECIMAL" => std::option::Option::Some(Self::HEXADECIMAL),
+                "UPPER_CASE_ALPHA_NUMERIC" => {
+                    std::option::Option::Some(Self::UPPER_CASE_ALPHA_NUMERIC)
+                }
+                "ALPHA_NUMERIC" => std::option::Option::Some(Self::ALPHA_NUMERIC),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for FfxCommonNativeAlphabet {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for FfxCommonNativeAlphabet {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for FfxCommonNativeAlphabet {
         fn default() -> Self {
-            ffx_common_native_alphabet::FFX_COMMON_NATIVE_ALPHABET_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -10933,41 +11216,55 @@ pub mod record_condition {
 
         /// Logical operators for conditional checks.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct LogicalOperator(std::borrow::Cow<'static, str>);
+        pub struct LogicalOperator(i32);
 
         impl LogicalOperator {
+            /// Unused
+            pub const LOGICAL_OPERATOR_UNSPECIFIED: LogicalOperator = LogicalOperator::new(0);
+
+            /// Conditional AND
+            pub const AND: LogicalOperator = LogicalOperator::new(1);
+
             /// Creates a new LogicalOperator instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("LOGICAL_OPERATOR_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("AND"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "LOGICAL_OPERATOR_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::LOGICAL_OPERATOR_UNSPECIFIED)
+                    }
+                    "AND" => std::option::Option::Some(Self::AND),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [LogicalOperator](LogicalOperator)
-        pub mod logical_operator {
-            use super::LogicalOperator;
-
-            /// Unused
-            pub const LOGICAL_OPERATOR_UNSPECIFIED: LogicalOperator =
-                LogicalOperator::new("LOGICAL_OPERATOR_UNSPECIFIED");
-
-            /// Conditional AND
-            pub const AND: LogicalOperator = LogicalOperator::new("AND");
-        }
-
-        impl std::convert::From<std::string::String> for LogicalOperator {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for LogicalOperator {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for LogicalOperator {
             fn default() -> Self {
-                logical_operator::LOGICAL_OPERATOR_UNSPECIFIED
+                Self::new(0)
             }
         }
 
@@ -11207,44 +11504,61 @@ pub mod transformation_summary {
 
     /// Possible outcomes of transformations.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TransformationResultCode(std::borrow::Cow<'static, str>);
+    pub struct TransformationResultCode(i32);
 
     impl TransformationResultCode {
+        /// Unused
+        pub const TRANSFORMATION_RESULT_CODE_UNSPECIFIED: TransformationResultCode =
+            TransformationResultCode::new(0);
+
+        /// Transformation completed without an error.
+        pub const SUCCESS: TransformationResultCode = TransformationResultCode::new(1);
+
+        /// Transformation had an error.
+        pub const ERROR: TransformationResultCode = TransformationResultCode::new(2);
+
         /// Creates a new TransformationResultCode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TRANSFORMATION_RESULT_CODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SUCCESS"),
+                2 => std::borrow::Cow::Borrowed("ERROR"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TRANSFORMATION_RESULT_CODE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::TRANSFORMATION_RESULT_CODE_UNSPECIFIED)
+                }
+                "SUCCESS" => std::option::Option::Some(Self::SUCCESS),
+                "ERROR" => std::option::Option::Some(Self::ERROR),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [TransformationResultCode](TransformationResultCode)
-    pub mod transformation_result_code {
-        use super::TransformationResultCode;
-
-        /// Unused
-        pub const TRANSFORMATION_RESULT_CODE_UNSPECIFIED: TransformationResultCode =
-            TransformationResultCode::new("TRANSFORMATION_RESULT_CODE_UNSPECIFIED");
-
-        /// Transformation completed without an error.
-        pub const SUCCESS: TransformationResultCode = TransformationResultCode::new("SUCCESS");
-
-        /// Transformation had an error.
-        pub const ERROR: TransformationResultCode = TransformationResultCode::new("ERROR");
-    }
-
-    impl std::convert::From<std::string::String> for TransformationResultCode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TransformationResultCode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TransformationResultCode {
         fn default() -> Self {
-            transformation_result_code::TRANSFORMATION_RESULT_CODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -12118,46 +12432,62 @@ pub mod error {
 
     /// Additional information about the error.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ErrorExtraInfo(std::borrow::Cow<'static, str>);
+    pub struct ErrorExtraInfo(i32);
 
     impl ErrorExtraInfo {
+        /// Unused.
+        pub const ERROR_INFO_UNSPECIFIED: ErrorExtraInfo = ErrorExtraInfo::new(0);
+
+        /// Image scan is not available in the region.
+        pub const IMAGE_SCAN_UNAVAILABLE_IN_REGION: ErrorExtraInfo = ErrorExtraInfo::new(1);
+
+        /// File store cluster is not supported for profile generation.
+        pub const FILE_STORE_CLUSTER_UNSUPPORTED: ErrorExtraInfo = ErrorExtraInfo::new(2);
+
         /// Creates a new ErrorExtraInfo instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ERROR_INFO_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IMAGE_SCAN_UNAVAILABLE_IN_REGION"),
+                2 => std::borrow::Cow::Borrowed("FILE_STORE_CLUSTER_UNSUPPORTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ERROR_INFO_UNSPECIFIED" => std::option::Option::Some(Self::ERROR_INFO_UNSPECIFIED),
+                "IMAGE_SCAN_UNAVAILABLE_IN_REGION" => {
+                    std::option::Option::Some(Self::IMAGE_SCAN_UNAVAILABLE_IN_REGION)
+                }
+                "FILE_STORE_CLUSTER_UNSUPPORTED" => {
+                    std::option::Option::Some(Self::FILE_STORE_CLUSTER_UNSUPPORTED)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ErrorExtraInfo](ErrorExtraInfo)
-    pub mod error_extra_info {
-        use super::ErrorExtraInfo;
-
-        /// Unused.
-        pub const ERROR_INFO_UNSPECIFIED: ErrorExtraInfo =
-            ErrorExtraInfo::new("ERROR_INFO_UNSPECIFIED");
-
-        /// Image scan is not available in the region.
-        pub const IMAGE_SCAN_UNAVAILABLE_IN_REGION: ErrorExtraInfo =
-            ErrorExtraInfo::new("IMAGE_SCAN_UNAVAILABLE_IN_REGION");
-
-        /// File store cluster is not supported for profile generation.
-        pub const FILE_STORE_CLUSTER_UNSUPPORTED: ErrorExtraInfo =
-            ErrorExtraInfo::new("FILE_STORE_CLUSTER_UNSUPPORTED");
-    }
-
-    impl std::convert::From<std::string::String> for ErrorExtraInfo {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ErrorExtraInfo {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ErrorExtraInfo {
         fn default() -> Self {
-            error_extra_info::ERROR_INFO_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -12462,46 +12792,63 @@ pub mod job_trigger {
     /// pause triggers experiencing frequent errors. To restart a job, set the
     /// status to HEALTHY after correcting user errors.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(std::borrow::Cow<'static, str>);
+    pub struct Status(i32);
 
     impl Status {
+        /// Unused.
+        pub const STATUS_UNSPECIFIED: Status = Status::new(0);
+
+        /// Trigger is healthy.
+        pub const HEALTHY: Status = Status::new(1);
+
+        /// Trigger is temporarily paused.
+        pub const PAUSED: Status = Status::new(2);
+
+        /// Trigger is cancelled and can not be resumed.
+        pub const CANCELLED: Status = Status::new(3);
+
         /// Creates a new Status instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATUS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("HEALTHY"),
+                2 => std::borrow::Cow::Borrowed("PAUSED"),
+                3 => std::borrow::Cow::Borrowed("CANCELLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATUS_UNSPECIFIED" => std::option::Option::Some(Self::STATUS_UNSPECIFIED),
+                "HEALTHY" => std::option::Option::Some(Self::HEALTHY),
+                "PAUSED" => std::option::Option::Some(Self::PAUSED),
+                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Status](Status)
-    pub mod status {
-        use super::Status;
-
-        /// Unused.
-        pub const STATUS_UNSPECIFIED: Status = Status::new("STATUS_UNSPECIFIED");
-
-        /// Trigger is healthy.
-        pub const HEALTHY: Status = Status::new("HEALTHY");
-
-        /// Trigger is temporarily paused.
-        pub const PAUSED: Status = Status::new("PAUSED");
-
-        /// Trigger is cancelled and can not be resumed.
-        pub const CANCELLED: Status = Status::new("CANCELLED");
-    }
-
-    impl std::convert::From<std::string::String> for Status {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            status::STATUS_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -14929,47 +15276,65 @@ pub mod data_profile_action {
 
         /// The levels of detail that can be included in the Pub/Sub message.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct DetailLevel(std::borrow::Cow<'static, str>);
+        pub struct DetailLevel(i32);
 
         impl DetailLevel {
+            /// Unused.
+            pub const DETAIL_LEVEL_UNSPECIFIED: DetailLevel = DetailLevel::new(0);
+
+            /// The full table data profile.
+            pub const TABLE_PROFILE: DetailLevel = DetailLevel::new(1);
+
+            /// The name of the profiled resource.
+            pub const RESOURCE_NAME: DetailLevel = DetailLevel::new(2);
+
+            /// The full file store data profile.
+            pub const FILE_STORE_PROFILE: DetailLevel = DetailLevel::new(3);
+
             /// Creates a new DetailLevel instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("DETAIL_LEVEL_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("TABLE_PROFILE"),
+                    2 => std::borrow::Cow::Borrowed("RESOURCE_NAME"),
+                    3 => std::borrow::Cow::Borrowed("FILE_STORE_PROFILE"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "DETAIL_LEVEL_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::DETAIL_LEVEL_UNSPECIFIED)
+                    }
+                    "TABLE_PROFILE" => std::option::Option::Some(Self::TABLE_PROFILE),
+                    "RESOURCE_NAME" => std::option::Option::Some(Self::RESOURCE_NAME),
+                    "FILE_STORE_PROFILE" => std::option::Option::Some(Self::FILE_STORE_PROFILE),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [DetailLevel](DetailLevel)
-        pub mod detail_level {
-            use super::DetailLevel;
-
-            /// Unused.
-            pub const DETAIL_LEVEL_UNSPECIFIED: DetailLevel =
-                DetailLevel::new("DETAIL_LEVEL_UNSPECIFIED");
-
-            /// The full table data profile.
-            pub const TABLE_PROFILE: DetailLevel = DetailLevel::new("TABLE_PROFILE");
-
-            /// The name of the profiled resource.
-            pub const RESOURCE_NAME: DetailLevel = DetailLevel::new("RESOURCE_NAME");
-
-            /// The full file store data profile.
-            pub const FILE_STORE_PROFILE: DetailLevel = DetailLevel::new("FILE_STORE_PROFILE");
-        }
-
-        impl std::convert::From<std::string::String> for DetailLevel {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for DetailLevel {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for DetailLevel {
             fn default() -> Self {
-                detail_level::DETAIL_LEVEL_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -15289,51 +15654,70 @@ pub mod data_profile_action {
 
     /// Types of event that can trigger an action.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EventType(std::borrow::Cow<'static, str>);
+    pub struct EventType(i32);
 
     impl EventType {
-        /// Creates a new EventType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [EventType](EventType)
-    pub mod event_type {
-        use super::EventType;
-
         /// Unused.
-        pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new("EVENT_TYPE_UNSPECIFIED");
+        pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new(0);
 
         /// New profile (not a re-profile).
-        pub const NEW_PROFILE: EventType = EventType::new("NEW_PROFILE");
+        pub const NEW_PROFILE: EventType = EventType::new(1);
 
         /// One of the following profile metrics changed: Data risk score,
         /// Sensitivity score, Resource visibility, Encryption type, Predicted
         /// infoTypes, Other infoTypes
-        pub const CHANGED_PROFILE: EventType = EventType::new("CHANGED_PROFILE");
+        pub const CHANGED_PROFILE: EventType = EventType::new(2);
 
         /// Table data risk score or sensitivity score increased.
-        pub const SCORE_INCREASED: EventType = EventType::new("SCORE_INCREASED");
+        pub const SCORE_INCREASED: EventType = EventType::new(3);
 
         /// A user (non-internal) error occurred.
-        pub const ERROR_CHANGED: EventType = EventType::new("ERROR_CHANGED");
+        pub const ERROR_CHANGED: EventType = EventType::new(4);
+
+        /// Creates a new EventType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EVENT_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NEW_PROFILE"),
+                2 => std::borrow::Cow::Borrowed("CHANGED_PROFILE"),
+                3 => std::borrow::Cow::Borrowed("SCORE_INCREASED"),
+                4 => std::borrow::Cow::Borrowed("ERROR_CHANGED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EVENT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::EVENT_TYPE_UNSPECIFIED),
+                "NEW_PROFILE" => std::option::Option::Some(Self::NEW_PROFILE),
+                "CHANGED_PROFILE" => std::option::Option::Some(Self::CHANGED_PROFILE),
+                "SCORE_INCREASED" => std::option::Option::Some(Self::SCORE_INCREASED),
+                "ERROR_CHANGED" => std::option::Option::Some(Self::ERROR_CHANGED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for EventType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EventType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EventType {
         fn default() -> Self {
-            event_type::EVENT_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -16001,43 +16385,58 @@ pub mod discovery_config {
     /// Whether the discovery config is currently active. New options may be added
     /// at a later time.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(std::borrow::Cow<'static, str>);
+    pub struct Status(i32);
 
     impl Status {
+        /// Unused
+        pub const STATUS_UNSPECIFIED: Status = Status::new(0);
+
+        /// The discovery config is currently active.
+        pub const RUNNING: Status = Status::new(1);
+
+        /// The discovery config is paused temporarily.
+        pub const PAUSED: Status = Status::new(2);
+
         /// Creates a new Status instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATUS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RUNNING"),
+                2 => std::borrow::Cow::Borrowed("PAUSED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATUS_UNSPECIFIED" => std::option::Option::Some(Self::STATUS_UNSPECIFIED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "PAUSED" => std::option::Option::Some(Self::PAUSED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Status](Status)
-    pub mod status {
-        use super::Status;
-
-        /// Unused
-        pub const STATUS_UNSPECIFIED: Status = Status::new("STATUS_UNSPECIFIED");
-
-        /// The discovery config is currently active.
-        pub const RUNNING: Status = Status::new("RUNNING");
-
-        /// The discovery config is paused temporarily.
-        pub const PAUSED: Status = Status::new("PAUSED");
-    }
-
-    impl std::convert::From<std::string::String> for Status {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            status::STATUS_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -17796,93 +18195,132 @@ pub mod discovery_cloud_sql_conditions {
 
     /// The database engines that should be profiled.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DatabaseEngine(std::borrow::Cow<'static, str>);
+    pub struct DatabaseEngine(i32);
 
     impl DatabaseEngine {
+        /// Unused.
+        pub const DATABASE_ENGINE_UNSPECIFIED: DatabaseEngine = DatabaseEngine::new(0);
+
+        /// Include all supported database engines.
+        pub const ALL_SUPPORTED_DATABASE_ENGINES: DatabaseEngine = DatabaseEngine::new(1);
+
+        /// MySQL database.
+        pub const MYSQL: DatabaseEngine = DatabaseEngine::new(2);
+
+        /// PostgreSQL database.
+        pub const POSTGRES: DatabaseEngine = DatabaseEngine::new(3);
+
         /// Creates a new DatabaseEngine instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATABASE_ENGINE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALL_SUPPORTED_DATABASE_ENGINES"),
+                2 => std::borrow::Cow::Borrowed("MYSQL"),
+                3 => std::borrow::Cow::Borrowed("POSTGRES"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATABASE_ENGINE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DATABASE_ENGINE_UNSPECIFIED)
+                }
+                "ALL_SUPPORTED_DATABASE_ENGINES" => {
+                    std::option::Option::Some(Self::ALL_SUPPORTED_DATABASE_ENGINES)
+                }
+                "MYSQL" => std::option::Option::Some(Self::MYSQL),
+                "POSTGRES" => std::option::Option::Some(Self::POSTGRES),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DatabaseEngine](DatabaseEngine)
-    pub mod database_engine {
-        use super::DatabaseEngine;
-
-        /// Unused.
-        pub const DATABASE_ENGINE_UNSPECIFIED: DatabaseEngine =
-            DatabaseEngine::new("DATABASE_ENGINE_UNSPECIFIED");
-
-        /// Include all supported database engines.
-        pub const ALL_SUPPORTED_DATABASE_ENGINES: DatabaseEngine =
-            DatabaseEngine::new("ALL_SUPPORTED_DATABASE_ENGINES");
-
-        /// MySQL database.
-        pub const MYSQL: DatabaseEngine = DatabaseEngine::new("MYSQL");
-
-        /// PostgreSQL database.
-        pub const POSTGRES: DatabaseEngine = DatabaseEngine::new("POSTGRES");
-    }
-
-    impl std::convert::From<std::string::String> for DatabaseEngine {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DatabaseEngine {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DatabaseEngine {
         fn default() -> Self {
-            database_engine::DATABASE_ENGINE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Cloud SQL database resource types. New values can be added at a later time.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DatabaseResourceType(std::borrow::Cow<'static, str>);
+    pub struct DatabaseResourceType(i32);
 
     impl DatabaseResourceType {
-        /// Creates a new DatabaseResourceType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DatabaseResourceType](DatabaseResourceType)
-    pub mod database_resource_type {
-        use super::DatabaseResourceType;
-
         /// Unused.
         pub const DATABASE_RESOURCE_TYPE_UNSPECIFIED: DatabaseResourceType =
-            DatabaseResourceType::new("DATABASE_RESOURCE_TYPE_UNSPECIFIED");
+            DatabaseResourceType::new(0);
 
         /// Includes database resource types that become supported at a later time.
         pub const DATABASE_RESOURCE_TYPE_ALL_SUPPORTED_TYPES: DatabaseResourceType =
-            DatabaseResourceType::new("DATABASE_RESOURCE_TYPE_ALL_SUPPORTED_TYPES");
+            DatabaseResourceType::new(1);
 
         /// Tables.
-        pub const DATABASE_RESOURCE_TYPE_TABLE: DatabaseResourceType =
-            DatabaseResourceType::new("DATABASE_RESOURCE_TYPE_TABLE");
+        pub const DATABASE_RESOURCE_TYPE_TABLE: DatabaseResourceType = DatabaseResourceType::new(2);
+
+        /// Creates a new DatabaseResourceType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATABASE_RESOURCE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DATABASE_RESOURCE_TYPE_ALL_SUPPORTED_TYPES"),
+                2 => std::borrow::Cow::Borrowed("DATABASE_RESOURCE_TYPE_TABLE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATABASE_RESOURCE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DATABASE_RESOURCE_TYPE_UNSPECIFIED)
+                }
+                "DATABASE_RESOURCE_TYPE_ALL_SUPPORTED_TYPES" => {
+                    std::option::Option::Some(Self::DATABASE_RESOURCE_TYPE_ALL_SUPPORTED_TYPES)
+                }
+                "DATABASE_RESOURCE_TYPE_TABLE" => {
+                    std::option::Option::Some(Self::DATABASE_RESOURCE_TYPE_TABLE)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DatabaseResourceType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DatabaseResourceType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DatabaseResourceType {
         fn default() -> Self {
-            database_resource_type::DATABASE_RESOURCE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -18027,46 +18465,62 @@ pub mod discovery_cloud_sql_generation_cadence {
 
         /// The type of modification that causes a profile update.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct CloudSqlSchemaModification(std::borrow::Cow<'static, str>);
+        pub struct CloudSqlSchemaModification(i32);
 
         impl CloudSqlSchemaModification {
-            /// Creates a new CloudSqlSchemaModification instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
-            }
-        }
-
-        /// Useful constants to work with [CloudSqlSchemaModification](CloudSqlSchemaModification)
-        pub mod cloud_sql_schema_modification {
-            use super::CloudSqlSchemaModification;
-
             /// Unused.
             pub const SQL_SCHEMA_MODIFICATION_UNSPECIFIED: CloudSqlSchemaModification =
-                CloudSqlSchemaModification::new("SQL_SCHEMA_MODIFICATION_UNSPECIFIED");
+                CloudSqlSchemaModification::new(0);
 
             /// New columns have appeared.
-            pub const NEW_COLUMNS: CloudSqlSchemaModification =
-                CloudSqlSchemaModification::new("NEW_COLUMNS");
+            pub const NEW_COLUMNS: CloudSqlSchemaModification = CloudSqlSchemaModification::new(1);
 
             /// Columns have been removed from the table.
             pub const REMOVED_COLUMNS: CloudSqlSchemaModification =
-                CloudSqlSchemaModification::new("REMOVED_COLUMNS");
+                CloudSqlSchemaModification::new(2);
+
+            /// Creates a new CloudSqlSchemaModification instance.
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
+            }
+
+            /// Gets the enum value.
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("SQL_SCHEMA_MODIFICATION_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("NEW_COLUMNS"),
+                    2 => std::borrow::Cow::Borrowed("REMOVED_COLUMNS"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "SQL_SCHEMA_MODIFICATION_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::SQL_SCHEMA_MODIFICATION_UNSPECIFIED)
+                    }
+                    "NEW_COLUMNS" => std::option::Option::Some(Self::NEW_COLUMNS),
+                    "REMOVED_COLUMNS" => std::option::Option::Some(Self::REMOVED_COLUMNS),
+                    _ => std::option::Option::None,
+                }
+            }
         }
 
-        impl std::convert::From<std::string::String> for CloudSqlSchemaModification {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for CloudSqlSchemaModification {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for CloudSqlSchemaModification {
             fn default() -> Self {
-                cloud_sql_schema_modification::SQL_SCHEMA_MODIFICATION_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
@@ -18837,128 +19291,172 @@ pub mod discovery_cloud_storage_conditions {
     /// <https://cloud.google.com/storage/docs/storage-classes> for more information
     /// on storage classes.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CloudStorageObjectAttribute(std::borrow::Cow<'static, str>);
+    pub struct CloudStorageObjectAttribute(i32);
 
     impl CloudStorageObjectAttribute {
-        /// Creates a new CloudStorageObjectAttribute instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CloudStorageObjectAttribute](CloudStorageObjectAttribute)
-    pub mod cloud_storage_object_attribute {
-        use super::CloudStorageObjectAttribute;
-
         /// Unused.
         pub const CLOUD_STORAGE_OBJECT_ATTRIBUTE_UNSPECIFIED: CloudStorageObjectAttribute =
-            CloudStorageObjectAttribute::new("CLOUD_STORAGE_OBJECT_ATTRIBUTE_UNSPECIFIED");
+            CloudStorageObjectAttribute::new(0);
 
         /// Scan objects regardless of the attribute.
         pub const ALL_SUPPORTED_OBJECTS: CloudStorageObjectAttribute =
-            CloudStorageObjectAttribute::new("ALL_SUPPORTED_OBJECTS");
+            CloudStorageObjectAttribute::new(1);
 
         /// Scan objects with the standard storage class.
-        pub const STANDARD: CloudStorageObjectAttribute =
-            CloudStorageObjectAttribute::new("STANDARD");
+        pub const STANDARD: CloudStorageObjectAttribute = CloudStorageObjectAttribute::new(2);
 
         /// Scan objects with the nearline storage class. This will incur retrieval
         /// fees.
-        pub const NEARLINE: CloudStorageObjectAttribute =
-            CloudStorageObjectAttribute::new("NEARLINE");
+        pub const NEARLINE: CloudStorageObjectAttribute = CloudStorageObjectAttribute::new(3);
 
         /// Scan objects with the coldline storage class. This will incur retrieval
         /// fees.
-        pub const COLDLINE: CloudStorageObjectAttribute =
-            CloudStorageObjectAttribute::new("COLDLINE");
+        pub const COLDLINE: CloudStorageObjectAttribute = CloudStorageObjectAttribute::new(4);
 
         /// Scan objects with the archive storage class. This will incur retrieval
         /// fees.
-        pub const ARCHIVE: CloudStorageObjectAttribute =
-            CloudStorageObjectAttribute::new("ARCHIVE");
+        pub const ARCHIVE: CloudStorageObjectAttribute = CloudStorageObjectAttribute::new(5);
 
         /// Scan objects with the regional storage class.
-        pub const REGIONAL: CloudStorageObjectAttribute =
-            CloudStorageObjectAttribute::new("REGIONAL");
+        pub const REGIONAL: CloudStorageObjectAttribute = CloudStorageObjectAttribute::new(6);
 
         /// Scan objects with the multi-regional storage class.
-        pub const MULTI_REGIONAL: CloudStorageObjectAttribute =
-            CloudStorageObjectAttribute::new("MULTI_REGIONAL");
+        pub const MULTI_REGIONAL: CloudStorageObjectAttribute = CloudStorageObjectAttribute::new(7);
 
         /// Scan objects with the dual-regional storage class. This will incur
         /// retrieval fees.
         pub const DURABLE_REDUCED_AVAILABILITY: CloudStorageObjectAttribute =
-            CloudStorageObjectAttribute::new("DURABLE_REDUCED_AVAILABILITY");
+            CloudStorageObjectAttribute::new(8);
+
+        /// Creates a new CloudStorageObjectAttribute instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CLOUD_STORAGE_OBJECT_ATTRIBUTE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALL_SUPPORTED_OBJECTS"),
+                2 => std::borrow::Cow::Borrowed("STANDARD"),
+                3 => std::borrow::Cow::Borrowed("NEARLINE"),
+                4 => std::borrow::Cow::Borrowed("COLDLINE"),
+                5 => std::borrow::Cow::Borrowed("ARCHIVE"),
+                6 => std::borrow::Cow::Borrowed("REGIONAL"),
+                7 => std::borrow::Cow::Borrowed("MULTI_REGIONAL"),
+                8 => std::borrow::Cow::Borrowed("DURABLE_REDUCED_AVAILABILITY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CLOUD_STORAGE_OBJECT_ATTRIBUTE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CLOUD_STORAGE_OBJECT_ATTRIBUTE_UNSPECIFIED)
+                }
+                "ALL_SUPPORTED_OBJECTS" => std::option::Option::Some(Self::ALL_SUPPORTED_OBJECTS),
+                "STANDARD" => std::option::Option::Some(Self::STANDARD),
+                "NEARLINE" => std::option::Option::Some(Self::NEARLINE),
+                "COLDLINE" => std::option::Option::Some(Self::COLDLINE),
+                "ARCHIVE" => std::option::Option::Some(Self::ARCHIVE),
+                "REGIONAL" => std::option::Option::Some(Self::REGIONAL),
+                "MULTI_REGIONAL" => std::option::Option::Some(Self::MULTI_REGIONAL),
+                "DURABLE_REDUCED_AVAILABILITY" => {
+                    std::option::Option::Some(Self::DURABLE_REDUCED_AVAILABILITY)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CloudStorageObjectAttribute {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CloudStorageObjectAttribute {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CloudStorageObjectAttribute {
         fn default() -> Self {
-            cloud_storage_object_attribute::CLOUD_STORAGE_OBJECT_ATTRIBUTE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The attribute of a bucket.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CloudStorageBucketAttribute(std::borrow::Cow<'static, str>);
+    pub struct CloudStorageBucketAttribute(i32);
 
     impl CloudStorageBucketAttribute {
-        /// Creates a new CloudStorageBucketAttribute instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CloudStorageBucketAttribute](CloudStorageBucketAttribute)
-    pub mod cloud_storage_bucket_attribute {
-        use super::CloudStorageBucketAttribute;
-
         /// Unused.
         pub const CLOUD_STORAGE_BUCKET_ATTRIBUTE_UNSPECIFIED: CloudStorageBucketAttribute =
-            CloudStorageBucketAttribute::new("CLOUD_STORAGE_BUCKET_ATTRIBUTE_UNSPECIFIED");
+            CloudStorageBucketAttribute::new(0);
 
         /// Scan buckets regardless of the attribute.
         pub const ALL_SUPPORTED_BUCKETS: CloudStorageBucketAttribute =
-            CloudStorageBucketAttribute::new("ALL_SUPPORTED_BUCKETS");
+            CloudStorageBucketAttribute::new(1);
 
         /// Buckets with [Autoclass](https://cloud.google.com/storage/docs/autoclass)
         /// disabled. Only one of
         /// AUTOCLASS_DISABLED or AUTOCLASS_ENABLED should be set.
         pub const AUTOCLASS_DISABLED: CloudStorageBucketAttribute =
-            CloudStorageBucketAttribute::new("AUTOCLASS_DISABLED");
+            CloudStorageBucketAttribute::new(2);
 
         /// Buckets with [Autoclass](https://cloud.google.com/storage/docs/autoclass)
         /// enabled. Only one of
         /// AUTOCLASS_DISABLED or AUTOCLASS_ENABLED should be set. Scanning
         /// Autoclass-enabled buckets can affect object storage classes.
         pub const AUTOCLASS_ENABLED: CloudStorageBucketAttribute =
-            CloudStorageBucketAttribute::new("AUTOCLASS_ENABLED");
+            CloudStorageBucketAttribute::new(3);
+
+        /// Creates a new CloudStorageBucketAttribute instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CLOUD_STORAGE_BUCKET_ATTRIBUTE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALL_SUPPORTED_BUCKETS"),
+                2 => std::borrow::Cow::Borrowed("AUTOCLASS_DISABLED"),
+                3 => std::borrow::Cow::Borrowed("AUTOCLASS_ENABLED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CLOUD_STORAGE_BUCKET_ATTRIBUTE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::CLOUD_STORAGE_BUCKET_ATTRIBUTE_UNSPECIFIED)
+                }
+                "ALL_SUPPORTED_BUCKETS" => std::option::Option::Some(Self::ALL_SUPPORTED_BUCKETS),
+                "AUTOCLASS_DISABLED" => std::option::Option::Some(Self::AUTOCLASS_DISABLED),
+                "AUTOCLASS_ENABLED" => std::option::Option::Some(Self::AUTOCLASS_ENABLED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CloudStorageBucketAttribute {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CloudStorageBucketAttribute {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CloudStorageBucketAttribute {
         fn default() -> Self {
-            cloud_storage_bucket_attribute::CLOUD_STORAGE_BUCKET_ATTRIBUTE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -20006,99 +20504,135 @@ pub mod amazon_s_3_bucket_conditions {
     /// Supported Amazon S3 bucket types.
     /// Defaults to TYPE_ALL_SUPPORTED.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BucketType(std::borrow::Cow<'static, str>);
+    pub struct BucketType(i32);
 
     impl BucketType {
+        /// Unused.
+        pub const TYPE_UNSPECIFIED: BucketType = BucketType::new(0);
+
+        /// All supported classes.
+        pub const TYPE_ALL_SUPPORTED: BucketType = BucketType::new(1);
+
+        /// A general purpose Amazon S3 bucket.
+        pub const TYPE_GENERAL_PURPOSE: BucketType = BucketType::new(2);
+
         /// Creates a new BucketType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TYPE_ALL_SUPPORTED"),
+                2 => std::borrow::Cow::Borrowed("TYPE_GENERAL_PURPOSE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "TYPE_ALL_SUPPORTED" => std::option::Option::Some(Self::TYPE_ALL_SUPPORTED),
+                "TYPE_GENERAL_PURPOSE" => std::option::Option::Some(Self::TYPE_GENERAL_PURPOSE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [BucketType](BucketType)
-    pub mod bucket_type {
-        use super::BucketType;
-
-        /// Unused.
-        pub const TYPE_UNSPECIFIED: BucketType = BucketType::new("TYPE_UNSPECIFIED");
-
-        /// All supported classes.
-        pub const TYPE_ALL_SUPPORTED: BucketType = BucketType::new("TYPE_ALL_SUPPORTED");
-
-        /// A general purpose Amazon S3 bucket.
-        pub const TYPE_GENERAL_PURPOSE: BucketType = BucketType::new("TYPE_GENERAL_PURPOSE");
-    }
-
-    impl std::convert::From<std::string::String> for BucketType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for BucketType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for BucketType {
         fn default() -> Self {
-            bucket_type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Supported Amazon S3 object storage classes.
     /// Defaults to ALL_SUPPORTED_CLASSES.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ObjectStorageClass(std::borrow::Cow<'static, str>);
+    pub struct ObjectStorageClass(i32);
 
     impl ObjectStorageClass {
+        /// Unused.
+        pub const UNSPECIFIED: ObjectStorageClass = ObjectStorageClass::new(0);
+
+        /// All supported classes.
+        pub const ALL_SUPPORTED_CLASSES: ObjectStorageClass = ObjectStorageClass::new(1);
+
+        /// Standard object class.
+        pub const STANDARD: ObjectStorageClass = ObjectStorageClass::new(2);
+
+        /// Standard - infrequent access object class.
+        pub const STANDARD_INFREQUENT_ACCESS: ObjectStorageClass = ObjectStorageClass::new(4);
+
+        /// Glacier - instant retrieval object class.
+        pub const GLACIER_INSTANT_RETRIEVAL: ObjectStorageClass = ObjectStorageClass::new(6);
+
+        /// Objects in the S3 Intelligent-Tiering access tiers.
+        pub const INTELLIGENT_TIERING: ObjectStorageClass = ObjectStorageClass::new(7);
+
         /// Creates a new ObjectStorageClass instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ALL_SUPPORTED_CLASSES"),
+                2 => std::borrow::Cow::Borrowed("STANDARD"),
+                4 => std::borrow::Cow::Borrowed("STANDARD_INFREQUENT_ACCESS"),
+                6 => std::borrow::Cow::Borrowed("GLACIER_INSTANT_RETRIEVAL"),
+                7 => std::borrow::Cow::Borrowed("INTELLIGENT_TIERING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
+                "ALL_SUPPORTED_CLASSES" => std::option::Option::Some(Self::ALL_SUPPORTED_CLASSES),
+                "STANDARD" => std::option::Option::Some(Self::STANDARD),
+                "STANDARD_INFREQUENT_ACCESS" => {
+                    std::option::Option::Some(Self::STANDARD_INFREQUENT_ACCESS)
+                }
+                "GLACIER_INSTANT_RETRIEVAL" => {
+                    std::option::Option::Some(Self::GLACIER_INSTANT_RETRIEVAL)
+                }
+                "INTELLIGENT_TIERING" => std::option::Option::Some(Self::INTELLIGENT_TIERING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ObjectStorageClass](ObjectStorageClass)
-    pub mod object_storage_class {
-        use super::ObjectStorageClass;
-
-        /// Unused.
-        pub const UNSPECIFIED: ObjectStorageClass = ObjectStorageClass::new("UNSPECIFIED");
-
-        /// All supported classes.
-        pub const ALL_SUPPORTED_CLASSES: ObjectStorageClass =
-            ObjectStorageClass::new("ALL_SUPPORTED_CLASSES");
-
-        /// Standard object class.
-        pub const STANDARD: ObjectStorageClass = ObjectStorageClass::new("STANDARD");
-
-        /// Standard - infrequent access object class.
-        pub const STANDARD_INFREQUENT_ACCESS: ObjectStorageClass =
-            ObjectStorageClass::new("STANDARD_INFREQUENT_ACCESS");
-
-        /// Glacier - instant retrieval object class.
-        pub const GLACIER_INSTANT_RETRIEVAL: ObjectStorageClass =
-            ObjectStorageClass::new("GLACIER_INSTANT_RETRIEVAL");
-
-        /// Objects in the S3 Intelligent-Tiering access tiers.
-        pub const INTELLIGENT_TIERING: ObjectStorageClass =
-            ObjectStorageClass::new("INTELLIGENT_TIERING");
-    }
-
-    impl std::convert::From<std::string::String> for ObjectStorageClass {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ObjectStorageClass {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ObjectStorageClass {
         fn default() -> Self {
-            object_storage_class::UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -21308,59 +21842,82 @@ pub mod dlp_job {
 
     /// Possible states of a job. New items may be added.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct JobState(std::borrow::Cow<'static, str>);
+    pub struct JobState(i32);
 
     impl JobState {
-        /// Creates a new JobState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [JobState](JobState)
-    pub mod job_state {
-        use super::JobState;
-
         /// Unused.
-        pub const JOB_STATE_UNSPECIFIED: JobState = JobState::new("JOB_STATE_UNSPECIFIED");
+        pub const JOB_STATE_UNSPECIFIED: JobState = JobState::new(0);
 
         /// The job has not yet started.
-        pub const PENDING: JobState = JobState::new("PENDING");
+        pub const PENDING: JobState = JobState::new(1);
 
         /// The job is currently running. Once a job has finished it will transition
         /// to FAILED or DONE.
-        pub const RUNNING: JobState = JobState::new("RUNNING");
+        pub const RUNNING: JobState = JobState::new(2);
 
         /// The job is no longer running.
-        pub const DONE: JobState = JobState::new("DONE");
+        pub const DONE: JobState = JobState::new(3);
 
         /// The job was canceled before it could be completed.
-        pub const CANCELED: JobState = JobState::new("CANCELED");
+        pub const CANCELED: JobState = JobState::new(4);
 
         /// The job had an error and did not complete.
-        pub const FAILED: JobState = JobState::new("FAILED");
+        pub const FAILED: JobState = JobState::new(5);
 
         /// The job is currently accepting findings via hybridInspect.
         /// A hybrid job in ACTIVE state may continue to have findings added to it
         /// through the calling of hybridInspect. After the job has finished no more
         /// calls to hybridInspect may be made. ACTIVE jobs can transition to DONE.
-        pub const ACTIVE: JobState = JobState::new("ACTIVE");
+        pub const ACTIVE: JobState = JobState::new(6);
+
+        /// Creates a new JobState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("JOB_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PENDING"),
+                2 => std::borrow::Cow::Borrowed("RUNNING"),
+                3 => std::borrow::Cow::Borrowed("DONE"),
+                4 => std::borrow::Cow::Borrowed("CANCELED"),
+                5 => std::borrow::Cow::Borrowed("FAILED"),
+                6 => std::borrow::Cow::Borrowed("ACTIVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "JOB_STATE_UNSPECIFIED" => std::option::Option::Some(Self::JOB_STATE_UNSPECIFIED),
+                "PENDING" => std::option::Option::Some(Self::PENDING),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "DONE" => std::option::Option::Some(Self::DONE),
+                "CANCELED" => std::option::Option::Some(Self::CANCELED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for JobState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for JobState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for JobState {
         fn default() -> Self {
-            job_state::JOB_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -23843,56 +24400,74 @@ pub mod data_risk_level {
 
     /// Various score levels for resources.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataRiskLevelScore(std::borrow::Cow<'static, str>);
+    pub struct DataRiskLevelScore(i32);
 
     impl DataRiskLevelScore {
-        /// Creates a new DataRiskLevelScore instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DataRiskLevelScore](DataRiskLevelScore)
-    pub mod data_risk_level_score {
-        use super::DataRiskLevelScore;
-
         /// Unused.
-        pub const RISK_SCORE_UNSPECIFIED: DataRiskLevelScore =
-            DataRiskLevelScore::new("RISK_SCORE_UNSPECIFIED");
+        pub const RISK_SCORE_UNSPECIFIED: DataRiskLevelScore = DataRiskLevelScore::new(0);
 
         /// Low risk - Lower indication of sensitive data that appears to have
         /// additional access restrictions in place or no indication of sensitive
         /// data found.
-        pub const RISK_LOW: DataRiskLevelScore = DataRiskLevelScore::new("RISK_LOW");
+        pub const RISK_LOW: DataRiskLevelScore = DataRiskLevelScore::new(10);
 
         /// Unable to determine risk.
-        pub const RISK_UNKNOWN: DataRiskLevelScore = DataRiskLevelScore::new("RISK_UNKNOWN");
+        pub const RISK_UNKNOWN: DataRiskLevelScore = DataRiskLevelScore::new(12);
 
         /// Medium risk - Sensitive data may be present but additional access or fine
         /// grain access restrictions appear to be present.  Consider limiting
         /// access even further or transform data to mask.
-        pub const RISK_MODERATE: DataRiskLevelScore = DataRiskLevelScore::new("RISK_MODERATE");
+        pub const RISK_MODERATE: DataRiskLevelScore = DataRiskLevelScore::new(20);
 
         /// High risk – SPII may be present. Access controls may include public
         /// ACLs. Exfiltration of data may lead to user data loss. Re-identification
         /// of users may be possible. Consider limiting usage and or removing SPII.
-        pub const RISK_HIGH: DataRiskLevelScore = DataRiskLevelScore::new("RISK_HIGH");
+        pub const RISK_HIGH: DataRiskLevelScore = DataRiskLevelScore::new(30);
+
+        /// Creates a new DataRiskLevelScore instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RISK_SCORE_UNSPECIFIED"),
+                10 => std::borrow::Cow::Borrowed("RISK_LOW"),
+                12 => std::borrow::Cow::Borrowed("RISK_UNKNOWN"),
+                20 => std::borrow::Cow::Borrowed("RISK_MODERATE"),
+                30 => std::borrow::Cow::Borrowed("RISK_HIGH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RISK_SCORE_UNSPECIFIED" => std::option::Option::Some(Self::RISK_SCORE_UNSPECIFIED),
+                "RISK_LOW" => std::option::Option::Some(Self::RISK_LOW),
+                "RISK_UNKNOWN" => std::option::Option::Some(Self::RISK_UNKNOWN),
+                "RISK_MODERATE" => std::option::Option::Some(Self::RISK_MODERATE),
+                "RISK_HIGH" => std::option::Option::Some(Self::RISK_HIGH),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DataRiskLevelScore {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DataRiskLevelScore {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DataRiskLevelScore {
         fn default() -> Self {
-            data_risk_level_score::RISK_SCORE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -24491,46 +25066,61 @@ pub mod table_data_profile {
 
     /// Possible states of a profile. New items may be added.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unused.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The profile is currently running. Once a profile has finished it will
         /// transition to DONE.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(1);
 
         /// The profile is no longer generating.
         /// If profile_status.status.code is 0, the profile succeeded, otherwise, it
         /// failed.
-        pub const DONE: State = State::new("DONE");
+        pub const DONE: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RUNNING"),
+                2 => std::borrow::Cow::Borrowed("DONE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "DONE" => std::option::Option::Some(Self::DONE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -24967,180 +25557,255 @@ pub mod column_data_profile {
 
     /// Possible states of a profile. New items may be added.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unused.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The profile is currently running. Once a profile has finished it will
         /// transition to DONE.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(1);
 
         /// The profile is no longer generating.
         /// If profile_status.status.code is 0, the profile succeeded, otherwise, it
         /// failed.
-        pub const DONE: State = State::new("DONE");
+        pub const DONE: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RUNNING"),
+                2 => std::borrow::Cow::Borrowed("DONE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "DONE" => std::option::Option::Some(Self::DONE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Data types of the data in a column. Types may be added over time.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ColumnDataType(std::borrow::Cow<'static, str>);
+    pub struct ColumnDataType(i32);
 
     impl ColumnDataType {
-        /// Creates a new ColumnDataType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ColumnDataType](ColumnDataType)
-    pub mod column_data_type {
-        use super::ColumnDataType;
-
         /// Invalid type.
-        pub const COLUMN_DATA_TYPE_UNSPECIFIED: ColumnDataType =
-            ColumnDataType::new("COLUMN_DATA_TYPE_UNSPECIFIED");
+        pub const COLUMN_DATA_TYPE_UNSPECIFIED: ColumnDataType = ColumnDataType::new(0);
 
         /// Encoded as a string in decimal format.
-        pub const TYPE_INT64: ColumnDataType = ColumnDataType::new("TYPE_INT64");
+        pub const TYPE_INT64: ColumnDataType = ColumnDataType::new(1);
 
         /// Encoded as a boolean "false" or "true".
-        pub const TYPE_BOOL: ColumnDataType = ColumnDataType::new("TYPE_BOOL");
+        pub const TYPE_BOOL: ColumnDataType = ColumnDataType::new(2);
 
         /// Encoded as a number, or string "NaN", "Infinity" or "-Infinity".
-        pub const TYPE_FLOAT64: ColumnDataType = ColumnDataType::new("TYPE_FLOAT64");
+        pub const TYPE_FLOAT64: ColumnDataType = ColumnDataType::new(3);
 
         /// Encoded as a string value.
-        pub const TYPE_STRING: ColumnDataType = ColumnDataType::new("TYPE_STRING");
+        pub const TYPE_STRING: ColumnDataType = ColumnDataType::new(4);
 
         /// Encoded as a base64 string per RFC 4648, section 4.
-        pub const TYPE_BYTES: ColumnDataType = ColumnDataType::new("TYPE_BYTES");
+        pub const TYPE_BYTES: ColumnDataType = ColumnDataType::new(5);
 
         /// Encoded as an RFC 3339 timestamp with mandatory "Z" time zone string:
         /// 1985-04-12T23:20:50.52Z
-        pub const TYPE_TIMESTAMP: ColumnDataType = ColumnDataType::new("TYPE_TIMESTAMP");
+        pub const TYPE_TIMESTAMP: ColumnDataType = ColumnDataType::new(6);
 
         /// Encoded as RFC 3339 full-date format string: 1985-04-12
-        pub const TYPE_DATE: ColumnDataType = ColumnDataType::new("TYPE_DATE");
+        pub const TYPE_DATE: ColumnDataType = ColumnDataType::new(7);
 
         /// Encoded as RFC 3339 partial-time format string: 23:20:50.52
-        pub const TYPE_TIME: ColumnDataType = ColumnDataType::new("TYPE_TIME");
+        pub const TYPE_TIME: ColumnDataType = ColumnDataType::new(8);
 
         /// Encoded as RFC 3339 full-date "T" partial-time: 1985-04-12T23:20:50.52
-        pub const TYPE_DATETIME: ColumnDataType = ColumnDataType::new("TYPE_DATETIME");
+        pub const TYPE_DATETIME: ColumnDataType = ColumnDataType::new(9);
 
         /// Encoded as WKT
-        pub const TYPE_GEOGRAPHY: ColumnDataType = ColumnDataType::new("TYPE_GEOGRAPHY");
+        pub const TYPE_GEOGRAPHY: ColumnDataType = ColumnDataType::new(10);
 
         /// Encoded as a decimal string.
-        pub const TYPE_NUMERIC: ColumnDataType = ColumnDataType::new("TYPE_NUMERIC");
+        pub const TYPE_NUMERIC: ColumnDataType = ColumnDataType::new(11);
 
         /// Container of ordered fields, each with a type and field name.
-        pub const TYPE_RECORD: ColumnDataType = ColumnDataType::new("TYPE_RECORD");
+        pub const TYPE_RECORD: ColumnDataType = ColumnDataType::new(12);
 
         /// Decimal type.
-        pub const TYPE_BIGNUMERIC: ColumnDataType = ColumnDataType::new("TYPE_BIGNUMERIC");
+        pub const TYPE_BIGNUMERIC: ColumnDataType = ColumnDataType::new(13);
 
         /// Json type.
-        pub const TYPE_JSON: ColumnDataType = ColumnDataType::new("TYPE_JSON");
+        pub const TYPE_JSON: ColumnDataType = ColumnDataType::new(14);
 
         /// Interval type.
-        pub const TYPE_INTERVAL: ColumnDataType = ColumnDataType::new("TYPE_INTERVAL");
+        pub const TYPE_INTERVAL: ColumnDataType = ColumnDataType::new(15);
 
         /// `Range<Date>` type.
-        pub const TYPE_RANGE_DATE: ColumnDataType = ColumnDataType::new("TYPE_RANGE_DATE");
+        pub const TYPE_RANGE_DATE: ColumnDataType = ColumnDataType::new(16);
 
         /// `Range<Datetime>` type.
-        pub const TYPE_RANGE_DATETIME: ColumnDataType = ColumnDataType::new("TYPE_RANGE_DATETIME");
+        pub const TYPE_RANGE_DATETIME: ColumnDataType = ColumnDataType::new(17);
 
         /// `Range<Timestamp>` type.
-        pub const TYPE_RANGE_TIMESTAMP: ColumnDataType =
-            ColumnDataType::new("TYPE_RANGE_TIMESTAMP");
+        pub const TYPE_RANGE_TIMESTAMP: ColumnDataType = ColumnDataType::new(18);
+
+        /// Creates a new ColumnDataType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COLUMN_DATA_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TYPE_INT64"),
+                2 => std::borrow::Cow::Borrowed("TYPE_BOOL"),
+                3 => std::borrow::Cow::Borrowed("TYPE_FLOAT64"),
+                4 => std::borrow::Cow::Borrowed("TYPE_STRING"),
+                5 => std::borrow::Cow::Borrowed("TYPE_BYTES"),
+                6 => std::borrow::Cow::Borrowed("TYPE_TIMESTAMP"),
+                7 => std::borrow::Cow::Borrowed("TYPE_DATE"),
+                8 => std::borrow::Cow::Borrowed("TYPE_TIME"),
+                9 => std::borrow::Cow::Borrowed("TYPE_DATETIME"),
+                10 => std::borrow::Cow::Borrowed("TYPE_GEOGRAPHY"),
+                11 => std::borrow::Cow::Borrowed("TYPE_NUMERIC"),
+                12 => std::borrow::Cow::Borrowed("TYPE_RECORD"),
+                13 => std::borrow::Cow::Borrowed("TYPE_BIGNUMERIC"),
+                14 => std::borrow::Cow::Borrowed("TYPE_JSON"),
+                15 => std::borrow::Cow::Borrowed("TYPE_INTERVAL"),
+                16 => std::borrow::Cow::Borrowed("TYPE_RANGE_DATE"),
+                17 => std::borrow::Cow::Borrowed("TYPE_RANGE_DATETIME"),
+                18 => std::borrow::Cow::Borrowed("TYPE_RANGE_TIMESTAMP"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COLUMN_DATA_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::COLUMN_DATA_TYPE_UNSPECIFIED)
+                }
+                "TYPE_INT64" => std::option::Option::Some(Self::TYPE_INT64),
+                "TYPE_BOOL" => std::option::Option::Some(Self::TYPE_BOOL),
+                "TYPE_FLOAT64" => std::option::Option::Some(Self::TYPE_FLOAT64),
+                "TYPE_STRING" => std::option::Option::Some(Self::TYPE_STRING),
+                "TYPE_BYTES" => std::option::Option::Some(Self::TYPE_BYTES),
+                "TYPE_TIMESTAMP" => std::option::Option::Some(Self::TYPE_TIMESTAMP),
+                "TYPE_DATE" => std::option::Option::Some(Self::TYPE_DATE),
+                "TYPE_TIME" => std::option::Option::Some(Self::TYPE_TIME),
+                "TYPE_DATETIME" => std::option::Option::Some(Self::TYPE_DATETIME),
+                "TYPE_GEOGRAPHY" => std::option::Option::Some(Self::TYPE_GEOGRAPHY),
+                "TYPE_NUMERIC" => std::option::Option::Some(Self::TYPE_NUMERIC),
+                "TYPE_RECORD" => std::option::Option::Some(Self::TYPE_RECORD),
+                "TYPE_BIGNUMERIC" => std::option::Option::Some(Self::TYPE_BIGNUMERIC),
+                "TYPE_JSON" => std::option::Option::Some(Self::TYPE_JSON),
+                "TYPE_INTERVAL" => std::option::Option::Some(Self::TYPE_INTERVAL),
+                "TYPE_RANGE_DATE" => std::option::Option::Some(Self::TYPE_RANGE_DATE),
+                "TYPE_RANGE_DATETIME" => std::option::Option::Some(Self::TYPE_RANGE_DATETIME),
+                "TYPE_RANGE_TIMESTAMP" => std::option::Option::Some(Self::TYPE_RANGE_TIMESTAMP),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ColumnDataType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ColumnDataType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ColumnDataType {
         fn default() -> Self {
-            column_data_type::COLUMN_DATA_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The possible policy states for a column.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ColumnPolicyState(std::borrow::Cow<'static, str>);
+    pub struct ColumnPolicyState(i32);
 
     impl ColumnPolicyState {
+        /// No policy tags.
+        pub const COLUMN_POLICY_STATE_UNSPECIFIED: ColumnPolicyState = ColumnPolicyState::new(0);
+
+        /// Column has policy tag applied.
+        pub const COLUMN_POLICY_TAGGED: ColumnPolicyState = ColumnPolicyState::new(1);
+
         /// Creates a new ColumnPolicyState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("COLUMN_POLICY_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("COLUMN_POLICY_TAGGED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "COLUMN_POLICY_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::COLUMN_POLICY_STATE_UNSPECIFIED)
+                }
+                "COLUMN_POLICY_TAGGED" => std::option::Option::Some(Self::COLUMN_POLICY_TAGGED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ColumnPolicyState](ColumnPolicyState)
-    pub mod column_policy_state {
-        use super::ColumnPolicyState;
-
-        /// No policy tags.
-        pub const COLUMN_POLICY_STATE_UNSPECIFIED: ColumnPolicyState =
-            ColumnPolicyState::new("COLUMN_POLICY_STATE_UNSPECIFIED");
-
-        /// Column has policy tag applied.
-        pub const COLUMN_POLICY_TAGGED: ColumnPolicyState =
-            ColumnPolicyState::new("COLUMN_POLICY_TAGGED");
-    }
-
-    impl std::convert::From<std::string::String> for ColumnPolicyState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ColumnPolicyState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ColumnPolicyState {
         fn default() -> Self {
-            column_policy_state::COLUMN_POLICY_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -25518,46 +26183,61 @@ pub mod file_store_data_profile {
 
     /// Possible states of a profile. New items may be added.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Unused.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The profile is currently running. Once a profile has finished it will
         /// transition to DONE.
-        pub const RUNNING: State = State::new("RUNNING");
+        pub const RUNNING: State = State::new(1);
 
         /// The profile is no longer generating.
         /// If profile_status.status.code is 0, the profile succeeded, otherwise, it
         /// failed.
-        pub const DONE: State = State::new("DONE");
+        pub const DONE: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("RUNNING"),
+                2 => std::borrow::Cow::Borrowed("DONE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "RUNNING" => std::option::Option::Some(Self::RUNNING),
+                "DONE" => std::option::Option::Some(Self::DONE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -26345,88 +27025,121 @@ pub mod data_profile_pub_sub_condition {
 
         /// Logical operators for conditional checks.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct PubSubLogicalOperator(std::borrow::Cow<'static, str>);
+        pub struct PubSubLogicalOperator(i32);
 
         impl PubSubLogicalOperator {
+            /// Unused.
+            pub const LOGICAL_OPERATOR_UNSPECIFIED: PubSubLogicalOperator =
+                PubSubLogicalOperator::new(0);
+
+            /// Conditional OR.
+            pub const OR: PubSubLogicalOperator = PubSubLogicalOperator::new(1);
+
+            /// Conditional AND.
+            pub const AND: PubSubLogicalOperator = PubSubLogicalOperator::new(2);
+
             /// Creates a new PubSubLogicalOperator instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("LOGICAL_OPERATOR_UNSPECIFIED"),
+                    1 => std::borrow::Cow::Borrowed("OR"),
+                    2 => std::borrow::Cow::Borrowed("AND"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "LOGICAL_OPERATOR_UNSPECIFIED" => {
+                        std::option::Option::Some(Self::LOGICAL_OPERATOR_UNSPECIFIED)
+                    }
+                    "OR" => std::option::Option::Some(Self::OR),
+                    "AND" => std::option::Option::Some(Self::AND),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [PubSubLogicalOperator](PubSubLogicalOperator)
-        pub mod pub_sub_logical_operator {
-            use super::PubSubLogicalOperator;
-
-            /// Unused.
-            pub const LOGICAL_OPERATOR_UNSPECIFIED: PubSubLogicalOperator =
-                PubSubLogicalOperator::new("LOGICAL_OPERATOR_UNSPECIFIED");
-
-            /// Conditional OR.
-            pub const OR: PubSubLogicalOperator = PubSubLogicalOperator::new("OR");
-
-            /// Conditional AND.
-            pub const AND: PubSubLogicalOperator = PubSubLogicalOperator::new("AND");
-        }
-
-        impl std::convert::From<std::string::String> for PubSubLogicalOperator {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for PubSubLogicalOperator {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for PubSubLogicalOperator {
             fn default() -> Self {
-                pub_sub_logical_operator::LOGICAL_OPERATOR_UNSPECIFIED
+                Self::new(0)
             }
         }
     }
 
     /// Various score levels for resources.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ProfileScoreBucket(std::borrow::Cow<'static, str>);
+    pub struct ProfileScoreBucket(i32);
 
     impl ProfileScoreBucket {
+        /// Unused.
+        pub const PROFILE_SCORE_BUCKET_UNSPECIFIED: ProfileScoreBucket = ProfileScoreBucket::new(0);
+
+        /// High risk/sensitivity detected.
+        pub const HIGH: ProfileScoreBucket = ProfileScoreBucket::new(1);
+
+        /// Medium or high risk/sensitivity detected.
+        pub const MEDIUM_OR_HIGH: ProfileScoreBucket = ProfileScoreBucket::new(2);
+
         /// Creates a new ProfileScoreBucket instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PROFILE_SCORE_BUCKET_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("HIGH"),
+                2 => std::borrow::Cow::Borrowed("MEDIUM_OR_HIGH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PROFILE_SCORE_BUCKET_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PROFILE_SCORE_BUCKET_UNSPECIFIED)
+                }
+                "HIGH" => std::option::Option::Some(Self::HIGH),
+                "MEDIUM_OR_HIGH" => std::option::Option::Some(Self::MEDIUM_OR_HIGH),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ProfileScoreBucket](ProfileScoreBucket)
-    pub mod profile_score_bucket {
-        use super::ProfileScoreBucket;
-
-        /// Unused.
-        pub const PROFILE_SCORE_BUCKET_UNSPECIFIED: ProfileScoreBucket =
-            ProfileScoreBucket::new("PROFILE_SCORE_BUCKET_UNSPECIFIED");
-
-        /// High risk/sensitivity detected.
-        pub const HIGH: ProfileScoreBucket = ProfileScoreBucket::new("HIGH");
-
-        /// Medium or high risk/sensitivity detected.
-        pub const MEDIUM_OR_HIGH: ProfileScoreBucket = ProfileScoreBucket::new("MEDIUM_OR_HIGH");
-    }
-
-    impl std::convert::From<std::string::String> for ProfileScoreBucket {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ProfileScoreBucket {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ProfileScoreBucket {
         fn default() -> Self {
-            profile_score_bucket::PROFILE_SCORE_BUCKET_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -27237,46 +27950,62 @@ pub mod cloud_sql_properties {
     /// Database engine of a Cloud SQL instance.
     /// New values may be added over time.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DatabaseEngine(std::borrow::Cow<'static, str>);
+    pub struct DatabaseEngine(i32);
 
     impl DatabaseEngine {
+        /// An engine that is not currently supported by Sensitive Data Protection.
+        pub const DATABASE_ENGINE_UNKNOWN: DatabaseEngine = DatabaseEngine::new(0);
+
+        /// Cloud SQL for MySQL instance.
+        pub const DATABASE_ENGINE_MYSQL: DatabaseEngine = DatabaseEngine::new(1);
+
+        /// Cloud SQL for PostgreSQL instance.
+        pub const DATABASE_ENGINE_POSTGRES: DatabaseEngine = DatabaseEngine::new(2);
+
         /// Creates a new DatabaseEngine instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DATABASE_ENGINE_UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("DATABASE_ENGINE_MYSQL"),
+                2 => std::borrow::Cow::Borrowed("DATABASE_ENGINE_POSTGRES"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DATABASE_ENGINE_UNKNOWN" => {
+                    std::option::Option::Some(Self::DATABASE_ENGINE_UNKNOWN)
+                }
+                "DATABASE_ENGINE_MYSQL" => std::option::Option::Some(Self::DATABASE_ENGINE_MYSQL),
+                "DATABASE_ENGINE_POSTGRES" => {
+                    std::option::Option::Some(Self::DATABASE_ENGINE_POSTGRES)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [DatabaseEngine](DatabaseEngine)
-    pub mod database_engine {
-        use super::DatabaseEngine;
-
-        /// An engine that is not currently supported by Sensitive Data Protection.
-        pub const DATABASE_ENGINE_UNKNOWN: DatabaseEngine =
-            DatabaseEngine::new("DATABASE_ENGINE_UNKNOWN");
-
-        /// Cloud SQL for MySQL instance.
-        pub const DATABASE_ENGINE_MYSQL: DatabaseEngine =
-            DatabaseEngine::new("DATABASE_ENGINE_MYSQL");
-
-        /// Cloud SQL for PostgreSQL instance.
-        pub const DATABASE_ENGINE_POSTGRES: DatabaseEngine =
-            DatabaseEngine::new("DATABASE_ENGINE_POSTGRES");
-    }
-
-    impl std::convert::From<std::string::String> for DatabaseEngine {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DatabaseEngine {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DatabaseEngine {
         fn default() -> Self {
-            database_engine::DATABASE_ENGINE_UNKNOWN
+            Self::new(0)
         }
     }
 
@@ -27426,67 +28155,100 @@ pub mod file_cluster_type {
     /// Cluster type. Each cluster corresponds to a set of file types.
     /// Over time, new types may be added and files may move between clusters.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Cluster(std::borrow::Cow<'static, str>);
+    pub struct Cluster(i32);
 
     impl Cluster {
+        /// Unused.
+        pub const CLUSTER_UNSPECIFIED: Cluster = Cluster::new(0);
+
+        /// Unsupported files.
+        pub const CLUSTER_UNKNOWN: Cluster = Cluster::new(1);
+
+        /// Plain text.
+        pub const CLUSTER_TEXT: Cluster = Cluster::new(2);
+
+        /// Structured data like CSV, TSV etc.
+        pub const CLUSTER_STRUCTURED_DATA: Cluster = Cluster::new(3);
+
+        /// Source code.
+        pub const CLUSTER_SOURCE_CODE: Cluster = Cluster::new(4);
+
+        /// Rich document like docx, xlsx etc.
+        pub const CLUSTER_RICH_DOCUMENT: Cluster = Cluster::new(5);
+
+        /// Images like jpeg, bmp.
+        pub const CLUSTER_IMAGE: Cluster = Cluster::new(6);
+
+        /// Archives and containers like .zip, .tar etc.
+        pub const CLUSTER_ARCHIVE: Cluster = Cluster::new(7);
+
+        /// Multimedia like .mp4, .avi etc.
+        pub const CLUSTER_MULTIMEDIA: Cluster = Cluster::new(8);
+
+        /// Executable files like .exe, .class, .apk etc.
+        pub const CLUSTER_EXECUTABLE: Cluster = Cluster::new(9);
+
+        /// AI models like .tflite etc.
+        pub const CLUSTER_AI_MODEL: Cluster = Cluster::new(10);
+
         /// Creates a new Cluster instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CLUSTER_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CLUSTER_UNKNOWN"),
+                2 => std::borrow::Cow::Borrowed("CLUSTER_TEXT"),
+                3 => std::borrow::Cow::Borrowed("CLUSTER_STRUCTURED_DATA"),
+                4 => std::borrow::Cow::Borrowed("CLUSTER_SOURCE_CODE"),
+                5 => std::borrow::Cow::Borrowed("CLUSTER_RICH_DOCUMENT"),
+                6 => std::borrow::Cow::Borrowed("CLUSTER_IMAGE"),
+                7 => std::borrow::Cow::Borrowed("CLUSTER_ARCHIVE"),
+                8 => std::borrow::Cow::Borrowed("CLUSTER_MULTIMEDIA"),
+                9 => std::borrow::Cow::Borrowed("CLUSTER_EXECUTABLE"),
+                10 => std::borrow::Cow::Borrowed("CLUSTER_AI_MODEL"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CLUSTER_UNSPECIFIED" => std::option::Option::Some(Self::CLUSTER_UNSPECIFIED),
+                "CLUSTER_UNKNOWN" => std::option::Option::Some(Self::CLUSTER_UNKNOWN),
+                "CLUSTER_TEXT" => std::option::Option::Some(Self::CLUSTER_TEXT),
+                "CLUSTER_STRUCTURED_DATA" => {
+                    std::option::Option::Some(Self::CLUSTER_STRUCTURED_DATA)
+                }
+                "CLUSTER_SOURCE_CODE" => std::option::Option::Some(Self::CLUSTER_SOURCE_CODE),
+                "CLUSTER_RICH_DOCUMENT" => std::option::Option::Some(Self::CLUSTER_RICH_DOCUMENT),
+                "CLUSTER_IMAGE" => std::option::Option::Some(Self::CLUSTER_IMAGE),
+                "CLUSTER_ARCHIVE" => std::option::Option::Some(Self::CLUSTER_ARCHIVE),
+                "CLUSTER_MULTIMEDIA" => std::option::Option::Some(Self::CLUSTER_MULTIMEDIA),
+                "CLUSTER_EXECUTABLE" => std::option::Option::Some(Self::CLUSTER_EXECUTABLE),
+                "CLUSTER_AI_MODEL" => std::option::Option::Some(Self::CLUSTER_AI_MODEL),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Cluster](Cluster)
-    pub mod cluster {
-        use super::Cluster;
-
-        /// Unused.
-        pub const CLUSTER_UNSPECIFIED: Cluster = Cluster::new("CLUSTER_UNSPECIFIED");
-
-        /// Unsupported files.
-        pub const CLUSTER_UNKNOWN: Cluster = Cluster::new("CLUSTER_UNKNOWN");
-
-        /// Plain text.
-        pub const CLUSTER_TEXT: Cluster = Cluster::new("CLUSTER_TEXT");
-
-        /// Structured data like CSV, TSV etc.
-        pub const CLUSTER_STRUCTURED_DATA: Cluster = Cluster::new("CLUSTER_STRUCTURED_DATA");
-
-        /// Source code.
-        pub const CLUSTER_SOURCE_CODE: Cluster = Cluster::new("CLUSTER_SOURCE_CODE");
-
-        /// Rich document like docx, xlsx etc.
-        pub const CLUSTER_RICH_DOCUMENT: Cluster = Cluster::new("CLUSTER_RICH_DOCUMENT");
-
-        /// Images like jpeg, bmp.
-        pub const CLUSTER_IMAGE: Cluster = Cluster::new("CLUSTER_IMAGE");
-
-        /// Archives and containers like .zip, .tar etc.
-        pub const CLUSTER_ARCHIVE: Cluster = Cluster::new("CLUSTER_ARCHIVE");
-
-        /// Multimedia like .mp4, .avi etc.
-        pub const CLUSTER_MULTIMEDIA: Cluster = Cluster::new("CLUSTER_MULTIMEDIA");
-
-        /// Executable files like .exe, .class, .apk etc.
-        pub const CLUSTER_EXECUTABLE: Cluster = Cluster::new("CLUSTER_EXECUTABLE");
-
-        /// AI models like .tflite etc.
-        pub const CLUSTER_AI_MODEL: Cluster = Cluster::new("CLUSTER_AI_MODEL");
-    }
-
-    impl std::convert::From<std::string::String> for Cluster {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Cluster {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Cluster {
         fn default() -> Self {
-            cluster::CLUSTER_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -27743,61 +28505,78 @@ pub mod sensitivity_score {
 
     /// Various sensitivity score levels for resources.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SensitivityScoreLevel(std::borrow::Cow<'static, str>);
+    pub struct SensitivityScoreLevel(i32);
 
     impl SensitivityScoreLevel {
-        /// Creates a new SensitivityScoreLevel instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [SensitivityScoreLevel](SensitivityScoreLevel)
-    pub mod sensitivity_score_level {
-        use super::SensitivityScoreLevel;
-
         /// Unused.
         pub const SENSITIVITY_SCORE_UNSPECIFIED: SensitivityScoreLevel =
-            SensitivityScoreLevel::new("SENSITIVITY_SCORE_UNSPECIFIED");
+            SensitivityScoreLevel::new(0);
 
         /// No sensitive information detected. The resource isn't publicly
         /// accessible.
-        pub const SENSITIVITY_LOW: SensitivityScoreLevel =
-            SensitivityScoreLevel::new("SENSITIVITY_LOW");
+        pub const SENSITIVITY_LOW: SensitivityScoreLevel = SensitivityScoreLevel::new(10);
 
         /// Unable to determine sensitivity.
-        pub const SENSITIVITY_UNKNOWN: SensitivityScoreLevel =
-            SensitivityScoreLevel::new("SENSITIVITY_UNKNOWN");
+        pub const SENSITIVITY_UNKNOWN: SensitivityScoreLevel = SensitivityScoreLevel::new(12);
 
         /// Medium risk. Contains personally identifiable information (PII),
         /// potentially sensitive data, or fields with free-text data that are at a
         /// higher risk of having intermittent sensitive data. Consider limiting
         /// access.
-        pub const SENSITIVITY_MODERATE: SensitivityScoreLevel =
-            SensitivityScoreLevel::new("SENSITIVITY_MODERATE");
+        pub const SENSITIVITY_MODERATE: SensitivityScoreLevel = SensitivityScoreLevel::new(20);
 
         /// High risk. Sensitive personally identifiable information (SPII) can be
         /// present. Exfiltration of data can lead to user data loss.
         /// Re-identification of users might be possible. Consider limiting usage and
         /// or removing SPII.
-        pub const SENSITIVITY_HIGH: SensitivityScoreLevel =
-            SensitivityScoreLevel::new("SENSITIVITY_HIGH");
+        pub const SENSITIVITY_HIGH: SensitivityScoreLevel = SensitivityScoreLevel::new(30);
+
+        /// Creates a new SensitivityScoreLevel instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SENSITIVITY_SCORE_UNSPECIFIED"),
+                10 => std::borrow::Cow::Borrowed("SENSITIVITY_LOW"),
+                12 => std::borrow::Cow::Borrowed("SENSITIVITY_UNKNOWN"),
+                20 => std::borrow::Cow::Borrowed("SENSITIVITY_MODERATE"),
+                30 => std::borrow::Cow::Borrowed("SENSITIVITY_HIGH"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SENSITIVITY_SCORE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SENSITIVITY_SCORE_UNSPECIFIED)
+                }
+                "SENSITIVITY_LOW" => std::option::Option::Some(Self::SENSITIVITY_LOW),
+                "SENSITIVITY_UNKNOWN" => std::option::Option::Some(Self::SENSITIVITY_UNKNOWN),
+                "SENSITIVITY_MODERATE" => std::option::Option::Some(Self::SENSITIVITY_MODERATE),
+                "SENSITIVITY_HIGH" => std::option::Option::Some(Self::SENSITIVITY_HIGH),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for SensitivityScoreLevel {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SensitivityScoreLevel {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SensitivityScoreLevel {
         fn default() -> Self {
-            sensitivity_score_level::SENSITIVITY_SCORE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -28667,43 +29446,56 @@ pub mod custom_info_type {
 
     /// Type of exclusion rule.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ExclusionType(std::borrow::Cow<'static, str>);
+    pub struct ExclusionType(i32);
 
     impl ExclusionType {
-        /// Creates a new ExclusionType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ExclusionType](ExclusionType)
-    pub mod exclusion_type {
-        use super::ExclusionType;
-
         /// A finding of this custom info type will not be excluded from results.
-        pub const EXCLUSION_TYPE_UNSPECIFIED: ExclusionType =
-            ExclusionType::new("EXCLUSION_TYPE_UNSPECIFIED");
+        pub const EXCLUSION_TYPE_UNSPECIFIED: ExclusionType = ExclusionType::new(0);
 
         /// A finding of this custom info type will be excluded from final results,
         /// but can still affect rule execution.
-        pub const EXCLUSION_TYPE_EXCLUDE: ExclusionType =
-            ExclusionType::new("EXCLUSION_TYPE_EXCLUDE");
+        pub const EXCLUSION_TYPE_EXCLUDE: ExclusionType = ExclusionType::new(1);
+
+        /// Creates a new ExclusionType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EXCLUSION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("EXCLUSION_TYPE_EXCLUDE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EXCLUSION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::EXCLUSION_TYPE_UNSPECIFIED)
+                }
+                "EXCLUSION_TYPE_EXCLUDE" => std::option::Option::Some(Self::EXCLUSION_TYPE_EXCLUDE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ExclusionType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ExclusionType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ExclusionType {
         fn default() -> Self {
-            exclusion_type::EXCLUSION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -29155,45 +29947,61 @@ pub mod cloud_storage_options {
     /// in conjunction with bytes_limit_per_file. If not specified, scanning would
     /// start from the top.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SampleMethod(std::borrow::Cow<'static, str>);
+    pub struct SampleMethod(i32);
 
     impl SampleMethod {
-        /// Creates a new SampleMethod instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [SampleMethod](SampleMethod)
-    pub mod sample_method {
-        use super::SampleMethod;
-
         /// No sampling.
-        pub const SAMPLE_METHOD_UNSPECIFIED: SampleMethod =
-            SampleMethod::new("SAMPLE_METHOD_UNSPECIFIED");
+        pub const SAMPLE_METHOD_UNSPECIFIED: SampleMethod = SampleMethod::new(0);
 
         /// Scan from the top (default).
-        pub const TOP: SampleMethod = SampleMethod::new("TOP");
+        pub const TOP: SampleMethod = SampleMethod::new(1);
 
         /// For each file larger than bytes_limit_per_file, randomly pick the offset
         /// to start scanning. The scanned bytes are contiguous.
-        pub const RANDOM_START: SampleMethod = SampleMethod::new("RANDOM_START");
+        pub const RANDOM_START: SampleMethod = SampleMethod::new(2);
+
+        /// Creates a new SampleMethod instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SAMPLE_METHOD_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TOP"),
+                2 => std::borrow::Cow::Borrowed("RANDOM_START"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SAMPLE_METHOD_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SAMPLE_METHOD_UNSPECIFIED)
+                }
+                "TOP" => std::option::Option::Some(Self::TOP),
+                "RANDOM_START" => std::option::Option::Some(Self::RANDOM_START),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for SampleMethod {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SampleMethod {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SampleMethod {
         fn default() -> Self {
-            sample_method::SAMPLE_METHOD_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -29402,46 +30210,62 @@ pub mod big_query_options {
     /// in conjunction with either rows_limit or rows_limit_percent. If not
     /// specified, rows are scanned in the order BigQuery reads them.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SampleMethod(std::borrow::Cow<'static, str>);
+    pub struct SampleMethod(i32);
 
     impl SampleMethod {
-        /// Creates a new SampleMethod instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [SampleMethod](SampleMethod)
-    pub mod sample_method {
-        use super::SampleMethod;
-
         /// No sampling.
-        pub const SAMPLE_METHOD_UNSPECIFIED: SampleMethod =
-            SampleMethod::new("SAMPLE_METHOD_UNSPECIFIED");
+        pub const SAMPLE_METHOD_UNSPECIFIED: SampleMethod = SampleMethod::new(0);
 
         /// Scan groups of rows in the order BigQuery provides (default). Multiple
         /// groups of rows may be scanned in parallel, so results may not appear in
         /// the same order the rows are read.
-        pub const TOP: SampleMethod = SampleMethod::new("TOP");
+        pub const TOP: SampleMethod = SampleMethod::new(1);
 
         /// Randomly pick groups of rows to scan.
-        pub const RANDOM_START: SampleMethod = SampleMethod::new("RANDOM_START");
+        pub const RANDOM_START: SampleMethod = SampleMethod::new(2);
+
+        /// Creates a new SampleMethod instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SAMPLE_METHOD_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TOP"),
+                2 => std::borrow::Cow::Borrowed("RANDOM_START"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SAMPLE_METHOD_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::SAMPLE_METHOD_UNSPECIFIED)
+                }
+                "TOP" => std::option::Option::Some(Self::TOP),
+                "RANDOM_START" => std::option::Option::Some(Self::RANDOM_START),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for SampleMethod {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for SampleMethod {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for SampleMethod {
         fn default() -> Self {
-            sample_method::SAMPLE_METHOD_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -30456,108 +31280,144 @@ impl wkt::message::Message for TableOptions {
 /// storing of transformation was successful, otherwise, reason for not
 /// transforming.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TransformationResultStatusType(std::borrow::Cow<'static, str>);
+pub struct TransformationResultStatusType(i32);
 
 impl TransformationResultStatusType {
-    /// Creates a new TransformationResultStatusType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [TransformationResultStatusType](TransformationResultStatusType)
-pub mod transformation_result_status_type {
-    use super::TransformationResultStatusType;
-
     /// Unused.
     pub const STATE_TYPE_UNSPECIFIED: TransformationResultStatusType =
-        TransformationResultStatusType::new("STATE_TYPE_UNSPECIFIED");
+        TransformationResultStatusType::new(0);
 
     /// This will be set when a finding could not be transformed (i.e. outside user
     /// set bucket range).
     pub const INVALID_TRANSFORM: TransformationResultStatusType =
-        TransformationResultStatusType::new("INVALID_TRANSFORM");
+        TransformationResultStatusType::new(1);
 
     /// This will be set when a BigQuery transformation was successful but could
     /// not be stored back in BigQuery because the transformed row exceeds
     /// BigQuery's max row size.
     pub const BIGQUERY_MAX_ROW_SIZE_EXCEEDED: TransformationResultStatusType =
-        TransformationResultStatusType::new("BIGQUERY_MAX_ROW_SIZE_EXCEEDED");
+        TransformationResultStatusType::new(2);
 
     /// This will be set when there is a finding in the custom metadata of a file,
     /// but at the write time of the transformed file, this key / value pair is
     /// unretrievable.
     pub const METADATA_UNRETRIEVABLE: TransformationResultStatusType =
-        TransformationResultStatusType::new("METADATA_UNRETRIEVABLE");
+        TransformationResultStatusType::new(3);
 
     /// This will be set when the transformation and storing of it is successful.
-    pub const SUCCESS: TransformationResultStatusType =
-        TransformationResultStatusType::new("SUCCESS");
+    pub const SUCCESS: TransformationResultStatusType = TransformationResultStatusType::new(4);
+
+    /// Creates a new TransformationResultStatusType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("STATE_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("INVALID_TRANSFORM"),
+            2 => std::borrow::Cow::Borrowed("BIGQUERY_MAX_ROW_SIZE_EXCEEDED"),
+            3 => std::borrow::Cow::Borrowed("METADATA_UNRETRIEVABLE"),
+            4 => std::borrow::Cow::Borrowed("SUCCESS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "STATE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_TYPE_UNSPECIFIED),
+            "INVALID_TRANSFORM" => std::option::Option::Some(Self::INVALID_TRANSFORM),
+            "BIGQUERY_MAX_ROW_SIZE_EXCEEDED" => {
+                std::option::Option::Some(Self::BIGQUERY_MAX_ROW_SIZE_EXCEEDED)
+            }
+            "METADATA_UNRETRIEVABLE" => std::option::Option::Some(Self::METADATA_UNRETRIEVABLE),
+            "SUCCESS" => std::option::Option::Some(Self::SUCCESS),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for TransformationResultStatusType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for TransformationResultStatusType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for TransformationResultStatusType {
     fn default() -> Self {
-        transformation_result_status_type::STATE_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Describes functionality of a given container in its original format.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TransformationContainerType(std::borrow::Cow<'static, str>);
+pub struct TransformationContainerType(i32);
 
 impl TransformationContainerType {
+    /// Unused.
+    pub const TRANSFORM_UNKNOWN_CONTAINER: TransformationContainerType =
+        TransformationContainerType::new(0);
+
+    /// Body of a file.
+    pub const TRANSFORM_BODY: TransformationContainerType = TransformationContainerType::new(1);
+
+    /// Metadata for a file.
+    pub const TRANSFORM_METADATA: TransformationContainerType = TransformationContainerType::new(2);
+
+    /// A table.
+    pub const TRANSFORM_TABLE: TransformationContainerType = TransformationContainerType::new(3);
+
     /// Creates a new TransformationContainerType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("TRANSFORM_UNKNOWN_CONTAINER"),
+            1 => std::borrow::Cow::Borrowed("TRANSFORM_BODY"),
+            2 => std::borrow::Cow::Borrowed("TRANSFORM_METADATA"),
+            3 => std::borrow::Cow::Borrowed("TRANSFORM_TABLE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "TRANSFORM_UNKNOWN_CONTAINER" => {
+                std::option::Option::Some(Self::TRANSFORM_UNKNOWN_CONTAINER)
+            }
+            "TRANSFORM_BODY" => std::option::Option::Some(Self::TRANSFORM_BODY),
+            "TRANSFORM_METADATA" => std::option::Option::Some(Self::TRANSFORM_METADATA),
+            "TRANSFORM_TABLE" => std::option::Option::Some(Self::TRANSFORM_TABLE),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [TransformationContainerType](TransformationContainerType)
-pub mod transformation_container_type {
-    use super::TransformationContainerType;
-
-    /// Unused.
-    pub const TRANSFORM_UNKNOWN_CONTAINER: TransformationContainerType =
-        TransformationContainerType::new("TRANSFORM_UNKNOWN_CONTAINER");
-
-    /// Body of a file.
-    pub const TRANSFORM_BODY: TransformationContainerType =
-        TransformationContainerType::new("TRANSFORM_BODY");
-
-    /// Metadata for a file.
-    pub const TRANSFORM_METADATA: TransformationContainerType =
-        TransformationContainerType::new("TRANSFORM_METADATA");
-
-    /// A table.
-    pub const TRANSFORM_TABLE: TransformationContainerType =
-        TransformationContainerType::new("TRANSFORM_TABLE");
-}
-
-impl std::convert::From<std::string::String> for TransformationContainerType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for TransformationContainerType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for TransformationContainerType {
     fn default() -> Self {
-        transformation_container_type::TRANSFORM_UNKNOWN_CONTAINER
+        Self::new(0)
     }
 }
 
@@ -30565,158 +31425,195 @@ impl std::default::Default for TransformationContainerType {
 /// record suppression, or one of the transformation rules specified under
 /// `PrimitiveTransformation`.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TransformationType(std::borrow::Cow<'static, str>);
+pub struct TransformationType(i32);
 
 impl TransformationType {
+    /// Unused
+    pub const TRANSFORMATION_TYPE_UNSPECIFIED: TransformationType = TransformationType::new(0);
+
+    /// Record suppression
+    pub const RECORD_SUPPRESSION: TransformationType = TransformationType::new(1);
+
+    /// Replace value
+    pub const REPLACE_VALUE: TransformationType = TransformationType::new(2);
+
+    /// Replace value using a dictionary.
+    pub const REPLACE_DICTIONARY: TransformationType = TransformationType::new(15);
+
+    /// Redact
+    pub const REDACT: TransformationType = TransformationType::new(3);
+
+    /// Character mask
+    pub const CHARACTER_MASK: TransformationType = TransformationType::new(4);
+
+    /// FFX-FPE
+    pub const CRYPTO_REPLACE_FFX_FPE: TransformationType = TransformationType::new(5);
+
+    /// Fixed size bucketing
+    pub const FIXED_SIZE_BUCKETING: TransformationType = TransformationType::new(6);
+
+    /// Bucketing
+    pub const BUCKETING: TransformationType = TransformationType::new(7);
+
+    /// Replace with info type
+    pub const REPLACE_WITH_INFO_TYPE: TransformationType = TransformationType::new(8);
+
+    /// Time part
+    pub const TIME_PART: TransformationType = TransformationType::new(9);
+
+    /// Crypto hash
+    pub const CRYPTO_HASH: TransformationType = TransformationType::new(10);
+
+    /// Date shift
+    pub const DATE_SHIFT: TransformationType = TransformationType::new(12);
+
+    /// Deterministic crypto
+    pub const CRYPTO_DETERMINISTIC_CONFIG: TransformationType = TransformationType::new(13);
+
+    /// Redact image
+    pub const REDACT_IMAGE: TransformationType = TransformationType::new(14);
+
     /// Creates a new TransformationType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("TRANSFORMATION_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("RECORD_SUPPRESSION"),
+            2 => std::borrow::Cow::Borrowed("REPLACE_VALUE"),
+            3 => std::borrow::Cow::Borrowed("REDACT"),
+            4 => std::borrow::Cow::Borrowed("CHARACTER_MASK"),
+            5 => std::borrow::Cow::Borrowed("CRYPTO_REPLACE_FFX_FPE"),
+            6 => std::borrow::Cow::Borrowed("FIXED_SIZE_BUCKETING"),
+            7 => std::borrow::Cow::Borrowed("BUCKETING"),
+            8 => std::borrow::Cow::Borrowed("REPLACE_WITH_INFO_TYPE"),
+            9 => std::borrow::Cow::Borrowed("TIME_PART"),
+            10 => std::borrow::Cow::Borrowed("CRYPTO_HASH"),
+            12 => std::borrow::Cow::Borrowed("DATE_SHIFT"),
+            13 => std::borrow::Cow::Borrowed("CRYPTO_DETERMINISTIC_CONFIG"),
+            14 => std::borrow::Cow::Borrowed("REDACT_IMAGE"),
+            15 => std::borrow::Cow::Borrowed("REPLACE_DICTIONARY"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "TRANSFORMATION_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::TRANSFORMATION_TYPE_UNSPECIFIED)
+            }
+            "RECORD_SUPPRESSION" => std::option::Option::Some(Self::RECORD_SUPPRESSION),
+            "REPLACE_VALUE" => std::option::Option::Some(Self::REPLACE_VALUE),
+            "REPLACE_DICTIONARY" => std::option::Option::Some(Self::REPLACE_DICTIONARY),
+            "REDACT" => std::option::Option::Some(Self::REDACT),
+            "CHARACTER_MASK" => std::option::Option::Some(Self::CHARACTER_MASK),
+            "CRYPTO_REPLACE_FFX_FPE" => std::option::Option::Some(Self::CRYPTO_REPLACE_FFX_FPE),
+            "FIXED_SIZE_BUCKETING" => std::option::Option::Some(Self::FIXED_SIZE_BUCKETING),
+            "BUCKETING" => std::option::Option::Some(Self::BUCKETING),
+            "REPLACE_WITH_INFO_TYPE" => std::option::Option::Some(Self::REPLACE_WITH_INFO_TYPE),
+            "TIME_PART" => std::option::Option::Some(Self::TIME_PART),
+            "CRYPTO_HASH" => std::option::Option::Some(Self::CRYPTO_HASH),
+            "DATE_SHIFT" => std::option::Option::Some(Self::DATE_SHIFT),
+            "CRYPTO_DETERMINISTIC_CONFIG" => {
+                std::option::Option::Some(Self::CRYPTO_DETERMINISTIC_CONFIG)
+            }
+            "REDACT_IMAGE" => std::option::Option::Some(Self::REDACT_IMAGE),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [TransformationType](TransformationType)
-pub mod transformation_type {
-    use super::TransformationType;
-
-    /// Unused
-    pub const TRANSFORMATION_TYPE_UNSPECIFIED: TransformationType =
-        TransformationType::new("TRANSFORMATION_TYPE_UNSPECIFIED");
-
-    /// Record suppression
-    pub const RECORD_SUPPRESSION: TransformationType =
-        TransformationType::new("RECORD_SUPPRESSION");
-
-    /// Replace value
-    pub const REPLACE_VALUE: TransformationType = TransformationType::new("REPLACE_VALUE");
-
-    /// Replace value using a dictionary.
-    pub const REPLACE_DICTIONARY: TransformationType =
-        TransformationType::new("REPLACE_DICTIONARY");
-
-    /// Redact
-    pub const REDACT: TransformationType = TransformationType::new("REDACT");
-
-    /// Character mask
-    pub const CHARACTER_MASK: TransformationType = TransformationType::new("CHARACTER_MASK");
-
-    /// FFX-FPE
-    pub const CRYPTO_REPLACE_FFX_FPE: TransformationType =
-        TransformationType::new("CRYPTO_REPLACE_FFX_FPE");
-
-    /// Fixed size bucketing
-    pub const FIXED_SIZE_BUCKETING: TransformationType =
-        TransformationType::new("FIXED_SIZE_BUCKETING");
-
-    /// Bucketing
-    pub const BUCKETING: TransformationType = TransformationType::new("BUCKETING");
-
-    /// Replace with info type
-    pub const REPLACE_WITH_INFO_TYPE: TransformationType =
-        TransformationType::new("REPLACE_WITH_INFO_TYPE");
-
-    /// Time part
-    pub const TIME_PART: TransformationType = TransformationType::new("TIME_PART");
-
-    /// Crypto hash
-    pub const CRYPTO_HASH: TransformationType = TransformationType::new("CRYPTO_HASH");
-
-    /// Date shift
-    pub const DATE_SHIFT: TransformationType = TransformationType::new("DATE_SHIFT");
-
-    /// Deterministic crypto
-    pub const CRYPTO_DETERMINISTIC_CONFIG: TransformationType =
-        TransformationType::new("CRYPTO_DETERMINISTIC_CONFIG");
-
-    /// Redact image
-    pub const REDACT_IMAGE: TransformationType = TransformationType::new("REDACT_IMAGE");
-}
-
-impl std::convert::From<std::string::String> for TransformationType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for TransformationType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for TransformationType {
     fn default() -> Self {
-        transformation_type::TRANSFORMATION_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Whether a profile being created is the first generation or an update.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ProfileGeneration(std::borrow::Cow<'static, str>);
+pub struct ProfileGeneration(i32);
 
 impl ProfileGeneration {
+    /// Unused.
+    pub const PROFILE_GENERATION_UNSPECIFIED: ProfileGeneration = ProfileGeneration::new(0);
+
+    /// The profile is the first profile for the resource.
+    pub const PROFILE_GENERATION_NEW: ProfileGeneration = ProfileGeneration::new(1);
+
+    /// The profile is an update to a previous profile.
+    pub const PROFILE_GENERATION_UPDATE: ProfileGeneration = ProfileGeneration::new(2);
+
     /// Creates a new ProfileGeneration instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("PROFILE_GENERATION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PROFILE_GENERATION_NEW"),
+            2 => std::borrow::Cow::Borrowed("PROFILE_GENERATION_UPDATE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "PROFILE_GENERATION_UNSPECIFIED" => {
+                std::option::Option::Some(Self::PROFILE_GENERATION_UNSPECIFIED)
+            }
+            "PROFILE_GENERATION_NEW" => std::option::Option::Some(Self::PROFILE_GENERATION_NEW),
+            "PROFILE_GENERATION_UPDATE" => {
+                std::option::Option::Some(Self::PROFILE_GENERATION_UPDATE)
+            }
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [ProfileGeneration](ProfileGeneration)
-pub mod profile_generation {
-    use super::ProfileGeneration;
-
-    /// Unused.
-    pub const PROFILE_GENERATION_UNSPECIFIED: ProfileGeneration =
-        ProfileGeneration::new("PROFILE_GENERATION_UNSPECIFIED");
-
-    /// The profile is the first profile for the resource.
-    pub const PROFILE_GENERATION_NEW: ProfileGeneration =
-        ProfileGeneration::new("PROFILE_GENERATION_NEW");
-
-    /// The profile is an update to a previous profile.
-    pub const PROFILE_GENERATION_UPDATE: ProfileGeneration =
-        ProfileGeneration::new("PROFILE_GENERATION_UPDATE");
-}
-
-impl std::convert::From<std::string::String> for ProfileGeneration {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ProfileGeneration {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ProfileGeneration {
     fn default() -> Self {
-        profile_generation::PROFILE_GENERATION_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Over time new types may be added. Currently VIEW, MATERIALIZED_VIEW, and
 /// non-BigLake external tables are not supported.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct BigQueryTableTypeCollection(std::borrow::Cow<'static, str>);
+pub struct BigQueryTableTypeCollection(i32);
 
 impl BigQueryTableTypeCollection {
-    /// Creates a new BigQueryTableTypeCollection instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [BigQueryTableTypeCollection](BigQueryTableTypeCollection)
-pub mod big_query_table_type_collection {
-    use super::BigQueryTableTypeCollection;
-
     /// Unused.
     pub const BIG_QUERY_COLLECTION_UNSPECIFIED: BigQueryTableTypeCollection =
-        BigQueryTableTypeCollection::new("BIG_QUERY_COLLECTION_UNSPECIFIED");
+        BigQueryTableTypeCollection::new(0);
 
     /// Automatically generate profiles for all tables, even if the table type is
     /// not yet fully supported for analysis. Profiles for unsupported tables will
@@ -30724,274 +31621,405 @@ pub mod big_query_table_type_collection {
     /// support is added, the tables will automatically be profiled during the next
     /// scheduled run.
     pub const BIG_QUERY_COLLECTION_ALL_TYPES: BigQueryTableTypeCollection =
-        BigQueryTableTypeCollection::new("BIG_QUERY_COLLECTION_ALL_TYPES");
+        BigQueryTableTypeCollection::new(1);
 
     /// Only those types fully supported will be profiled. Will expand
     /// automatically as Cloud DLP adds support for new table types. Unsupported
     /// table types will not have partial profiles generated.
     pub const BIG_QUERY_COLLECTION_ONLY_SUPPORTED_TYPES: BigQueryTableTypeCollection =
-        BigQueryTableTypeCollection::new("BIG_QUERY_COLLECTION_ONLY_SUPPORTED_TYPES");
+        BigQueryTableTypeCollection::new(2);
+
+    /// Creates a new BigQueryTableTypeCollection instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("BIG_QUERY_COLLECTION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("BIG_QUERY_COLLECTION_ALL_TYPES"),
+            2 => std::borrow::Cow::Borrowed("BIG_QUERY_COLLECTION_ONLY_SUPPORTED_TYPES"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "BIG_QUERY_COLLECTION_UNSPECIFIED" => {
+                std::option::Option::Some(Self::BIG_QUERY_COLLECTION_UNSPECIFIED)
+            }
+            "BIG_QUERY_COLLECTION_ALL_TYPES" => {
+                std::option::Option::Some(Self::BIG_QUERY_COLLECTION_ALL_TYPES)
+            }
+            "BIG_QUERY_COLLECTION_ONLY_SUPPORTED_TYPES" => {
+                std::option::Option::Some(Self::BIG_QUERY_COLLECTION_ONLY_SUPPORTED_TYPES)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for BigQueryTableTypeCollection {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for BigQueryTableTypeCollection {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for BigQueryTableTypeCollection {
     fn default() -> Self {
-        big_query_table_type_collection::BIG_QUERY_COLLECTION_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Over time new types may be added. Currently VIEW, MATERIALIZED_VIEW, and
 /// non-BigLake external tables are not supported.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct BigQueryTableType(std::borrow::Cow<'static, str>);
+pub struct BigQueryTableType(i32);
 
 impl BigQueryTableType {
+    /// Unused.
+    pub const BIG_QUERY_TABLE_TYPE_UNSPECIFIED: BigQueryTableType = BigQueryTableType::new(0);
+
+    /// A normal BigQuery table.
+    pub const BIG_QUERY_TABLE_TYPE_TABLE: BigQueryTableType = BigQueryTableType::new(1);
+
+    /// A table that references data stored in Cloud Storage.
+    pub const BIG_QUERY_TABLE_TYPE_EXTERNAL_BIG_LAKE: BigQueryTableType = BigQueryTableType::new(2);
+
+    /// A snapshot of a BigQuery table.
+    pub const BIG_QUERY_TABLE_TYPE_SNAPSHOT: BigQueryTableType = BigQueryTableType::new(3);
+
     /// Creates a new BigQueryTableType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("BIG_QUERY_TABLE_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("BIG_QUERY_TABLE_TYPE_TABLE"),
+            2 => std::borrow::Cow::Borrowed("BIG_QUERY_TABLE_TYPE_EXTERNAL_BIG_LAKE"),
+            3 => std::borrow::Cow::Borrowed("BIG_QUERY_TABLE_TYPE_SNAPSHOT"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "BIG_QUERY_TABLE_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::BIG_QUERY_TABLE_TYPE_UNSPECIFIED)
+            }
+            "BIG_QUERY_TABLE_TYPE_TABLE" => {
+                std::option::Option::Some(Self::BIG_QUERY_TABLE_TYPE_TABLE)
+            }
+            "BIG_QUERY_TABLE_TYPE_EXTERNAL_BIG_LAKE" => {
+                std::option::Option::Some(Self::BIG_QUERY_TABLE_TYPE_EXTERNAL_BIG_LAKE)
+            }
+            "BIG_QUERY_TABLE_TYPE_SNAPSHOT" => {
+                std::option::Option::Some(Self::BIG_QUERY_TABLE_TYPE_SNAPSHOT)
+            }
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [BigQueryTableType](BigQueryTableType)
-pub mod big_query_table_type {
-    use super::BigQueryTableType;
-
-    /// Unused.
-    pub const BIG_QUERY_TABLE_TYPE_UNSPECIFIED: BigQueryTableType =
-        BigQueryTableType::new("BIG_QUERY_TABLE_TYPE_UNSPECIFIED");
-
-    /// A normal BigQuery table.
-    pub const BIG_QUERY_TABLE_TYPE_TABLE: BigQueryTableType =
-        BigQueryTableType::new("BIG_QUERY_TABLE_TYPE_TABLE");
-
-    /// A table that references data stored in Cloud Storage.
-    pub const BIG_QUERY_TABLE_TYPE_EXTERNAL_BIG_LAKE: BigQueryTableType =
-        BigQueryTableType::new("BIG_QUERY_TABLE_TYPE_EXTERNAL_BIG_LAKE");
-
-    /// A snapshot of a BigQuery table.
-    pub const BIG_QUERY_TABLE_TYPE_SNAPSHOT: BigQueryTableType =
-        BigQueryTableType::new("BIG_QUERY_TABLE_TYPE_SNAPSHOT");
-}
-
-impl std::convert::From<std::string::String> for BigQueryTableType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for BigQueryTableType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for BigQueryTableType {
     fn default() -> Self {
-        big_query_table_type::BIG_QUERY_TABLE_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// How frequently data profiles can be updated. New options can be added at a
 /// later time.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DataProfileUpdateFrequency(std::borrow::Cow<'static, str>);
+pub struct DataProfileUpdateFrequency(i32);
 
 impl DataProfileUpdateFrequency {
-    /// Creates a new DataProfileUpdateFrequency instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [DataProfileUpdateFrequency](DataProfileUpdateFrequency)
-pub mod data_profile_update_frequency {
-    use super::DataProfileUpdateFrequency;
-
     /// Unspecified.
     pub const UPDATE_FREQUENCY_UNSPECIFIED: DataProfileUpdateFrequency =
-        DataProfileUpdateFrequency::new("UPDATE_FREQUENCY_UNSPECIFIED");
+        DataProfileUpdateFrequency::new(0);
 
     /// After the data profile is created, it will never be updated.
     pub const UPDATE_FREQUENCY_NEVER: DataProfileUpdateFrequency =
-        DataProfileUpdateFrequency::new("UPDATE_FREQUENCY_NEVER");
+        DataProfileUpdateFrequency::new(1);
 
     /// The data profile can be updated up to once every 24 hours.
     pub const UPDATE_FREQUENCY_DAILY: DataProfileUpdateFrequency =
-        DataProfileUpdateFrequency::new("UPDATE_FREQUENCY_DAILY");
+        DataProfileUpdateFrequency::new(2);
 
     /// The data profile can be updated up to once every 30 days. Default.
     pub const UPDATE_FREQUENCY_MONTHLY: DataProfileUpdateFrequency =
-        DataProfileUpdateFrequency::new("UPDATE_FREQUENCY_MONTHLY");
+        DataProfileUpdateFrequency::new(4);
+
+    /// Creates a new DataProfileUpdateFrequency instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("UPDATE_FREQUENCY_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("UPDATE_FREQUENCY_NEVER"),
+            2 => std::borrow::Cow::Borrowed("UPDATE_FREQUENCY_DAILY"),
+            4 => std::borrow::Cow::Borrowed("UPDATE_FREQUENCY_MONTHLY"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "UPDATE_FREQUENCY_UNSPECIFIED" => {
+                std::option::Option::Some(Self::UPDATE_FREQUENCY_UNSPECIFIED)
+            }
+            "UPDATE_FREQUENCY_NEVER" => std::option::Option::Some(Self::UPDATE_FREQUENCY_NEVER),
+            "UPDATE_FREQUENCY_DAILY" => std::option::Option::Some(Self::UPDATE_FREQUENCY_DAILY),
+            "UPDATE_FREQUENCY_MONTHLY" => std::option::Option::Some(Self::UPDATE_FREQUENCY_MONTHLY),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for DataProfileUpdateFrequency {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DataProfileUpdateFrequency {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DataProfileUpdateFrequency {
     fn default() -> Self {
-        data_profile_update_frequency::UPDATE_FREQUENCY_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Attributes evaluated to determine if a table has been modified. New values
 /// may be added at a later time.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct BigQueryTableModification(std::borrow::Cow<'static, str>);
+pub struct BigQueryTableModification(i32);
 
 impl BigQueryTableModification {
-    /// Creates a new BigQueryTableModification instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [BigQueryTableModification](BigQueryTableModification)
-pub mod big_query_table_modification {
-    use super::BigQueryTableModification;
-
     /// Unused.
     pub const TABLE_MODIFICATION_UNSPECIFIED: BigQueryTableModification =
-        BigQueryTableModification::new("TABLE_MODIFICATION_UNSPECIFIED");
+        BigQueryTableModification::new(0);
 
     /// A table will be considered modified when the last_modified_time from
     /// BigQuery has been updated.
     pub const TABLE_MODIFIED_TIMESTAMP: BigQueryTableModification =
-        BigQueryTableModification::new("TABLE_MODIFIED_TIMESTAMP");
+        BigQueryTableModification::new(1);
+
+    /// Creates a new BigQueryTableModification instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("TABLE_MODIFICATION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("TABLE_MODIFIED_TIMESTAMP"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "TABLE_MODIFICATION_UNSPECIFIED" => {
+                std::option::Option::Some(Self::TABLE_MODIFICATION_UNSPECIFIED)
+            }
+            "TABLE_MODIFIED_TIMESTAMP" => std::option::Option::Some(Self::TABLE_MODIFIED_TIMESTAMP),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for BigQueryTableModification {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for BigQueryTableModification {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for BigQueryTableModification {
     fn default() -> Self {
-        big_query_table_modification::TABLE_MODIFICATION_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Attributes evaluated to determine if a schema has been modified. New values
 /// may be added at a later time.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct BigQuerySchemaModification(std::borrow::Cow<'static, str>);
+pub struct BigQuerySchemaModification(i32);
 
 impl BigQuerySchemaModification {
-    /// Creates a new BigQuerySchemaModification instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [BigQuerySchemaModification](BigQuerySchemaModification)
-pub mod big_query_schema_modification {
-    use super::BigQuerySchemaModification;
-
     /// Unused
     pub const SCHEMA_MODIFICATION_UNSPECIFIED: BigQuerySchemaModification =
-        BigQuerySchemaModification::new("SCHEMA_MODIFICATION_UNSPECIFIED");
+        BigQuerySchemaModification::new(0);
 
     /// Profiles should be regenerated when new columns are added to the table.
     /// Default.
-    pub const SCHEMA_NEW_COLUMNS: BigQuerySchemaModification =
-        BigQuerySchemaModification::new("SCHEMA_NEW_COLUMNS");
+    pub const SCHEMA_NEW_COLUMNS: BigQuerySchemaModification = BigQuerySchemaModification::new(1);
 
     /// Profiles should be regenerated when columns are removed from the table.
     pub const SCHEMA_REMOVED_COLUMNS: BigQuerySchemaModification =
-        BigQuerySchemaModification::new("SCHEMA_REMOVED_COLUMNS");
+        BigQuerySchemaModification::new(2);
+
+    /// Creates a new BigQuerySchemaModification instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SCHEMA_MODIFICATION_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("SCHEMA_NEW_COLUMNS"),
+            2 => std::borrow::Cow::Borrowed("SCHEMA_REMOVED_COLUMNS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SCHEMA_MODIFICATION_UNSPECIFIED" => {
+                std::option::Option::Some(Self::SCHEMA_MODIFICATION_UNSPECIFIED)
+            }
+            "SCHEMA_NEW_COLUMNS" => std::option::Option::Some(Self::SCHEMA_NEW_COLUMNS),
+            "SCHEMA_REMOVED_COLUMNS" => std::option::Option::Some(Self::SCHEMA_REMOVED_COLUMNS),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for BigQuerySchemaModification {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for BigQuerySchemaModification {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for BigQuerySchemaModification {
     fn default() -> Self {
-        big_query_schema_modification::SCHEMA_MODIFICATION_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Operators available for comparing the value of fields.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RelationalOperator(std::borrow::Cow<'static, str>);
+pub struct RelationalOperator(i32);
 
 impl RelationalOperator {
+    /// Unused
+    pub const RELATIONAL_OPERATOR_UNSPECIFIED: RelationalOperator = RelationalOperator::new(0);
+
+    /// Equal. Attempts to match even with incompatible types.
+    pub const EQUAL_TO: RelationalOperator = RelationalOperator::new(1);
+
+    /// Not equal to. Attempts to match even with incompatible types.
+    pub const NOT_EQUAL_TO: RelationalOperator = RelationalOperator::new(2);
+
+    /// Greater than.
+    pub const GREATER_THAN: RelationalOperator = RelationalOperator::new(3);
+
+    /// Less than.
+    pub const LESS_THAN: RelationalOperator = RelationalOperator::new(4);
+
+    /// Greater than or equals.
+    pub const GREATER_THAN_OR_EQUALS: RelationalOperator = RelationalOperator::new(5);
+
+    /// Less than or equals.
+    pub const LESS_THAN_OR_EQUALS: RelationalOperator = RelationalOperator::new(6);
+
+    /// Exists
+    pub const EXISTS: RelationalOperator = RelationalOperator::new(7);
+
     /// Creates a new RelationalOperator instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("RELATIONAL_OPERATOR_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("EQUAL_TO"),
+            2 => std::borrow::Cow::Borrowed("NOT_EQUAL_TO"),
+            3 => std::borrow::Cow::Borrowed("GREATER_THAN"),
+            4 => std::borrow::Cow::Borrowed("LESS_THAN"),
+            5 => std::borrow::Cow::Borrowed("GREATER_THAN_OR_EQUALS"),
+            6 => std::borrow::Cow::Borrowed("LESS_THAN_OR_EQUALS"),
+            7 => std::borrow::Cow::Borrowed("EXISTS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "RELATIONAL_OPERATOR_UNSPECIFIED" => {
+                std::option::Option::Some(Self::RELATIONAL_OPERATOR_UNSPECIFIED)
+            }
+            "EQUAL_TO" => std::option::Option::Some(Self::EQUAL_TO),
+            "NOT_EQUAL_TO" => std::option::Option::Some(Self::NOT_EQUAL_TO),
+            "GREATER_THAN" => std::option::Option::Some(Self::GREATER_THAN),
+            "LESS_THAN" => std::option::Option::Some(Self::LESS_THAN),
+            "GREATER_THAN_OR_EQUALS" => std::option::Option::Some(Self::GREATER_THAN_OR_EQUALS),
+            "LESS_THAN_OR_EQUALS" => std::option::Option::Some(Self::LESS_THAN_OR_EQUALS),
+            "EXISTS" => std::option::Option::Some(Self::EXISTS),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [RelationalOperator](RelationalOperator)
-pub mod relational_operator {
-    use super::RelationalOperator;
-
-    /// Unused
-    pub const RELATIONAL_OPERATOR_UNSPECIFIED: RelationalOperator =
-        RelationalOperator::new("RELATIONAL_OPERATOR_UNSPECIFIED");
-
-    /// Equal. Attempts to match even with incompatible types.
-    pub const EQUAL_TO: RelationalOperator = RelationalOperator::new("EQUAL_TO");
-
-    /// Not equal to. Attempts to match even with incompatible types.
-    pub const NOT_EQUAL_TO: RelationalOperator = RelationalOperator::new("NOT_EQUAL_TO");
-
-    /// Greater than.
-    pub const GREATER_THAN: RelationalOperator = RelationalOperator::new("GREATER_THAN");
-
-    /// Less than.
-    pub const LESS_THAN: RelationalOperator = RelationalOperator::new("LESS_THAN");
-
-    /// Greater than or equals.
-    pub const GREATER_THAN_OR_EQUALS: RelationalOperator =
-        RelationalOperator::new("GREATER_THAN_OR_EQUALS");
-
-    /// Less than or equals.
-    pub const LESS_THAN_OR_EQUALS: RelationalOperator =
-        RelationalOperator::new("LESS_THAN_OR_EQUALS");
-
-    /// Exists
-    pub const EXISTS: RelationalOperator = RelationalOperator::new("EXISTS");
-}
-
-impl std::convert::From<std::string::String> for RelationalOperator {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for RelationalOperator {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for RelationalOperator {
     fn default() -> Self {
-        relational_operator::RELATIONAL_OPERATOR_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -30999,432 +32027,582 @@ impl std::default::Default for RelationalOperator {
 /// Dictionary, regular expression and intersecting with findings of another
 /// info type.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct MatchingType(std::borrow::Cow<'static, str>);
+pub struct MatchingType(i32);
 
 impl MatchingType {
-    /// Creates a new MatchingType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [MatchingType](MatchingType)
-pub mod matching_type {
-    use super::MatchingType;
-
     /// Invalid.
-    pub const MATCHING_TYPE_UNSPECIFIED: MatchingType =
-        MatchingType::new("MATCHING_TYPE_UNSPECIFIED");
+    pub const MATCHING_TYPE_UNSPECIFIED: MatchingType = MatchingType::new(0);
 
     /// Full match.
     ///
     /// - Dictionary: join of Dictionary results matched complete finding quote
     /// - Regex: all regex matches fill a finding quote start to end
     /// - Exclude info type: completely inside affecting info types findings
-    pub const MATCHING_TYPE_FULL_MATCH: MatchingType =
-        MatchingType::new("MATCHING_TYPE_FULL_MATCH");
+    pub const MATCHING_TYPE_FULL_MATCH: MatchingType = MatchingType::new(1);
 
     /// Partial match.
     ///
     /// - Dictionary: at least one of the tokens in the finding matches
     /// - Regex: substring of the finding matches
     /// - Exclude info type: intersects with affecting info types findings
-    pub const MATCHING_TYPE_PARTIAL_MATCH: MatchingType =
-        MatchingType::new("MATCHING_TYPE_PARTIAL_MATCH");
+    pub const MATCHING_TYPE_PARTIAL_MATCH: MatchingType = MatchingType::new(2);
 
     /// Inverse match.
     ///
     /// - Dictionary: no tokens in the finding match the dictionary
     /// - Regex: finding doesn't match the regex
     /// - Exclude info type: no intersection with affecting info types findings
-    pub const MATCHING_TYPE_INVERSE_MATCH: MatchingType =
-        MatchingType::new("MATCHING_TYPE_INVERSE_MATCH");
+    pub const MATCHING_TYPE_INVERSE_MATCH: MatchingType = MatchingType::new(3);
+
+    /// Creates a new MatchingType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("MATCHING_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("MATCHING_TYPE_FULL_MATCH"),
+            2 => std::borrow::Cow::Borrowed("MATCHING_TYPE_PARTIAL_MATCH"),
+            3 => std::borrow::Cow::Borrowed("MATCHING_TYPE_INVERSE_MATCH"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "MATCHING_TYPE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::MATCHING_TYPE_UNSPECIFIED)
+            }
+            "MATCHING_TYPE_FULL_MATCH" => std::option::Option::Some(Self::MATCHING_TYPE_FULL_MATCH),
+            "MATCHING_TYPE_PARTIAL_MATCH" => {
+                std::option::Option::Some(Self::MATCHING_TYPE_PARTIAL_MATCH)
+            }
+            "MATCHING_TYPE_INVERSE_MATCH" => {
+                std::option::Option::Some(Self::MATCHING_TYPE_INVERSE_MATCH)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for MatchingType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for MatchingType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for MatchingType {
     fn default() -> Self {
-        matching_type::MATCHING_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Deprecated and unused.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ContentOption(std::borrow::Cow<'static, str>);
+pub struct ContentOption(i32);
 
 impl ContentOption {
+    /// Includes entire content of a file or a data stream.
+    pub const CONTENT_UNSPECIFIED: ContentOption = ContentOption::new(0);
+
+    /// Text content within the data, excluding any metadata.
+    pub const CONTENT_TEXT: ContentOption = ContentOption::new(1);
+
+    /// Images found in the data.
+    pub const CONTENT_IMAGE: ContentOption = ContentOption::new(2);
+
     /// Creates a new ContentOption instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("CONTENT_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("CONTENT_TEXT"),
+            2 => std::borrow::Cow::Borrowed("CONTENT_IMAGE"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "CONTENT_UNSPECIFIED" => std::option::Option::Some(Self::CONTENT_UNSPECIFIED),
+            "CONTENT_TEXT" => std::option::Option::Some(Self::CONTENT_TEXT),
+            "CONTENT_IMAGE" => std::option::Option::Some(Self::CONTENT_IMAGE),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [ContentOption](ContentOption)
-pub mod content_option {
-    use super::ContentOption;
-
-    /// Includes entire content of a file or a data stream.
-    pub const CONTENT_UNSPECIFIED: ContentOption = ContentOption::new("CONTENT_UNSPECIFIED");
-
-    /// Text content within the data, excluding any metadata.
-    pub const CONTENT_TEXT: ContentOption = ContentOption::new("CONTENT_TEXT");
-
-    /// Images found in the data.
-    pub const CONTENT_IMAGE: ContentOption = ContentOption::new("CONTENT_IMAGE");
-}
-
-impl std::convert::From<std::string::String> for ContentOption {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ContentOption {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ContentOption {
     fn default() -> Self {
-        content_option::CONTENT_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Type of metadata containing the finding.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct MetadataType(std::borrow::Cow<'static, str>);
+pub struct MetadataType(i32);
 
 impl MetadataType {
+    /// Unused
+    pub const METADATATYPE_UNSPECIFIED: MetadataType = MetadataType::new(0);
+
+    /// General file metadata provided by Cloud Storage.
+    pub const STORAGE_METADATA: MetadataType = MetadataType::new(2);
+
     /// Creates a new MetadataType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("METADATATYPE_UNSPECIFIED"),
+            2 => std::borrow::Cow::Borrowed("STORAGE_METADATA"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "METADATATYPE_UNSPECIFIED" => std::option::Option::Some(Self::METADATATYPE_UNSPECIFIED),
+            "STORAGE_METADATA" => std::option::Option::Some(Self::STORAGE_METADATA),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [MetadataType](MetadataType)
-pub mod metadata_type {
-    use super::MetadataType;
-
-    /// Unused
-    pub const METADATATYPE_UNSPECIFIED: MetadataType =
-        MetadataType::new("METADATATYPE_UNSPECIFIED");
-
-    /// General file metadata provided by Cloud Storage.
-    pub const STORAGE_METADATA: MetadataType = MetadataType::new("STORAGE_METADATA");
-}
-
-impl std::convert::From<std::string::String> for MetadataType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for MetadataType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for MetadataType {
     fn default() -> Self {
-        metadata_type::METADATATYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Parts of the APIs which use certain infoTypes.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct InfoTypeSupportedBy(std::borrow::Cow<'static, str>);
+pub struct InfoTypeSupportedBy(i32);
 
 impl InfoTypeSupportedBy {
+    /// Unused.
+    pub const ENUM_TYPE_UNSPECIFIED: InfoTypeSupportedBy = InfoTypeSupportedBy::new(0);
+
+    /// Supported by the inspect operations.
+    pub const INSPECT: InfoTypeSupportedBy = InfoTypeSupportedBy::new(1);
+
+    /// Supported by the risk analysis operations.
+    pub const RISK_ANALYSIS: InfoTypeSupportedBy = InfoTypeSupportedBy::new(2);
+
     /// Creates a new InfoTypeSupportedBy instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ENUM_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("INSPECT"),
+            2 => std::borrow::Cow::Borrowed("RISK_ANALYSIS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ENUM_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::ENUM_TYPE_UNSPECIFIED),
+            "INSPECT" => std::option::Option::Some(Self::INSPECT),
+            "RISK_ANALYSIS" => std::option::Option::Some(Self::RISK_ANALYSIS),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [InfoTypeSupportedBy](InfoTypeSupportedBy)
-pub mod info_type_supported_by {
-    use super::InfoTypeSupportedBy;
-
-    /// Unused.
-    pub const ENUM_TYPE_UNSPECIFIED: InfoTypeSupportedBy =
-        InfoTypeSupportedBy::new("ENUM_TYPE_UNSPECIFIED");
-
-    /// Supported by the inspect operations.
-    pub const INSPECT: InfoTypeSupportedBy = InfoTypeSupportedBy::new("INSPECT");
-
-    /// Supported by the risk analysis operations.
-    pub const RISK_ANALYSIS: InfoTypeSupportedBy = InfoTypeSupportedBy::new("RISK_ANALYSIS");
-}
-
-impl std::convert::From<std::string::String> for InfoTypeSupportedBy {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for InfoTypeSupportedBy {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for InfoTypeSupportedBy {
     fn default() -> Self {
-        info_type_supported_by::ENUM_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// An enum to represent the various types of DLP jobs.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DlpJobType(std::borrow::Cow<'static, str>);
+pub struct DlpJobType(i32);
 
 impl DlpJobType {
+    /// Defaults to INSPECT_JOB.
+    pub const DLP_JOB_TYPE_UNSPECIFIED: DlpJobType = DlpJobType::new(0);
+
+    /// The job inspected Google Cloud for sensitive data.
+    pub const INSPECT_JOB: DlpJobType = DlpJobType::new(1);
+
+    /// The job executed a Risk Analysis computation.
+    pub const RISK_ANALYSIS_JOB: DlpJobType = DlpJobType::new(2);
+
     /// Creates a new DlpJobType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DLP_JOB_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("INSPECT_JOB"),
+            2 => std::borrow::Cow::Borrowed("RISK_ANALYSIS_JOB"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DLP_JOB_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::DLP_JOB_TYPE_UNSPECIFIED),
+            "INSPECT_JOB" => std::option::Option::Some(Self::INSPECT_JOB),
+            "RISK_ANALYSIS_JOB" => std::option::Option::Some(Self::RISK_ANALYSIS_JOB),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [DlpJobType](DlpJobType)
-pub mod dlp_job_type {
-    use super::DlpJobType;
-
-    /// Defaults to INSPECT_JOB.
-    pub const DLP_JOB_TYPE_UNSPECIFIED: DlpJobType = DlpJobType::new("DLP_JOB_TYPE_UNSPECIFIED");
-
-    /// The job inspected Google Cloud for sensitive data.
-    pub const INSPECT_JOB: DlpJobType = DlpJobType::new("INSPECT_JOB");
-
-    /// The job executed a Risk Analysis computation.
-    pub const RISK_ANALYSIS_JOB: DlpJobType = DlpJobType::new("RISK_ANALYSIS_JOB");
-}
-
-impl std::convert::From<std::string::String> for DlpJobType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DlpJobType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DlpJobType {
     fn default() -> Self {
-        dlp_job_type::DLP_JOB_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// State of a StoredInfoType version.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct StoredInfoTypeState(std::borrow::Cow<'static, str>);
+pub struct StoredInfoTypeState(i32);
 
 impl StoredInfoTypeState {
-    /// Creates a new StoredInfoTypeState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [StoredInfoTypeState](StoredInfoTypeState)
-pub mod stored_info_type_state {
-    use super::StoredInfoTypeState;
-
     /// Unused
-    pub const STORED_INFO_TYPE_STATE_UNSPECIFIED: StoredInfoTypeState =
-        StoredInfoTypeState::new("STORED_INFO_TYPE_STATE_UNSPECIFIED");
+    pub const STORED_INFO_TYPE_STATE_UNSPECIFIED: StoredInfoTypeState = StoredInfoTypeState::new(0);
 
     /// StoredInfoType version is being created.
-    pub const PENDING: StoredInfoTypeState = StoredInfoTypeState::new("PENDING");
+    pub const PENDING: StoredInfoTypeState = StoredInfoTypeState::new(1);
 
     /// StoredInfoType version is ready for use.
-    pub const READY: StoredInfoTypeState = StoredInfoTypeState::new("READY");
+    pub const READY: StoredInfoTypeState = StoredInfoTypeState::new(2);
 
     /// StoredInfoType creation failed. All relevant error messages are returned in
     /// the `StoredInfoTypeVersion` message.
-    pub const FAILED: StoredInfoTypeState = StoredInfoTypeState::new("FAILED");
+    pub const FAILED: StoredInfoTypeState = StoredInfoTypeState::new(3);
 
     /// StoredInfoType is no longer valid because artifacts stored in
     /// user-controlled storage were modified. To fix an invalid StoredInfoType,
     /// use the `UpdateStoredInfoType` method to create a new version.
-    pub const INVALID: StoredInfoTypeState = StoredInfoTypeState::new("INVALID");
+    pub const INVALID: StoredInfoTypeState = StoredInfoTypeState::new(4);
+
+    /// Creates a new StoredInfoTypeState instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("STORED_INFO_TYPE_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("PENDING"),
+            2 => std::borrow::Cow::Borrowed("READY"),
+            3 => std::borrow::Cow::Borrowed("FAILED"),
+            4 => std::borrow::Cow::Borrowed("INVALID"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "STORED_INFO_TYPE_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::STORED_INFO_TYPE_STATE_UNSPECIFIED)
+            }
+            "PENDING" => std::option::Option::Some(Self::PENDING),
+            "READY" => std::option::Option::Some(Self::READY),
+            "FAILED" => std::option::Option::Some(Self::FAILED),
+            "INVALID" => std::option::Option::Some(Self::INVALID),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for StoredInfoTypeState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for StoredInfoTypeState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for StoredInfoTypeState {
     fn default() -> Self {
-        stored_info_type_state::STORED_INFO_TYPE_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// How broadly the data in the resource has been shared. New items may be added
 /// over time. A higher number means more restricted.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ResourceVisibility(std::borrow::Cow<'static, str>);
+pub struct ResourceVisibility(i32);
 
 impl ResourceVisibility {
-    /// Creates a new ResourceVisibility instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ResourceVisibility](ResourceVisibility)
-pub mod resource_visibility {
-    use super::ResourceVisibility;
-
     /// Unused.
-    pub const RESOURCE_VISIBILITY_UNSPECIFIED: ResourceVisibility =
-        ResourceVisibility::new("RESOURCE_VISIBILITY_UNSPECIFIED");
+    pub const RESOURCE_VISIBILITY_UNSPECIFIED: ResourceVisibility = ResourceVisibility::new(0);
 
     /// Visible to any user.
-    pub const RESOURCE_VISIBILITY_PUBLIC: ResourceVisibility =
-        ResourceVisibility::new("RESOURCE_VISIBILITY_PUBLIC");
+    pub const RESOURCE_VISIBILITY_PUBLIC: ResourceVisibility = ResourceVisibility::new(10);
 
     /// May contain public items.
     /// For example, if a Cloud Storage bucket has uniform bucket level access
     /// disabled, some objects inside it may be public, but none are known yet.
-    pub const RESOURCE_VISIBILITY_INCONCLUSIVE: ResourceVisibility =
-        ResourceVisibility::new("RESOURCE_VISIBILITY_INCONCLUSIVE");
+    pub const RESOURCE_VISIBILITY_INCONCLUSIVE: ResourceVisibility = ResourceVisibility::new(15);
 
     /// Visible only to specific users.
-    pub const RESOURCE_VISIBILITY_RESTRICTED: ResourceVisibility =
-        ResourceVisibility::new("RESOURCE_VISIBILITY_RESTRICTED");
+    pub const RESOURCE_VISIBILITY_RESTRICTED: ResourceVisibility = ResourceVisibility::new(20);
+
+    /// Creates a new ResourceVisibility instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("RESOURCE_VISIBILITY_UNSPECIFIED"),
+            10 => std::borrow::Cow::Borrowed("RESOURCE_VISIBILITY_PUBLIC"),
+            15 => std::borrow::Cow::Borrowed("RESOURCE_VISIBILITY_INCONCLUSIVE"),
+            20 => std::borrow::Cow::Borrowed("RESOURCE_VISIBILITY_RESTRICTED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "RESOURCE_VISIBILITY_UNSPECIFIED" => {
+                std::option::Option::Some(Self::RESOURCE_VISIBILITY_UNSPECIFIED)
+            }
+            "RESOURCE_VISIBILITY_PUBLIC" => {
+                std::option::Option::Some(Self::RESOURCE_VISIBILITY_PUBLIC)
+            }
+            "RESOURCE_VISIBILITY_INCONCLUSIVE" => {
+                std::option::Option::Some(Self::RESOURCE_VISIBILITY_INCONCLUSIVE)
+            }
+            "RESOURCE_VISIBILITY_RESTRICTED" => {
+                std::option::Option::Some(Self::RESOURCE_VISIBILITY_RESTRICTED)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ResourceVisibility {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ResourceVisibility {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ResourceVisibility {
     fn default() -> Self {
-        resource_visibility::RESOURCE_VISIBILITY_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// How a resource is encrypted.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EncryptionStatus(std::borrow::Cow<'static, str>);
+pub struct EncryptionStatus(i32);
 
 impl EncryptionStatus {
+    /// Unused.
+    pub const ENCRYPTION_STATUS_UNSPECIFIED: EncryptionStatus = EncryptionStatus::new(0);
+
+    /// Google manages server-side encryption keys on your behalf.
+    pub const ENCRYPTION_GOOGLE_MANAGED: EncryptionStatus = EncryptionStatus::new(1);
+
+    /// Customer provides the key.
+    pub const ENCRYPTION_CUSTOMER_MANAGED: EncryptionStatus = EncryptionStatus::new(2);
+
     /// Creates a new EncryptionStatus instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("ENCRYPTION_STATUS_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("ENCRYPTION_GOOGLE_MANAGED"),
+            2 => std::borrow::Cow::Borrowed("ENCRYPTION_CUSTOMER_MANAGED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "ENCRYPTION_STATUS_UNSPECIFIED" => {
+                std::option::Option::Some(Self::ENCRYPTION_STATUS_UNSPECIFIED)
+            }
+            "ENCRYPTION_GOOGLE_MANAGED" => {
+                std::option::Option::Some(Self::ENCRYPTION_GOOGLE_MANAGED)
+            }
+            "ENCRYPTION_CUSTOMER_MANAGED" => {
+                std::option::Option::Some(Self::ENCRYPTION_CUSTOMER_MANAGED)
+            }
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [EncryptionStatus](EncryptionStatus)
-pub mod encryption_status {
-    use super::EncryptionStatus;
-
-    /// Unused.
-    pub const ENCRYPTION_STATUS_UNSPECIFIED: EncryptionStatus =
-        EncryptionStatus::new("ENCRYPTION_STATUS_UNSPECIFIED");
-
-    /// Google manages server-side encryption keys on your behalf.
-    pub const ENCRYPTION_GOOGLE_MANAGED: EncryptionStatus =
-        EncryptionStatus::new("ENCRYPTION_GOOGLE_MANAGED");
-
-    /// Customer provides the key.
-    pub const ENCRYPTION_CUSTOMER_MANAGED: EncryptionStatus =
-        EncryptionStatus::new("ENCRYPTION_CUSTOMER_MANAGED");
-}
-
-impl std::convert::From<std::string::String> for EncryptionStatus {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for EncryptionStatus {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for EncryptionStatus {
     fn default() -> Self {
-        encryption_status::ENCRYPTION_STATUS_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Bucketized nullness percentage levels. A higher level means a higher
 /// percentage of the column is null.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct NullPercentageLevel(std::borrow::Cow<'static, str>);
+pub struct NullPercentageLevel(i32);
 
 impl NullPercentageLevel {
+    /// Unused.
+    pub const NULL_PERCENTAGE_LEVEL_UNSPECIFIED: NullPercentageLevel = NullPercentageLevel::new(0);
+
+    /// Very few null entries.
+    pub const NULL_PERCENTAGE_VERY_LOW: NullPercentageLevel = NullPercentageLevel::new(1);
+
+    /// Some null entries.
+    pub const NULL_PERCENTAGE_LOW: NullPercentageLevel = NullPercentageLevel::new(2);
+
+    /// A few null entries.
+    pub const NULL_PERCENTAGE_MEDIUM: NullPercentageLevel = NullPercentageLevel::new(3);
+
+    /// A lot of null entries.
+    pub const NULL_PERCENTAGE_HIGH: NullPercentageLevel = NullPercentageLevel::new(4);
+
     /// Creates a new NullPercentageLevel instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("NULL_PERCENTAGE_LEVEL_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("NULL_PERCENTAGE_VERY_LOW"),
+            2 => std::borrow::Cow::Borrowed("NULL_PERCENTAGE_LOW"),
+            3 => std::borrow::Cow::Borrowed("NULL_PERCENTAGE_MEDIUM"),
+            4 => std::borrow::Cow::Borrowed("NULL_PERCENTAGE_HIGH"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "NULL_PERCENTAGE_LEVEL_UNSPECIFIED" => {
+                std::option::Option::Some(Self::NULL_PERCENTAGE_LEVEL_UNSPECIFIED)
+            }
+            "NULL_PERCENTAGE_VERY_LOW" => std::option::Option::Some(Self::NULL_PERCENTAGE_VERY_LOW),
+            "NULL_PERCENTAGE_LOW" => std::option::Option::Some(Self::NULL_PERCENTAGE_LOW),
+            "NULL_PERCENTAGE_MEDIUM" => std::option::Option::Some(Self::NULL_PERCENTAGE_MEDIUM),
+            "NULL_PERCENTAGE_HIGH" => std::option::Option::Some(Self::NULL_PERCENTAGE_HIGH),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [NullPercentageLevel](NullPercentageLevel)
-pub mod null_percentage_level {
-    use super::NullPercentageLevel;
-
-    /// Unused.
-    pub const NULL_PERCENTAGE_LEVEL_UNSPECIFIED: NullPercentageLevel =
-        NullPercentageLevel::new("NULL_PERCENTAGE_LEVEL_UNSPECIFIED");
-
-    /// Very few null entries.
-    pub const NULL_PERCENTAGE_VERY_LOW: NullPercentageLevel =
-        NullPercentageLevel::new("NULL_PERCENTAGE_VERY_LOW");
-
-    /// Some null entries.
-    pub const NULL_PERCENTAGE_LOW: NullPercentageLevel =
-        NullPercentageLevel::new("NULL_PERCENTAGE_LOW");
-
-    /// A few null entries.
-    pub const NULL_PERCENTAGE_MEDIUM: NullPercentageLevel =
-        NullPercentageLevel::new("NULL_PERCENTAGE_MEDIUM");
-
-    /// A lot of null entries.
-    pub const NULL_PERCENTAGE_HIGH: NullPercentageLevel =
-        NullPercentageLevel::new("NULL_PERCENTAGE_HIGH");
-}
-
-impl std::convert::From<std::string::String> for NullPercentageLevel {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for NullPercentageLevel {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for NullPercentageLevel {
     fn default() -> Self {
-        null_percentage_level::NULL_PERCENTAGE_LEVEL_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -31433,85 +32611,85 @@ impl std::default::Default for NullPercentageLevel {
 /// value indicates that the column contains few unique values like booleans or
 /// other classifiers.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct UniquenessScoreLevel(std::borrow::Cow<'static, str>);
+pub struct UniquenessScoreLevel(i32);
 
 impl UniquenessScoreLevel {
-    /// Creates a new UniquenessScoreLevel instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [UniquenessScoreLevel](UniquenessScoreLevel)
-pub mod uniqueness_score_level {
-    use super::UniquenessScoreLevel;
-
     /// Some columns do not have estimated uniqueness. Possible reasons include
     /// having too few values.
     pub const UNIQUENESS_SCORE_LEVEL_UNSPECIFIED: UniquenessScoreLevel =
-        UniquenessScoreLevel::new("UNIQUENESS_SCORE_LEVEL_UNSPECIFIED");
+        UniquenessScoreLevel::new(0);
 
     /// Low uniqueness, possibly a boolean, enum or similiarly typed column.
-    pub const UNIQUENESS_SCORE_LOW: UniquenessScoreLevel =
-        UniquenessScoreLevel::new("UNIQUENESS_SCORE_LOW");
+    pub const UNIQUENESS_SCORE_LOW: UniquenessScoreLevel = UniquenessScoreLevel::new(1);
 
     /// Medium uniqueness.
-    pub const UNIQUENESS_SCORE_MEDIUM: UniquenessScoreLevel =
-        UniquenessScoreLevel::new("UNIQUENESS_SCORE_MEDIUM");
+    pub const UNIQUENESS_SCORE_MEDIUM: UniquenessScoreLevel = UniquenessScoreLevel::new(2);
 
     /// High uniqueness, possibly a column of free text or unique identifiers.
-    pub const UNIQUENESS_SCORE_HIGH: UniquenessScoreLevel =
-        UniquenessScoreLevel::new("UNIQUENESS_SCORE_HIGH");
+    pub const UNIQUENESS_SCORE_HIGH: UniquenessScoreLevel = UniquenessScoreLevel::new(3);
+
+    /// Creates a new UniquenessScoreLevel instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("UNIQUENESS_SCORE_LEVEL_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("UNIQUENESS_SCORE_LOW"),
+            2 => std::borrow::Cow::Borrowed("UNIQUENESS_SCORE_MEDIUM"),
+            3 => std::borrow::Cow::Borrowed("UNIQUENESS_SCORE_HIGH"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "UNIQUENESS_SCORE_LEVEL_UNSPECIFIED" => {
+                std::option::Option::Some(Self::UNIQUENESS_SCORE_LEVEL_UNSPECIFIED)
+            }
+            "UNIQUENESS_SCORE_LOW" => std::option::Option::Some(Self::UNIQUENESS_SCORE_LOW),
+            "UNIQUENESS_SCORE_MEDIUM" => std::option::Option::Some(Self::UNIQUENESS_SCORE_MEDIUM),
+            "UNIQUENESS_SCORE_HIGH" => std::option::Option::Some(Self::UNIQUENESS_SCORE_HIGH),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for UniquenessScoreLevel {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for UniquenessScoreLevel {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for UniquenessScoreLevel {
     fn default() -> Self {
-        uniqueness_score_level::UNIQUENESS_SCORE_LEVEL_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// State of the connection.
 /// New values may be added over time.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ConnectionState(std::borrow::Cow<'static, str>);
+pub struct ConnectionState(i32);
 
 impl ConnectionState {
-    /// Creates a new ConnectionState instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [ConnectionState](ConnectionState)
-pub mod connection_state {
-    use super::ConnectionState;
-
     /// Unused
-    pub const CONNECTION_STATE_UNSPECIFIED: ConnectionState =
-        ConnectionState::new("CONNECTION_STATE_UNSPECIFIED");
+    pub const CONNECTION_STATE_UNSPECIFIED: ConnectionState = ConnectionState::new(0);
 
     /// The DLP API automatically created this connection during an initial scan,
     /// and it is awaiting full configuration by a user.
-    pub const MISSING_CREDENTIALS: ConnectionState = ConnectionState::new("MISSING_CREDENTIALS");
+    pub const MISSING_CREDENTIALS: ConnectionState = ConnectionState::new(1);
 
     /// A configured connection that has not encountered any errors.
-    pub const AVAILABLE: ConnectionState = ConnectionState::new("AVAILABLE");
+    pub const AVAILABLE: ConnectionState = ConnectionState::new(2);
 
     /// A configured connection that encountered errors during its last use. It
     /// will not be used again until it is set to AVAILABLE.
@@ -31520,18 +32698,52 @@ pub mod connection_state {
     /// request to set the status to AVAILABLE when the connection is ready for
     /// use. If the resolution doesn't require external action, then any changes to
     /// the connection properties will automatically mark it as AVAILABLE.
-    pub const ERROR: ConnectionState = ConnectionState::new("ERROR");
+    pub const ERROR: ConnectionState = ConnectionState::new(3);
+
+    /// Creates a new ConnectionState instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("CONNECTION_STATE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("MISSING_CREDENTIALS"),
+            2 => std::borrow::Cow::Borrowed("AVAILABLE"),
+            3 => std::borrow::Cow::Borrowed("ERROR"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "CONNECTION_STATE_UNSPECIFIED" => {
+                std::option::Option::Some(Self::CONNECTION_STATE_UNSPECIFIED)
+            }
+            "MISSING_CREDENTIALS" => std::option::Option::Some(Self::MISSING_CREDENTIALS),
+            "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
+            "ERROR" => std::option::Option::Some(Self::ERROR),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for ConnectionState {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for ConnectionState {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for ConnectionState {
     fn default() -> Self {
-        connection_state::CONNECTION_STATE_UNSPECIFIED
+        Self::new(0)
     }
 }
 
@@ -31551,85 +32763,91 @@ impl std::default::Default for ConnectionState {
 /// and how likelihood works, see [Match
 /// likelihood](https://cloud.google.com/sensitive-data-protection/docs/likelihood).
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Likelihood(std::borrow::Cow<'static, str>);
+pub struct Likelihood(i32);
 
 impl Likelihood {
+    /// Default value; same as POSSIBLE.
+    pub const LIKELIHOOD_UNSPECIFIED: Likelihood = Likelihood::new(0);
+
+    /// Highest chance of a false positive.
+    pub const VERY_UNLIKELY: Likelihood = Likelihood::new(1);
+
+    /// High chance of a false positive.
+    pub const UNLIKELY: Likelihood = Likelihood::new(2);
+
+    /// Some matching signals. The default value.
+    pub const POSSIBLE: Likelihood = Likelihood::new(3);
+
+    /// Low chance of a false positive.
+    pub const LIKELY: Likelihood = Likelihood::new(4);
+
+    /// Confidence level is high. Lowest chance of a false positive.
+    pub const VERY_LIKELY: Likelihood = Likelihood::new(5);
+
     /// Creates a new Likelihood instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("LIKELIHOOD_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("VERY_UNLIKELY"),
+            2 => std::borrow::Cow::Borrowed("UNLIKELY"),
+            3 => std::borrow::Cow::Borrowed("POSSIBLE"),
+            4 => std::borrow::Cow::Borrowed("LIKELY"),
+            5 => std::borrow::Cow::Borrowed("VERY_LIKELY"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "LIKELIHOOD_UNSPECIFIED" => std::option::Option::Some(Self::LIKELIHOOD_UNSPECIFIED),
+            "VERY_UNLIKELY" => std::option::Option::Some(Self::VERY_UNLIKELY),
+            "UNLIKELY" => std::option::Option::Some(Self::UNLIKELY),
+            "POSSIBLE" => std::option::Option::Some(Self::POSSIBLE),
+            "LIKELY" => std::option::Option::Some(Self::LIKELY),
+            "VERY_LIKELY" => std::option::Option::Some(Self::VERY_LIKELY),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [Likelihood](Likelihood)
-pub mod likelihood {
-    use super::Likelihood;
-
-    /// Default value; same as POSSIBLE.
-    pub const LIKELIHOOD_UNSPECIFIED: Likelihood = Likelihood::new("LIKELIHOOD_UNSPECIFIED");
-
-    /// Highest chance of a false positive.
-    pub const VERY_UNLIKELY: Likelihood = Likelihood::new("VERY_UNLIKELY");
-
-    /// High chance of a false positive.
-    pub const UNLIKELY: Likelihood = Likelihood::new("UNLIKELY");
-
-    /// Some matching signals. The default value.
-    pub const POSSIBLE: Likelihood = Likelihood::new("POSSIBLE");
-
-    /// Low chance of a false positive.
-    pub const LIKELY: Likelihood = Likelihood::new("LIKELY");
-
-    /// Confidence level is high. Lowest chance of a false positive.
-    pub const VERY_LIKELY: Likelihood = Likelihood::new("VERY_LIKELY");
-}
-
-impl std::convert::From<std::string::String> for Likelihood {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Likelihood {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Likelihood {
     fn default() -> Self {
-        likelihood::LIKELIHOOD_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Definitions of file type groups to scan. New types will be added to this
 /// list.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct FileType(std::borrow::Cow<'static, str>);
+pub struct FileType(i32);
 
 impl FileType {
-    /// Creates a new FileType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [FileType](FileType)
-pub mod file_type {
-    use super::FileType;
-
     /// Includes all files.
-    pub const FILE_TYPE_UNSPECIFIED: FileType = FileType::new("FILE_TYPE_UNSPECIFIED");
+    pub const FILE_TYPE_UNSPECIFIED: FileType = FileType::new(0);
 
     /// Includes all file extensions not covered by another entry. Binary
     /// scanning attempts to convert the content of the file to utf_8 to scan
     /// the file.
     /// If you wish to avoid this fall back, specify one or more of the other
     /// file types in your storage scan.
-    pub const BINARY_FILE: FileType = FileType::new("BINARY_FILE");
+    pub const BINARY_FILE: FileType = FileType::new(1);
 
     /// Included file extensions:
     /// asc,asp, aspx, brf, c, cc,cfm, cgi, cpp, csv, cxx, c++, cs, css, dart,
@@ -31639,7 +32857,7 @@ pub mod file_type {
     /// shtml, shtm, xhtml, lhs, ics, ini, java, js, json, jsonl, kix, kml,
     /// ocaml, md, txt, text, tsv, vb, vcard, vcs, wml, xcodeproj, xml, xsl, xsd,
     /// yml, yaml.
-    pub const TEXT_FILE: FileType = FileType::new("TEXT_FILE");
+    pub const TEXT_FILE: FileType = FileType::new(2);
 
     /// Included file extensions:
     /// bmp, gif, jpg, jpeg, jpe, png. Setting
@@ -31650,53 +32868,99 @@ pub mod file_type {
     /// `global`, `us`, `asia`, and `europe` regions.
     ///
     /// [google.privacy.dlp.v2.CloudStorageOptions.bytes_limit_per_file]: crate::model::CloudStorageOptions::bytes_limit_per_file
-    pub const IMAGE: FileType = FileType::new("IMAGE");
+    pub const IMAGE: FileType = FileType::new(3);
 
     /// Microsoft Word files larger than 30 MB will be scanned as binary files.
     /// Included file extensions:
     /// docx, dotx, docm, dotm. Setting `bytes_limit_per_file` or
     /// `bytes_limit_per_file_percent` has no effect on Word files.
-    pub const WORD: FileType = FileType::new("WORD");
+    pub const WORD: FileType = FileType::new(5);
 
     /// PDF files larger than 30 MB will be scanned as binary files.
     /// Included file extensions:
     /// pdf. Setting `bytes_limit_per_file` or `bytes_limit_per_file_percent`
     /// has no effect on PDF files.
-    pub const PDF: FileType = FileType::new("PDF");
+    pub const PDF: FileType = FileType::new(6);
 
     /// Included file extensions:
     /// avro
-    pub const AVRO: FileType = FileType::new("AVRO");
+    pub const AVRO: FileType = FileType::new(7);
 
     /// Included file extensions:
     /// csv
-    pub const CSV: FileType = FileType::new("CSV");
+    pub const CSV: FileType = FileType::new(8);
 
     /// Included file extensions:
     /// tsv
-    pub const TSV: FileType = FileType::new("TSV");
+    pub const TSV: FileType = FileType::new(9);
 
     /// Microsoft PowerPoint files larger than 30 MB will be scanned as binary
     /// files. Included file extensions:
     /// pptx, pptm, potx, potm, pot. Setting `bytes_limit_per_file` or
     /// `bytes_limit_per_file_percent` has no effect on PowerPoint files.
-    pub const POWERPOINT: FileType = FileType::new("POWERPOINT");
+    pub const POWERPOINT: FileType = FileType::new(11);
 
     /// Microsoft Excel files larger than 30 MB will be scanned as binary files.
     /// Included file extensions:
     /// xlsx, xlsm, xltx, xltm. Setting `bytes_limit_per_file` or
     /// `bytes_limit_per_file_percent` has no effect on Excel files.
-    pub const EXCEL: FileType = FileType::new("EXCEL");
+    pub const EXCEL: FileType = FileType::new(12);
+
+    /// Creates a new FileType instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("FILE_TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("BINARY_FILE"),
+            2 => std::borrow::Cow::Borrowed("TEXT_FILE"),
+            3 => std::borrow::Cow::Borrowed("IMAGE"),
+            5 => std::borrow::Cow::Borrowed("WORD"),
+            6 => std::borrow::Cow::Borrowed("PDF"),
+            7 => std::borrow::Cow::Borrowed("AVRO"),
+            8 => std::borrow::Cow::Borrowed("CSV"),
+            9 => std::borrow::Cow::Borrowed("TSV"),
+            11 => std::borrow::Cow::Borrowed("POWERPOINT"),
+            12 => std::borrow::Cow::Borrowed("EXCEL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "FILE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::FILE_TYPE_UNSPECIFIED),
+            "BINARY_FILE" => std::option::Option::Some(Self::BINARY_FILE),
+            "TEXT_FILE" => std::option::Option::Some(Self::TEXT_FILE),
+            "IMAGE" => std::option::Option::Some(Self::IMAGE),
+            "WORD" => std::option::Option::Some(Self::WORD),
+            "PDF" => std::option::Option::Some(Self::PDF),
+            "AVRO" => std::option::Option::Some(Self::AVRO),
+            "CSV" => std::option::Option::Some(Self::CSV),
+            "TSV" => std::option::Option::Some(Self::TSV),
+            "POWERPOINT" => std::option::Option::Some(Self::POWERPOINT),
+            "EXCEL" => std::option::Option::Some(Self::EXCEL),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for FileType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for FileType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for FileType {
     fn default() -> Self {
-        file_type::FILE_TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/privacy/dlp/v2/src/transport.rs
+++ b/src/generated/privacy/dlp/v2/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::DlpService for DlpService {
                 reqwest::Method::POST,
                 format!("/v2/{}/content:inspect", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -72,7 +72,7 @@ impl crate::stubs::DlpService for DlpService {
                 reqwest::Method::POST,
                 format!("/v2/{}/image:redact", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -92,7 +92,7 @@ impl crate::stubs::DlpService for DlpService {
                 reqwest::Method::POST,
                 format!("/v2/{}/content:deidentify", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -112,7 +112,7 @@ impl crate::stubs::DlpService for DlpService {
                 reqwest::Method::POST,
                 format!("/v2/{}/content:reidentify", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -129,7 +129,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v2/infoTypes".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -155,7 +155,7 @@ impl crate::stubs::DlpService for DlpService {
                 reqwest::Method::POST,
                 format!("/v2/{}/inspectTemplates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -172,7 +172,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -189,7 +189,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -211,7 +211,7 @@ impl crate::stubs::DlpService for DlpService {
                 reqwest::Method::GET,
                 format!("/v2/{}/inspectTemplates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -234,7 +234,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -256,7 +256,7 @@ impl crate::stubs::DlpService for DlpService {
                 reqwest::Method::POST,
                 format!("/v2/{}/deidentifyTemplates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -273,7 +273,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -290,7 +290,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -312,7 +312,7 @@ impl crate::stubs::DlpService for DlpService {
                 reqwest::Method::GET,
                 format!("/v2/{}/deidentifyTemplates", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -335,7 +335,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -357,7 +357,7 @@ impl crate::stubs::DlpService for DlpService {
                 reqwest::Method::POST,
                 format!("/v2/{}/jobTriggers", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -374,7 +374,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -394,7 +394,7 @@ impl crate::stubs::DlpService for DlpService {
                 reqwest::Method::POST,
                 format!("/v2/{}:hybridInspect", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -411,7 +411,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -433,7 +433,7 @@ impl crate::stubs::DlpService for DlpService {
                 reqwest::Method::GET,
                 format!("/v2/{}/jobTriggers", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -458,7 +458,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -477,7 +477,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:activate", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -497,7 +497,7 @@ impl crate::stubs::DlpService for DlpService {
                 reqwest::Method::POST,
                 format!("/v2/{}/discoveryConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -514,7 +514,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -531,7 +531,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -553,7 +553,7 @@ impl crate::stubs::DlpService for DlpService {
                 reqwest::Method::GET,
                 format!("/v2/{}/discoveryConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -575,7 +575,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -594,7 +594,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}/dlpJobs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -611,7 +611,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}/dlpJobs", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -636,7 +636,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -655,7 +655,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -674,7 +674,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -694,7 +694,7 @@ impl crate::stubs::DlpService for DlpService {
                 reqwest::Method::POST,
                 format!("/v2/{}/storedInfoTypes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -711,7 +711,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -728,7 +728,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -750,7 +750,7 @@ impl crate::stubs::DlpService for DlpService {
                 reqwest::Method::GET,
                 format!("/v2/{}/storedInfoTypes", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -773,7 +773,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -795,7 +795,7 @@ impl crate::stubs::DlpService for DlpService {
                 reqwest::Method::GET,
                 format!("/v2/{}/projectDataProfiles", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -821,7 +821,7 @@ impl crate::stubs::DlpService for DlpService {
                 reqwest::Method::GET,
                 format!("/v2/{}/tableDataProfiles", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -847,7 +847,7 @@ impl crate::stubs::DlpService for DlpService {
                 reqwest::Method::GET,
                 format!("/v2/{}/columnDataProfiles", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -870,7 +870,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -892,7 +892,7 @@ impl crate::stubs::DlpService for DlpService {
                 reqwest::Method::GET,
                 format!("/v2/{}/fileStoreDataProfiles", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -915,7 +915,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -934,7 +934,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -953,7 +953,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -972,7 +972,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -991,7 +991,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1013,7 +1013,7 @@ impl crate::stubs::DlpService for DlpService {
                 reqwest::Method::POST,
                 format!("/v2/{}:hybridInspect", req.name),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1030,7 +1030,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v2/{}:finish", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1050,7 +1050,7 @@ impl crate::stubs::DlpService for DlpService {
                 reqwest::Method::POST,
                 format!("/v2/{}/connections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1067,7 +1067,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1089,7 +1089,7 @@ impl crate::stubs::DlpService for DlpService {
                 reqwest::Method::GET,
                 format!("/v2/{}/connections", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1114,7 +1114,7 @@ impl crate::stubs::DlpService for DlpService {
                 reqwest::Method::GET,
                 format!("/v2/{}/connections:search", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1136,7 +1136,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -1155,7 +1155,7 @@ impl crate::stubs::DlpService for DlpService {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v2/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/rpc/types/src/model.rs
+++ b/src/generated/rpc/types/src/model.rs
@@ -1040,33 +1040,18 @@ impl wkt::message::Message for Status {
 /// `OUT_OF_RANGE` over `FAILED_PRECONDITION` if both codes apply.
 /// Similarly prefer `NOT_FOUND` or `ALREADY_EXISTS` over `FAILED_PRECONDITION`.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Code(std::borrow::Cow<'static, str>);
+pub struct Code(i32);
 
 impl Code {
-    /// Creates a new Code instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [Code](Code)
-pub mod code {
-    use super::Code;
-
     /// Not an error; returned on success.
     ///
     /// HTTP Mapping: 200 OK
-    pub const OK: Code = Code::new("OK");
+    pub const OK: Code = Code::new(0);
 
     /// The operation was cancelled, typically by the caller.
     ///
     /// HTTP Mapping: 499 Client Closed Request
-    pub const CANCELLED: Code = Code::new("CANCELLED");
+    pub const CANCELLED: Code = Code::new(1);
 
     /// Unknown error.  For example, this error may be returned when
     /// a `Status` value received from another address space belongs to
@@ -1075,7 +1060,7 @@ pub mod code {
     /// may be converted to this error.
     ///
     /// HTTP Mapping: 500 Internal Server Error
-    pub const UNKNOWN: Code = Code::new("UNKNOWN");
+    pub const UNKNOWN: Code = Code::new(2);
 
     /// The client specified an invalid argument.  Note that this differs
     /// from `FAILED_PRECONDITION`.  `INVALID_ARGUMENT` indicates arguments
@@ -1083,7 +1068,7 @@ pub mod code {
     /// (e.g., a malformed file name).
     ///
     /// HTTP Mapping: 400 Bad Request
-    pub const INVALID_ARGUMENT: Code = Code::new("INVALID_ARGUMENT");
+    pub const INVALID_ARGUMENT: Code = Code::new(3);
 
     /// The deadline expired before the operation could complete. For operations
     /// that change the state of the system, this error may be returned
@@ -1092,7 +1077,7 @@ pub mod code {
     /// enough for the deadline to expire.
     ///
     /// HTTP Mapping: 504 Gateway Timeout
-    pub const DEADLINE_EXCEEDED: Code = Code::new("DEADLINE_EXCEEDED");
+    pub const DEADLINE_EXCEEDED: Code = Code::new(4);
 
     /// Some requested entity (e.g., file or directory) was not found.
     ///
@@ -1103,13 +1088,13 @@ pub mod code {
     /// must be used.
     ///
     /// HTTP Mapping: 404 Not Found
-    pub const NOT_FOUND: Code = Code::new("NOT_FOUND");
+    pub const NOT_FOUND: Code = Code::new(5);
 
     /// The entity that a client attempted to create (e.g., file or directory)
     /// already exists.
     ///
     /// HTTP Mapping: 409 Conflict
-    pub const ALREADY_EXISTS: Code = Code::new("ALREADY_EXISTS");
+    pub const ALREADY_EXISTS: Code = Code::new(6);
 
     /// The caller does not have permission to execute the specified
     /// operation. `PERMISSION_DENIED` must not be used for rejections
@@ -1121,19 +1106,19 @@ pub mod code {
     /// other pre-conditions.
     ///
     /// HTTP Mapping: 403 Forbidden
-    pub const PERMISSION_DENIED: Code = Code::new("PERMISSION_DENIED");
+    pub const PERMISSION_DENIED: Code = Code::new(7);
 
     /// The request does not have valid authentication credentials for the
     /// operation.
     ///
     /// HTTP Mapping: 401 Unauthorized
-    pub const UNAUTHENTICATED: Code = Code::new("UNAUTHENTICATED");
+    pub const UNAUTHENTICATED: Code = Code::new(16);
 
     /// Some resource has been exhausted, perhaps a per-user quota, or
     /// perhaps the entire file system is out of space.
     ///
     /// HTTP Mapping: 429 Too Many Requests
-    pub const RESOURCE_EXHAUSTED: Code = Code::new("RESOURCE_EXHAUSTED");
+    pub const RESOURCE_EXHAUSTED: Code = Code::new(8);
 
     /// The operation was rejected because the system is not in a state
     /// required for the operation's execution.  For example, the directory
@@ -1153,7 +1138,7 @@ pub mod code {
     /// the files are deleted from the directory.
     ///
     /// HTTP Mapping: 400 Bad Request
-    pub const FAILED_PRECONDITION: Code = Code::new("FAILED_PRECONDITION");
+    pub const FAILED_PRECONDITION: Code = Code::new(9);
 
     /// The operation was aborted, typically due to a concurrency issue such as
     /// a sequencer check failure or transaction abort.
@@ -1162,7 +1147,7 @@ pub mod code {
     /// `ABORTED`, and `UNAVAILABLE`.
     ///
     /// HTTP Mapping: 409 Conflict
-    pub const ABORTED: Code = Code::new("ABORTED");
+    pub const ABORTED: Code = Code::new(10);
 
     /// The operation was attempted past the valid range.  E.g., seeking or
     /// reading past end-of-file.
@@ -1181,20 +1166,20 @@ pub mod code {
     /// they are done.
     ///
     /// HTTP Mapping: 400 Bad Request
-    pub const OUT_OF_RANGE: Code = Code::new("OUT_OF_RANGE");
+    pub const OUT_OF_RANGE: Code = Code::new(11);
 
     /// The operation is not implemented or is not supported/enabled in this
     /// service.
     ///
     /// HTTP Mapping: 501 Not Implemented
-    pub const UNIMPLEMENTED: Code = Code::new("UNIMPLEMENTED");
+    pub const UNIMPLEMENTED: Code = Code::new(12);
 
     /// Internal errors.  This means that some invariants expected by the
     /// underlying system have been broken.  This error code is reserved
     /// for serious errors.
     ///
     /// HTTP Mapping: 500 Internal Server Error
-    pub const INTERNAL: Code = Code::new("INTERNAL");
+    pub const INTERNAL: Code = Code::new(13);
 
     /// The service is currently unavailable.  This is most likely a
     /// transient condition, which can be corrected by retrying with
@@ -1205,22 +1190,80 @@ pub mod code {
     /// `ABORTED`, and `UNAVAILABLE`.
     ///
     /// HTTP Mapping: 503 Service Unavailable
-    pub const UNAVAILABLE: Code = Code::new("UNAVAILABLE");
+    pub const UNAVAILABLE: Code = Code::new(14);
 
     /// Unrecoverable data loss or corruption.
     ///
     /// HTTP Mapping: 500 Internal Server Error
-    pub const DATA_LOSS: Code = Code::new("DATA_LOSS");
+    pub const DATA_LOSS: Code = Code::new(15);
+
+    /// Creates a new Code instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("OK"),
+            1 => std::borrow::Cow::Borrowed("CANCELLED"),
+            2 => std::borrow::Cow::Borrowed("UNKNOWN"),
+            3 => std::borrow::Cow::Borrowed("INVALID_ARGUMENT"),
+            4 => std::borrow::Cow::Borrowed("DEADLINE_EXCEEDED"),
+            5 => std::borrow::Cow::Borrowed("NOT_FOUND"),
+            6 => std::borrow::Cow::Borrowed("ALREADY_EXISTS"),
+            7 => std::borrow::Cow::Borrowed("PERMISSION_DENIED"),
+            8 => std::borrow::Cow::Borrowed("RESOURCE_EXHAUSTED"),
+            9 => std::borrow::Cow::Borrowed("FAILED_PRECONDITION"),
+            10 => std::borrow::Cow::Borrowed("ABORTED"),
+            11 => std::borrow::Cow::Borrowed("OUT_OF_RANGE"),
+            12 => std::borrow::Cow::Borrowed("UNIMPLEMENTED"),
+            13 => std::borrow::Cow::Borrowed("INTERNAL"),
+            14 => std::borrow::Cow::Borrowed("UNAVAILABLE"),
+            15 => std::borrow::Cow::Borrowed("DATA_LOSS"),
+            16 => std::borrow::Cow::Borrowed("UNAUTHENTICATED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "OK" => std::option::Option::Some(Self::OK),
+            "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
+            "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
+            "INVALID_ARGUMENT" => std::option::Option::Some(Self::INVALID_ARGUMENT),
+            "DEADLINE_EXCEEDED" => std::option::Option::Some(Self::DEADLINE_EXCEEDED),
+            "NOT_FOUND" => std::option::Option::Some(Self::NOT_FOUND),
+            "ALREADY_EXISTS" => std::option::Option::Some(Self::ALREADY_EXISTS),
+            "PERMISSION_DENIED" => std::option::Option::Some(Self::PERMISSION_DENIED),
+            "UNAUTHENTICATED" => std::option::Option::Some(Self::UNAUTHENTICATED),
+            "RESOURCE_EXHAUSTED" => std::option::Option::Some(Self::RESOURCE_EXHAUSTED),
+            "FAILED_PRECONDITION" => std::option::Option::Some(Self::FAILED_PRECONDITION),
+            "ABORTED" => std::option::Option::Some(Self::ABORTED),
+            "OUT_OF_RANGE" => std::option::Option::Some(Self::OUT_OF_RANGE),
+            "UNIMPLEMENTED" => std::option::Option::Some(Self::UNIMPLEMENTED),
+            "INTERNAL" => std::option::Option::Some(Self::INTERNAL),
+            "UNAVAILABLE" => std::option::Option::Some(Self::UNAVAILABLE),
+            "DATA_LOSS" => std::option::Option::Some(Self::DATA_LOSS),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for Code {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Code {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Code {
     fn default() -> Self {
-        code::OK
+        Self::new(0)
     }
 }

--- a/src/generated/spanner/admin/database/v1/src/model.rs
+++ b/src/generated/spanner/admin/database/v1/src/model.rs
@@ -391,44 +391,59 @@ pub mod backup {
 
     /// Indicates the current state of the backup.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Not specified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The pending backup is still being created. Operations on the
         /// backup may fail with `FAILED_PRECONDITION` in this state.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The backup is complete and ready for use.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1473,27 +1488,11 @@ pub mod create_backup_encryption_config {
 
     /// Encryption types for the backup.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EncryptionType(std::borrow::Cow<'static, str>);
+    pub struct EncryptionType(i32);
 
     impl EncryptionType {
-        /// Creates a new EncryptionType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [EncryptionType](EncryptionType)
-    pub mod encryption_type {
-        use super::EncryptionType;
-
         /// Unspecified. Do not use.
-        pub const ENCRYPTION_TYPE_UNSPECIFIED: EncryptionType =
-            EncryptionType::new("ENCRYPTION_TYPE_UNSPECIFIED");
+        pub const ENCRYPTION_TYPE_UNSPECIFIED: EncryptionType = EncryptionType::new(0);
 
         /// Use the same encryption configuration as the database. This is the
         /// default option when
@@ -1503,28 +1502,65 @@ pub mod create_backup_encryption_config {
         /// KMS key as the database.
         ///
         /// [google.spanner.admin.database.v1.CreateBackupEncryptionConfig]: crate::model::CreateBackupEncryptionConfig
-        pub const USE_DATABASE_ENCRYPTION: EncryptionType =
-            EncryptionType::new("USE_DATABASE_ENCRYPTION");
+        pub const USE_DATABASE_ENCRYPTION: EncryptionType = EncryptionType::new(1);
 
         /// Use Google default encryption.
-        pub const GOOGLE_DEFAULT_ENCRYPTION: EncryptionType =
-            EncryptionType::new("GOOGLE_DEFAULT_ENCRYPTION");
+        pub const GOOGLE_DEFAULT_ENCRYPTION: EncryptionType = EncryptionType::new(2);
 
         /// Use customer managed encryption. If specified, `kms_key_name`
         /// must contain a valid Cloud KMS key.
-        pub const CUSTOMER_MANAGED_ENCRYPTION: EncryptionType =
-            EncryptionType::new("CUSTOMER_MANAGED_ENCRYPTION");
+        pub const CUSTOMER_MANAGED_ENCRYPTION: EncryptionType = EncryptionType::new(3);
+
+        /// Creates a new EncryptionType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ENCRYPTION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("USE_DATABASE_ENCRYPTION"),
+                2 => std::borrow::Cow::Borrowed("GOOGLE_DEFAULT_ENCRYPTION"),
+                3 => std::borrow::Cow::Borrowed("CUSTOMER_MANAGED_ENCRYPTION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ENCRYPTION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ENCRYPTION_TYPE_UNSPECIFIED)
+                }
+                "USE_DATABASE_ENCRYPTION" => {
+                    std::option::Option::Some(Self::USE_DATABASE_ENCRYPTION)
+                }
+                "GOOGLE_DEFAULT_ENCRYPTION" => {
+                    std::option::Option::Some(Self::GOOGLE_DEFAULT_ENCRYPTION)
+                }
+                "CUSTOMER_MANAGED_ENCRYPTION" => {
+                    std::option::Option::Some(Self::CUSTOMER_MANAGED_ENCRYPTION)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for EncryptionType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EncryptionType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EncryptionType {
         fn default() -> Self {
-            encryption_type::ENCRYPTION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1616,27 +1652,11 @@ pub mod copy_backup_encryption_config {
 
     /// Encryption types for the backup.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EncryptionType(std::borrow::Cow<'static, str>);
+    pub struct EncryptionType(i32);
 
     impl EncryptionType {
-        /// Creates a new EncryptionType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [EncryptionType](EncryptionType)
-    pub mod encryption_type {
-        use super::EncryptionType;
-
         /// Unspecified. Do not use.
-        pub const ENCRYPTION_TYPE_UNSPECIFIED: EncryptionType =
-            EncryptionType::new("ENCRYPTION_TYPE_UNSPECIFIED");
+        pub const ENCRYPTION_TYPE_UNSPECIFIED: EncryptionType = EncryptionType::new(0);
 
         /// This is the default option for
         /// [CopyBackup][google.spanner.admin.database.v1.DatabaseAdmin.CopyBackup]
@@ -1648,28 +1668,65 @@ pub mod copy_backup_encryption_config {
         ///
         /// [google.spanner.admin.database.v1.CopyBackupEncryptionConfig]: crate::model::CopyBackupEncryptionConfig
         /// [google.spanner.admin.database.v1.DatabaseAdmin.CopyBackup]: crate::client::DatabaseAdmin::copy_backup
-        pub const USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION: EncryptionType =
-            EncryptionType::new("USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION");
+        pub const USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION: EncryptionType = EncryptionType::new(1);
 
         /// Use Google default encryption.
-        pub const GOOGLE_DEFAULT_ENCRYPTION: EncryptionType =
-            EncryptionType::new("GOOGLE_DEFAULT_ENCRYPTION");
+        pub const GOOGLE_DEFAULT_ENCRYPTION: EncryptionType = EncryptionType::new(2);
 
         /// Use customer managed encryption. If specified, either `kms_key_name` or
         /// `kms_key_names` must contain valid Cloud KMS key(s).
-        pub const CUSTOMER_MANAGED_ENCRYPTION: EncryptionType =
-            EncryptionType::new("CUSTOMER_MANAGED_ENCRYPTION");
+        pub const CUSTOMER_MANAGED_ENCRYPTION: EncryptionType = EncryptionType::new(3);
+
+        /// Creates a new EncryptionType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ENCRYPTION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION"),
+                2 => std::borrow::Cow::Borrowed("GOOGLE_DEFAULT_ENCRYPTION"),
+                3 => std::borrow::Cow::Borrowed("CUSTOMER_MANAGED_ENCRYPTION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ENCRYPTION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ENCRYPTION_TYPE_UNSPECIFIED)
+                }
+                "USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION" => {
+                    std::option::Option::Some(Self::USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION)
+                }
+                "GOOGLE_DEFAULT_ENCRYPTION" => {
+                    std::option::Option::Some(Self::GOOGLE_DEFAULT_ENCRYPTION)
+                }
+                "CUSTOMER_MANAGED_ENCRYPTION" => {
+                    std::option::Option::Some(Self::CUSTOMER_MANAGED_ENCRYPTION)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for EncryptionType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EncryptionType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EncryptionType {
         fn default() -> Self {
-            encryption_type::ENCRYPTION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2598,47 +2655,66 @@ pub mod encryption_info {
 
     /// Possible encryption types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// Encryption type was not specified, though data at rest remains encrypted.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
 
         /// The data is encrypted at rest with a key that is
         /// fully managed by Google. No key version or status will be populated.
         /// This is the default state.
-        pub const GOOGLE_DEFAULT_ENCRYPTION: Type = Type::new("GOOGLE_DEFAULT_ENCRYPTION");
+        pub const GOOGLE_DEFAULT_ENCRYPTION: Type = Type::new(1);
 
         /// The data is encrypted at rest with a key that is
         /// managed by the customer. The active version of the key. `kms_key_version`
         /// will be populated, and `encryption_status` may be populated.
-        pub const CUSTOMER_MANAGED_ENCRYPTION: Type = Type::new("CUSTOMER_MANAGED_ENCRYPTION");
+        pub const CUSTOMER_MANAGED_ENCRYPTION: Type = Type::new(2);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GOOGLE_DEFAULT_ENCRYPTION"),
+                2 => std::borrow::Cow::Borrowed("CUSTOMER_MANAGED_ENCRYPTION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "GOOGLE_DEFAULT_ENCRYPTION" => {
+                    std::option::Option::Some(Self::GOOGLE_DEFAULT_ENCRYPTION)
+                }
+                "CUSTOMER_MANAGED_ENCRYPTION" => {
+                    std::option::Option::Some(Self::CUSTOMER_MANAGED_ENCRYPTION)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2937,33 +3013,18 @@ pub mod database {
 
     /// Indicates the current state of the database.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Not specified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The database is still being created. Operations on the database may fail
         /// with `FAILED_PRECONDITION` in this state.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The database is fully created and ready for use.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(2);
 
         /// The database is fully created and ready for use, but is still
         /// being optimized for performance and cannot handle full load.
@@ -2973,18 +3034,50 @@ pub mod database {
         /// from being deleted. When optimizations are complete, the full performance
         /// of the database will be restored, and the database will transition to
         /// `READY` state.
-        pub const READY_OPTIMIZING: State = State::new("READY_OPTIMIZING");
+        pub const READY_OPTIMIZING: State = State::new(3);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                3 => std::borrow::Cow::Borrowed("READY_OPTIMIZING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                "READY_OPTIMIZING" => std::option::Option::Some(Self::READY_OPTIMIZING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4249,55 +4342,76 @@ pub mod restore_database_encryption_config {
 
     /// Encryption types for the database to be restored.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EncryptionType(std::borrow::Cow<'static, str>);
+    pub struct EncryptionType(i32);
 
     impl EncryptionType {
-        /// Creates a new EncryptionType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [EncryptionType](EncryptionType)
-    pub mod encryption_type {
-        use super::EncryptionType;
-
         /// Unspecified. Do not use.
-        pub const ENCRYPTION_TYPE_UNSPECIFIED: EncryptionType =
-            EncryptionType::new("ENCRYPTION_TYPE_UNSPECIFIED");
+        pub const ENCRYPTION_TYPE_UNSPECIFIED: EncryptionType = EncryptionType::new(0);
 
         /// This is the default option when
         /// [encryption_config][google.spanner.admin.database.v1.RestoreDatabaseEncryptionConfig]
         /// is not specified.
         ///
         /// [google.spanner.admin.database.v1.RestoreDatabaseEncryptionConfig]: crate::model::RestoreDatabaseEncryptionConfig
-        pub const USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION: EncryptionType =
-            EncryptionType::new("USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION");
+        pub const USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION: EncryptionType = EncryptionType::new(1);
 
         /// Use Google default encryption.
-        pub const GOOGLE_DEFAULT_ENCRYPTION: EncryptionType =
-            EncryptionType::new("GOOGLE_DEFAULT_ENCRYPTION");
+        pub const GOOGLE_DEFAULT_ENCRYPTION: EncryptionType = EncryptionType::new(2);
 
         /// Use customer managed encryption. If specified, `kms_key_name` must
         /// must contain a valid Cloud KMS key.
-        pub const CUSTOMER_MANAGED_ENCRYPTION: EncryptionType =
-            EncryptionType::new("CUSTOMER_MANAGED_ENCRYPTION");
+        pub const CUSTOMER_MANAGED_ENCRYPTION: EncryptionType = EncryptionType::new(3);
+
+        /// Creates a new EncryptionType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ENCRYPTION_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION"),
+                2 => std::borrow::Cow::Borrowed("GOOGLE_DEFAULT_ENCRYPTION"),
+                3 => std::borrow::Cow::Borrowed("CUSTOMER_MANAGED_ENCRYPTION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ENCRYPTION_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::ENCRYPTION_TYPE_UNSPECIFIED)
+                }
+                "USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION" => {
+                    std::option::Option::Some(Self::USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION)
+                }
+                "GOOGLE_DEFAULT_ENCRYPTION" => {
+                    std::option::Option::Some(Self::GOOGLE_DEFAULT_ENCRYPTION)
+                }
+                "CUSTOMER_MANAGED_ENCRYPTION" => {
+                    std::option::Option::Some(Self::CUSTOMER_MANAGED_ENCRYPTION)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for EncryptionType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EncryptionType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EncryptionType {
         fn default() -> Self {
-            encryption_type::ENCRYPTION_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4885,83 +4999,112 @@ pub mod split_points {
 
 /// Indicates the dialect type of a database.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DatabaseDialect(std::borrow::Cow<'static, str>);
+pub struct DatabaseDialect(i32);
 
 impl DatabaseDialect {
+    /// Default value. This value will create a database with the
+    /// GOOGLE_STANDARD_SQL dialect.
+    pub const DATABASE_DIALECT_UNSPECIFIED: DatabaseDialect = DatabaseDialect::new(0);
+
+    /// GoogleSQL supported SQL.
+    pub const GOOGLE_STANDARD_SQL: DatabaseDialect = DatabaseDialect::new(1);
+
+    /// PostgreSQL supported SQL.
+    pub const POSTGRESQL: DatabaseDialect = DatabaseDialect::new(2);
+
     /// Creates a new DatabaseDialect instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DATABASE_DIALECT_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("GOOGLE_STANDARD_SQL"),
+            2 => std::borrow::Cow::Borrowed("POSTGRESQL"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DATABASE_DIALECT_UNSPECIFIED" => {
+                std::option::Option::Some(Self::DATABASE_DIALECT_UNSPECIFIED)
+            }
+            "GOOGLE_STANDARD_SQL" => std::option::Option::Some(Self::GOOGLE_STANDARD_SQL),
+            "POSTGRESQL" => std::option::Option::Some(Self::POSTGRESQL),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [DatabaseDialect](DatabaseDialect)
-pub mod database_dialect {
-    use super::DatabaseDialect;
-
-    /// Default value. This value will create a database with the
-    /// GOOGLE_STANDARD_SQL dialect.
-    pub const DATABASE_DIALECT_UNSPECIFIED: DatabaseDialect =
-        DatabaseDialect::new("DATABASE_DIALECT_UNSPECIFIED");
-
-    /// GoogleSQL supported SQL.
-    pub const GOOGLE_STANDARD_SQL: DatabaseDialect = DatabaseDialect::new("GOOGLE_STANDARD_SQL");
-
-    /// PostgreSQL supported SQL.
-    pub const POSTGRESQL: DatabaseDialect = DatabaseDialect::new("POSTGRESQL");
-}
-
-impl std::convert::From<std::string::String> for DatabaseDialect {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DatabaseDialect {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DatabaseDialect {
     fn default() -> Self {
-        database_dialect::DATABASE_DIALECT_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Indicates the type of the restore source.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RestoreSourceType(std::borrow::Cow<'static, str>);
+pub struct RestoreSourceType(i32);
 
 impl RestoreSourceType {
+    /// No restore associated.
+    pub const TYPE_UNSPECIFIED: RestoreSourceType = RestoreSourceType::new(0);
+
+    /// A backup was used as the source of the restore.
+    pub const BACKUP: RestoreSourceType = RestoreSourceType::new(1);
+
     /// Creates a new RestoreSourceType instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("BACKUP"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+            "BACKUP" => std::option::Option::Some(Self::BACKUP),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [RestoreSourceType](RestoreSourceType)
-pub mod restore_source_type {
-    use super::RestoreSourceType;
-
-    /// No restore associated.
-    pub const TYPE_UNSPECIFIED: RestoreSourceType = RestoreSourceType::new("TYPE_UNSPECIFIED");
-
-    /// A backup was used as the source of the restore.
-    pub const BACKUP: RestoreSourceType = RestoreSourceType::new("BACKUP");
-}
-
-impl std::convert::From<std::string::String> for RestoreSourceType {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for RestoreSourceType {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for RestoreSourceType {
     fn default() -> Self {
-        restore_source_type::TYPE_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/spanner/admin/database/v1/src/transport.rs
+++ b/src/generated/spanner/admin/database/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
                 reqwest::Method::GET,
                 format!("/v1/{}/databases", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -76,7 +76,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}/databases", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -93,7 +93,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -121,7 +121,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -150,7 +150,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v1/{}/ddl", req.database))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -167,7 +167,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.database))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -186,7 +186,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/ddl", req.database))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -208,7 +208,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -228,7 +228,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -248,7 +248,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -265,7 +265,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/backups", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -296,7 +296,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}/backups:copy", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -313,7 +313,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -341,7 +341,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -368,7 +368,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -387,7 +387,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/backups", req.parent))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -412,7 +412,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}/databases:restore", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -432,7 +432,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
                 reqwest::Method::GET,
                 format!("/v1/{}/databaseOperations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -457,7 +457,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
                 reqwest::Method::GET,
                 format!("/v1/{}/backupOperations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -482,7 +482,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
                 reqwest::Method::GET,
                 format!("/v1/{}/databaseRoles", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -506,7 +506,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}:addSplitPoints", req.database),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -526,7 +526,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}/backupSchedules", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -546,7 +546,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -574,7 +574,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -603,7 +603,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -625,7 +625,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
                 reqwest::Method::GET,
                 format!("/v1/{}/backupSchedules", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -646,7 +646,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -668,7 +668,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -687,7 +687,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -706,7 +706,7 @@ impl crate::stubs::DatabaseAdmin for DatabaseAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/spanner/admin/instance/v1/src/model.rs
+++ b/src/generated/spanner/admin/instance/v1/src/model.rs
@@ -180,26 +180,11 @@ pub mod replica_info {
     /// documentation](https://cloud.google.com/spanner/docs/replication#replica_types)
     /// for more details.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ReplicaType(std::borrow::Cow<'static, str>);
+    pub struct ReplicaType(i32);
 
     impl ReplicaType {
-        /// Creates a new ReplicaType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ReplicaType](ReplicaType)
-    pub mod replica_type {
-        use super::ReplicaType;
-
         /// Not specified.
-        pub const TYPE_UNSPECIFIED: ReplicaType = ReplicaType::new("TYPE_UNSPECIFIED");
+        pub const TYPE_UNSPECIFIED: ReplicaType = ReplicaType::new(0);
 
         /// Read-write replicas support both reads and writes. These replicas:
         ///
@@ -208,7 +193,7 @@ pub mod replica_info {
         /// * Can vote whether to commit a write.
         /// * Participate in leadership election.
         /// * Are eligible to become a leader.
-        pub const READ_WRITE: ReplicaType = ReplicaType::new("READ_WRITE");
+        pub const READ_WRITE: ReplicaType = ReplicaType::new(1);
 
         /// Read-only replicas only support reads (not writes). Read-only replicas:
         ///
@@ -216,7 +201,7 @@ pub mod replica_info {
         /// * Serve reads.
         /// * Do not participate in voting to commit writes.
         /// * Are not eligible to become a leader.
-        pub const READ_ONLY: ReplicaType = ReplicaType::new("READ_ONLY");
+        pub const READ_ONLY: ReplicaType = ReplicaType::new(2);
 
         /// Witness replicas don't support reads but do participate in voting to
         /// commit writes. Witness replicas:
@@ -225,18 +210,50 @@ pub mod replica_info {
         /// * Do not serve reads.
         /// * Vote whether to commit writes.
         /// * Participate in leader election but are not eligible to become leader.
-        pub const WITNESS: ReplicaType = ReplicaType::new("WITNESS");
+        pub const WITNESS: ReplicaType = ReplicaType::new(3);
+
+        /// Creates a new ReplicaType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("READ_WRITE"),
+                2 => std::borrow::Cow::Borrowed("READ_ONLY"),
+                3 => std::borrow::Cow::Borrowed("WITNESS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "READ_WRITE" => std::option::Option::Some(Self::READ_WRITE),
+                "READ_ONLY" => std::option::Option::Some(Self::READ_ONLY),
+                "WITNESS" => std::option::Option::Some(Self::WITNESS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ReplicaType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ReplicaType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ReplicaType {
         fn default() -> Self {
-            replica_type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -491,172 +508,206 @@ pub mod instance_config {
 
     /// The type of this configuration.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
+        /// Unspecified.
+        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
+
+        /// Google-managed configuration.
+        pub const GOOGLE_MANAGED: Type = Type::new(1);
+
+        /// User-managed configuration.
+        pub const USER_MANAGED: Type = Type::new(2);
+
         /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GOOGLE_MANAGED"),
+                2 => std::borrow::Cow::Borrowed("USER_MANAGED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
+                "GOOGLE_MANAGED" => std::option::Option::Some(Self::GOOGLE_MANAGED),
+                "USER_MANAGED" => std::option::Option::Some(Self::USER_MANAGED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
-        /// Unspecified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new("TYPE_UNSPECIFIED");
-
-        /// Google-managed configuration.
-        pub const GOOGLE_MANAGED: Type = Type::new("GOOGLE_MANAGED");
-
-        /// User-managed configuration.
-        pub const USER_MANAGED: Type = Type::new("USER_MANAGED");
-    }
-
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            r#type::TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Indicates the current state of the instance configuration.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Not specified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The instance configuration is still being created.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The instance configuration is fully created and ready to be used to
         /// create instances.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Describes the availability for free instances to be created in an instance
     /// configuration.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FreeInstanceAvailability(std::borrow::Cow<'static, str>);
+    pub struct FreeInstanceAvailability(i32);
 
     impl FreeInstanceAvailability {
-        /// Creates a new FreeInstanceAvailability instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [FreeInstanceAvailability](FreeInstanceAvailability)
-    pub mod free_instance_availability {
-        use super::FreeInstanceAvailability;
-
         /// Not specified.
         pub const FREE_INSTANCE_AVAILABILITY_UNSPECIFIED: FreeInstanceAvailability =
-            FreeInstanceAvailability::new("FREE_INSTANCE_AVAILABILITY_UNSPECIFIED");
+            FreeInstanceAvailability::new(0);
 
         /// Indicates that free instances are available to be created in this
         /// instance configuration.
-        pub const AVAILABLE: FreeInstanceAvailability = FreeInstanceAvailability::new("AVAILABLE");
+        pub const AVAILABLE: FreeInstanceAvailability = FreeInstanceAvailability::new(1);
 
         /// Indicates that free instances are not supported in this instance
         /// configuration.
-        pub const UNSUPPORTED: FreeInstanceAvailability =
-            FreeInstanceAvailability::new("UNSUPPORTED");
+        pub const UNSUPPORTED: FreeInstanceAvailability = FreeInstanceAvailability::new(2);
 
         /// Indicates that free instances are currently not available to be created
         /// in this instance configuration.
-        pub const DISABLED: FreeInstanceAvailability = FreeInstanceAvailability::new("DISABLED");
+        pub const DISABLED: FreeInstanceAvailability = FreeInstanceAvailability::new(3);
 
         /// Indicates that additional free instances cannot be created in this
         /// instance configuration because the project has reached its limit of free
         /// instances.
-        pub const QUOTA_EXCEEDED: FreeInstanceAvailability =
-            FreeInstanceAvailability::new("QUOTA_EXCEEDED");
+        pub const QUOTA_EXCEEDED: FreeInstanceAvailability = FreeInstanceAvailability::new(4);
+
+        /// Creates a new FreeInstanceAvailability instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FREE_INSTANCE_AVAILABILITY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AVAILABLE"),
+                2 => std::borrow::Cow::Borrowed("UNSUPPORTED"),
+                3 => std::borrow::Cow::Borrowed("DISABLED"),
+                4 => std::borrow::Cow::Borrowed("QUOTA_EXCEEDED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FREE_INSTANCE_AVAILABILITY_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::FREE_INSTANCE_AVAILABILITY_UNSPECIFIED)
+                }
+                "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
+                "UNSUPPORTED" => std::option::Option::Some(Self::UNSUPPORTED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "QUOTA_EXCEEDED" => std::option::Option::Some(Self::QUOTA_EXCEEDED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for FreeInstanceAvailability {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for FreeInstanceAvailability {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for FreeInstanceAvailability {
         fn default() -> Self {
-            free_instance_availability::FREE_INSTANCE_AVAILABILITY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Indicates the quorum type of this instance configuration.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct QuorumType(std::borrow::Cow<'static, str>);
+    pub struct QuorumType(i32);
 
     impl QuorumType {
-        /// Creates a new QuorumType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [QuorumType](QuorumType)
-    pub mod quorum_type {
-        use super::QuorumType;
-
         /// Quorum type not specified.
-        pub const QUORUM_TYPE_UNSPECIFIED: QuorumType = QuorumType::new("QUORUM_TYPE_UNSPECIFIED");
+        pub const QUORUM_TYPE_UNSPECIFIED: QuorumType = QuorumType::new(0);
 
         /// An instance configuration tagged with `REGION` quorum type forms a write
         /// quorum in a single region.
-        pub const REGION: QuorumType = QuorumType::new("REGION");
+        pub const REGION: QuorumType = QuorumType::new(1);
 
         /// An instance configuration tagged with the `DUAL_REGION` quorum type forms
         /// a write quorum with exactly two read-write regions in a multi-region
@@ -664,23 +715,57 @@ pub mod instance_config {
         ///
         /// This instance configuration requires failover in the event of
         /// regional failures.
-        pub const DUAL_REGION: QuorumType = QuorumType::new("DUAL_REGION");
+        pub const DUAL_REGION: QuorumType = QuorumType::new(2);
 
         /// An instance configuration tagged with the `MULTI_REGION` quorum type
         /// forms a write quorum from replicas that are spread across more than one
         /// region in a multi-region configuration.
-        pub const MULTI_REGION: QuorumType = QuorumType::new("MULTI_REGION");
+        pub const MULTI_REGION: QuorumType = QuorumType::new(3);
+
+        /// Creates a new QuorumType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("QUORUM_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REGION"),
+                2 => std::borrow::Cow::Borrowed("DUAL_REGION"),
+                3 => std::borrow::Cow::Borrowed("MULTI_REGION"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "QUORUM_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::QUORUM_TYPE_UNSPECIFIED)
+                }
+                "REGION" => std::option::Option::Some(Self::REGION),
+                "DUAL_REGION" => std::option::Option::Some(Self::DUAL_REGION),
+                "MULTI_REGION" => std::option::Option::Some(Self::MULTI_REGION),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for QuorumType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for QuorumType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for QuorumType {
         fn default() -> Self {
-            quorum_type::QUORUM_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -1561,46 +1646,61 @@ pub mod instance {
 
     /// Indicates the current state of the instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Not specified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The instance is still being created. Resources may not be
         /// available yet, and operations such as database creation may not
         /// work.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The instance is fully created and ready to do work such as
         /// creating databases.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1609,93 +1709,126 @@ pub mod instance {
     /// billing. Currently this is used to distinguish FREE_INSTANCE vs PROVISIONED
     /// instances.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct InstanceType(std::borrow::Cow<'static, str>);
+    pub struct InstanceType(i32);
 
     impl InstanceType {
-        /// Creates a new InstanceType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [InstanceType](InstanceType)
-    pub mod instance_type {
-        use super::InstanceType;
-
         /// Not specified.
-        pub const INSTANCE_TYPE_UNSPECIFIED: InstanceType =
-            InstanceType::new("INSTANCE_TYPE_UNSPECIFIED");
+        pub const INSTANCE_TYPE_UNSPECIFIED: InstanceType = InstanceType::new(0);
 
         /// Provisioned instances have dedicated resources, standard usage limits and
         /// support.
-        pub const PROVISIONED: InstanceType = InstanceType::new("PROVISIONED");
+        pub const PROVISIONED: InstanceType = InstanceType::new(1);
 
         /// Free instances provide no guarantee for dedicated resources,
         /// [node_count, processing_units] should be 0. They come
         /// with stricter usage limits and limited support.
-        pub const FREE_INSTANCE: InstanceType = InstanceType::new("FREE_INSTANCE");
+        pub const FREE_INSTANCE: InstanceType = InstanceType::new(2);
+
+        /// Creates a new InstanceType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("INSTANCE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("PROVISIONED"),
+                2 => std::borrow::Cow::Borrowed("FREE_INSTANCE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "INSTANCE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::INSTANCE_TYPE_UNSPECIFIED)
+                }
+                "PROVISIONED" => std::option::Option::Some(Self::PROVISIONED),
+                "FREE_INSTANCE" => std::option::Option::Some(Self::FREE_INSTANCE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for InstanceType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for InstanceType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for InstanceType {
         fn default() -> Self {
-            instance_type::INSTANCE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The edition selected for this instance. Different editions provide
     /// different capabilities at different price points.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Edition(std::borrow::Cow<'static, str>);
+    pub struct Edition(i32);
 
     impl Edition {
+        /// Edition not specified.
+        pub const EDITION_UNSPECIFIED: Edition = Edition::new(0);
+
+        /// Standard edition.
+        pub const STANDARD: Edition = Edition::new(1);
+
+        /// Enterprise edition.
+        pub const ENTERPRISE: Edition = Edition::new(2);
+
+        /// Enterprise Plus edition.
+        pub const ENTERPRISE_PLUS: Edition = Edition::new(3);
+
         /// Creates a new Edition instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EDITION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STANDARD"),
+                2 => std::borrow::Cow::Borrowed("ENTERPRISE"),
+                3 => std::borrow::Cow::Borrowed("ENTERPRISE_PLUS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EDITION_UNSPECIFIED" => std::option::Option::Some(Self::EDITION_UNSPECIFIED),
+                "STANDARD" => std::option::Option::Some(Self::STANDARD),
+                "ENTERPRISE" => std::option::Option::Some(Self::ENTERPRISE),
+                "ENTERPRISE_PLUS" => std::option::Option::Some(Self::ENTERPRISE_PLUS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Edition](Edition)
-    pub mod edition {
-        use super::Edition;
-
-        /// Edition not specified.
-        pub const EDITION_UNSPECIFIED: Edition = Edition::new("EDITION_UNSPECIFIED");
-
-        /// Standard edition.
-        pub const STANDARD: Edition = Edition::new("STANDARD");
-
-        /// Enterprise edition.
-        pub const ENTERPRISE: Edition = Edition::new("ENTERPRISE");
-
-        /// Enterprise Plus edition.
-        pub const ENTERPRISE_PLUS: Edition = Edition::new("ENTERPRISE_PLUS");
-    }
-
-    impl std::convert::From<std::string::String> for Edition {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Edition {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Edition {
         fn default() -> Self {
-            edition::EDITION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -1704,49 +1837,65 @@ pub mod instance {
     /// schedule](https://cloud.google.com/spanner/docs/backup#default-backup-schedules)
     /// behavior for new databases within the instance.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DefaultBackupScheduleType(std::borrow::Cow<'static, str>);
+    pub struct DefaultBackupScheduleType(i32);
 
     impl DefaultBackupScheduleType {
-        /// Creates a new DefaultBackupScheduleType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [DefaultBackupScheduleType](DefaultBackupScheduleType)
-    pub mod default_backup_schedule_type {
-        use super::DefaultBackupScheduleType;
-
         /// Not specified.
         pub const DEFAULT_BACKUP_SCHEDULE_TYPE_UNSPECIFIED: DefaultBackupScheduleType =
-            DefaultBackupScheduleType::new("DEFAULT_BACKUP_SCHEDULE_TYPE_UNSPECIFIED");
+            DefaultBackupScheduleType::new(0);
 
         /// A default backup schedule isn't created automatically when a new database
         /// is created in the instance.
-        pub const NONE: DefaultBackupScheduleType = DefaultBackupScheduleType::new("NONE");
+        pub const NONE: DefaultBackupScheduleType = DefaultBackupScheduleType::new(1);
 
         /// A default backup schedule is created automatically when a new database
         /// is created in the instance. The default backup schedule creates a full
         /// backup every 24 hours. These full backups are retained for 7 days.
         /// You can edit or delete the default backup schedule once it's created.
-        pub const AUTOMATIC: DefaultBackupScheduleType =
-            DefaultBackupScheduleType::new("AUTOMATIC");
+        pub const AUTOMATIC: DefaultBackupScheduleType = DefaultBackupScheduleType::new(2);
+
+        /// Creates a new DefaultBackupScheduleType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DEFAULT_BACKUP_SCHEDULE_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NONE"),
+                2 => std::borrow::Cow::Borrowed("AUTOMATIC"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DEFAULT_BACKUP_SCHEDULE_TYPE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::DEFAULT_BACKUP_SCHEDULE_TYPE_UNSPECIFIED)
+                }
+                "NONE" => std::option::Option::Some(Self::NONE),
+                "AUTOMATIC" => std::option::Option::Some(Self::AUTOMATIC),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for DefaultBackupScheduleType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for DefaultBackupScheduleType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for DefaultBackupScheduleType {
         fn default() -> Self {
-            default_backup_schedule_type::DEFAULT_BACKUP_SCHEDULE_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2958,47 +3107,64 @@ pub mod free_instance_metadata {
 
     /// Allows users to change behavior when a free instance expires.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ExpireBehavior(std::borrow::Cow<'static, str>);
+    pub struct ExpireBehavior(i32);
 
     impl ExpireBehavior {
-        /// Creates a new ExpireBehavior instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [ExpireBehavior](ExpireBehavior)
-    pub mod expire_behavior {
-        use super::ExpireBehavior;
-
         /// Not specified.
-        pub const EXPIRE_BEHAVIOR_UNSPECIFIED: ExpireBehavior =
-            ExpireBehavior::new("EXPIRE_BEHAVIOR_UNSPECIFIED");
+        pub const EXPIRE_BEHAVIOR_UNSPECIFIED: ExpireBehavior = ExpireBehavior::new(0);
 
         /// When the free instance expires, upgrade the instance to a provisioned
         /// instance.
-        pub const FREE_TO_PROVISIONED: ExpireBehavior = ExpireBehavior::new("FREE_TO_PROVISIONED");
+        pub const FREE_TO_PROVISIONED: ExpireBehavior = ExpireBehavior::new(1);
 
         /// When the free instance expires, disable the instance, and delete it
         /// after the grace period passes if it has not been upgraded.
-        pub const REMOVE_AFTER_GRACE_PERIOD: ExpireBehavior =
-            ExpireBehavior::new("REMOVE_AFTER_GRACE_PERIOD");
+        pub const REMOVE_AFTER_GRACE_PERIOD: ExpireBehavior = ExpireBehavior::new(2);
+
+        /// Creates a new ExpireBehavior instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EXPIRE_BEHAVIOR_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FREE_TO_PROVISIONED"),
+                2 => std::borrow::Cow::Borrowed("REMOVE_AFTER_GRACE_PERIOD"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EXPIRE_BEHAVIOR_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::EXPIRE_BEHAVIOR_UNSPECIFIED)
+                }
+                "FREE_TO_PROVISIONED" => std::option::Option::Some(Self::FREE_TO_PROVISIONED),
+                "REMOVE_AFTER_GRACE_PERIOD" => {
+                    std::option::Option::Some(Self::REMOVE_AFTER_GRACE_PERIOD)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for ExpireBehavior {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ExpireBehavior {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ExpireBehavior {
         fn default() -> Self {
-            expire_behavior::EXPIRE_BEHAVIOR_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3375,46 +3541,61 @@ pub mod instance_partition {
 
     /// Indicates the current state of the instance partition.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Not specified.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// The instance partition is still being created. Resources may not be
         /// available yet, and operations such as creating placements using this
         /// instance partition may not work.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// The instance partition is fully created and ready to do work such as
         /// creating placements and using in databases.
-        pub const READY: State = State::new("READY");
+        pub const READY: State = State::new(2);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("READY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "READY" => std::option::Option::Some(Self::READY),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
@@ -4348,47 +4529,65 @@ impl wkt::message::Message for MoveInstanceMetadata {
 
 /// Indicates the expected fulfillment period of an operation.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct FulfillmentPeriod(std::borrow::Cow<'static, str>);
+pub struct FulfillmentPeriod(i32);
 
 impl FulfillmentPeriod {
-    /// Creates a new FulfillmentPeriod instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [FulfillmentPeriod](FulfillmentPeriod)
-pub mod fulfillment_period {
-    use super::FulfillmentPeriod;
-
     /// Not specified.
-    pub const FULFILLMENT_PERIOD_UNSPECIFIED: FulfillmentPeriod =
-        FulfillmentPeriod::new("FULFILLMENT_PERIOD_UNSPECIFIED");
+    pub const FULFILLMENT_PERIOD_UNSPECIFIED: FulfillmentPeriod = FulfillmentPeriod::new(0);
 
     /// Normal fulfillment period. The operation is expected to complete within
     /// minutes.
-    pub const FULFILLMENT_PERIOD_NORMAL: FulfillmentPeriod =
-        FulfillmentPeriod::new("FULFILLMENT_PERIOD_NORMAL");
+    pub const FULFILLMENT_PERIOD_NORMAL: FulfillmentPeriod = FulfillmentPeriod::new(1);
 
     /// Extended fulfillment period. It can take up to an hour for the operation
     /// to complete.
-    pub const FULFILLMENT_PERIOD_EXTENDED: FulfillmentPeriod =
-        FulfillmentPeriod::new("FULFILLMENT_PERIOD_EXTENDED");
+    pub const FULFILLMENT_PERIOD_EXTENDED: FulfillmentPeriod = FulfillmentPeriod::new(2);
+
+    /// Creates a new FulfillmentPeriod instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("FULFILLMENT_PERIOD_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("FULFILLMENT_PERIOD_NORMAL"),
+            2 => std::borrow::Cow::Borrowed("FULFILLMENT_PERIOD_EXTENDED"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "FULFILLMENT_PERIOD_UNSPECIFIED" => {
+                std::option::Option::Some(Self::FULFILLMENT_PERIOD_UNSPECIFIED)
+            }
+            "FULFILLMENT_PERIOD_NORMAL" => {
+                std::option::Option::Some(Self::FULFILLMENT_PERIOD_NORMAL)
+            }
+            "FULFILLMENT_PERIOD_EXTENDED" => {
+                std::option::Option::Some(Self::FULFILLMENT_PERIOD_EXTENDED)
+            }
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for FulfillmentPeriod {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for FulfillmentPeriod {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for FulfillmentPeriod {
     fn default() -> Self {
-        fulfillment_period::FULFILLMENT_PERIOD_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/generated/spanner/admin/instance/v1/src/transport.rs
+++ b/src/generated/spanner/admin/instance/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
                 reqwest::Method::GET,
                 format!("/v1/{}/instanceConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -73,7 +73,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -95,7 +95,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}/instanceConfigs", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -121,7 +121,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -138,7 +138,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -162,7 +162,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
                 reqwest::Method::GET,
                 format!("/v1/{}/instanceConfigOperations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -187,7 +187,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
                 reqwest::Method::GET,
                 format!("/v1/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -222,7 +222,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
                 reqwest::Method::GET,
                 format!("/v1/{}/instancePartitions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -253,7 +253,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -285,7 +285,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}/instances", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -311,7 +311,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -328,7 +328,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -350,7 +350,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}:setIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -370,7 +370,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}:getIamPolicy", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -390,7 +390,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}:testIamPermissions", req.resource),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -407,7 +407,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -429,7 +429,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
                 reqwest::Method::POST,
                 format!("/v1/{}/instancePartitions", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -446,7 +446,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -475,7 +475,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -495,7 +495,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
                 reqwest::Method::GET,
                 format!("/v1/{}/instancePartitionOperations", req.parent),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -527,7 +527,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:move", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -544,7 +544,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -566,7 +566,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -585,7 +585,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -604,7 +604,7 @@ impl crate::stubs::InstanceAdmin for InstanceAdmin {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/storagetransfer/v1/src/model.rs
+++ b/src/generated/storagetransfer/v1/src/model.rs
@@ -1913,181 +1913,247 @@ pub mod s_3_compatible_metadata {
 
     /// The authentication and authorization method used by the storage service.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AuthMethod(std::borrow::Cow<'static, str>);
+    pub struct AuthMethod(i32);
 
     impl AuthMethod {
+        /// AuthMethod is not specified.
+        pub const AUTH_METHOD_UNSPECIFIED: AuthMethod = AuthMethod::new(0);
+
+        /// Auth requests with AWS SigV4.
+        pub const AUTH_METHOD_AWS_SIGNATURE_V4: AuthMethod = AuthMethod::new(1);
+
+        /// Auth requests with AWS SigV2.
+        pub const AUTH_METHOD_AWS_SIGNATURE_V2: AuthMethod = AuthMethod::new(2);
+
         /// Creates a new AuthMethod instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("AUTH_METHOD_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("AUTH_METHOD_AWS_SIGNATURE_V4"),
+                2 => std::borrow::Cow::Borrowed("AUTH_METHOD_AWS_SIGNATURE_V2"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "AUTH_METHOD_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::AUTH_METHOD_UNSPECIFIED)
+                }
+                "AUTH_METHOD_AWS_SIGNATURE_V4" => {
+                    std::option::Option::Some(Self::AUTH_METHOD_AWS_SIGNATURE_V4)
+                }
+                "AUTH_METHOD_AWS_SIGNATURE_V2" => {
+                    std::option::Option::Some(Self::AUTH_METHOD_AWS_SIGNATURE_V2)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [AuthMethod](AuthMethod)
-    pub mod auth_method {
-        use super::AuthMethod;
-
-        /// AuthMethod is not specified.
-        pub const AUTH_METHOD_UNSPECIFIED: AuthMethod = AuthMethod::new("AUTH_METHOD_UNSPECIFIED");
-
-        /// Auth requests with AWS SigV4.
-        pub const AUTH_METHOD_AWS_SIGNATURE_V4: AuthMethod =
-            AuthMethod::new("AUTH_METHOD_AWS_SIGNATURE_V4");
-
-        /// Auth requests with AWS SigV2.
-        pub const AUTH_METHOD_AWS_SIGNATURE_V2: AuthMethod =
-            AuthMethod::new("AUTH_METHOD_AWS_SIGNATURE_V2");
-    }
-
-    impl std::convert::From<std::string::String> for AuthMethod {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for AuthMethod {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for AuthMethod {
         fn default() -> Self {
-            auth_method::AUTH_METHOD_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The request model of the API.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RequestModel(std::borrow::Cow<'static, str>);
+    pub struct RequestModel(i32);
 
     impl RequestModel {
-        /// Creates a new RequestModel instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [RequestModel](RequestModel)
-    pub mod request_model {
-        use super::RequestModel;
-
         /// RequestModel is not specified.
-        pub const REQUEST_MODEL_UNSPECIFIED: RequestModel =
-            RequestModel::new("REQUEST_MODEL_UNSPECIFIED");
+        pub const REQUEST_MODEL_UNSPECIFIED: RequestModel = RequestModel::new(0);
 
         /// Perform requests using Virtual Hosted Style.
         /// Example: <https://bucket-name.s3.region.amazonaws.com/key-name>
-        pub const REQUEST_MODEL_VIRTUAL_HOSTED_STYLE: RequestModel =
-            RequestModel::new("REQUEST_MODEL_VIRTUAL_HOSTED_STYLE");
+        pub const REQUEST_MODEL_VIRTUAL_HOSTED_STYLE: RequestModel = RequestModel::new(1);
 
         /// Perform requests using Path Style.
         /// Example: <https://s3.region.amazonaws.com/bucket-name/key-name>
-        pub const REQUEST_MODEL_PATH_STYLE: RequestModel =
-            RequestModel::new("REQUEST_MODEL_PATH_STYLE");
+        pub const REQUEST_MODEL_PATH_STYLE: RequestModel = RequestModel::new(2);
+
+        /// Creates a new RequestModel instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("REQUEST_MODEL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("REQUEST_MODEL_VIRTUAL_HOSTED_STYLE"),
+                2 => std::borrow::Cow::Borrowed("REQUEST_MODEL_PATH_STYLE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "REQUEST_MODEL_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::REQUEST_MODEL_UNSPECIFIED)
+                }
+                "REQUEST_MODEL_VIRTUAL_HOSTED_STYLE" => {
+                    std::option::Option::Some(Self::REQUEST_MODEL_VIRTUAL_HOSTED_STYLE)
+                }
+                "REQUEST_MODEL_PATH_STYLE" => {
+                    std::option::Option::Some(Self::REQUEST_MODEL_PATH_STYLE)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for RequestModel {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RequestModel {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RequestModel {
         fn default() -> Self {
-            request_model::REQUEST_MODEL_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The agent network protocol to access the storage service.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NetworkProtocol(std::borrow::Cow<'static, str>);
+    pub struct NetworkProtocol(i32);
 
     impl NetworkProtocol {
-        /// Creates a new NetworkProtocol instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [NetworkProtocol](NetworkProtocol)
-    pub mod network_protocol {
-        use super::NetworkProtocol;
-
         /// NetworkProtocol is not specified.
-        pub const NETWORK_PROTOCOL_UNSPECIFIED: NetworkProtocol =
-            NetworkProtocol::new("NETWORK_PROTOCOL_UNSPECIFIED");
+        pub const NETWORK_PROTOCOL_UNSPECIFIED: NetworkProtocol = NetworkProtocol::new(0);
 
         /// Perform requests using HTTPS.
-        pub const NETWORK_PROTOCOL_HTTPS: NetworkProtocol =
-            NetworkProtocol::new("NETWORK_PROTOCOL_HTTPS");
+        pub const NETWORK_PROTOCOL_HTTPS: NetworkProtocol = NetworkProtocol::new(1);
 
         /// Not recommended: This sends data in clear-text. This is only
         /// appropriate within a closed network or for publicly available data.
         /// Perform requests using HTTP.
-        pub const NETWORK_PROTOCOL_HTTP: NetworkProtocol =
-            NetworkProtocol::new("NETWORK_PROTOCOL_HTTP");
+        pub const NETWORK_PROTOCOL_HTTP: NetworkProtocol = NetworkProtocol::new(2);
+
+        /// Creates a new NetworkProtocol instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("NETWORK_PROTOCOL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NETWORK_PROTOCOL_HTTPS"),
+                2 => std::borrow::Cow::Borrowed("NETWORK_PROTOCOL_HTTP"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "NETWORK_PROTOCOL_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::NETWORK_PROTOCOL_UNSPECIFIED)
+                }
+                "NETWORK_PROTOCOL_HTTPS" => std::option::Option::Some(Self::NETWORK_PROTOCOL_HTTPS),
+                "NETWORK_PROTOCOL_HTTP" => std::option::Option::Some(Self::NETWORK_PROTOCOL_HTTP),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for NetworkProtocol {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for NetworkProtocol {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for NetworkProtocol {
         fn default() -> Self {
-            network_protocol::NETWORK_PROTOCOL_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// The Listing API to use for discovering objects.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ListApi(std::borrow::Cow<'static, str>);
+    pub struct ListApi(i32);
 
     impl ListApi {
+        /// ListApi is not specified.
+        pub const LIST_API_UNSPECIFIED: ListApi = ListApi::new(0);
+
+        /// Perform listing using ListObjectsV2 API.
+        pub const LIST_OBJECTS_V2: ListApi = ListApi::new(1);
+
+        /// Legacy ListObjects API.
+        pub const LIST_OBJECTS: ListApi = ListApi::new(2);
+
         /// Creates a new ListApi instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LIST_API_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("LIST_OBJECTS_V2"),
+                2 => std::borrow::Cow::Borrowed("LIST_OBJECTS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LIST_API_UNSPECIFIED" => std::option::Option::Some(Self::LIST_API_UNSPECIFIED),
+                "LIST_OBJECTS_V2" => std::option::Option::Some(Self::LIST_OBJECTS_V2),
+                "LIST_OBJECTS" => std::option::Option::Some(Self::LIST_OBJECTS),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [ListApi](ListApi)
-    pub mod list_api {
-        use super::ListApi;
-
-        /// ListApi is not specified.
-        pub const LIST_API_UNSPECIFIED: ListApi = ListApi::new("LIST_API_UNSPECIFIED");
-
-        /// Perform listing using ListObjectsV2 API.
-        pub const LIST_OBJECTS_V2: ListApi = ListApi::new("LIST_OBJECTS_V2");
-
-        /// Legacy ListObjects API.
-        pub const LIST_OBJECTS: ListApi = ListApi::new("LIST_OBJECTS");
-    }
-
-    impl std::convert::From<std::string::String> for ListApi {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for ListApi {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for ListApi {
         fn default() -> Self {
-            list_api::LIST_API_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2198,49 +2264,66 @@ pub mod agent_pool {
 
     /// The state of an AgentPool.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(std::borrow::Cow<'static, str>);
+    pub struct State(i32);
 
     impl State {
-        /// Creates a new State instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [State](State)
-    pub mod state {
-        use super::State;
-
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new("STATE_UNSPECIFIED");
+        pub const STATE_UNSPECIFIED: State = State::new(0);
 
         /// This is an initialization state. During this stage, resources are
         /// allocated for the AgentPool.
-        pub const CREATING: State = State::new("CREATING");
+        pub const CREATING: State = State::new(1);
 
         /// Determines that the AgentPool is created for use. At this state, Agents
         /// can join the AgentPool and participate in the transfer jobs in that pool.
-        pub const CREATED: State = State::new("CREATED");
+        pub const CREATED: State = State::new(2);
 
         /// Determines that the AgentPool deletion has been initiated, and all the
         /// resources are scheduled to be cleaned up and freed.
-        pub const DELETING: State = State::new("DELETING");
+        pub const DELETING: State = State::new(3);
+
+        /// Creates a new State instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("CREATING"),
+                2 => std::borrow::Cow::Borrowed("CREATED"),
+                3 => std::borrow::Cow::Borrowed("DELETING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
+                "CREATING" => std::option::Option::Some(Self::CREATING),
+                "CREATED" => std::option::Option::Some(Self::CREATED),
+                "DELETING" => std::option::Option::Some(Self::DELETING),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for State {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            state::STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -2354,50 +2437,68 @@ pub mod transfer_options {
     /// Specifies when to overwrite an object in the sink when an object with
     /// matching name is found in the source.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OverwriteWhen(std::borrow::Cow<'static, str>);
+    pub struct OverwriteWhen(i32);
 
     impl OverwriteWhen {
-        /// Creates a new OverwriteWhen instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [OverwriteWhen](OverwriteWhen)
-    pub mod overwrite_when {
-        use super::OverwriteWhen;
-
         /// Overwrite behavior is unspecified.
-        pub const OVERWRITE_WHEN_UNSPECIFIED: OverwriteWhen =
-            OverwriteWhen::new("OVERWRITE_WHEN_UNSPECIFIED");
+        pub const OVERWRITE_WHEN_UNSPECIFIED: OverwriteWhen = OverwriteWhen::new(0);
 
         /// Overwrites destination objects with the source objects, only if the
         /// objects have the same name but different HTTP ETags or checksum values.
-        pub const DIFFERENT: OverwriteWhen = OverwriteWhen::new("DIFFERENT");
+        pub const DIFFERENT: OverwriteWhen = OverwriteWhen::new(1);
 
         /// Never overwrites a destination object if a source object has the
         /// same name. In this case, the source object is not transferred.
-        pub const NEVER: OverwriteWhen = OverwriteWhen::new("NEVER");
+        pub const NEVER: OverwriteWhen = OverwriteWhen::new(2);
 
         /// Always overwrite the destination object with the source object, even if
         /// the HTTP Etags or checksum values are the same.
-        pub const ALWAYS: OverwriteWhen = OverwriteWhen::new("ALWAYS");
+        pub const ALWAYS: OverwriteWhen = OverwriteWhen::new(3);
+
+        /// Creates a new OverwriteWhen instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("OVERWRITE_WHEN_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("DIFFERENT"),
+                2 => std::borrow::Cow::Borrowed("NEVER"),
+                3 => std::borrow::Cow::Borrowed("ALWAYS"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "OVERWRITE_WHEN_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::OVERWRITE_WHEN_UNSPECIFIED)
+                }
+                "DIFFERENT" => std::option::Option::Some(Self::DIFFERENT),
+                "NEVER" => std::option::Option::Some(Self::NEVER),
+                "ALWAYS" => std::option::Option::Some(Self::ALWAYS),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for OverwriteWhen {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for OverwriteWhen {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for OverwriteWhen {
         fn default() -> Self {
-            overwrite_when::OVERWRITE_WHEN_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -3251,415 +3352,563 @@ pub mod metadata_options {
 
     /// Whether symlinks should be skipped or preserved during a transfer job.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Symlink(std::borrow::Cow<'static, str>);
+    pub struct Symlink(i32);
 
     impl Symlink {
+        /// Symlink behavior is unspecified.
+        pub const SYMLINK_UNSPECIFIED: Symlink = Symlink::new(0);
+
+        /// Do not preserve symlinks during a transfer job.
+        pub const SYMLINK_SKIP: Symlink = Symlink::new(1);
+
+        /// Preserve symlinks during a transfer job.
+        pub const SYMLINK_PRESERVE: Symlink = Symlink::new(2);
+
         /// Creates a new Symlink instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("SYMLINK_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SYMLINK_SKIP"),
+                2 => std::borrow::Cow::Borrowed("SYMLINK_PRESERVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SYMLINK_UNSPECIFIED" => std::option::Option::Some(Self::SYMLINK_UNSPECIFIED),
+                "SYMLINK_SKIP" => std::option::Option::Some(Self::SYMLINK_SKIP),
+                "SYMLINK_PRESERVE" => std::option::Option::Some(Self::SYMLINK_PRESERVE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Symlink](Symlink)
-    pub mod symlink {
-        use super::Symlink;
-
-        /// Symlink behavior is unspecified.
-        pub const SYMLINK_UNSPECIFIED: Symlink = Symlink::new("SYMLINK_UNSPECIFIED");
-
-        /// Do not preserve symlinks during a transfer job.
-        pub const SYMLINK_SKIP: Symlink = Symlink::new("SYMLINK_SKIP");
-
-        /// Preserve symlinks during a transfer job.
-        pub const SYMLINK_PRESERVE: Symlink = Symlink::new("SYMLINK_PRESERVE");
-    }
-
-    impl std::convert::From<std::string::String> for Symlink {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Symlink {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Symlink {
         fn default() -> Self {
-            symlink::SYMLINK_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Options for handling file mode attribute.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(std::borrow::Cow<'static, str>);
+    pub struct Mode(i32);
 
     impl Mode {
+        /// Mode behavior is unspecified.
+        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
+
+        /// Do not preserve mode during a transfer job.
+        pub const MODE_SKIP: Mode = Mode::new(1);
+
+        /// Preserve mode during a transfer job.
+        pub const MODE_PRESERVE: Mode = Mode::new(2);
+
         /// Creates a new Mode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("MODE_SKIP"),
+                2 => std::borrow::Cow::Borrowed("MODE_PRESERVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
+                "MODE_SKIP" => std::option::Option::Some(Self::MODE_SKIP),
+                "MODE_PRESERVE" => std::option::Option::Some(Self::MODE_PRESERVE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Mode](Mode)
-    pub mod mode {
-        use super::Mode;
-
-        /// Mode behavior is unspecified.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new("MODE_UNSPECIFIED");
-
-        /// Do not preserve mode during a transfer job.
-        pub const MODE_SKIP: Mode = Mode::new("MODE_SKIP");
-
-        /// Preserve mode during a transfer job.
-        pub const MODE_PRESERVE: Mode = Mode::new("MODE_PRESERVE");
-    }
-
-    impl std::convert::From<std::string::String> for Mode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            mode::MODE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Options for handling file GID attribute.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Gid(std::borrow::Cow<'static, str>);
+    pub struct Gid(i32);
 
     impl Gid {
+        /// GID behavior is unspecified.
+        pub const GID_UNSPECIFIED: Gid = Gid::new(0);
+
+        /// Do not preserve GID during a transfer job.
+        pub const GID_SKIP: Gid = Gid::new(1);
+
+        /// Preserve GID during a transfer job.
+        pub const GID_NUMBER: Gid = Gid::new(2);
+
         /// Creates a new Gid instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("GID_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("GID_SKIP"),
+                2 => std::borrow::Cow::Borrowed("GID_NUMBER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "GID_UNSPECIFIED" => std::option::Option::Some(Self::GID_UNSPECIFIED),
+                "GID_SKIP" => std::option::Option::Some(Self::GID_SKIP),
+                "GID_NUMBER" => std::option::Option::Some(Self::GID_NUMBER),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Gid](Gid)
-    pub mod gid {
-        use super::Gid;
-
-        /// GID behavior is unspecified.
-        pub const GID_UNSPECIFIED: Gid = Gid::new("GID_UNSPECIFIED");
-
-        /// Do not preserve GID during a transfer job.
-        pub const GID_SKIP: Gid = Gid::new("GID_SKIP");
-
-        /// Preserve GID during a transfer job.
-        pub const GID_NUMBER: Gid = Gid::new("GID_NUMBER");
-    }
-
-    impl std::convert::From<std::string::String> for Gid {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Gid {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Gid {
         fn default() -> Self {
-            gid::GID_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Options for handling file UID attribute.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Uid(std::borrow::Cow<'static, str>);
+    pub struct Uid(i32);
 
     impl Uid {
+        /// UID behavior is unspecified.
+        pub const UID_UNSPECIFIED: Uid = Uid::new(0);
+
+        /// Do not preserve UID during a transfer job.
+        pub const UID_SKIP: Uid = Uid::new(1);
+
+        /// Preserve UID during a transfer job.
+        pub const UID_NUMBER: Uid = Uid::new(2);
+
         /// Creates a new Uid instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UID_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("UID_SKIP"),
+                2 => std::borrow::Cow::Borrowed("UID_NUMBER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UID_UNSPECIFIED" => std::option::Option::Some(Self::UID_UNSPECIFIED),
+                "UID_SKIP" => std::option::Option::Some(Self::UID_SKIP),
+                "UID_NUMBER" => std::option::Option::Some(Self::UID_NUMBER),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Uid](Uid)
-    pub mod uid {
-        use super::Uid;
-
-        /// UID behavior is unspecified.
-        pub const UID_UNSPECIFIED: Uid = Uid::new("UID_UNSPECIFIED");
-
-        /// Do not preserve UID during a transfer job.
-        pub const UID_SKIP: Uid = Uid::new("UID_SKIP");
-
-        /// Preserve UID during a transfer job.
-        pub const UID_NUMBER: Uid = Uid::new("UID_NUMBER");
-    }
-
-    impl std::convert::From<std::string::String> for Uid {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Uid {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Uid {
         fn default() -> Self {
-            uid::UID_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Options for handling Cloud Storage object ACLs.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Acl(std::borrow::Cow<'static, str>);
+    pub struct Acl(i32);
 
     impl Acl {
-        /// Creates a new Acl instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Acl](Acl)
-    pub mod acl {
-        use super::Acl;
-
         /// ACL behavior is unspecified.
-        pub const ACL_UNSPECIFIED: Acl = Acl::new("ACL_UNSPECIFIED");
+        pub const ACL_UNSPECIFIED: Acl = Acl::new(0);
 
         /// Use the destination bucket's default object ACLS, if applicable.
-        pub const ACL_DESTINATION_BUCKET_DEFAULT: Acl = Acl::new("ACL_DESTINATION_BUCKET_DEFAULT");
+        pub const ACL_DESTINATION_BUCKET_DEFAULT: Acl = Acl::new(1);
 
         /// Preserve the object's original ACLs. This requires the service account
         /// to have `storage.objects.getIamPolicy` permission for the source object.
         /// [Uniform bucket-level
         /// access](https://cloud.google.com/storage/docs/uniform-bucket-level-access)
         /// must not be enabled on either the source or destination buckets.
-        pub const ACL_PRESERVE: Acl = Acl::new("ACL_PRESERVE");
+        pub const ACL_PRESERVE: Acl = Acl::new(2);
+
+        /// Creates a new Acl instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ACL_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ACL_DESTINATION_BUCKET_DEFAULT"),
+                2 => std::borrow::Cow::Borrowed("ACL_PRESERVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ACL_UNSPECIFIED" => std::option::Option::Some(Self::ACL_UNSPECIFIED),
+                "ACL_DESTINATION_BUCKET_DEFAULT" => {
+                    std::option::Option::Some(Self::ACL_DESTINATION_BUCKET_DEFAULT)
+                }
+                "ACL_PRESERVE" => std::option::Option::Some(Self::ACL_PRESERVE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Acl {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Acl {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Acl {
         fn default() -> Self {
-            acl::ACL_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Options for handling Google Cloud Storage object storage class.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StorageClass(std::borrow::Cow<'static, str>);
+    pub struct StorageClass(i32);
 
     impl StorageClass {
-        /// Creates a new StorageClass instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [StorageClass](StorageClass)
-    pub mod storage_class {
-        use super::StorageClass;
-
         /// Storage class behavior is unspecified.
-        pub const STORAGE_CLASS_UNSPECIFIED: StorageClass =
-            StorageClass::new("STORAGE_CLASS_UNSPECIFIED");
+        pub const STORAGE_CLASS_UNSPECIFIED: StorageClass = StorageClass::new(0);
 
         /// Use the destination bucket's default storage class.
-        pub const STORAGE_CLASS_DESTINATION_BUCKET_DEFAULT: StorageClass =
-            StorageClass::new("STORAGE_CLASS_DESTINATION_BUCKET_DEFAULT");
+        pub const STORAGE_CLASS_DESTINATION_BUCKET_DEFAULT: StorageClass = StorageClass::new(1);
 
         /// Preserve the object's original storage class. This is only supported for
         /// transfers from Google Cloud Storage buckets. REGIONAL and MULTI_REGIONAL
         /// storage classes will be mapped to STANDARD to ensure they can be written
         /// to the destination bucket.
-        pub const STORAGE_CLASS_PRESERVE: StorageClass =
-            StorageClass::new("STORAGE_CLASS_PRESERVE");
+        pub const STORAGE_CLASS_PRESERVE: StorageClass = StorageClass::new(2);
 
         /// Set the storage class to STANDARD.
-        pub const STORAGE_CLASS_STANDARD: StorageClass =
-            StorageClass::new("STORAGE_CLASS_STANDARD");
+        pub const STORAGE_CLASS_STANDARD: StorageClass = StorageClass::new(3);
 
         /// Set the storage class to NEARLINE.
-        pub const STORAGE_CLASS_NEARLINE: StorageClass =
-            StorageClass::new("STORAGE_CLASS_NEARLINE");
+        pub const STORAGE_CLASS_NEARLINE: StorageClass = StorageClass::new(4);
 
         /// Set the storage class to COLDLINE.
-        pub const STORAGE_CLASS_COLDLINE: StorageClass =
-            StorageClass::new("STORAGE_CLASS_COLDLINE");
+        pub const STORAGE_CLASS_COLDLINE: StorageClass = StorageClass::new(5);
 
         /// Set the storage class to ARCHIVE.
-        pub const STORAGE_CLASS_ARCHIVE: StorageClass = StorageClass::new("STORAGE_CLASS_ARCHIVE");
+        pub const STORAGE_CLASS_ARCHIVE: StorageClass = StorageClass::new(6);
+
+        /// Creates a new StorageClass instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STORAGE_CLASS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("STORAGE_CLASS_DESTINATION_BUCKET_DEFAULT"),
+                2 => std::borrow::Cow::Borrowed("STORAGE_CLASS_PRESERVE"),
+                3 => std::borrow::Cow::Borrowed("STORAGE_CLASS_STANDARD"),
+                4 => std::borrow::Cow::Borrowed("STORAGE_CLASS_NEARLINE"),
+                5 => std::borrow::Cow::Borrowed("STORAGE_CLASS_COLDLINE"),
+                6 => std::borrow::Cow::Borrowed("STORAGE_CLASS_ARCHIVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STORAGE_CLASS_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::STORAGE_CLASS_UNSPECIFIED)
+                }
+                "STORAGE_CLASS_DESTINATION_BUCKET_DEFAULT" => {
+                    std::option::Option::Some(Self::STORAGE_CLASS_DESTINATION_BUCKET_DEFAULT)
+                }
+                "STORAGE_CLASS_PRESERVE" => std::option::Option::Some(Self::STORAGE_CLASS_PRESERVE),
+                "STORAGE_CLASS_STANDARD" => std::option::Option::Some(Self::STORAGE_CLASS_STANDARD),
+                "STORAGE_CLASS_NEARLINE" => std::option::Option::Some(Self::STORAGE_CLASS_NEARLINE),
+                "STORAGE_CLASS_COLDLINE" => std::option::Option::Some(Self::STORAGE_CLASS_COLDLINE),
+                "STORAGE_CLASS_ARCHIVE" => std::option::Option::Some(Self::STORAGE_CLASS_ARCHIVE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for StorageClass {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for StorageClass {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for StorageClass {
         fn default() -> Self {
-            storage_class::STORAGE_CLASS_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Options for handling temporary holds for Google Cloud Storage objects.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TemporaryHold(std::borrow::Cow<'static, str>);
+    pub struct TemporaryHold(i32);
 
     impl TemporaryHold {
+        /// Temporary hold behavior is unspecified.
+        pub const TEMPORARY_HOLD_UNSPECIFIED: TemporaryHold = TemporaryHold::new(0);
+
+        /// Do not set a temporary hold on the destination object.
+        pub const TEMPORARY_HOLD_SKIP: TemporaryHold = TemporaryHold::new(1);
+
+        /// Preserve the object's original temporary hold status.
+        pub const TEMPORARY_HOLD_PRESERVE: TemporaryHold = TemporaryHold::new(2);
+
         /// Creates a new TemporaryHold instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TEMPORARY_HOLD_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TEMPORARY_HOLD_SKIP"),
+                2 => std::borrow::Cow::Borrowed("TEMPORARY_HOLD_PRESERVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TEMPORARY_HOLD_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::TEMPORARY_HOLD_UNSPECIFIED)
+                }
+                "TEMPORARY_HOLD_SKIP" => std::option::Option::Some(Self::TEMPORARY_HOLD_SKIP),
+                "TEMPORARY_HOLD_PRESERVE" => {
+                    std::option::Option::Some(Self::TEMPORARY_HOLD_PRESERVE)
+                }
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [TemporaryHold](TemporaryHold)
-    pub mod temporary_hold {
-        use super::TemporaryHold;
-
-        /// Temporary hold behavior is unspecified.
-        pub const TEMPORARY_HOLD_UNSPECIFIED: TemporaryHold =
-            TemporaryHold::new("TEMPORARY_HOLD_UNSPECIFIED");
-
-        /// Do not set a temporary hold on the destination object.
-        pub const TEMPORARY_HOLD_SKIP: TemporaryHold = TemporaryHold::new("TEMPORARY_HOLD_SKIP");
-
-        /// Preserve the object's original temporary hold status.
-        pub const TEMPORARY_HOLD_PRESERVE: TemporaryHold =
-            TemporaryHold::new("TEMPORARY_HOLD_PRESERVE");
-    }
-
-    impl std::convert::From<std::string::String> for TemporaryHold {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TemporaryHold {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TemporaryHold {
         fn default() -> Self {
-            temporary_hold::TEMPORARY_HOLD_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Options for handling the KmsKey setting for Google Cloud Storage objects.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct KmsKey(std::borrow::Cow<'static, str>);
+    pub struct KmsKey(i32);
 
     impl KmsKey {
-        /// Creates a new KmsKey instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [KmsKey](KmsKey)
-    pub mod kms_key {
-        use super::KmsKey;
-
         /// KmsKey behavior is unspecified.
-        pub const KMS_KEY_UNSPECIFIED: KmsKey = KmsKey::new("KMS_KEY_UNSPECIFIED");
+        pub const KMS_KEY_UNSPECIFIED: KmsKey = KmsKey::new(0);
 
         /// Use the destination bucket's default encryption settings.
-        pub const KMS_KEY_DESTINATION_BUCKET_DEFAULT: KmsKey =
-            KmsKey::new("KMS_KEY_DESTINATION_BUCKET_DEFAULT");
+        pub const KMS_KEY_DESTINATION_BUCKET_DEFAULT: KmsKey = KmsKey::new(1);
 
         /// Preserve the object's original Cloud KMS customer-managed encryption key
         /// (CMEK) if present. Objects that do not use a Cloud KMS encryption key
         /// will be encrypted using the destination bucket's encryption settings.
-        pub const KMS_KEY_PRESERVE: KmsKey = KmsKey::new("KMS_KEY_PRESERVE");
+        pub const KMS_KEY_PRESERVE: KmsKey = KmsKey::new(2);
+
+        /// Creates a new KmsKey instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("KMS_KEY_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("KMS_KEY_DESTINATION_BUCKET_DEFAULT"),
+                2 => std::borrow::Cow::Borrowed("KMS_KEY_PRESERVE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "KMS_KEY_UNSPECIFIED" => std::option::Option::Some(Self::KMS_KEY_UNSPECIFIED),
+                "KMS_KEY_DESTINATION_BUCKET_DEFAULT" => {
+                    std::option::Option::Some(Self::KMS_KEY_DESTINATION_BUCKET_DEFAULT)
+                }
+                "KMS_KEY_PRESERVE" => std::option::Option::Some(Self::KMS_KEY_PRESERVE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for KmsKey {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for KmsKey {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for KmsKey {
         fn default() -> Self {
-            kms_key::KMS_KEY_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Options for handling `timeCreated` metadata for Google Cloud Storage
     /// objects.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TimeCreated(std::borrow::Cow<'static, str>);
+    pub struct TimeCreated(i32);
 
     impl TimeCreated {
-        /// Creates a new TimeCreated instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [TimeCreated](TimeCreated)
-    pub mod time_created {
-        use super::TimeCreated;
-
         /// TimeCreated behavior is unspecified.
-        pub const TIME_CREATED_UNSPECIFIED: TimeCreated =
-            TimeCreated::new("TIME_CREATED_UNSPECIFIED");
+        pub const TIME_CREATED_UNSPECIFIED: TimeCreated = TimeCreated::new(0);
 
         /// Do not preserve the `timeCreated` metadata from the source object.
-        pub const TIME_CREATED_SKIP: TimeCreated = TimeCreated::new("TIME_CREATED_SKIP");
+        pub const TIME_CREATED_SKIP: TimeCreated = TimeCreated::new(1);
 
         /// Preserves the source object's `timeCreated` or `lastModified` metadata in
         /// the `customTime` field in the destination object.  Note that any value
         /// stored in the source object's `customTime` field will not be propagated
         /// to the destination object.
-        pub const TIME_CREATED_PRESERVE_AS_CUSTOM_TIME: TimeCreated =
-            TimeCreated::new("TIME_CREATED_PRESERVE_AS_CUSTOM_TIME");
+        pub const TIME_CREATED_PRESERVE_AS_CUSTOM_TIME: TimeCreated = TimeCreated::new(2);
+
+        /// Creates a new TimeCreated instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TIME_CREATED_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TIME_CREATED_SKIP"),
+                2 => std::borrow::Cow::Borrowed("TIME_CREATED_PRESERVE_AS_CUSTOM_TIME"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TIME_CREATED_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::TIME_CREATED_UNSPECIFIED)
+                }
+                "TIME_CREATED_SKIP" => std::option::Option::Some(Self::TIME_CREATED_SKIP),
+                "TIME_CREATED_PRESERVE_AS_CUSTOM_TIME" => {
+                    std::option::Option::Some(Self::TIME_CREATED_PRESERVE_AS_CUSTOM_TIME)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for TimeCreated {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for TimeCreated {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for TimeCreated {
         fn default() -> Self {
-            time_created::TIME_CREATED_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4178,49 +4427,66 @@ pub mod transfer_job {
 
     /// The status of the transfer job.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(std::borrow::Cow<'static, str>);
+    pub struct Status(i32);
 
     impl Status {
-        /// Creates a new Status instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Status](Status)
-    pub mod status {
-        use super::Status;
-
         /// Zero is an illegal value.
-        pub const STATUS_UNSPECIFIED: Status = Status::new("STATUS_UNSPECIFIED");
+        pub const STATUS_UNSPECIFIED: Status = Status::new(0);
 
         /// New transfers are performed based on the schedule.
-        pub const ENABLED: Status = Status::new("ENABLED");
+        pub const ENABLED: Status = Status::new(1);
 
         /// New transfers are not scheduled.
-        pub const DISABLED: Status = Status::new("DISABLED");
+        pub const DISABLED: Status = Status::new(2);
 
         /// This is a soft delete state. After a transfer job is set to this
         /// state, the job and all the transfer executions are subject to
         /// garbage collection. Transfer jobs become eligible for garbage collection
         /// 30 days after their status is set to `DELETED`.
-        pub const DELETED: Status = Status::new("DELETED");
+        pub const DELETED: Status = Status::new(3);
+
+        /// Creates a new Status instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATUS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("ENABLED"),
+                2 => std::borrow::Cow::Borrowed("DISABLED"),
+                3 => std::borrow::Cow::Borrowed("DELETED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATUS_UNSPECIFIED" => std::option::Option::Some(Self::STATUS_UNSPECIFIED),
+                "ENABLED" => std::option::Option::Some(Self::ENABLED),
+                "DISABLED" => std::option::Option::Some(Self::DISABLED),
+                "DELETED" => std::option::Option::Some(Self::DELETED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Status {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            status::STATUS_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4701,103 +4967,139 @@ pub mod notification_config {
     /// safely ignore unrecognized event types or explicitly specify which event
     /// types they are prepared to accept.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EventType(std::borrow::Cow<'static, str>);
+    pub struct EventType(i32);
 
     impl EventType {
-        /// Creates a new EventType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [EventType](EventType)
-    pub mod event_type {
-        use super::EventType;
-
         /// Illegal value, to avoid allowing a default.
-        pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new("EVENT_TYPE_UNSPECIFIED");
+        pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new(0);
 
         /// `TransferOperation` completed with status
         /// [SUCCESS][google.storagetransfer.v1.TransferOperation.Status.SUCCESS].
         ///
         /// [google.storagetransfer.v1.TransferOperation.Status.SUCCESS]: crate::model::transfer_operation::status::SUCCESS
-        pub const TRANSFER_OPERATION_SUCCESS: EventType =
-            EventType::new("TRANSFER_OPERATION_SUCCESS");
+        pub const TRANSFER_OPERATION_SUCCESS: EventType = EventType::new(1);
 
         /// `TransferOperation` completed with status
         /// [FAILED][google.storagetransfer.v1.TransferOperation.Status.FAILED].
         ///
         /// [google.storagetransfer.v1.TransferOperation.Status.FAILED]: crate::model::transfer_operation::status::FAILED
-        pub const TRANSFER_OPERATION_FAILED: EventType =
-            EventType::new("TRANSFER_OPERATION_FAILED");
+        pub const TRANSFER_OPERATION_FAILED: EventType = EventType::new(2);
 
         /// `TransferOperation` completed with status
         /// [ABORTED][google.storagetransfer.v1.TransferOperation.Status.ABORTED].
         ///
         /// [google.storagetransfer.v1.TransferOperation.Status.ABORTED]: crate::model::transfer_operation::status::ABORTED
-        pub const TRANSFER_OPERATION_ABORTED: EventType =
-            EventType::new("TRANSFER_OPERATION_ABORTED");
+        pub const TRANSFER_OPERATION_ABORTED: EventType = EventType::new(3);
+
+        /// Creates a new EventType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("EVENT_TYPE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("TRANSFER_OPERATION_SUCCESS"),
+                2 => std::borrow::Cow::Borrowed("TRANSFER_OPERATION_FAILED"),
+                3 => std::borrow::Cow::Borrowed("TRANSFER_OPERATION_ABORTED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "EVENT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::EVENT_TYPE_UNSPECIFIED),
+                "TRANSFER_OPERATION_SUCCESS" => {
+                    std::option::Option::Some(Self::TRANSFER_OPERATION_SUCCESS)
+                }
+                "TRANSFER_OPERATION_FAILED" => {
+                    std::option::Option::Some(Self::TRANSFER_OPERATION_FAILED)
+                }
+                "TRANSFER_OPERATION_ABORTED" => {
+                    std::option::Option::Some(Self::TRANSFER_OPERATION_ABORTED)
+                }
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for EventType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EventType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EventType {
         fn default() -> Self {
-            event_type::EVENT_TYPE_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Enum for specifying the format of a notification message's payload.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PayloadFormat(std::borrow::Cow<'static, str>);
+    pub struct PayloadFormat(i32);
 
     impl PayloadFormat {
-        /// Creates a new PayloadFormat instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [PayloadFormat](PayloadFormat)
-    pub mod payload_format {
-        use super::PayloadFormat;
-
         /// Illegal value, to avoid allowing a default.
-        pub const PAYLOAD_FORMAT_UNSPECIFIED: PayloadFormat =
-            PayloadFormat::new("PAYLOAD_FORMAT_UNSPECIFIED");
+        pub const PAYLOAD_FORMAT_UNSPECIFIED: PayloadFormat = PayloadFormat::new(0);
 
         /// No payload is included with the notification.
-        pub const NONE: PayloadFormat = PayloadFormat::new("NONE");
+        pub const NONE: PayloadFormat = PayloadFormat::new(1);
 
         /// `TransferOperation` is [formatted as a JSON
         /// response](https://developers.google.com/protocol-buffers/docs/proto3#json),
         /// in application/json.
-        pub const JSON: PayloadFormat = PayloadFormat::new("JSON");
+        pub const JSON: PayloadFormat = PayloadFormat::new(2);
+
+        /// Creates a new PayloadFormat instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("PAYLOAD_FORMAT_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("NONE"),
+                2 => std::borrow::Cow::Borrowed("JSON"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "PAYLOAD_FORMAT_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::PAYLOAD_FORMAT_UNSPECIFIED)
+                }
+                "NONE" => std::option::Option::Some(Self::NONE),
+                "JSON" => std::option::Option::Some(Self::JSON),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for PayloadFormat {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for PayloadFormat {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for PayloadFormat {
         fn default() -> Self {
-            payload_format::PAYLOAD_FORMAT_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -4881,92 +5183,127 @@ pub mod logging_config {
 
     /// Loggable actions.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LoggableAction(std::borrow::Cow<'static, str>);
+    pub struct LoggableAction(i32);
 
     impl LoggableAction {
+        /// Default value. This value is unused.
+        pub const LOGGABLE_ACTION_UNSPECIFIED: LoggableAction = LoggableAction::new(0);
+
+        /// Listing objects in a bucket.
+        pub const FIND: LoggableAction = LoggableAction::new(1);
+
+        /// Deleting objects at the source or the destination.
+        pub const DELETE: LoggableAction = LoggableAction::new(2);
+
+        /// Copying objects to Google Cloud Storage.
+        pub const COPY: LoggableAction = LoggableAction::new(3);
+
         /// Creates a new LoggableAction instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LOGGABLE_ACTION_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("FIND"),
+                2 => std::borrow::Cow::Borrowed("DELETE"),
+                3 => std::borrow::Cow::Borrowed("COPY"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LOGGABLE_ACTION_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::LOGGABLE_ACTION_UNSPECIFIED)
+                }
+                "FIND" => std::option::Option::Some(Self::FIND),
+                "DELETE" => std::option::Option::Some(Self::DELETE),
+                "COPY" => std::option::Option::Some(Self::COPY),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [LoggableAction](LoggableAction)
-    pub mod loggable_action {
-        use super::LoggableAction;
-
-        /// Default value. This value is unused.
-        pub const LOGGABLE_ACTION_UNSPECIFIED: LoggableAction =
-            LoggableAction::new("LOGGABLE_ACTION_UNSPECIFIED");
-
-        /// Listing objects in a bucket.
-        pub const FIND: LoggableAction = LoggableAction::new("FIND");
-
-        /// Deleting objects at the source or the destination.
-        pub const DELETE: LoggableAction = LoggableAction::new("DELETE");
-
-        /// Copying objects to Google Cloud Storage.
-        pub const COPY: LoggableAction = LoggableAction::new("COPY");
-    }
-
-    impl std::convert::From<std::string::String> for LoggableAction {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LoggableAction {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LoggableAction {
         fn default() -> Self {
-            loggable_action::LOGGABLE_ACTION_UNSPECIFIED
+            Self::new(0)
         }
     }
 
     /// Loggable action states.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LoggableActionState(std::borrow::Cow<'static, str>);
+    pub struct LoggableActionState(i32);
 
     impl LoggableActionState {
-        /// Creates a new LoggableActionState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [LoggableActionState](LoggableActionState)
-    pub mod loggable_action_state {
-        use super::LoggableActionState;
-
         /// Default value. This value is unused.
         pub const LOGGABLE_ACTION_STATE_UNSPECIFIED: LoggableActionState =
-            LoggableActionState::new("LOGGABLE_ACTION_STATE_UNSPECIFIED");
+            LoggableActionState::new(0);
 
         /// `LoggableAction` completed successfully. `SUCCEEDED` actions are
         /// logged as [INFO][google.logging.type.LogSeverity.INFO].
-        pub const SUCCEEDED: LoggableActionState = LoggableActionState::new("SUCCEEDED");
+        pub const SUCCEEDED: LoggableActionState = LoggableActionState::new(1);
 
         /// `LoggableAction` terminated in an error state. `FAILED` actions are
         /// logged as [ERROR][google.logging.type.LogSeverity.ERROR].
-        pub const FAILED: LoggableActionState = LoggableActionState::new("FAILED");
+        pub const FAILED: LoggableActionState = LoggableActionState::new(2);
+
+        /// Creates a new LoggableActionState instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("LOGGABLE_ACTION_STATE_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("SUCCEEDED"),
+                2 => std::borrow::Cow::Borrowed("FAILED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LOGGABLE_ACTION_STATE_UNSPECIFIED" => {
+                    std::option::Option::Some(Self::LOGGABLE_ACTION_STATE_UNSPECIFIED)
+                }
+                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for LoggableActionState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for LoggableActionState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for LoggableActionState {
         fn default() -> Self {
-            loggable_action_state::LOGGABLE_ACTION_STATE_UNSPECIFIED
+            Self::new(0)
         }
     }
 }
@@ -5143,58 +5480,83 @@ pub mod transfer_operation {
 
     /// The status of a TransferOperation.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(std::borrow::Cow<'static, str>);
+    pub struct Status(i32);
 
     impl Status {
+        /// Zero is an illegal value.
+        pub const STATUS_UNSPECIFIED: Status = Status::new(0);
+
+        /// In progress.
+        pub const IN_PROGRESS: Status = Status::new(1);
+
+        /// Paused.
+        pub const PAUSED: Status = Status::new(2);
+
+        /// Completed successfully.
+        pub const SUCCESS: Status = Status::new(3);
+
+        /// Terminated due to an unrecoverable failure.
+        pub const FAILED: Status = Status::new(4);
+
+        /// Aborted by the user.
+        pub const ABORTED: Status = Status::new(5);
+
+        /// Temporarily delayed by the system. No user action is required.
+        pub const QUEUED: Status = Status::new(6);
+
+        /// The operation is suspending and draining the ongoing work to completion.
+        pub const SUSPENDING: Status = Status::new(7);
+
         /// Creates a new Status instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STATUS_UNSPECIFIED"),
+                1 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
+                2 => std::borrow::Cow::Borrowed("PAUSED"),
+                3 => std::borrow::Cow::Borrowed("SUCCESS"),
+                4 => std::borrow::Cow::Borrowed("FAILED"),
+                5 => std::borrow::Cow::Borrowed("ABORTED"),
+                6 => std::borrow::Cow::Borrowed("QUEUED"),
+                7 => std::borrow::Cow::Borrowed("SUSPENDING"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STATUS_UNSPECIFIED" => std::option::Option::Some(Self::STATUS_UNSPECIFIED),
+                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
+                "PAUSED" => std::option::Option::Some(Self::PAUSED),
+                "SUCCESS" => std::option::Option::Some(Self::SUCCESS),
+                "FAILED" => std::option::Option::Some(Self::FAILED),
+                "ABORTED" => std::option::Option::Some(Self::ABORTED),
+                "QUEUED" => std::option::Option::Some(Self::QUEUED),
+                "SUSPENDING" => std::option::Option::Some(Self::SUSPENDING),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Status](Status)
-    pub mod status {
-        use super::Status;
-
-        /// Zero is an illegal value.
-        pub const STATUS_UNSPECIFIED: Status = Status::new("STATUS_UNSPECIFIED");
-
-        /// In progress.
-        pub const IN_PROGRESS: Status = Status::new("IN_PROGRESS");
-
-        /// Paused.
-        pub const PAUSED: Status = Status::new("PAUSED");
-
-        /// Completed successfully.
-        pub const SUCCESS: Status = Status::new("SUCCESS");
-
-        /// Terminated due to an unrecoverable failure.
-        pub const FAILED: Status = Status::new("FAILED");
-
-        /// Aborted by the user.
-        pub const ABORTED: Status = Status::new("ABORTED");
-
-        /// Temporarily delayed by the system. No user action is required.
-        pub const QUEUED: Status = Status::new("QUEUED");
-
-        /// The operation is suspending and draining the ongoing work to completion.
-        pub const SUSPENDING: Status = Status::new("SUSPENDING");
-    }
-
-    impl std::convert::From<std::string::String> for Status {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            status::STATUS_UNSPECIFIED
+            Self::new(0)
         }
     }
 }

--- a/src/generated/storagetransfer/v1/src/transport.rs
+++ b/src/generated/storagetransfer/v1/src/transport.rs
@@ -52,7 +52,7 @@ impl crate::stubs::StorageTransferService for StorageTransferService {
                 reqwest::Method::GET,
                 format!("/v1/googleServiceAccounts/{}", req.project_id),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -71,7 +71,7 @@ impl crate::stubs::StorageTransferService for StorageTransferService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, "/v1/transferJobs".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -90,7 +90,7 @@ impl crate::stubs::StorageTransferService for StorageTransferService {
         let builder = self
             .inner
             .builder(reqwest::Method::PATCH, format!("/v1/{}", req.job_name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -107,7 +107,7 @@ impl crate::stubs::StorageTransferService for StorageTransferService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.job_name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -127,7 +127,7 @@ impl crate::stubs::StorageTransferService for StorageTransferService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, "/v1/transferJobs".to_string())
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -149,7 +149,7 @@ impl crate::stubs::StorageTransferService for StorageTransferService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:pause", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -166,7 +166,7 @@ impl crate::stubs::StorageTransferService for StorageTransferService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:resume", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -183,7 +183,7 @@ impl crate::stubs::StorageTransferService for StorageTransferService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:run", req.job_name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -200,7 +200,7 @@ impl crate::stubs::StorageTransferService for StorageTransferService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.job_name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -223,7 +223,7 @@ impl crate::stubs::StorageTransferService for StorageTransferService {
                 reqwest::Method::POST,
                 format!("/v1/projects/{}/agentPools", req.project_id),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -252,7 +252,7 @@ impl crate::stubs::StorageTransferService for StorageTransferService {
                         .name
                 ),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -281,7 +281,7 @@ impl crate::stubs::StorageTransferService for StorageTransferService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -303,7 +303,7 @@ impl crate::stubs::StorageTransferService for StorageTransferService {
                 reqwest::Method::GET,
                 format!("/v1/projects/{}/agentPools", req.project_id),
             )
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -325,7 +325,7 @@ impl crate::stubs::StorageTransferService for StorageTransferService {
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -344,7 +344,7 @@ impl crate::stubs::StorageTransferService for StorageTransferService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -366,7 +366,7 @@ impl crate::stubs::StorageTransferService for StorageTransferService {
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
@@ -385,7 +385,7 @@ impl crate::stubs::StorageTransferService for StorageTransferService {
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
-            .query(&[("alt", "json")])
+            .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),

--- a/src/generated/type/src/model.rs
+++ b/src/generated/type/src/model.rs
@@ -1580,191 +1580,277 @@ impl wkt::message::Message for TimeOfDay {
 /// a canonical start. Grammatically, "the start of the current
 /// `CalendarPeriod`." All calendar times begin at midnight UTC.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct CalendarPeriod(std::borrow::Cow<'static, str>);
+pub struct CalendarPeriod(i32);
 
 impl CalendarPeriod {
-    /// Creates a new CalendarPeriod instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [CalendarPeriod](CalendarPeriod)
-pub mod calendar_period {
-    use super::CalendarPeriod;
-
     /// Undefined period, raises an error.
-    pub const CALENDAR_PERIOD_UNSPECIFIED: CalendarPeriod =
-        CalendarPeriod::new("CALENDAR_PERIOD_UNSPECIFIED");
+    pub const CALENDAR_PERIOD_UNSPECIFIED: CalendarPeriod = CalendarPeriod::new(0);
 
     /// A day.
-    pub const DAY: CalendarPeriod = CalendarPeriod::new("DAY");
+    pub const DAY: CalendarPeriod = CalendarPeriod::new(1);
 
     /// A week. Weeks begin on Monday, following
     /// [ISO 8601](https://en.wikipedia.org/wiki/ISO_week_date).
-    pub const WEEK: CalendarPeriod = CalendarPeriod::new("WEEK");
+    pub const WEEK: CalendarPeriod = CalendarPeriod::new(2);
 
     /// A fortnight. The first calendar fortnight of the year begins at the start
     /// of week 1 according to
     /// [ISO 8601](https://en.wikipedia.org/wiki/ISO_week_date).
-    pub const FORTNIGHT: CalendarPeriod = CalendarPeriod::new("FORTNIGHT");
+    pub const FORTNIGHT: CalendarPeriod = CalendarPeriod::new(3);
 
     /// A month.
-    pub const MONTH: CalendarPeriod = CalendarPeriod::new("MONTH");
+    pub const MONTH: CalendarPeriod = CalendarPeriod::new(4);
 
     /// A quarter. Quarters start on dates 1-Jan, 1-Apr, 1-Jul, and 1-Oct of each
     /// year.
-    pub const QUARTER: CalendarPeriod = CalendarPeriod::new("QUARTER");
+    pub const QUARTER: CalendarPeriod = CalendarPeriod::new(5);
 
     /// A half-year. Half-years start on dates 1-Jan and 1-Jul.
-    pub const HALF: CalendarPeriod = CalendarPeriod::new("HALF");
+    pub const HALF: CalendarPeriod = CalendarPeriod::new(6);
 
     /// A year.
-    pub const YEAR: CalendarPeriod = CalendarPeriod::new("YEAR");
+    pub const YEAR: CalendarPeriod = CalendarPeriod::new(7);
+
+    /// Creates a new CalendarPeriod instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("CALENDAR_PERIOD_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("DAY"),
+            2 => std::borrow::Cow::Borrowed("WEEK"),
+            3 => std::borrow::Cow::Borrowed("FORTNIGHT"),
+            4 => std::borrow::Cow::Borrowed("MONTH"),
+            5 => std::borrow::Cow::Borrowed("QUARTER"),
+            6 => std::borrow::Cow::Borrowed("HALF"),
+            7 => std::borrow::Cow::Borrowed("YEAR"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "CALENDAR_PERIOD_UNSPECIFIED" => {
+                std::option::Option::Some(Self::CALENDAR_PERIOD_UNSPECIFIED)
+            }
+            "DAY" => std::option::Option::Some(Self::DAY),
+            "WEEK" => std::option::Option::Some(Self::WEEK),
+            "FORTNIGHT" => std::option::Option::Some(Self::FORTNIGHT),
+            "MONTH" => std::option::Option::Some(Self::MONTH),
+            "QUARTER" => std::option::Option::Some(Self::QUARTER),
+            "HALF" => std::option::Option::Some(Self::HALF),
+            "YEAR" => std::option::Option::Some(Self::YEAR),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for CalendarPeriod {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for CalendarPeriod {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for CalendarPeriod {
     fn default() -> Self {
-        calendar_period::CALENDAR_PERIOD_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Represents a day of the week.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DayOfWeek(std::borrow::Cow<'static, str>);
+pub struct DayOfWeek(i32);
 
 impl DayOfWeek {
+    /// The day of the week is unspecified.
+    pub const DAY_OF_WEEK_UNSPECIFIED: DayOfWeek = DayOfWeek::new(0);
+
+    /// Monday
+    pub const MONDAY: DayOfWeek = DayOfWeek::new(1);
+
+    /// Tuesday
+    pub const TUESDAY: DayOfWeek = DayOfWeek::new(2);
+
+    /// Wednesday
+    pub const WEDNESDAY: DayOfWeek = DayOfWeek::new(3);
+
+    /// Thursday
+    pub const THURSDAY: DayOfWeek = DayOfWeek::new(4);
+
+    /// Friday
+    pub const FRIDAY: DayOfWeek = DayOfWeek::new(5);
+
+    /// Saturday
+    pub const SATURDAY: DayOfWeek = DayOfWeek::new(6);
+
+    /// Sunday
+    pub const SUNDAY: DayOfWeek = DayOfWeek::new(7);
+
     /// Creates a new DayOfWeek instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("DAY_OF_WEEK_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("MONDAY"),
+            2 => std::borrow::Cow::Borrowed("TUESDAY"),
+            3 => std::borrow::Cow::Borrowed("WEDNESDAY"),
+            4 => std::borrow::Cow::Borrowed("THURSDAY"),
+            5 => std::borrow::Cow::Borrowed("FRIDAY"),
+            6 => std::borrow::Cow::Borrowed("SATURDAY"),
+            7 => std::borrow::Cow::Borrowed("SUNDAY"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "DAY_OF_WEEK_UNSPECIFIED" => std::option::Option::Some(Self::DAY_OF_WEEK_UNSPECIFIED),
+            "MONDAY" => std::option::Option::Some(Self::MONDAY),
+            "TUESDAY" => std::option::Option::Some(Self::TUESDAY),
+            "WEDNESDAY" => std::option::Option::Some(Self::WEDNESDAY),
+            "THURSDAY" => std::option::Option::Some(Self::THURSDAY),
+            "FRIDAY" => std::option::Option::Some(Self::FRIDAY),
+            "SATURDAY" => std::option::Option::Some(Self::SATURDAY),
+            "SUNDAY" => std::option::Option::Some(Self::SUNDAY),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [DayOfWeek](DayOfWeek)
-pub mod day_of_week {
-    use super::DayOfWeek;
-
-    /// The day of the week is unspecified.
-    pub const DAY_OF_WEEK_UNSPECIFIED: DayOfWeek = DayOfWeek::new("DAY_OF_WEEK_UNSPECIFIED");
-
-    /// Monday
-    pub const MONDAY: DayOfWeek = DayOfWeek::new("MONDAY");
-
-    /// Tuesday
-    pub const TUESDAY: DayOfWeek = DayOfWeek::new("TUESDAY");
-
-    /// Wednesday
-    pub const WEDNESDAY: DayOfWeek = DayOfWeek::new("WEDNESDAY");
-
-    /// Thursday
-    pub const THURSDAY: DayOfWeek = DayOfWeek::new("THURSDAY");
-
-    /// Friday
-    pub const FRIDAY: DayOfWeek = DayOfWeek::new("FRIDAY");
-
-    /// Saturday
-    pub const SATURDAY: DayOfWeek = DayOfWeek::new("SATURDAY");
-
-    /// Sunday
-    pub const SUNDAY: DayOfWeek = DayOfWeek::new("SUNDAY");
-}
-
-impl std::convert::From<std::string::String> for DayOfWeek {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for DayOfWeek {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for DayOfWeek {
     fn default() -> Self {
-        day_of_week::DAY_OF_WEEK_UNSPECIFIED
+        Self::new(0)
     }
 }
 
 /// Represents a month in the Gregorian calendar.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Month(std::borrow::Cow<'static, str>);
+pub struct Month(i32);
 
 impl Month {
+    /// The unspecified month.
+    pub const MONTH_UNSPECIFIED: Month = Month::new(0);
+
+    /// The month of January.
+    pub const JANUARY: Month = Month::new(1);
+
+    /// The month of February.
+    pub const FEBRUARY: Month = Month::new(2);
+
+    /// The month of March.
+    pub const MARCH: Month = Month::new(3);
+
+    /// The month of April.
+    pub const APRIL: Month = Month::new(4);
+
+    /// The month of May.
+    pub const MAY: Month = Month::new(5);
+
+    /// The month of June.
+    pub const JUNE: Month = Month::new(6);
+
+    /// The month of July.
+    pub const JULY: Month = Month::new(7);
+
+    /// The month of August.
+    pub const AUGUST: Month = Month::new(8);
+
+    /// The month of September.
+    pub const SEPTEMBER: Month = Month::new(9);
+
+    /// The month of October.
+    pub const OCTOBER: Month = Month::new(10);
+
+    /// The month of November.
+    pub const NOVEMBER: Month = Month::new(11);
+
+    /// The month of December.
+    pub const DECEMBER: Month = Month::new(12);
+
     /// Creates a new Month instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("MONTH_UNSPECIFIED"),
+            1 => std::borrow::Cow::Borrowed("JANUARY"),
+            2 => std::borrow::Cow::Borrowed("FEBRUARY"),
+            3 => std::borrow::Cow::Borrowed("MARCH"),
+            4 => std::borrow::Cow::Borrowed("APRIL"),
+            5 => std::borrow::Cow::Borrowed("MAY"),
+            6 => std::borrow::Cow::Borrowed("JUNE"),
+            7 => std::borrow::Cow::Borrowed("JULY"),
+            8 => std::borrow::Cow::Borrowed("AUGUST"),
+            9 => std::borrow::Cow::Borrowed("SEPTEMBER"),
+            10 => std::borrow::Cow::Borrowed("OCTOBER"),
+            11 => std::borrow::Cow::Borrowed("NOVEMBER"),
+            12 => std::borrow::Cow::Borrowed("DECEMBER"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "MONTH_UNSPECIFIED" => std::option::Option::Some(Self::MONTH_UNSPECIFIED),
+            "JANUARY" => std::option::Option::Some(Self::JANUARY),
+            "FEBRUARY" => std::option::Option::Some(Self::FEBRUARY),
+            "MARCH" => std::option::Option::Some(Self::MARCH),
+            "APRIL" => std::option::Option::Some(Self::APRIL),
+            "MAY" => std::option::Option::Some(Self::MAY),
+            "JUNE" => std::option::Option::Some(Self::JUNE),
+            "JULY" => std::option::Option::Some(Self::JULY),
+            "AUGUST" => std::option::Option::Some(Self::AUGUST),
+            "SEPTEMBER" => std::option::Option::Some(Self::SEPTEMBER),
+            "OCTOBER" => std::option::Option::Some(Self::OCTOBER),
+            "NOVEMBER" => std::option::Option::Some(Self::NOVEMBER),
+            "DECEMBER" => std::option::Option::Some(Self::DECEMBER),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [Month](Month)
-pub mod month {
-    use super::Month;
-
-    /// The unspecified month.
-    pub const MONTH_UNSPECIFIED: Month = Month::new("MONTH_UNSPECIFIED");
-
-    /// The month of January.
-    pub const JANUARY: Month = Month::new("JANUARY");
-
-    /// The month of February.
-    pub const FEBRUARY: Month = Month::new("FEBRUARY");
-
-    /// The month of March.
-    pub const MARCH: Month = Month::new("MARCH");
-
-    /// The month of April.
-    pub const APRIL: Month = Month::new("APRIL");
-
-    /// The month of May.
-    pub const MAY: Month = Month::new("MAY");
-
-    /// The month of June.
-    pub const JUNE: Month = Month::new("JUNE");
-
-    /// The month of July.
-    pub const JULY: Month = Month::new("JULY");
-
-    /// The month of August.
-    pub const AUGUST: Month = Month::new("AUGUST");
-
-    /// The month of September.
-    pub const SEPTEMBER: Month = Month::new("SEPTEMBER");
-
-    /// The month of October.
-    pub const OCTOBER: Month = Month::new("OCTOBER");
-
-    /// The month of November.
-    pub const NOVEMBER: Month = Month::new("NOVEMBER");
-
-    /// The month of December.
-    pub const DECEMBER: Month = Month::new("DECEMBER");
-}
-
-impl std::convert::From<std::string::String> for Month {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Month {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Month {
     fn default() -> Self {
-        month::MONTH_UNSPECIFIED
+        Self::new(0)
     }
 }

--- a/src/integration-tests/tests/enums.rs
+++ b/src/integration-tests/tests/enums.rs
@@ -19,7 +19,7 @@ mod enums {
     #[test]
     fn test_default_value() {
         let default = secret_version::State::default();
-        assert_eq!(default, secret_version::state::STATE_UNSPECIFIED);
+        assert_eq!(default, secret_version::State::STATE_UNSPECIFIED);
     }
 
     #[test]
@@ -30,7 +30,7 @@ mod enums {
         let secret_version = serde_json::from_value::<SecretVersion>(input).unwrap();
         assert_eq!(
             secret_version.state,
-            secret_version::state::STATE_UNSPECIFIED
+            secret_version::State::STATE_UNSPECIFIED
         );
     }
 }

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -47,9 +47,9 @@ pub enum PollingResult<R, M> {
     /// recover.
     ///
     /// [ServiceError]: gax::error::ServiceError
-    /// [NOT_FOUND]: rpc::model::code::NOT_FOUND
-    /// [ABORTED]: rpc::model::code::ABORTED
-    /// [PERMISSION_DENIED]: rpc::model::code::PERMISSION_DENIED
+    /// [NOT_FOUND]: rpc::model::Code::NOT_FOUND
+    /// [ABORTED]: rpc::model::Code::ABORTED
+    /// [PERMISSION_DENIED]: rpc::model::Code::PERMISSION_DENIED
     PollingError(Error),
 }
 

--- a/src/wkt/src/generated/mod.rs
+++ b/src/wkt/src/generated/mod.rs
@@ -1010,39 +1010,52 @@ pub mod extension_range_options {
 
     /// The verification state of the extension range.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VerificationState(std::borrow::Cow<'static, str>);
+    pub struct VerificationState(i32);
 
     impl VerificationState {
+        /// All the extensions of the range must be declared.
+        pub const DECLARATION: VerificationState = VerificationState::new(0);
+
+        pub const UNVERIFIED: VerificationState = VerificationState::new(1);
+
         /// Creates a new VerificationState instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("DECLARATION"),
+                1 => std::borrow::Cow::Borrowed("UNVERIFIED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "DECLARATION" => std::option::Option::Some(Self::DECLARATION),
+                "UNVERIFIED" => std::option::Option::Some(Self::UNVERIFIED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [VerificationState](VerificationState)
-    pub mod verification_state {
-        use super::VerificationState;
-
-        /// All the extensions of the range must be declared.
-        pub const DECLARATION: VerificationState = VerificationState::new("DECLARATION");
-
-        pub const UNVERIFIED: VerificationState = VerificationState::new("UNVERIFIED");
-    }
-
-    impl std::convert::From<std::string::String> for VerificationState {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for VerificationState {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for VerificationState {
         fn default() -> Self {
-            verification_state::DECLARATION
+            Self::new(0)
         }
     }
 }
@@ -1216,124 +1229,184 @@ pub mod field_descriptor_proto {
     use super::*;
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(std::borrow::Cow<'static, str>);
+    pub struct Type(i32);
 
     impl Type {
-        /// Creates a new Type instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Type](Type)
-    pub mod r#type {
-        use super::Type;
-
         /// 0 is reserved for errors.
         /// Order is weird for historical reasons.
-        pub const TYPE_DOUBLE: Type = Type::new("TYPE_DOUBLE");
+        pub const TYPE_DOUBLE: Type = Type::new(1);
 
-        pub const TYPE_FLOAT: Type = Type::new("TYPE_FLOAT");
+        pub const TYPE_FLOAT: Type = Type::new(2);
 
         /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
         /// negative values are likely.
-        pub const TYPE_INT64: Type = Type::new("TYPE_INT64");
+        pub const TYPE_INT64: Type = Type::new(3);
 
-        pub const TYPE_UINT64: Type = Type::new("TYPE_UINT64");
+        pub const TYPE_UINT64: Type = Type::new(4);
 
         /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
         /// negative values are likely.
-        pub const TYPE_INT32: Type = Type::new("TYPE_INT32");
+        pub const TYPE_INT32: Type = Type::new(5);
 
-        pub const TYPE_FIXED64: Type = Type::new("TYPE_FIXED64");
+        pub const TYPE_FIXED64: Type = Type::new(6);
 
-        pub const TYPE_FIXED32: Type = Type::new("TYPE_FIXED32");
+        pub const TYPE_FIXED32: Type = Type::new(7);
 
-        pub const TYPE_BOOL: Type = Type::new("TYPE_BOOL");
+        pub const TYPE_BOOL: Type = Type::new(8);
 
-        pub const TYPE_STRING: Type = Type::new("TYPE_STRING");
+        pub const TYPE_STRING: Type = Type::new(9);
 
         /// Tag-delimited aggregate.
         /// Group type is deprecated and not supported after google.protobuf. However, Proto3
         /// implementations should still be able to parse the group wire format and
         /// treat group fields as unknown fields.  In Editions, the group wire format
         /// can be enabled via the `message_encoding` feature.
-        pub const TYPE_GROUP: Type = Type::new("TYPE_GROUP");
+        pub const TYPE_GROUP: Type = Type::new(10);
 
-        pub const TYPE_MESSAGE: Type = Type::new("TYPE_MESSAGE");
+        pub const TYPE_MESSAGE: Type = Type::new(11);
 
         /// New in version 2.
-        pub const TYPE_BYTES: Type = Type::new("TYPE_BYTES");
+        pub const TYPE_BYTES: Type = Type::new(12);
 
-        pub const TYPE_UINT32: Type = Type::new("TYPE_UINT32");
+        pub const TYPE_UINT32: Type = Type::new(13);
 
-        pub const TYPE_ENUM: Type = Type::new("TYPE_ENUM");
+        pub const TYPE_ENUM: Type = Type::new(14);
 
-        pub const TYPE_SFIXED32: Type = Type::new("TYPE_SFIXED32");
+        pub const TYPE_SFIXED32: Type = Type::new(15);
 
-        pub const TYPE_SFIXED64: Type = Type::new("TYPE_SFIXED64");
+        pub const TYPE_SFIXED64: Type = Type::new(16);
 
-        pub const TYPE_SINT32: Type = Type::new("TYPE_SINT32");
+        pub const TYPE_SINT32: Type = Type::new(17);
 
-        pub const TYPE_SINT64: Type = Type::new("TYPE_SINT64");
+        pub const TYPE_SINT64: Type = Type::new(18);
+
+        /// Creates a new Type instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                1 => std::borrow::Cow::Borrowed("TYPE_DOUBLE"),
+                2 => std::borrow::Cow::Borrowed("TYPE_FLOAT"),
+                3 => std::borrow::Cow::Borrowed("TYPE_INT64"),
+                4 => std::borrow::Cow::Borrowed("TYPE_UINT64"),
+                5 => std::borrow::Cow::Borrowed("TYPE_INT32"),
+                6 => std::borrow::Cow::Borrowed("TYPE_FIXED64"),
+                7 => std::borrow::Cow::Borrowed("TYPE_FIXED32"),
+                8 => std::borrow::Cow::Borrowed("TYPE_BOOL"),
+                9 => std::borrow::Cow::Borrowed("TYPE_STRING"),
+                10 => std::borrow::Cow::Borrowed("TYPE_GROUP"),
+                11 => std::borrow::Cow::Borrowed("TYPE_MESSAGE"),
+                12 => std::borrow::Cow::Borrowed("TYPE_BYTES"),
+                13 => std::borrow::Cow::Borrowed("TYPE_UINT32"),
+                14 => std::borrow::Cow::Borrowed("TYPE_ENUM"),
+                15 => std::borrow::Cow::Borrowed("TYPE_SFIXED32"),
+                16 => std::borrow::Cow::Borrowed("TYPE_SFIXED64"),
+                17 => std::borrow::Cow::Borrowed("TYPE_SINT32"),
+                18 => std::borrow::Cow::Borrowed("TYPE_SINT64"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_DOUBLE" => std::option::Option::Some(Self::TYPE_DOUBLE),
+                "TYPE_FLOAT" => std::option::Option::Some(Self::TYPE_FLOAT),
+                "TYPE_INT64" => std::option::Option::Some(Self::TYPE_INT64),
+                "TYPE_UINT64" => std::option::Option::Some(Self::TYPE_UINT64),
+                "TYPE_INT32" => std::option::Option::Some(Self::TYPE_INT32),
+                "TYPE_FIXED64" => std::option::Option::Some(Self::TYPE_FIXED64),
+                "TYPE_FIXED32" => std::option::Option::Some(Self::TYPE_FIXED32),
+                "TYPE_BOOL" => std::option::Option::Some(Self::TYPE_BOOL),
+                "TYPE_STRING" => std::option::Option::Some(Self::TYPE_STRING),
+                "TYPE_GROUP" => std::option::Option::Some(Self::TYPE_GROUP),
+                "TYPE_MESSAGE" => std::option::Option::Some(Self::TYPE_MESSAGE),
+                "TYPE_BYTES" => std::option::Option::Some(Self::TYPE_BYTES),
+                "TYPE_UINT32" => std::option::Option::Some(Self::TYPE_UINT32),
+                "TYPE_ENUM" => std::option::Option::Some(Self::TYPE_ENUM),
+                "TYPE_SFIXED32" => std::option::Option::Some(Self::TYPE_SFIXED32),
+                "TYPE_SFIXED64" => std::option::Option::Some(Self::TYPE_SFIXED64),
+                "TYPE_SINT32" => std::option::Option::Some(Self::TYPE_SINT32),
+                "TYPE_SINT64" => std::option::Option::Some(Self::TYPE_SINT64),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Type {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new("")
+            Self::new(0)
         }
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Label(std::borrow::Cow<'static, str>);
+    pub struct Label(i32);
 
     impl Label {
-        /// Creates a new Label instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [Label](Label)
-    pub mod label {
-        use super::Label;
-
         /// 0 is reserved for errors
-        pub const LABEL_OPTIONAL: Label = Label::new("LABEL_OPTIONAL");
+        pub const LABEL_OPTIONAL: Label = Label::new(1);
 
-        pub const LABEL_REPEATED: Label = Label::new("LABEL_REPEATED");
+        pub const LABEL_REPEATED: Label = Label::new(3);
 
         /// The required label is only allowed in google.protobuf.  In proto3 and Editions
         /// it's explicitly prohibited.  In Editions, the `field_presence` feature
         /// can be used to get this behavior.
-        pub const LABEL_REQUIRED: Label = Label::new("LABEL_REQUIRED");
+        pub const LABEL_REQUIRED: Label = Label::new(2);
+
+        /// Creates a new Label instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                1 => std::borrow::Cow::Borrowed("LABEL_OPTIONAL"),
+                2 => std::borrow::Cow::Borrowed("LABEL_REQUIRED"),
+                3 => std::borrow::Cow::Borrowed("LABEL_REPEATED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "LABEL_OPTIONAL" => std::option::Option::Some(Self::LABEL_OPTIONAL),
+                "LABEL_REPEATED" => std::option::Option::Some(Self::LABEL_REPEATED),
+                "LABEL_REQUIRED" => std::option::Option::Some(Self::LABEL_REQUIRED),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for Label {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Label {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Label {
         fn default() -> Self {
-            Self::new("")
+            Self::new(0)
         }
     }
 }
@@ -1991,41 +2064,56 @@ pub mod file_options {
 
     /// Generated classes can be optimized for speed or code size.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OptimizeMode(std::borrow::Cow<'static, str>);
+    pub struct OptimizeMode(i32);
 
     impl OptimizeMode {
+        pub const SPEED: OptimizeMode = OptimizeMode::new(1);
+
+        /// etc.
+        pub const CODE_SIZE: OptimizeMode = OptimizeMode::new(2);
+
+        pub const LITE_RUNTIME: OptimizeMode = OptimizeMode::new(3);
+
         /// Creates a new OptimizeMode instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                1 => std::borrow::Cow::Borrowed("SPEED"),
+                2 => std::borrow::Cow::Borrowed("CODE_SIZE"),
+                3 => std::borrow::Cow::Borrowed("LITE_RUNTIME"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "SPEED" => std::option::Option::Some(Self::SPEED),
+                "CODE_SIZE" => std::option::Option::Some(Self::CODE_SIZE),
+                "LITE_RUNTIME" => std::option::Option::Some(Self::LITE_RUNTIME),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [OptimizeMode](OptimizeMode)
-    pub mod optimize_mode {
-        use super::OptimizeMode;
-
-        pub const SPEED: OptimizeMode = OptimizeMode::new("SPEED");
-
-        /// etc.
-        pub const CODE_SIZE: OptimizeMode = OptimizeMode::new("CODE_SIZE");
-
-        pub const LITE_RUNTIME: OptimizeMode = OptimizeMode::new("LITE_RUNTIME");
-    }
-
-    impl std::convert::From<std::string::String> for OptimizeMode {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for OptimizeMode {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for OptimizeMode {
         fn default() -> Self {
-            Self::new("")
+            Self::new(0)
         }
     }
 }
@@ -2510,26 +2598,11 @@ pub mod field_options {
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CType(std::borrow::Cow<'static, str>);
+    pub struct CType(i32);
 
     impl CType {
-        /// Creates a new CType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
-        }
-    }
-
-    /// Useful constants to work with [CType](CType)
-    pub mod c_type {
-        use super::CType;
-
         /// Default mode.
-        pub const STRING: CType = CType::new("STRING");
+        pub const STRING: CType = CType::new(0);
 
         /// The option [ctype=CORD] may be applied to a non-repeated field of type
         /// "bytes". It indicates that in C++, the data should be stored in a Cord
@@ -2537,100 +2610,160 @@ pub mod field_options {
         /// fragmentation. It may also allow better performance when parsing from a
         /// Cord, or when parsing with aliasing enabled, as the parsed Cord may then
         /// alias the original buffer.
-        pub const CORD: CType = CType::new("CORD");
+        pub const CORD: CType = CType::new(1);
 
-        pub const STRING_PIECE: CType = CType::new("STRING_PIECE");
+        pub const STRING_PIECE: CType = CType::new(2);
+
+        /// Creates a new CType instance.
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
+        }
+
+        /// Gets the enum value.
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("STRING"),
+                1 => std::borrow::Cow::Borrowed("CORD"),
+                2 => std::borrow::Cow::Borrowed("STRING_PIECE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "STRING" => std::option::Option::Some(Self::STRING),
+                "CORD" => std::option::Option::Some(Self::CORD),
+                "STRING_PIECE" => std::option::Option::Some(Self::STRING_PIECE),
+                _ => std::option::Option::None,
+            }
+        }
     }
 
-    impl std::convert::From<std::string::String> for CType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for CType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for CType {
         fn default() -> Self {
-            c_type::STRING
+            Self::new(0)
         }
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct JSType(std::borrow::Cow<'static, str>);
+    pub struct JSType(i32);
 
     impl JSType {
+        /// Use the default type.
+        pub const JS_NORMAL: JSType = JSType::new(0);
+
+        /// Use JavaScript strings.
+        pub const JS_STRING: JSType = JSType::new(1);
+
+        /// Use JavaScript numbers.
+        pub const JS_NUMBER: JSType = JSType::new(2);
+
         /// Creates a new JSType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("JS_NORMAL"),
+                1 => std::borrow::Cow::Borrowed("JS_STRING"),
+                2 => std::borrow::Cow::Borrowed("JS_NUMBER"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "JS_NORMAL" => std::option::Option::Some(Self::JS_NORMAL),
+                "JS_STRING" => std::option::Option::Some(Self::JS_STRING),
+                "JS_NUMBER" => std::option::Option::Some(Self::JS_NUMBER),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [JSType](JSType)
-    pub mod js_type {
-        use super::JSType;
-
-        /// Use the default type.
-        pub const JS_NORMAL: JSType = JSType::new("JS_NORMAL");
-
-        /// Use JavaScript strings.
-        pub const JS_STRING: JSType = JSType::new("JS_STRING");
-
-        /// Use JavaScript numbers.
-        pub const JS_NUMBER: JSType = JSType::new("JS_NUMBER");
-    }
-
-    impl std::convert::From<std::string::String> for JSType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for JSType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for JSType {
         fn default() -> Self {
-            js_type::JS_NORMAL
+            Self::new(0)
         }
     }
 
     /// If set to RETENTION_SOURCE, the option will be omitted from the binary.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OptionRetention(std::borrow::Cow<'static, str>);
+    pub struct OptionRetention(i32);
 
     impl OptionRetention {
+        pub const RETENTION_UNKNOWN: OptionRetention = OptionRetention::new(0);
+
+        pub const RETENTION_RUNTIME: OptionRetention = OptionRetention::new(1);
+
+        pub const RETENTION_SOURCE: OptionRetention = OptionRetention::new(2);
+
         /// Creates a new OptionRetention instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("RETENTION_UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("RETENTION_RUNTIME"),
+                2 => std::borrow::Cow::Borrowed("RETENTION_SOURCE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "RETENTION_UNKNOWN" => std::option::Option::Some(Self::RETENTION_UNKNOWN),
+                "RETENTION_RUNTIME" => std::option::Option::Some(Self::RETENTION_RUNTIME),
+                "RETENTION_SOURCE" => std::option::Option::Some(Self::RETENTION_SOURCE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [OptionRetention](OptionRetention)
-    pub mod option_retention {
-        use super::OptionRetention;
-
-        pub const RETENTION_UNKNOWN: OptionRetention = OptionRetention::new("RETENTION_UNKNOWN");
-
-        pub const RETENTION_RUNTIME: OptionRetention = OptionRetention::new("RETENTION_RUNTIME");
-
-        pub const RETENTION_SOURCE: OptionRetention = OptionRetention::new("RETENTION_SOURCE");
-    }
-
-    impl std::convert::From<std::string::String> for OptionRetention {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for OptionRetention {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for OptionRetention {
         fn default() -> Self {
-            option_retention::RETENTION_UNKNOWN
+            Self::new(0)
         }
     }
 
@@ -2638,60 +2771,85 @@ pub mod field_options {
     /// as an option. If it is unset, then the field may be freely used as an
     /// option on any kind of entity.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OptionTargetType(std::borrow::Cow<'static, str>);
+    pub struct OptionTargetType(i32);
 
     impl OptionTargetType {
+        pub const TARGET_TYPE_UNKNOWN: OptionTargetType = OptionTargetType::new(0);
+
+        pub const TARGET_TYPE_FILE: OptionTargetType = OptionTargetType::new(1);
+
+        pub const TARGET_TYPE_EXTENSION_RANGE: OptionTargetType = OptionTargetType::new(2);
+
+        pub const TARGET_TYPE_MESSAGE: OptionTargetType = OptionTargetType::new(3);
+
+        pub const TARGET_TYPE_FIELD: OptionTargetType = OptionTargetType::new(4);
+
+        pub const TARGET_TYPE_ONEOF: OptionTargetType = OptionTargetType::new(5);
+
+        pub const TARGET_TYPE_ENUM: OptionTargetType = OptionTargetType::new(6);
+
+        pub const TARGET_TYPE_ENUM_ENTRY: OptionTargetType = OptionTargetType::new(7);
+
+        pub const TARGET_TYPE_SERVICE: OptionTargetType = OptionTargetType::new(8);
+
+        pub const TARGET_TYPE_METHOD: OptionTargetType = OptionTargetType::new(9);
+
         /// Creates a new OptionTargetType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TARGET_TYPE_UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("TARGET_TYPE_FILE"),
+                2 => std::borrow::Cow::Borrowed("TARGET_TYPE_EXTENSION_RANGE"),
+                3 => std::borrow::Cow::Borrowed("TARGET_TYPE_MESSAGE"),
+                4 => std::borrow::Cow::Borrowed("TARGET_TYPE_FIELD"),
+                5 => std::borrow::Cow::Borrowed("TARGET_TYPE_ONEOF"),
+                6 => std::borrow::Cow::Borrowed("TARGET_TYPE_ENUM"),
+                7 => std::borrow::Cow::Borrowed("TARGET_TYPE_ENUM_ENTRY"),
+                8 => std::borrow::Cow::Borrowed("TARGET_TYPE_SERVICE"),
+                9 => std::borrow::Cow::Borrowed("TARGET_TYPE_METHOD"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TARGET_TYPE_UNKNOWN" => std::option::Option::Some(Self::TARGET_TYPE_UNKNOWN),
+                "TARGET_TYPE_FILE" => std::option::Option::Some(Self::TARGET_TYPE_FILE),
+                "TARGET_TYPE_EXTENSION_RANGE" => {
+                    std::option::Option::Some(Self::TARGET_TYPE_EXTENSION_RANGE)
+                }
+                "TARGET_TYPE_MESSAGE" => std::option::Option::Some(Self::TARGET_TYPE_MESSAGE),
+                "TARGET_TYPE_FIELD" => std::option::Option::Some(Self::TARGET_TYPE_FIELD),
+                "TARGET_TYPE_ONEOF" => std::option::Option::Some(Self::TARGET_TYPE_ONEOF),
+                "TARGET_TYPE_ENUM" => std::option::Option::Some(Self::TARGET_TYPE_ENUM),
+                "TARGET_TYPE_ENUM_ENTRY" => std::option::Option::Some(Self::TARGET_TYPE_ENUM_ENTRY),
+                "TARGET_TYPE_SERVICE" => std::option::Option::Some(Self::TARGET_TYPE_SERVICE),
+                "TARGET_TYPE_METHOD" => std::option::Option::Some(Self::TARGET_TYPE_METHOD),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [OptionTargetType](OptionTargetType)
-    pub mod option_target_type {
-        use super::OptionTargetType;
-
-        pub const TARGET_TYPE_UNKNOWN: OptionTargetType =
-            OptionTargetType::new("TARGET_TYPE_UNKNOWN");
-
-        pub const TARGET_TYPE_FILE: OptionTargetType = OptionTargetType::new("TARGET_TYPE_FILE");
-
-        pub const TARGET_TYPE_EXTENSION_RANGE: OptionTargetType =
-            OptionTargetType::new("TARGET_TYPE_EXTENSION_RANGE");
-
-        pub const TARGET_TYPE_MESSAGE: OptionTargetType =
-            OptionTargetType::new("TARGET_TYPE_MESSAGE");
-
-        pub const TARGET_TYPE_FIELD: OptionTargetType = OptionTargetType::new("TARGET_TYPE_FIELD");
-
-        pub const TARGET_TYPE_ONEOF: OptionTargetType = OptionTargetType::new("TARGET_TYPE_ONEOF");
-
-        pub const TARGET_TYPE_ENUM: OptionTargetType = OptionTargetType::new("TARGET_TYPE_ENUM");
-
-        pub const TARGET_TYPE_ENUM_ENTRY: OptionTargetType =
-            OptionTargetType::new("TARGET_TYPE_ENUM_ENTRY");
-
-        pub const TARGET_TYPE_SERVICE: OptionTargetType =
-            OptionTargetType::new("TARGET_TYPE_SERVICE");
-
-        pub const TARGET_TYPE_METHOD: OptionTargetType =
-            OptionTargetType::new("TARGET_TYPE_METHOD");
-    }
-
-    impl std::convert::From<std::string::String> for OptionTargetType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for OptionTargetType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for OptionTargetType {
         fn default() -> Self {
-            option_target_type::TARGET_TYPE_UNKNOWN
+            Self::new(0)
         }
     }
 }
@@ -3047,41 +3205,55 @@ pub mod method_options {
     /// or neither? HTTP based RPC implementation may choose GET verb for safe
     /// methods, and PUT verb for idempotent methods instead of the default POST.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IdempotencyLevel(std::borrow::Cow<'static, str>);
+    pub struct IdempotencyLevel(i32);
 
     impl IdempotencyLevel {
+        pub const IDEMPOTENCY_UNKNOWN: IdempotencyLevel = IdempotencyLevel::new(0);
+
+        pub const NO_SIDE_EFFECTS: IdempotencyLevel = IdempotencyLevel::new(1);
+
+        pub const IDEMPOTENT: IdempotencyLevel = IdempotencyLevel::new(2);
+
         /// Creates a new IdempotencyLevel instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("IDEMPOTENCY_UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("NO_SIDE_EFFECTS"),
+                2 => std::borrow::Cow::Borrowed("IDEMPOTENT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "IDEMPOTENCY_UNKNOWN" => std::option::Option::Some(Self::IDEMPOTENCY_UNKNOWN),
+                "NO_SIDE_EFFECTS" => std::option::Option::Some(Self::NO_SIDE_EFFECTS),
+                "IDEMPOTENT" => std::option::Option::Some(Self::IDEMPOTENT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [IdempotencyLevel](IdempotencyLevel)
-    pub mod idempotency_level {
-        use super::IdempotencyLevel;
-
-        pub const IDEMPOTENCY_UNKNOWN: IdempotencyLevel =
-            IdempotencyLevel::new("IDEMPOTENCY_UNKNOWN");
-
-        pub const NO_SIDE_EFFECTS: IdempotencyLevel = IdempotencyLevel::new("NO_SIDE_EFFECTS");
-
-        pub const IDEMPOTENT: IdempotencyLevel = IdempotencyLevel::new("IDEMPOTENT");
-    }
-
-    impl std::convert::From<std::string::String> for IdempotencyLevel {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for IdempotencyLevel {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for IdempotencyLevel {
         fn default() -> Self {
-            idempotency_level::IDEMPOTENCY_UNKNOWN
+            Self::new(0)
         }
     }
 }
@@ -3327,236 +3499,331 @@ pub mod feature_set {
     use super::*;
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FieldPresence(std::borrow::Cow<'static, str>);
+    pub struct FieldPresence(i32);
 
     impl FieldPresence {
+        pub const FIELD_PRESENCE_UNKNOWN: FieldPresence = FieldPresence::new(0);
+
+        pub const EXPLICIT: FieldPresence = FieldPresence::new(1);
+
+        pub const IMPLICIT: FieldPresence = FieldPresence::new(2);
+
+        pub const LEGACY_REQUIRED: FieldPresence = FieldPresence::new(3);
+
         /// Creates a new FieldPresence instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("FIELD_PRESENCE_UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("EXPLICIT"),
+                2 => std::borrow::Cow::Borrowed("IMPLICIT"),
+                3 => std::borrow::Cow::Borrowed("LEGACY_REQUIRED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "FIELD_PRESENCE_UNKNOWN" => std::option::Option::Some(Self::FIELD_PRESENCE_UNKNOWN),
+                "EXPLICIT" => std::option::Option::Some(Self::EXPLICIT),
+                "IMPLICIT" => std::option::Option::Some(Self::IMPLICIT),
+                "LEGACY_REQUIRED" => std::option::Option::Some(Self::LEGACY_REQUIRED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [FieldPresence](FieldPresence)
-    pub mod field_presence {
-        use super::FieldPresence;
-
-        pub const FIELD_PRESENCE_UNKNOWN: FieldPresence =
-            FieldPresence::new("FIELD_PRESENCE_UNKNOWN");
-
-        pub const EXPLICIT: FieldPresence = FieldPresence::new("EXPLICIT");
-
-        pub const IMPLICIT: FieldPresence = FieldPresence::new("IMPLICIT");
-
-        pub const LEGACY_REQUIRED: FieldPresence = FieldPresence::new("LEGACY_REQUIRED");
-    }
-
-    impl std::convert::From<std::string::String> for FieldPresence {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for FieldPresence {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for FieldPresence {
         fn default() -> Self {
-            field_presence::FIELD_PRESENCE_UNKNOWN
+            Self::new(0)
         }
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EnumType(std::borrow::Cow<'static, str>);
+    pub struct EnumType(i32);
 
     impl EnumType {
+        pub const ENUM_TYPE_UNKNOWN: EnumType = EnumType::new(0);
+
+        pub const OPEN: EnumType = EnumType::new(1);
+
+        pub const CLOSED: EnumType = EnumType::new(2);
+
         /// Creates a new EnumType instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("ENUM_TYPE_UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("OPEN"),
+                2 => std::borrow::Cow::Borrowed("CLOSED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "ENUM_TYPE_UNKNOWN" => std::option::Option::Some(Self::ENUM_TYPE_UNKNOWN),
+                "OPEN" => std::option::Option::Some(Self::OPEN),
+                "CLOSED" => std::option::Option::Some(Self::CLOSED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [EnumType](EnumType)
-    pub mod enum_type {
-        use super::EnumType;
-
-        pub const ENUM_TYPE_UNKNOWN: EnumType = EnumType::new("ENUM_TYPE_UNKNOWN");
-
-        pub const OPEN: EnumType = EnumType::new("OPEN");
-
-        pub const CLOSED: EnumType = EnumType::new("CLOSED");
-    }
-
-    impl std::convert::From<std::string::String> for EnumType {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for EnumType {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for EnumType {
         fn default() -> Self {
-            enum_type::ENUM_TYPE_UNKNOWN
+            Self::new(0)
         }
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RepeatedFieldEncoding(std::borrow::Cow<'static, str>);
+    pub struct RepeatedFieldEncoding(i32);
 
     impl RepeatedFieldEncoding {
+        pub const REPEATED_FIELD_ENCODING_UNKNOWN: RepeatedFieldEncoding =
+            RepeatedFieldEncoding::new(0);
+
+        pub const PACKED: RepeatedFieldEncoding = RepeatedFieldEncoding::new(1);
+
+        pub const EXPANDED: RepeatedFieldEncoding = RepeatedFieldEncoding::new(2);
+
         /// Creates a new RepeatedFieldEncoding instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("REPEATED_FIELD_ENCODING_UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("PACKED"),
+                2 => std::borrow::Cow::Borrowed("EXPANDED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "REPEATED_FIELD_ENCODING_UNKNOWN" => {
+                    std::option::Option::Some(Self::REPEATED_FIELD_ENCODING_UNKNOWN)
+                }
+                "PACKED" => std::option::Option::Some(Self::PACKED),
+                "EXPANDED" => std::option::Option::Some(Self::EXPANDED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [RepeatedFieldEncoding](RepeatedFieldEncoding)
-    pub mod repeated_field_encoding {
-        use super::RepeatedFieldEncoding;
-
-        pub const REPEATED_FIELD_ENCODING_UNKNOWN: RepeatedFieldEncoding =
-            RepeatedFieldEncoding::new("REPEATED_FIELD_ENCODING_UNKNOWN");
-
-        pub const PACKED: RepeatedFieldEncoding = RepeatedFieldEncoding::new("PACKED");
-
-        pub const EXPANDED: RepeatedFieldEncoding = RepeatedFieldEncoding::new("EXPANDED");
-    }
-
-    impl std::convert::From<std::string::String> for RepeatedFieldEncoding {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for RepeatedFieldEncoding {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for RepeatedFieldEncoding {
         fn default() -> Self {
-            repeated_field_encoding::REPEATED_FIELD_ENCODING_UNKNOWN
+            Self::new(0)
         }
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Utf8Validation(std::borrow::Cow<'static, str>);
+    pub struct Utf8Validation(i32);
 
     impl Utf8Validation {
+        pub const UTF8_VALIDATION_UNKNOWN: Utf8Validation = Utf8Validation::new(0);
+
+        pub const VERIFY: Utf8Validation = Utf8Validation::new(2);
+
+        pub const NONE: Utf8Validation = Utf8Validation::new(3);
+
         /// Creates a new Utf8Validation instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("UTF8_VALIDATION_UNKNOWN"),
+                2 => std::borrow::Cow::Borrowed("VERIFY"),
+                3 => std::borrow::Cow::Borrowed("NONE"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "UTF8_VALIDATION_UNKNOWN" => {
+                    std::option::Option::Some(Self::UTF8_VALIDATION_UNKNOWN)
+                }
+                "VERIFY" => std::option::Option::Some(Self::VERIFY),
+                "NONE" => std::option::Option::Some(Self::NONE),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Utf8Validation](Utf8Validation)
-    pub mod utf_8_validation {
-        use super::Utf8Validation;
-
-        pub const UTF8_VALIDATION_UNKNOWN: Utf8Validation =
-            Utf8Validation::new("UTF8_VALIDATION_UNKNOWN");
-
-        pub const VERIFY: Utf8Validation = Utf8Validation::new("VERIFY");
-
-        pub const NONE: Utf8Validation = Utf8Validation::new("NONE");
-    }
-
-    impl std::convert::From<std::string::String> for Utf8Validation {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Utf8Validation {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Utf8Validation {
         fn default() -> Self {
-            utf_8_validation::UTF8_VALIDATION_UNKNOWN
+            Self::new(0)
         }
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MessageEncoding(std::borrow::Cow<'static, str>);
+    pub struct MessageEncoding(i32);
 
     impl MessageEncoding {
+        pub const MESSAGE_ENCODING_UNKNOWN: MessageEncoding = MessageEncoding::new(0);
+
+        pub const LENGTH_PREFIXED: MessageEncoding = MessageEncoding::new(1);
+
+        pub const DELIMITED: MessageEncoding = MessageEncoding::new(2);
+
         /// Creates a new MessageEncoding instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("MESSAGE_ENCODING_UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("LENGTH_PREFIXED"),
+                2 => std::borrow::Cow::Borrowed("DELIMITED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "MESSAGE_ENCODING_UNKNOWN" => {
+                    std::option::Option::Some(Self::MESSAGE_ENCODING_UNKNOWN)
+                }
+                "LENGTH_PREFIXED" => std::option::Option::Some(Self::LENGTH_PREFIXED),
+                "DELIMITED" => std::option::Option::Some(Self::DELIMITED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [MessageEncoding](MessageEncoding)
-    pub mod message_encoding {
-        use super::MessageEncoding;
-
-        pub const MESSAGE_ENCODING_UNKNOWN: MessageEncoding =
-            MessageEncoding::new("MESSAGE_ENCODING_UNKNOWN");
-
-        pub const LENGTH_PREFIXED: MessageEncoding = MessageEncoding::new("LENGTH_PREFIXED");
-
-        pub const DELIMITED: MessageEncoding = MessageEncoding::new("DELIMITED");
-    }
-
-    impl std::convert::From<std::string::String> for MessageEncoding {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for MessageEncoding {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for MessageEncoding {
         fn default() -> Self {
-            message_encoding::MESSAGE_ENCODING_UNKNOWN
+            Self::new(0)
         }
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct JsonFormat(std::borrow::Cow<'static, str>);
+    pub struct JsonFormat(i32);
 
     impl JsonFormat {
+        pub const JSON_FORMAT_UNKNOWN: JsonFormat = JsonFormat::new(0);
+
+        pub const ALLOW: JsonFormat = JsonFormat::new(1);
+
+        pub const LEGACY_BEST_EFFORT: JsonFormat = JsonFormat::new(2);
+
         /// Creates a new JsonFormat instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("JSON_FORMAT_UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("ALLOW"),
+                2 => std::borrow::Cow::Borrowed("LEGACY_BEST_EFFORT"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "JSON_FORMAT_UNKNOWN" => std::option::Option::Some(Self::JSON_FORMAT_UNKNOWN),
+                "ALLOW" => std::option::Option::Some(Self::ALLOW),
+                "LEGACY_BEST_EFFORT" => std::option::Option::Some(Self::LEGACY_BEST_EFFORT),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [JsonFormat](JsonFormat)
-    pub mod json_format {
-        use super::JsonFormat;
-
-        pub const JSON_FORMAT_UNKNOWN: JsonFormat = JsonFormat::new("JSON_FORMAT_UNKNOWN");
-
-        pub const ALLOW: JsonFormat = JsonFormat::new("ALLOW");
-
-        pub const LEGACY_BEST_EFFORT: JsonFormat = JsonFormat::new("LEGACY_BEST_EFFORT");
-    }
-
-    impl std::convert::From<std::string::String> for JsonFormat {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for JsonFormat {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for JsonFormat {
         fn default() -> Self {
-            json_format::JSON_FORMAT_UNKNOWN
+            Self::new(0)
         }
     }
 }
@@ -4053,43 +4320,58 @@ pub mod generated_code_info {
         /// Represents the identified object's effect on the element in the original
         /// .proto file.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Semantic(std::borrow::Cow<'static, str>);
+        pub struct Semantic(i32);
 
         impl Semantic {
+            /// There is no effect or the effect is indescribable.
+            pub const NONE: Semantic = Semantic::new(0);
+
+            /// The element is set or otherwise mutated.
+            pub const SET: Semantic = Semantic::new(1);
+
+            /// An alias to the element is returned.
+            pub const ALIAS: Semantic = Semantic::new(2);
+
             /// Creates a new Semantic instance.
-            pub const fn new(v: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(v))
+            pub(crate) const fn new(value: i32) -> Self {
+                Self(value)
             }
 
             /// Gets the enum value.
-            pub fn value(&self) -> &str {
-                &self.0
+            pub fn value(&self) -> i32 {
+                self.0
+            }
+
+            /// Gets the enum value as a string.
+            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+                match self.0 {
+                    0 => std::borrow::Cow::Borrowed("NONE"),
+                    1 => std::borrow::Cow::Borrowed("SET"),
+                    2 => std::borrow::Cow::Borrowed("ALIAS"),
+                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                }
+            }
+
+            /// Creates an enum value from the value name.
+            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+                match name {
+                    "NONE" => std::option::Option::Some(Self::NONE),
+                    "SET" => std::option::Option::Some(Self::SET),
+                    "ALIAS" => std::option::Option::Some(Self::ALIAS),
+                    _ => std::option::Option::None,
+                }
             }
         }
 
-        /// Useful constants to work with [Semantic](Semantic)
-        pub mod semantic {
-            use super::Semantic;
-
-            /// There is no effect or the effect is indescribable.
-            pub const NONE: Semantic = Semantic::new("NONE");
-
-            /// The element is set or otherwise mutated.
-            pub const SET: Semantic = Semantic::new("SET");
-
-            /// An alias to the element is returned.
-            pub const ALIAS: Semantic = Semantic::new("ALIAS");
-        }
-
-        impl std::convert::From<std::string::String> for Semantic {
-            fn from(value: std::string::String) -> Self {
-                Self(std::borrow::Cow::Owned(value))
+        impl std::convert::From<i32> for Semantic {
+            fn from(value: i32) -> Self {
+                Self::new(value)
             }
         }
 
         impl std::default::Default for Semantic {
             fn default() -> Self {
-                semantic::NONE
+                Self::new(0)
             }
         }
     }
@@ -4363,136 +4645,200 @@ pub mod field {
 
     /// Basic field types.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Kind(std::borrow::Cow<'static, str>);
+    pub struct Kind(i32);
 
     impl Kind {
+        /// Field type unknown.
+        pub const TYPE_UNKNOWN: Kind = Kind::new(0);
+
+        /// Field type double.
+        pub const TYPE_DOUBLE: Kind = Kind::new(1);
+
+        /// Field type float.
+        pub const TYPE_FLOAT: Kind = Kind::new(2);
+
+        /// Field type int64.
+        pub const TYPE_INT64: Kind = Kind::new(3);
+
+        /// Field type uint64.
+        pub const TYPE_UINT64: Kind = Kind::new(4);
+
+        /// Field type int32.
+        pub const TYPE_INT32: Kind = Kind::new(5);
+
+        /// Field type fixed64.
+        pub const TYPE_FIXED64: Kind = Kind::new(6);
+
+        /// Field type fixed32.
+        pub const TYPE_FIXED32: Kind = Kind::new(7);
+
+        /// Field type bool.
+        pub const TYPE_BOOL: Kind = Kind::new(8);
+
+        /// Field type string.
+        pub const TYPE_STRING: Kind = Kind::new(9);
+
+        /// Field type group. Proto2 syntax only, and deprecated.
+        pub const TYPE_GROUP: Kind = Kind::new(10);
+
+        /// Field type message.
+        pub const TYPE_MESSAGE: Kind = Kind::new(11);
+
+        /// Field type bytes.
+        pub const TYPE_BYTES: Kind = Kind::new(12);
+
+        /// Field type uint32.
+        pub const TYPE_UINT32: Kind = Kind::new(13);
+
+        /// Field type enum.
+        pub const TYPE_ENUM: Kind = Kind::new(14);
+
+        /// Field type sfixed32.
+        pub const TYPE_SFIXED32: Kind = Kind::new(15);
+
+        /// Field type sfixed64.
+        pub const TYPE_SFIXED64: Kind = Kind::new(16);
+
+        /// Field type sint32.
+        pub const TYPE_SINT32: Kind = Kind::new(17);
+
+        /// Field type sint64.
+        pub const TYPE_SINT64: Kind = Kind::new(18);
+
         /// Creates a new Kind instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("TYPE_UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("TYPE_DOUBLE"),
+                2 => std::borrow::Cow::Borrowed("TYPE_FLOAT"),
+                3 => std::borrow::Cow::Borrowed("TYPE_INT64"),
+                4 => std::borrow::Cow::Borrowed("TYPE_UINT64"),
+                5 => std::borrow::Cow::Borrowed("TYPE_INT32"),
+                6 => std::borrow::Cow::Borrowed("TYPE_FIXED64"),
+                7 => std::borrow::Cow::Borrowed("TYPE_FIXED32"),
+                8 => std::borrow::Cow::Borrowed("TYPE_BOOL"),
+                9 => std::borrow::Cow::Borrowed("TYPE_STRING"),
+                10 => std::borrow::Cow::Borrowed("TYPE_GROUP"),
+                11 => std::borrow::Cow::Borrowed("TYPE_MESSAGE"),
+                12 => std::borrow::Cow::Borrowed("TYPE_BYTES"),
+                13 => std::borrow::Cow::Borrowed("TYPE_UINT32"),
+                14 => std::borrow::Cow::Borrowed("TYPE_ENUM"),
+                15 => std::borrow::Cow::Borrowed("TYPE_SFIXED32"),
+                16 => std::borrow::Cow::Borrowed("TYPE_SFIXED64"),
+                17 => std::borrow::Cow::Borrowed("TYPE_SINT32"),
+                18 => std::borrow::Cow::Borrowed("TYPE_SINT64"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "TYPE_UNKNOWN" => std::option::Option::Some(Self::TYPE_UNKNOWN),
+                "TYPE_DOUBLE" => std::option::Option::Some(Self::TYPE_DOUBLE),
+                "TYPE_FLOAT" => std::option::Option::Some(Self::TYPE_FLOAT),
+                "TYPE_INT64" => std::option::Option::Some(Self::TYPE_INT64),
+                "TYPE_UINT64" => std::option::Option::Some(Self::TYPE_UINT64),
+                "TYPE_INT32" => std::option::Option::Some(Self::TYPE_INT32),
+                "TYPE_FIXED64" => std::option::Option::Some(Self::TYPE_FIXED64),
+                "TYPE_FIXED32" => std::option::Option::Some(Self::TYPE_FIXED32),
+                "TYPE_BOOL" => std::option::Option::Some(Self::TYPE_BOOL),
+                "TYPE_STRING" => std::option::Option::Some(Self::TYPE_STRING),
+                "TYPE_GROUP" => std::option::Option::Some(Self::TYPE_GROUP),
+                "TYPE_MESSAGE" => std::option::Option::Some(Self::TYPE_MESSAGE),
+                "TYPE_BYTES" => std::option::Option::Some(Self::TYPE_BYTES),
+                "TYPE_UINT32" => std::option::Option::Some(Self::TYPE_UINT32),
+                "TYPE_ENUM" => std::option::Option::Some(Self::TYPE_ENUM),
+                "TYPE_SFIXED32" => std::option::Option::Some(Self::TYPE_SFIXED32),
+                "TYPE_SFIXED64" => std::option::Option::Some(Self::TYPE_SFIXED64),
+                "TYPE_SINT32" => std::option::Option::Some(Self::TYPE_SINT32),
+                "TYPE_SINT64" => std::option::Option::Some(Self::TYPE_SINT64),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Kind](Kind)
-    pub mod kind {
-        use super::Kind;
-
-        /// Field type unknown.
-        pub const TYPE_UNKNOWN: Kind = Kind::new("TYPE_UNKNOWN");
-
-        /// Field type double.
-        pub const TYPE_DOUBLE: Kind = Kind::new("TYPE_DOUBLE");
-
-        /// Field type float.
-        pub const TYPE_FLOAT: Kind = Kind::new("TYPE_FLOAT");
-
-        /// Field type int64.
-        pub const TYPE_INT64: Kind = Kind::new("TYPE_INT64");
-
-        /// Field type uint64.
-        pub const TYPE_UINT64: Kind = Kind::new("TYPE_UINT64");
-
-        /// Field type int32.
-        pub const TYPE_INT32: Kind = Kind::new("TYPE_INT32");
-
-        /// Field type fixed64.
-        pub const TYPE_FIXED64: Kind = Kind::new("TYPE_FIXED64");
-
-        /// Field type fixed32.
-        pub const TYPE_FIXED32: Kind = Kind::new("TYPE_FIXED32");
-
-        /// Field type bool.
-        pub const TYPE_BOOL: Kind = Kind::new("TYPE_BOOL");
-
-        /// Field type string.
-        pub const TYPE_STRING: Kind = Kind::new("TYPE_STRING");
-
-        /// Field type group. Proto2 syntax only, and deprecated.
-        pub const TYPE_GROUP: Kind = Kind::new("TYPE_GROUP");
-
-        /// Field type message.
-        pub const TYPE_MESSAGE: Kind = Kind::new("TYPE_MESSAGE");
-
-        /// Field type bytes.
-        pub const TYPE_BYTES: Kind = Kind::new("TYPE_BYTES");
-
-        /// Field type uint32.
-        pub const TYPE_UINT32: Kind = Kind::new("TYPE_UINT32");
-
-        /// Field type enum.
-        pub const TYPE_ENUM: Kind = Kind::new("TYPE_ENUM");
-
-        /// Field type sfixed32.
-        pub const TYPE_SFIXED32: Kind = Kind::new("TYPE_SFIXED32");
-
-        /// Field type sfixed64.
-        pub const TYPE_SFIXED64: Kind = Kind::new("TYPE_SFIXED64");
-
-        /// Field type sint32.
-        pub const TYPE_SINT32: Kind = Kind::new("TYPE_SINT32");
-
-        /// Field type sint64.
-        pub const TYPE_SINT64: Kind = Kind::new("TYPE_SINT64");
-    }
-
-    impl std::convert::From<std::string::String> for Kind {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Kind {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Kind {
         fn default() -> Self {
-            kind::TYPE_UNKNOWN
+            Self::new(0)
         }
     }
 
     /// Whether a field is optional, required, or repeated.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Cardinality(std::borrow::Cow<'static, str>);
+    pub struct Cardinality(i32);
 
     impl Cardinality {
+        /// For fields with unknown cardinality.
+        pub const CARDINALITY_UNKNOWN: Cardinality = Cardinality::new(0);
+
+        /// For optional fields.
+        pub const CARDINALITY_OPTIONAL: Cardinality = Cardinality::new(1);
+
+        /// For required fields. Proto2 syntax only.
+        pub const CARDINALITY_REQUIRED: Cardinality = Cardinality::new(2);
+
+        /// For repeated fields.
+        pub const CARDINALITY_REPEATED: Cardinality = Cardinality::new(3);
+
         /// Creates a new Cardinality instance.
-        pub const fn new(v: &'static str) -> Self {
-            Self(std::borrow::Cow::Borrowed(v))
+        pub(crate) const fn new(value: i32) -> Self {
+            Self(value)
         }
 
         /// Gets the enum value.
-        pub fn value(&self) -> &str {
-            &self.0
+        pub fn value(&self) -> i32 {
+            self.0
+        }
+
+        /// Gets the enum value as a string.
+        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+            match self.0 {
+                0 => std::borrow::Cow::Borrowed("CARDINALITY_UNKNOWN"),
+                1 => std::borrow::Cow::Borrowed("CARDINALITY_OPTIONAL"),
+                2 => std::borrow::Cow::Borrowed("CARDINALITY_REQUIRED"),
+                3 => std::borrow::Cow::Borrowed("CARDINALITY_REPEATED"),
+                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            }
+        }
+
+        /// Creates an enum value from the value name.
+        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+            match name {
+                "CARDINALITY_UNKNOWN" => std::option::Option::Some(Self::CARDINALITY_UNKNOWN),
+                "CARDINALITY_OPTIONAL" => std::option::Option::Some(Self::CARDINALITY_OPTIONAL),
+                "CARDINALITY_REQUIRED" => std::option::Option::Some(Self::CARDINALITY_REQUIRED),
+                "CARDINALITY_REPEATED" => std::option::Option::Some(Self::CARDINALITY_REPEATED),
+                _ => std::option::Option::None,
+            }
         }
     }
 
-    /// Useful constants to work with [Cardinality](Cardinality)
-    pub mod cardinality {
-        use super::Cardinality;
-
-        /// For fields with unknown cardinality.
-        pub const CARDINALITY_UNKNOWN: Cardinality = Cardinality::new("CARDINALITY_UNKNOWN");
-
-        /// For optional fields.
-        pub const CARDINALITY_OPTIONAL: Cardinality = Cardinality::new("CARDINALITY_OPTIONAL");
-
-        /// For required fields. Proto2 syntax only.
-        pub const CARDINALITY_REQUIRED: Cardinality = Cardinality::new("CARDINALITY_REQUIRED");
-
-        /// For repeated fields.
-        pub const CARDINALITY_REPEATED: Cardinality = Cardinality::new("CARDINALITY_REPEATED");
-    }
-
-    impl std::convert::From<std::string::String> for Cardinality {
-        fn from(value: std::string::String) -> Self {
-            Self(std::borrow::Cow::Owned(value))
+    impl std::convert::From<i32> for Cardinality {
+        fn from(value: i32) -> Self {
+            Self::new(value)
         }
     }
 
     impl std::default::Default for Cardinality {
         fn default() -> Self {
-            cardinality::CARDINALITY_UNKNOWN
+            Self::new(0)
         }
     }
 }
@@ -4692,114 +5038,162 @@ impl wkt::message::Message for Option {
 
 /// The full set of known editions.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Edition(std::borrow::Cow<'static, str>);
+pub struct Edition(i32);
 
 impl Edition {
-    /// Creates a new Edition instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Useful constants to work with [Edition](Edition)
-pub mod edition {
-    use super::Edition;
-
     /// A placeholder for an unknown edition value.
-    pub const EDITION_UNKNOWN: Edition = Edition::new("EDITION_UNKNOWN");
+    pub const EDITION_UNKNOWN: Edition = Edition::new(0);
 
     /// A placeholder edition for specifying default behaviors *before* a feature
     /// was first introduced.  This is effectively an "infinite past".
-    pub const EDITION_LEGACY: Edition = Edition::new("EDITION_LEGACY");
+    pub const EDITION_LEGACY: Edition = Edition::new(900);
 
     /// Legacy syntax "editions".  These pre-date editions, but behave much like
     /// distinct editions.  These can't be used to specify the edition of proto
     /// files, but feature definitions must supply proto2/proto3 defaults for
     /// backwards compatibility.
-    pub const EDITION_PROTO2: Edition = Edition::new("EDITION_PROTO2");
+    pub const EDITION_PROTO2: Edition = Edition::new(998);
 
-    pub const EDITION_PROTO3: Edition = Edition::new("EDITION_PROTO3");
+    pub const EDITION_PROTO3: Edition = Edition::new(999);
 
     /// Editions that have been released.  The specific values are arbitrary and
     /// should not be depended on, but they will always be time-ordered for easy
     /// comparison.
-    pub const EDITION_2023: Edition = Edition::new("EDITION_2023");
+    pub const EDITION_2023: Edition = Edition::new(1000);
 
-    pub const EDITION_2024: Edition = Edition::new("EDITION_2024");
+    pub const EDITION_2024: Edition = Edition::new(1001);
 
     /// Placeholder editions for testing feature resolution.  These should not be
     /// used or relied on outside of tests.
-    pub const EDITION_1_TEST_ONLY: Edition = Edition::new("EDITION_1_TEST_ONLY");
+    pub const EDITION_1_TEST_ONLY: Edition = Edition::new(1);
 
-    pub const EDITION_2_TEST_ONLY: Edition = Edition::new("EDITION_2_TEST_ONLY");
+    pub const EDITION_2_TEST_ONLY: Edition = Edition::new(2);
 
-    pub const EDITION_99997_TEST_ONLY: Edition = Edition::new("EDITION_99997_TEST_ONLY");
+    pub const EDITION_99997_TEST_ONLY: Edition = Edition::new(99997);
 
-    pub const EDITION_99998_TEST_ONLY: Edition = Edition::new("EDITION_99998_TEST_ONLY");
+    pub const EDITION_99998_TEST_ONLY: Edition = Edition::new(99998);
 
-    pub const EDITION_99999_TEST_ONLY: Edition = Edition::new("EDITION_99999_TEST_ONLY");
+    pub const EDITION_99999_TEST_ONLY: Edition = Edition::new(99999);
 
     /// Placeholder for specifying unbounded edition support.  This should only
     /// ever be used by plugins that can expect to never require any changes to
     /// support a new edition.
-    pub const EDITION_MAX: Edition = Edition::new("EDITION_MAX");
+    pub const EDITION_MAX: Edition = Edition::new(2147483647);
+
+    /// Creates a new Edition instance.
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("EDITION_UNKNOWN"),
+            1 => std::borrow::Cow::Borrowed("EDITION_1_TEST_ONLY"),
+            2 => std::borrow::Cow::Borrowed("EDITION_2_TEST_ONLY"),
+            900 => std::borrow::Cow::Borrowed("EDITION_LEGACY"),
+            998 => std::borrow::Cow::Borrowed("EDITION_PROTO2"),
+            999 => std::borrow::Cow::Borrowed("EDITION_PROTO3"),
+            1000 => std::borrow::Cow::Borrowed("EDITION_2023"),
+            1001 => std::borrow::Cow::Borrowed("EDITION_2024"),
+            99997 => std::borrow::Cow::Borrowed("EDITION_99997_TEST_ONLY"),
+            99998 => std::borrow::Cow::Borrowed("EDITION_99998_TEST_ONLY"),
+            99999 => std::borrow::Cow::Borrowed("EDITION_99999_TEST_ONLY"),
+            2147483647 => std::borrow::Cow::Borrowed("EDITION_MAX"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "EDITION_UNKNOWN" => std::option::Option::Some(Self::EDITION_UNKNOWN),
+            "EDITION_LEGACY" => std::option::Option::Some(Self::EDITION_LEGACY),
+            "EDITION_PROTO2" => std::option::Option::Some(Self::EDITION_PROTO2),
+            "EDITION_PROTO3" => std::option::Option::Some(Self::EDITION_PROTO3),
+            "EDITION_2023" => std::option::Option::Some(Self::EDITION_2023),
+            "EDITION_2024" => std::option::Option::Some(Self::EDITION_2024),
+            "EDITION_1_TEST_ONLY" => std::option::Option::Some(Self::EDITION_1_TEST_ONLY),
+            "EDITION_2_TEST_ONLY" => std::option::Option::Some(Self::EDITION_2_TEST_ONLY),
+            "EDITION_99997_TEST_ONLY" => std::option::Option::Some(Self::EDITION_99997_TEST_ONLY),
+            "EDITION_99998_TEST_ONLY" => std::option::Option::Some(Self::EDITION_99998_TEST_ONLY),
+            "EDITION_99999_TEST_ONLY" => std::option::Option::Some(Self::EDITION_99999_TEST_ONLY),
+            "EDITION_MAX" => std::option::Option::Some(Self::EDITION_MAX),
+            _ => std::option::Option::None,
+        }
+    }
 }
 
-impl std::convert::From<std::string::String> for Edition {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Edition {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Edition {
     fn default() -> Self {
-        edition::EDITION_UNKNOWN
+        Self::new(0)
     }
 }
 
 /// The syntax in which a protocol buffer element is defined.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Syntax(std::borrow::Cow<'static, str>);
+pub struct Syntax(i32);
 
 impl Syntax {
+    /// Syntax `proto2`.
+    pub const SYNTAX_PROTO2: Syntax = Syntax::new(0);
+
+    /// Syntax `proto3`.
+    pub const SYNTAX_PROTO3: Syntax = Syntax::new(1);
+
+    /// Syntax `editions`.
+    pub const SYNTAX_EDITIONS: Syntax = Syntax::new(2);
+
     /// Creates a new Syntax instance.
-    pub const fn new(v: &'static str) -> Self {
-        Self(std::borrow::Cow::Borrowed(v))
+    pub(crate) const fn new(value: i32) -> Self {
+        Self(value)
     }
 
     /// Gets the enum value.
-    pub fn value(&self) -> &str {
-        &self.0
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+
+    /// Gets the enum value as a string.
+    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
+        match self.0 {
+            0 => std::borrow::Cow::Borrowed("SYNTAX_PROTO2"),
+            1 => std::borrow::Cow::Borrowed("SYNTAX_PROTO3"),
+            2 => std::borrow::Cow::Borrowed("SYNTAX_EDITIONS"),
+            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        }
+    }
+
+    /// Creates an enum value from the value name.
+    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
+        match name {
+            "SYNTAX_PROTO2" => std::option::Option::Some(Self::SYNTAX_PROTO2),
+            "SYNTAX_PROTO3" => std::option::Option::Some(Self::SYNTAX_PROTO3),
+            "SYNTAX_EDITIONS" => std::option::Option::Some(Self::SYNTAX_EDITIONS),
+            _ => std::option::Option::None,
+        }
     }
 }
 
-/// Useful constants to work with [Syntax](Syntax)
-pub mod syntax {
-    use super::Syntax;
-
-    /// Syntax `proto2`.
-    pub const SYNTAX_PROTO2: Syntax = Syntax::new("SYNTAX_PROTO2");
-
-    /// Syntax `proto3`.
-    pub const SYNTAX_PROTO3: Syntax = Syntax::new("SYNTAX_PROTO3");
-
-    /// Syntax `editions`.
-    pub const SYNTAX_EDITIONS: Syntax = Syntax::new("SYNTAX_EDITIONS");
-}
-
-impl std::convert::From<std::string::String> for Syntax {
-    fn from(value: std::string::String) -> Self {
-        Self(std::borrow::Cow::Owned(value))
+impl std::convert::From<i32> for Syntax {
+    fn from(value: i32) -> Self {
+        Self::new(value)
     }
 }
 
 impl std::default::Default for Syntax {
     fn default() -> Self {
-        syntax::SYNTAX_PROTO2
+        Self::new(0)
     }
 }

--- a/src/wkt/tests/enums.rs
+++ b/src/wkt/tests/enums.rs
@@ -18,14 +18,14 @@ mod generated {
 
     #[test]
     fn string_to_constant() {
-        let got = Syntax::new("SYNTAX_PROTO2");
-        assert_eq!(google_cloud_wkt::syntax::SYNTAX_PROTO2, got);
+        let got = Syntax::from_str_name("SYNTAX_PROTO2");
+        assert_eq!(Some(google_cloud_wkt::Syntax::SYNTAX_PROTO2), got)
     }
 }
 
 #[cfg(test)]
 mod desired_protobuf {
-    use model::OptimizeMode;
+    use google_cloud_wkt::file_options::OptimizeMode;
     use serde_json::json;
     use test_case::test_case;
     type TestResult = Result<(), Box<dyn std::error::Error>>;
@@ -82,55 +82,5 @@ mod desired_protobuf {
     fn default() {
         let got = OptimizeMode::default();
         assert_eq!(got.value(), 0);
-    }
-
-    #[no_implicit_prelude]
-    mod model {
-        extern crate serde;
-        extern crate std;
-        // TODO(#1379) - replace this code with a `use google_cloud_wkt::model::OptimizeMode`
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct OptimizeMode(i32);
-
-        impl OptimizeMode {
-            pub const SPEED: OptimizeMode = OptimizeMode::new(1);
-            pub const CODE_SIZE: OptimizeMode = OptimizeMode::new(2);
-            pub const LITE_RUNTIME: OptimizeMode = OptimizeMode::new(3);
-
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-            pub fn value(&self) -> i32 {
-                self.0
-            }
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    1 => std::borrow::Cow::Borrowed("SPEED"),
-                    2 => std::borrow::Cow::Borrowed("CODE_SIZE"),
-                    3 => std::borrow::Cow::Borrowed("LITE_RUNTIME"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SPEED" => std::option::Option::Some(Self::SPEED),
-                    "CODE_SIZE" => std::option::Option::Some(Self::CODE_SIZE),
-                    "LITE_RUNTIME" => std::option::Option::Some(Self::LITE_RUNTIME),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for OptimizeMode {
-            fn from(value: i32) -> Self {
-                Self::new(value)
-            }
-        }
-
-        impl std::default::Default for OptimizeMode {
-            fn default() -> Self {
-                Self::new(0)
-            }
-        }
     }
 }


### PR DESCRIPTION
Change the enums to be integer-based as opposed to string-based. This
changes the API, so it is a breaking change. We need to make this change
to support client libraries based on gRPC. Unknown enums are received
as integers in that case. We need to make the change for all client
libraries, as any of them may need to switch the underlying transport if
they gain streaming RPCs.

Fixes #1379
