### PR TITLE
feat(generator/rust): option to override templates

### DIFF
--- a/generator/internal/sidekick/sidekick_test.go
+++ b/generator/internal/sidekick/sidekick_test.go
@@ -186,8 +186,8 @@ func TestRustModuleFromProtobuf(t *testing.T) {
 			Language:      "rust",
 			Output:        path.Join(testdataDir, "rust/protobuf/golden/module", config.Name),
 			Codec: map[string]string{
-				"copyright-year":  "2024",
-				"generate-module": "true",
+				"copyright-year":    "2024",
+				"template-override": "templates/mod",
 			},
 		}
 		for k, v := range config.ExtraOptions {
@@ -233,8 +233,8 @@ func TestRustBootstrapWkt(t *testing.T) {
 			Language: "rust",
 			Output:   path.Join(testdataDir, "rust/protobuf/golden/wkt/generated", config.Name),
 			Codec: map[string]string{
-				"copyright-year":  "2025",
-				"generate-module": "true",
+				"copyright-year":    "2025",
+				"template-override": "templates/mod",
 			},
 		}
 		for k, v := range config.SourceOptions {

--- a/generator/testdata/rust/protobuf/golden/module/rpc/.sidekick.toml
+++ b/generator/testdata/rust/protobuf/golden/module/rpc/.sidekick.toml
@@ -23,6 +23,6 @@ googleapis-root = 'testdata/googleapis'
 
 [codec]
 copyright-year = '2024'
-generate-module = 'true'
 module-path = 'crate::error::rpc::generated'
 'package:wkt' = 'package=google-cloud-wkt,path=src/wkt,source=google.protobuf'
+template-override = 'templates/mod'

--- a/generator/testdata/rust/protobuf/golden/module/type/.sidekick.toml
+++ b/generator/testdata/rust/protobuf/golden/module/type/.sidekick.toml
@@ -23,4 +23,4 @@ googleapis-root = 'testdata/googleapis'
 
 [codec]
 copyright-year = '2024'
-generate-module = 'true'
+template-override = 'templates/mod'

--- a/generator/testdata/rust/protobuf/golden/wkt/generated/wkt/.sidekick.toml
+++ b/generator/testdata/rust/protobuf/golden/wkt/generated/wkt/.sidekick.toml
@@ -23,5 +23,5 @@ include-list = 'source_context.proto'
 
 [codec]
 copyright-year = '2025'
-generate-module = 'true'
 module-path = 'crate'
+template-override = 'templates/mod'

--- a/src/firestore/src/generated/model/.sidekick.toml
+++ b/src/firestore/src/generated/model/.sidekick.toml
@@ -18,5 +18,5 @@ specification-source = 'google/firestore/v1'
 service-config       = 'google/firestore/v1/firestore_v1.yaml'
 
 [codec]
-copyright-year  = '2025'
-generate-module = 'true'
+copyright-year    = '2025'
+template-override = 'templates/mod'

--- a/src/wkt/src/generated/.sidekick.toml
+++ b/src/wkt/src/generated/.sidekick.toml
@@ -19,6 +19,6 @@ specification-source = 'google/protobuf'
 include-list = "api.proto,source_context.proto,type.proto,descriptor.proto"
 
 [codec]
-copyright-year  = '2025'
-generate-module = 'true'
-module-path     = 'crate'
+copyright-year    = '2025'
+template-override = 'templates/mod'
+module-path       = 'crate'


### PR DESCRIPTION
I am going to need a new template directory for Prost+Tonic libraries.
Instead of using a series of boolean options I opted for a single
option that overrides the template directory.

Part of the work for #1414
