### PR TITLE
refactor(auth): always compile integration tests

### DIFF
--- a/src/auth/integration-tests/Cargo.toml
+++ b/src/auth/integration-tests/Cargo.toml
@@ -23,13 +23,13 @@ publish           = false
 run-integration-tests = []
 
 [dependencies]
-
-[dev-dependencies]
 auth          = { path = "../../../src/auth", package = "google-cloud-auth" }
 gax           = { path = "../../../src/gax", package = "google-cloud-gax" }
 language      = { path = "../../../src/generated/cloud/language/v2", package = "google-cloud-language-v2" }
 scoped-env    = "2"
 secretmanager = { path = "../../../src/generated/cloud/secretmanager/v1", package = "google-cloud-secretmanager-v1" }
-serial_test   = "3"
 tempfile      = "3"
+
+[dev-dependencies]
+serial_test   = "3"
 tokio         = { version = "1", features = ["full", "macros"] }

--- a/src/auth/integration-tests/Cargo.toml
+++ b/src/auth/integration-tests/Cargo.toml
@@ -31,5 +31,5 @@ secretmanager = { path = "../../../src/generated/cloud/secretmanager/v1", packag
 tempfile      = "3"
 
 [dev-dependencies]
-serial_test   = "3"
-tokio         = { version = "1", features = ["full", "macros"] }
+serial_test = "3"
+tokio       = { version = "1", features = ["full", "macros"] }

--- a/src/auth/integration-tests/src/lib.rs
+++ b/src/auth/integration-tests/src/lib.rs
@@ -1,0 +1,115 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use auth::credentials::{create_access_token_credential, create_api_key_credential, ApiKeyOptions};
+use gax::error::Error;
+use gax::options::ClientConfig as Config;
+use language::client::LanguageService;
+use language::model::Document;
+use scoped_env::ScopedEnv;
+use secretmanager::client::SecretManagerService;
+
+pub type Result<T> = std::result::Result<T, gax::error::Error>;
+
+pub async fn service_account() -> Result<()> {
+    let project = std::env::var("GOOGLE_CLOUD_PROJECT").expect("GOOGLE_CLOUD_PROJECT not set");
+
+    // Create a SecretManager client. When running on GCB, this loads MDS
+    // credentials for our `integration-test-runner` service account.
+    let client = SecretManagerService::new().await?;
+
+    // Load the ADC json for the principal under test, in this case, a
+    // service account.
+    let response = client
+        .access_secret_version(format!(
+            "projects/{}/secrets/test-sa-creds-json/versions/latest",
+            project
+        ))
+        .send()
+        .await?;
+    let adc_json = response
+        .payload
+        .expect("missing payload in test-sa-creds-json response")
+        .data;
+
+    // Write the ADC to a temporary file
+    let file = tempfile::NamedTempFile::new().unwrap();
+    let path = file.into_temp_path();
+    std::fs::write(&path, adc_json).expect("Unable to write to temporary file.");
+
+    // Create credentials for the principal under test.
+    let _e = ScopedEnv::set("GOOGLE_APPLICATION_CREDENTIALS", path.to_str().unwrap());
+    let creds = create_access_token_credential()
+        .await
+        .map_err(Error::authentication)?;
+
+    // Construct a new SecretManager client using the credentials.
+    let config = Config::new().set_credential(creds);
+    let client = SecretManagerService::new_with_config(config).await?;
+
+    // Access a secret, which only this principal has permissions to do.
+    let response = client
+        .access_secret_version(format!(
+            "projects/{}/secrets/test-sa-creds-secret/versions/latest",
+            project
+        ))
+        .send()
+        .await?;
+    let secret = response
+        .payload
+        .expect("missing payload in test-sa-creds-secret response")
+        .data;
+    assert_eq!(secret, "service_account");
+
+    Ok(())
+}
+
+pub async fn api_key() -> Result<()> {
+    let project = std::env::var("GOOGLE_CLOUD_PROJECT").expect("GOOGLE_CLOUD_PROJECT not set");
+
+    // Create a SecretManager client. When running on GCB, this loads MDS
+    // credentials for our `integration-test-runner` service account.
+    let client = SecretManagerService::new().await?;
+
+    // Load the API key under test.
+    let response = client
+        .access_secret_version(format!(
+            "projects/{}/secrets/test-api-key/versions/latest",
+            project
+        ))
+        .send()
+        .await?;
+    let api_key = response
+        .payload
+        .expect("missing payload in test-api-key response")
+        .data;
+    let api_key = std::str::from_utf8(&api_key).unwrap();
+
+    // Create credentials using the API key.
+    let creds = create_api_key_credential(api_key, ApiKeyOptions::default())
+        .await
+        .map_err(Error::authentication)?;
+
+    // Construct a Natural Language client using the credentials.
+    let config = Config::new().set_credential(creds);
+    let client = LanguageService::new_with_config(config).await?;
+
+    // Make a request using the API key.
+    let d = Document::new()
+        .set_content("Hello, world!")
+        .set_type(language::model::document::Type::PLAIN_TEXT);
+    client.analyze_sentiment().set_document(d).send().await?;
+
+    Ok(())
+}


### PR DESCRIPTION
Split the code such that the bulk of the tests are always compiled, even
if they do not get to run. That makes it easier to detect build problems
before sending a PR for review.
