### PR TITLE
feat(generator/dart): introduce a base google_cloud_common package

### DIFF
--- a/.github/workflows/generator_dart.yaml
+++ b/.github/workflows/generator_dart.yaml
@@ -67,3 +67,7 @@ jobs:
       - name: "analyze package:google_cloud_type"
         run: dart analyze
         working-directory: generator/dart/packages/generated/google_cloud_type
+
+      - name: "analyze package:google_cloud_common"
+        run: dart analyze
+        working-directory: generator/dart/packages/google_cloud_common

--- a/generator/dart/.sidekick.toml
+++ b/generator/dart/.sidekick.toml
@@ -29,7 +29,8 @@ protobuf-subdir         = "src"
 version = "0.1.0"
 
 # Default package dependency versions.
-'package:http' = '^1.3.0'
+'package:google_cloud_common' = '^0.1.0'
+'package:http'                = '^1.3.0'
 
 # A mapping from protobuf packages to Dart imports.
 'proto:google.cloud.location' = 'package:google_cloud_location/location.dart'

--- a/generator/dart/packages/generated/google_cloud_protobuf/lib/protobuf.dart
+++ b/generator/dart/packages/generated/google_cloud_protobuf/lib/protobuf.dart
@@ -19,6 +19,7 @@
 /// Core Protobuf types used by most services.
 library;
 
+import 'package:google_cloud_common/common.dart';
 
 part 'src/protobuf.p.dart';
 
@@ -80,7 +81,7 @@ part 'src/protobuf.p.dart';
 /// encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should
 /// be expressed in JSON format as "3.000000001s", and 3 seconds and 1
 /// microsecond should be expressed in JSON format as "3.000001s".
-class Duration {
+class Duration extends CloudMessage {
 
   /// Signed seconds of the span of time. Must be from -315,576,000,000
   /// to +315,576,000,000 inclusive. Note: these bounds are computed from:
@@ -302,7 +303,7 @@ class Duration {
 /// The implementation of any API method which has a FieldMask type field in the
 /// request should verify the included field paths, and return an
 /// `INVALID_ARGUMENT` error if any path is unmappable.
-class FieldMask {
+class FieldMask extends CloudMessage {
 
   /// The set of field mask paths.
   final List<String>? paths;

--- a/generator/dart/packages/generated/google_cloud_protobuf/pubspec.yaml
+++ b/generator/dart/packages/generated/google_cloud_protobuf/pubspec.yaml
@@ -23,5 +23,8 @@ environment:
 
 resolution: workspace
 
+dependencies:
+  google_cloud_common: any
+
 dev_dependencies:
   test: any

--- a/generator/dart/packages/generated/google_cloud_rpc/lib/rpc.dart
+++ b/generator/dart/packages/generated/google_cloud_rpc/lib/rpc.dart
@@ -21,6 +21,7 @@ library;
 
 import 'dart:typed_data';
 
+import 'package:google_cloud_common/common.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
 
 /// Describes the cause of the error with structured details.
@@ -47,7 +48,7 @@ import 'package:google_cloud_protobuf/protobuf.dart';
 ///         "availableRegions": "us-central1,us-east2"
 ///       }
 ///     }
-class ErrorInfo {
+class ErrorInfo extends CloudMessage {
 
   /// The reason of the error. This is a constant value that identifies the
   /// proximate cause of the error. Error reasons are unique within a particular
@@ -95,7 +96,7 @@ class ErrorInfo {
 /// the delay between retries based on `retry_delay`, until either a maximum
 /// number of retries have been reached or a maximum retry delay cap has been
 /// reached.
-class RetryInfo {
+class RetryInfo extends CloudMessage {
 
   /// Clients should wait at least this long between retrying the same request.
   final Duration? retryDelay;
@@ -106,7 +107,7 @@ class RetryInfo {
 }
 
 /// Describes additional debugging info.
-class DebugInfo {
+class DebugInfo extends CloudMessage {
 
   /// The stack trace entries indicating where the error occurred.
   final List<String>? stackEntries;
@@ -131,7 +132,7 @@ class DebugInfo {
 ///
 /// Also see RetryInfo and Help types for other details about handling a
 /// quota failure.
-class QuotaFailure {
+class QuotaFailure extends CloudMessage {
 
   /// Describes all quota violations.
   final List<QuotaFailure$Violation>? violations;
@@ -143,7 +144,7 @@ class QuotaFailure {
 
 /// A message type used to describe a single quota violation.  For example, a
 /// daily quota or a custom quota that was exceeded.
-class QuotaFailure$Violation {
+class QuotaFailure$Violation extends CloudMessage {
 
   /// The subject on which the quota check failed.
   /// For example, "clientip:<ip address of client>" or "project:<Google
@@ -170,7 +171,7 @@ class QuotaFailure$Violation {
 /// For example, if an RPC failed because it required the Terms of Service to be
 /// acknowledged, it could list the terms of service violation in the
 /// PreconditionFailure message.
-class PreconditionFailure {
+class PreconditionFailure extends CloudMessage {
 
   /// Describes all precondition violations.
   final List<PreconditionFailure$Violation>? violations;
@@ -181,7 +182,7 @@ class PreconditionFailure {
 }
 
 /// A message type used to describe a single precondition failure.
-class PreconditionFailure$Violation {
+class PreconditionFailure$Violation extends CloudMessage {
 
   /// The type of PreconditionFailure. We recommend using a service-specific
   /// enum type to define the supported precondition violation subjects. For
@@ -208,7 +209,7 @@ class PreconditionFailure$Violation {
 
 /// Describes violations in a client request. This error type focuses on the
 /// syntactic aspects of the request.
-class BadRequest {
+class BadRequest extends CloudMessage {
 
   /// Describes all violations in a client request.
   final List<BadRequest$FieldViolation>? fieldViolations;
@@ -219,7 +220,7 @@ class BadRequest {
 }
 
 /// A message type used to describe a single bad request field.
-class BadRequest$FieldViolation {
+class BadRequest$FieldViolation extends CloudMessage {
 
   /// A path that leads to a field in the request body. The value will be a
   /// sequence of dot-separated identifiers that identify a protocol buffer
@@ -285,7 +286,7 @@ class BadRequest$FieldViolation {
 
 /// Contains metadata about the request that clients can attach when filing a bug
 /// or providing other forms of feedback.
-class RequestInfo {
+class RequestInfo extends CloudMessage {
 
   /// An opaque string that should only be interpreted by the service generating
   /// it. For example, it can be used to identify requests in the service's logs.
@@ -302,7 +303,7 @@ class RequestInfo {
 }
 
 /// Describes the resource that is being accessed.
-class ResourceInfo {
+class ResourceInfo extends CloudMessage {
 
   /// A name for the type of resource being accessed, e.g. "sql table",
   /// "cloud storage bucket", "file", "Google calendar"; or the type URL
@@ -338,7 +339,7 @@ class ResourceInfo {
 /// For example, if a quota check failed with an error indicating the calling
 /// project hasn't enabled the accessed service, this can contain a URL pointing
 /// directly to the right place in the developer console to flip the bit.
-class Help {
+class Help extends CloudMessage {
 
   /// URL(s) pointing to additional information on handling the current error.
   final List<Help$Link>? links;
@@ -349,7 +350,7 @@ class Help {
 }
 
 /// Describes a URL link.
-class Help$Link {
+class Help$Link extends CloudMessage {
 
   /// Describes what the link offers.
   final String? description;
@@ -365,7 +366,7 @@ class Help$Link {
 
 /// Provides a localized error message that is safe to return to the user
 /// which can be attached to an RPC error.
-class LocalizedMessage {
+class LocalizedMessage extends CloudMessage {
 
   /// The locale used following the specification defined at
   /// https://www.rfc-editor.org/rfc/bcp/bcp47.txt.
@@ -382,7 +383,7 @@ class LocalizedMessage {
 }
 
 /// Represents an HTTP request.
-class HttpRequest {
+class HttpRequest extends CloudMessage {
 
   /// The HTTP request method.
   final String? method;
@@ -406,7 +407,7 @@ class HttpRequest {
 }
 
 /// Represents an HTTP response.
-class HttpResponse {
+class HttpResponse extends CloudMessage {
 
   /// The HTTP status code, such as 200 or 404.
   final int? status;
@@ -430,7 +431,7 @@ class HttpResponse {
 }
 
 /// Represents an HTTP header.
-class HttpHeader {
+class HttpHeader extends CloudMessage {
 
   /// The HTTP header key. It is case insensitive.
   final String? key;
@@ -451,7 +452,7 @@ class HttpHeader {
 ///
 /// You can find out more about this error model and how to work with it in the
 /// [API Design Guide](https://cloud.google.com/apis/design/errors).
-class Status {
+class Status extends CloudMessage {
 
   /// The status code, which should be an enum value of
   /// [google.rpc.Code][google.rpc.Code].
@@ -481,16 +482,16 @@ class Status {
 /// the most specific error code that applies.  For example, prefer
 /// `OUT_OF_RANGE` over `FAILED_PRECONDITION` if both codes apply.
 /// Similarly prefer `NOT_FOUND` or `ALREADY_EXISTS` over `FAILED_PRECONDITION`.
-class Code {
+class Code extends CloudEnum {
   /// Not an error; returned on success.
   ///
   /// HTTP Mapping: 200 OK
-  static const Code ok = Code('OK');
+  static const ok = Code('OK');
 
   /// The operation was cancelled, typically by the caller.
   ///
   /// HTTP Mapping: 499 Client Closed Request
-  static const Code cancelled = Code('CANCELLED');
+  static const cancelled = Code('CANCELLED');
 
   /// Unknown error.  For example, this error may be returned when
   /// a `Status` value received from another address space belongs to
@@ -499,7 +500,7 @@ class Code {
   /// may be converted to this error.
   ///
   /// HTTP Mapping: 500 Internal Server Error
-  static const Code unknown = Code('UNKNOWN');
+  static const unknown = Code('UNKNOWN');
 
   /// The client specified an invalid argument.  Note that this differs
   /// from `FAILED_PRECONDITION`.  `INVALID_ARGUMENT` indicates arguments
@@ -507,7 +508,7 @@ class Code {
   /// (e.g., a malformed file name).
   ///
   /// HTTP Mapping: 400 Bad Request
-  static const Code invalidArgument = Code('INVALID_ARGUMENT');
+  static const invalidArgument = Code('INVALID_ARGUMENT');
 
   /// The deadline expired before the operation could complete. For operations
   /// that change the state of the system, this error may be returned
@@ -516,7 +517,7 @@ class Code {
   /// enough for the deadline to expire.
   ///
   /// HTTP Mapping: 504 Gateway Timeout
-  static const Code deadlineExceeded = Code('DEADLINE_EXCEEDED');
+  static const deadlineExceeded = Code('DEADLINE_EXCEEDED');
 
   /// Some requested entity (e.g., file or directory) was not found.
   ///
@@ -527,13 +528,13 @@ class Code {
   /// must be used.
   ///
   /// HTTP Mapping: 404 Not Found
-  static const Code notFound = Code('NOT_FOUND');
+  static const notFound = Code('NOT_FOUND');
 
   /// The entity that a client attempted to create (e.g., file or directory)
   /// already exists.
   ///
   /// HTTP Mapping: 409 Conflict
-  static const Code alreadyExists = Code('ALREADY_EXISTS');
+  static const alreadyExists = Code('ALREADY_EXISTS');
 
   /// The caller does not have permission to execute the specified
   /// operation. `PERMISSION_DENIED` must not be used for rejections
@@ -545,19 +546,19 @@ class Code {
   /// other pre-conditions.
   ///
   /// HTTP Mapping: 403 Forbidden
-  static const Code permissionDenied = Code('PERMISSION_DENIED');
+  static const permissionDenied = Code('PERMISSION_DENIED');
 
   /// The request does not have valid authentication credentials for the
   /// operation.
   ///
   /// HTTP Mapping: 401 Unauthorized
-  static const Code unauthenticated = Code('UNAUTHENTICATED');
+  static const unauthenticated = Code('UNAUTHENTICATED');
 
   /// Some resource has been exhausted, perhaps a per-user quota, or
   /// perhaps the entire file system is out of space.
   ///
   /// HTTP Mapping: 429 Too Many Requests
-  static const Code resourceExhausted = Code('RESOURCE_EXHAUSTED');
+  static const resourceExhausted = Code('RESOURCE_EXHAUSTED');
 
   /// The operation was rejected because the system is not in a state
   /// required for the operation's execution.  For example, the directory
@@ -577,7 +578,7 @@ class Code {
   ///      the files are deleted from the directory.
   ///
   /// HTTP Mapping: 400 Bad Request
-  static const Code failedPrecondition = Code('FAILED_PRECONDITION');
+  static const failedPrecondition = Code('FAILED_PRECONDITION');
 
   /// The operation was aborted, typically due to a concurrency issue such as
   /// a sequencer check failure or transaction abort.
@@ -586,7 +587,7 @@ class Code {
   /// `ABORTED`, and `UNAVAILABLE`.
   ///
   /// HTTP Mapping: 409 Conflict
-  static const Code aborted = Code('ABORTED');
+  static const aborted = Code('ABORTED');
 
   /// The operation was attempted past the valid range.  E.g., seeking or
   /// reading past end-of-file.
@@ -605,20 +606,20 @@ class Code {
   /// they are done.
   ///
   /// HTTP Mapping: 400 Bad Request
-  static const Code outOfRange = Code('OUT_OF_RANGE');
+  static const outOfRange = Code('OUT_OF_RANGE');
 
   /// The operation is not implemented or is not supported/enabled in this
   /// service.
   ///
   /// HTTP Mapping: 501 Not Implemented
-  static const Code unimplemented = Code('UNIMPLEMENTED');
+  static const unimplemented = Code('UNIMPLEMENTED');
 
   /// Internal errors.  This means that some invariants expected by the
   /// underlying system have been broken.  This error code is reserved
   /// for serious errors.
   ///
   /// HTTP Mapping: 500 Internal Server Error
-  static const Code internal = Code('INTERNAL');
+  static const internal = Code('INTERNAL');
 
   /// The service is currently unavailable.  This is most likely a
   /// transient condition, which can be corrected by retrying with
@@ -629,14 +630,21 @@ class Code {
   /// `ABORTED`, and `UNAVAILABLE`.
   ///
   /// HTTP Mapping: 503 Service Unavailable
-  static const Code unavailable = Code('UNAVAILABLE');
+  static const unavailable = Code('UNAVAILABLE');
 
   /// Unrecoverable data loss or corruption.
   ///
   /// HTTP Mapping: 500 Internal Server Error
-  static const Code dataLoss = Code('DATA_LOSS');
+  static const dataLoss = Code('DATA_LOSS');
 
-  final String value;
+  const Code(super.value);
 
-  const Code(this.value);
+  factory Code.fromJson(String json) => Code(json);
+
+  @override
+  bool operator ==(Object other) =>
+      other is Code && value == other.value;
+
+  @override
+  String toString() => 'Code.$value';
 }

--- a/generator/dart/packages/generated/google_cloud_rpc/pubspec.yaml
+++ b/generator/dart/packages/generated/google_cloud_rpc/pubspec.yaml
@@ -24,4 +24,5 @@ environment:
 resolution: workspace
 
 dependencies:
+  google_cloud_common: any
   google_cloud_protobuf: any

--- a/generator/dart/packages/generated/google_cloud_type/lib/type.dart
+++ b/generator/dart/packages/generated/google_cloud_type/lib/type.dart
@@ -19,6 +19,7 @@
 /// Defines common types for Google APIs.
 library;
 
+import 'package:google_cloud_common/common.dart';
 
 /// Represents a textual expression in the Common Expression Language (CEL)
 /// syntax. CEL is a C-like expression language. The syntax and semantics of CEL
@@ -51,7 +52,7 @@ library;
 /// The exact variables and functions that may be referenced within an expression
 /// are determined by the service that evaluates it. See the service
 /// documentation for additional information.
-class Expr {
+class Expr extends CloudMessage {
 
   /// Textual representation of an expression in Common Expression Language
   /// syntax.

--- a/generator/dart/packages/generated/google_cloud_type/pubspec.yaml
+++ b/generator/dart/packages/generated/google_cloud_type/pubspec.yaml
@@ -22,3 +22,6 @@ environment:
   sdk: ^3.6.0
 
 resolution: workspace
+
+dependencies:
+  google_cloud_common: any

--- a/generator/dart/packages/google_cloud_common/README.md
+++ b/generator/dart/packages/google_cloud_common/README.md
@@ -4,7 +4,7 @@ Common code for the Google Cloud client library packages.
 
 > [!CAUTION]
 > This package is under active development! We expect multiple breaking changes
-in upcoming releases. Testing is also incomplete; we do **not** recommend that
-you use this package in production.
+> in upcoming releases. Testing is also incomplete; we do **not** recommend that
+> you use this package in production.
 
 We welcome feedback about the APIs, documentation, missing features, bugs, etc.

--- a/generator/dart/packages/google_cloud_common/README.md
+++ b/generator/dart/packages/google_cloud_common/README.md
@@ -1,0 +1,10 @@
+## Google Cloud Common
+
+Common code for the Google Cloud client library packages.
+
+> [!CAUTION]
+> This package is under active development! We expect multiple breaking changes
+in upcoming releases. Testing is also incomplete; we do **not** recommend that
+you use this package in production.
+
+We welcome feedback about the APIs, documentation, missing features, bugs, etc.

--- a/generator/dart/packages/google_cloud_common/lib/common.dart
+++ b/generator/dart/packages/google_cloud_common/lib/common.dart
@@ -1,0 +1,97 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:http/http.dart';
+
+const _clientName = 'dart-test-client';
+
+abstract class Jsonable {
+  Object toJson();
+}
+
+abstract class CloudMessage {}
+
+abstract class CloudEnum {
+  final String value;
+
+  const CloudEnum(this.value);
+
+  @override
+  int get hashCode => value.hashCode;
+
+  Object toJson() => value;
+}
+
+abstract class CloudService {
+  final Client client;
+
+  CloudService({required this.client});
+
+  Future<Map<String, dynamic>> $get(Uri url) async {
+    final response = await client.get(
+      url,
+      headers: {
+        'x-goog-api-client': _clientName,
+      },
+    );
+    return _processResponse(response);
+  }
+
+  Future<Map<String, dynamic>> $post(Uri url, {Jsonable? body}) async {
+    final response = await client.post(
+      url,
+      body: body == null ? null : jsonEncode(body.toJson()),
+      headers: {
+        'x-goog-api-client': _clientName,
+        if (body != null) 'content-type': 'application/json',
+      },
+    );
+    return _processResponse(response);
+  }
+
+  Future<Map<String, dynamic>> $patch(Uri url, {Jsonable? body}) async {
+    final response = await client.patch(
+      url,
+      body: body == null ? null : jsonEncode(body.toJson()),
+      headers: {
+        'x-goog-api-client': _clientName,
+        if (body != null) 'content-type': 'application/json',
+      },
+    );
+    return _processResponse(response);
+  }
+
+  Future<Map<String, dynamic>> $delete(Uri url) async {
+    final response = await client.delete(
+      url,
+      headers: {
+        'x-goog-api-client': _clientName,
+      },
+    );
+    return _processResponse(response);
+  }
+
+  Map<String, dynamic> _processResponse(Response response) {
+    final statusOK = response.statusCode >= 200 && response.statusCode < 300;
+    if (statusOK) {
+      final body = response.body;
+      return body.isEmpty ? {} : jsonDecode(body);
+    }
+
+    // TODO(#1454): This is a placeholder until we're able to parse 'Status'.
+    throw ClientException('${response.statusCode}: ${response.reasonPhrase}');
+  }
+}

--- a/generator/dart/packages/google_cloud_common/pubspec.yaml
+++ b/generator/dart/packages/google_cloud_common/pubspec.yaml
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: pkg_workspace
-publish_to: none
+name: google_cloud_common
+description: Common code for the Google Cloud client library packages.
+version: 0.1.0
 
 environment:
   sdk: ^3.6.0
 
-workspace:
-  - packages/generated/google_cloud_protobuf
-  - packages/generated/google_cloud_rpc
-  - packages/generated/google_cloud_type
-  - packages/google_cloud_common
+resolution: workspace
+
+dependencies:
+  http: ^1.3.0

--- a/generator/internal/dart/darttemplate.go
+++ b/generator/internal/dart/darttemplate.go
@@ -180,6 +180,10 @@ func annotateModel(model *api.API, options map[string]string) (*modelAnnotations
 	// Remove our self-reference.
 	delete(imports, model.PackageName)
 
+	// Add the import for the base google_cloud_common package.
+	commonImport := "package:google_cloud_common/common.dart"
+	imports["google_cloud_common"] = commonImport
+
 	deps := calculateDependencies(imports)
 
 	ann := &modelAnnotations{

--- a/generator/internal/dart/darttemplate_test.go
+++ b/generator/internal/dart/darttemplate_test.go
@@ -89,13 +89,13 @@ func TestAnnotateMethod(t *testing.T) {
 	}
 
 	got = codec.RequestType
-	want = "ListSecretVersionRequest" // todo:
+	want = "ListSecretVersionRequest"
 	if got != want {
 		t.Errorf("mismatched type, got=%q, want=%q", got, want)
 	}
 
 	got = codec.ResponseType
-	want = "ListSecretVersionsResponse" // todo:
+	want = "ListSecretVersionsResponse"
 	if got != want {
 		t.Errorf("mismatched type, got=%q, want=%q", got, want)
 	}

--- a/generator/internal/dart/templates/lib/enum.mustache
+++ b/generator/internal/dart/templates/lib/enum.mustache
@@ -17,15 +17,22 @@ limitations under the License.
 {{#Codec.DocLines}}
 {{{.}}}
 {{/Codec.DocLines}}
-class {{Codec.Name}} {
+class {{Codec.Name}} extends CloudEnum {
   {{#Values}}
   {{#Codec.DocLines}}
   {{{.}}}
   {{/Codec.DocLines}}
-  static const {{Parent.Codec.Name}} {{Codec.Name}} = {{Parent.Codec.Name}}('{{Name}}');
+  static const {{Codec.Name}} = {{Parent.Codec.Name}}('{{Name}}');
 
   {{/Values}}
-  final String value;
+  const {{Codec.Name}}(super.value);
 
-  const {{Codec.Name}}(this.value);
+  factory {{Codec.Name}}.fromJson(String json) => {{Codec.Name}}(json);
+
+  @override
+  bool operator ==(Object other) =>
+      other is {{Codec.Name}} && value == other.value;
+
+  @override
+  String toString() => '{{Name}}.$value';
 }

--- a/generator/internal/dart/templates/lib/message.mustache
+++ b/generator/internal/dart/templates/lib/message.mustache
@@ -18,7 +18,7 @@ limitations under the License.
 {{#Codec.DocLines}}
 {{{.}}}
 {{/Codec.DocLines}}
-class {{Codec.Name}} {
+class {{Codec.Name}} extends CloudMessage {
   {{#Fields}}
   {{> field}}
   {{/Fields}}

--- a/generator/internal/dart/templates/lib/service.mustache
+++ b/generator/internal/dart/templates/lib/service.mustache
@@ -17,8 +17,10 @@ limitations under the License.
 {{#Codec.DocLines}}
 {{{.}}}
 {{/Codec.DocLines}}
-class {{Codec.Name}} {
-  static const String defaultHost = 'https://{{DefaultHost}}';
+class {{Codec.Name}} extends CloudService {
+  static const String host = '{{DefaultHost}}';
+
+  {{Codec.Name}}({required super.client});
   {{#Methods}}
   {{> method}}
   {{/Methods}}

--- a/generator/testdata/dart/protobuf/golden/secretmanager/lib/secretmanager.dart
+++ b/generator/testdata/dart/protobuf/golden/secretmanager/lib/secretmanager.dart
@@ -22,6 +22,7 @@ library;
 
 import 'dart:typed_data';
 
+import 'package:google_cloud_common/common.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:http/http.dart';
 
@@ -32,8 +33,10 @@ import 'package:http/http.dart';
 ///
 /// * [Secret][google.cloud.secretmanager.v1.Secret]
 /// * [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]
-class SecretManagerService {
-  static const String defaultHost = 'https://secretmanager.googleapis.com';
+class SecretManagerService extends CloudService {
+  static const String host = 'secretmanager.googleapis.com';
+
+  SecretManagerService({required super.client});
 
   /// Lists [Secrets][google.cloud.secretmanager.v1.Secret].
   Future<ListSecretsResponse> listSecrets(ListSecretsRequest request) {
@@ -166,7 +169,7 @@ class SecretManagerService {
 /// A [Secret][google.cloud.secretmanager.v1.Secret] is made up of zero or more
 /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] that represent
 /// the secret data.
-class Secret {
+class Secret extends CloudMessage {
 
   /// Output only. The resource name of the
   /// [Secret][google.cloud.secretmanager.v1.Secret] in the format
@@ -282,7 +285,7 @@ class Secret {
 }
 
 /// A secret version resource in the Secret Manager API.
-class SecretVersion {
+class SecretVersion extends CloudMessage {
 
   /// Output only. The resource name of the
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] in the format
@@ -354,33 +357,40 @@ class SecretVersion {
 /// The state of a
 /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion], indicating if
 /// it can be accessed.
-class SecretVersion$State {
+class SecretVersion$State extends CloudEnum {
   /// Not specified. This value is unused and invalid.
-  static const SecretVersion$State stateUnspecified = SecretVersion$State('STATE_UNSPECIFIED');
+  static const stateUnspecified = SecretVersion$State('STATE_UNSPECIFIED');
 
   /// The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] may be
   /// accessed.
-  static const SecretVersion$State enabled = SecretVersion$State('ENABLED');
+  static const enabled = SecretVersion$State('ENABLED');
 
   /// The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] may not
   /// be accessed, but the secret data is still available and can be placed
   /// back into the
   /// [ENABLED][google.cloud.secretmanager.v1.SecretVersion.State.ENABLED]
   /// state.
-  static const SecretVersion$State disabled = SecretVersion$State('DISABLED');
+  static const disabled = SecretVersion$State('DISABLED');
 
   /// The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] is
   /// destroyed and the secret data is no longer stored. A version may not
   /// leave this state once entered.
-  static const SecretVersion$State destroyed = SecretVersion$State('DESTROYED');
+  static const destroyed = SecretVersion$State('DESTROYED');
 
-  final String value;
+  const SecretVersion$State(super.value);
 
-  const SecretVersion$State(this.value);
+  factory SecretVersion$State.fromJson(String json) => SecretVersion$State(json);
+
+  @override
+  bool operator ==(Object other) =>
+      other is SecretVersion$State && value == other.value;
+
+  @override
+  String toString() => 'State.$value';
 }
 
 /// A policy that defines the replication and encryption configuration of data.
-class Replication {
+class Replication extends CloudMessage {
 
   /// The [Secret][google.cloud.secretmanager.v1.Secret] will automatically be
   /// replicated without any restrictions.
@@ -399,7 +409,7 @@ class Replication {
 /// A replication policy that replicates the
 /// [Secret][google.cloud.secretmanager.v1.Secret] payload without any
 /// restrictions.
-class Replication$Automatic {
+class Replication$Automatic extends CloudMessage {
 
   /// Optional. The customer-managed encryption configuration of the
   /// [Secret][google.cloud.secretmanager.v1.Secret]. If no configuration is
@@ -420,7 +430,7 @@ class Replication$Automatic {
 /// A replication policy that replicates the
 /// [Secret][google.cloud.secretmanager.v1.Secret] payload into the locations
 /// specified in [Secret.replication.user_managed.replicas][]
-class Replication$UserManaged {
+class Replication$UserManaged extends CloudMessage {
 
   /// Required. The list of Replicas for this
   /// [Secret][google.cloud.secretmanager.v1.Secret].
@@ -435,7 +445,7 @@ class Replication$UserManaged {
 
 /// Represents a Replica for this
 /// [Secret][google.cloud.secretmanager.v1.Secret].
-class Replication$UserManaged$Replica {
+class Replication$UserManaged$Replica extends CloudMessage {
 
   /// The canonical IDs of the location to replicate data.
   /// For example: `"us-east1"`.
@@ -460,7 +470,7 @@ class Replication$UserManaged$Replica {
 
 /// Configuration for encrypting secret payloads using customer-managed
 /// encryption keys (CMEK).
-class CustomerManagedEncryption {
+class CustomerManagedEncryption extends CloudMessage {
 
   /// Required. The resource name of the Cloud KMS CryptoKey used to encrypt
   /// secret payloads.
@@ -484,7 +494,7 @@ class CustomerManagedEncryption {
 
 /// The replication status of a
 /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-class ReplicationStatus {
+class ReplicationStatus extends CloudMessage {
 
   /// Describes the replication status of a
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] with
@@ -516,7 +526,7 @@ class ReplicationStatus {
 ///
 /// Only populated if the parent [Secret][google.cloud.secretmanager.v1.Secret]
 /// has an automatic replication policy.
-class ReplicationStatus$AutomaticStatus {
+class ReplicationStatus$AutomaticStatus extends CloudMessage {
 
   /// Output only. The customer-managed encryption status of the
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. Only
@@ -534,7 +544,7 @@ class ReplicationStatus$AutomaticStatus {
 ///
 /// Only populated if the parent [Secret][google.cloud.secretmanager.v1.Secret]
 /// has a user-managed replication policy.
-class ReplicationStatus$UserManagedStatus {
+class ReplicationStatus$UserManagedStatus extends CloudMessage {
 
   /// Output only. The list of replica statuses for the
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -547,7 +557,7 @@ class ReplicationStatus$UserManagedStatus {
 
 /// Describes the status of a user-managed replica for the
 /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-class ReplicationStatus$UserManagedStatus$ReplicaStatus {
+class ReplicationStatus$UserManagedStatus$ReplicaStatus extends CloudMessage {
 
   /// Output only. The canonical ID of the replica location.
   /// For example: `"us-east1"`.
@@ -565,7 +575,7 @@ class ReplicationStatus$UserManagedStatus$ReplicaStatus {
 }
 
 /// Describes the status of customer-managed encryption.
-class CustomerManagedEncryptionStatus {
+class CustomerManagedEncryptionStatus extends CloudMessage {
 
   /// Required. The resource name of the Cloud KMS CryptoKeyVersion used to
   /// encrypt the secret payload, in the following format:
@@ -579,7 +589,7 @@ class CustomerManagedEncryptionStatus {
 
 /// A Pub/Sub topic which Secret Manager will publish to when control plane
 /// events occur on this secret.
-class Topic {
+class Topic extends CloudMessage {
 
   /// Required. The resource name of the Pub/Sub topic that will be published to,
   /// in the following format: `projects/*/topics/*`. For publication to succeed,
@@ -598,7 +608,7 @@ class Topic {
 /// Manager will send a Pub/Sub notification to the topics configured on the
 /// Secret. [Secret.topics][google.cloud.secretmanager.v1.Secret.topics] must be
 /// set to configure rotation.
-class Rotation {
+class Rotation extends CloudMessage {
 
   /// Optional. Timestamp in UTC at which the
   /// [Secret][google.cloud.secretmanager.v1.Secret] is scheduled to rotate.
@@ -633,7 +643,7 @@ class Rotation {
 /// A secret payload resource in the Secret Manager API. This contains the
 /// sensitive secret payload that is associated with a
 /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-class SecretPayload {
+class SecretPayload extends CloudMessage {
 
   /// The secret data. Must be no larger than 64KiB.
   final Uint8List? data;
@@ -664,7 +674,7 @@ class SecretPayload {
 
 /// Request message for
 /// [SecretManagerService.ListSecrets][google.cloud.secretmanager.v1.SecretManagerService.ListSecrets].
-class ListSecretsRequest {
+class ListSecretsRequest extends CloudMessage {
 
   /// Required. The resource name of the project associated with the
   /// [Secrets][google.cloud.secretmanager.v1.Secret], in the format `projects/*`
@@ -697,7 +707,7 @@ class ListSecretsRequest {
 
 /// Response message for
 /// [SecretManagerService.ListSecrets][google.cloud.secretmanager.v1.SecretManagerService.ListSecrets].
-class ListSecretsResponse {
+class ListSecretsResponse extends CloudMessage {
 
   /// The list of [Secrets][google.cloud.secretmanager.v1.Secret] sorted in
   /// reverse by create_time (newest first).
@@ -723,7 +733,7 @@ class ListSecretsResponse {
 
 /// Request message for
 /// [SecretManagerService.CreateSecret][google.cloud.secretmanager.v1.SecretManagerService.CreateSecret].
-class CreateSecretRequest {
+class CreateSecretRequest extends CloudMessage {
 
   /// Required. The resource name of the project to associate with the
   /// [Secret][google.cloud.secretmanager.v1.Secret], in the format `projects/*`
@@ -750,7 +760,7 @@ class CreateSecretRequest {
 
 /// Request message for
 /// [SecretManagerService.AddSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion].
-class AddSecretVersionRequest {
+class AddSecretVersionRequest extends CloudMessage {
 
   /// Required. The resource name of the
   /// [Secret][google.cloud.secretmanager.v1.Secret] to associate with the
@@ -770,7 +780,7 @@ class AddSecretVersionRequest {
 
 /// Request message for
 /// [SecretManagerService.GetSecret][google.cloud.secretmanager.v1.SecretManagerService.GetSecret].
-class GetSecretRequest {
+class GetSecretRequest extends CloudMessage {
 
   /// Required. The resource name of the
   /// [Secret][google.cloud.secretmanager.v1.Secret], in the format
@@ -784,7 +794,7 @@ class GetSecretRequest {
 
 /// Request message for
 /// [SecretManagerService.ListSecretVersions][google.cloud.secretmanager.v1.SecretManagerService.ListSecretVersions].
-class ListSecretVersionsRequest {
+class ListSecretVersionsRequest extends CloudMessage {
 
   /// Required. The resource name of the
   /// [Secret][google.cloud.secretmanager.v1.Secret] associated with the
@@ -818,7 +828,7 @@ class ListSecretVersionsRequest {
 
 /// Response message for
 /// [SecretManagerService.ListSecretVersions][google.cloud.secretmanager.v1.SecretManagerService.ListSecretVersions].
-class ListSecretVersionsResponse {
+class ListSecretVersionsResponse extends CloudMessage {
 
   /// The list of [SecretVersions][google.cloud.secretmanager.v1.SecretVersion]
   /// sorted in reverse by create_time (newest first).
@@ -845,7 +855,7 @@ class ListSecretVersionsResponse {
 
 /// Request message for
 /// [SecretManagerService.GetSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.GetSecretVersion].
-class GetSecretVersionRequest {
+class GetSecretVersionRequest extends CloudMessage {
 
   /// Required. The resource name of the
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] in the format
@@ -865,7 +875,7 @@ class GetSecretVersionRequest {
 
 /// Request message for
 /// [SecretManagerService.UpdateSecret][google.cloud.secretmanager.v1.SecretManagerService.UpdateSecret].
-class UpdateSecretRequest {
+class UpdateSecretRequest extends CloudMessage {
 
   /// Required. [Secret][google.cloud.secretmanager.v1.Secret] with updated field
   /// values.
@@ -882,7 +892,7 @@ class UpdateSecretRequest {
 
 /// Request message for
 /// [SecretManagerService.AccessSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion].
-class AccessSecretVersionRequest {
+class AccessSecretVersionRequest extends CloudMessage {
 
   /// Required. The resource name of the
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] in the format
@@ -902,7 +912,7 @@ class AccessSecretVersionRequest {
 
 /// Response message for
 /// [SecretManagerService.AccessSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion].
-class AccessSecretVersionResponse {
+class AccessSecretVersionResponse extends CloudMessage {
 
   /// The resource name of the
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] in the format
@@ -921,7 +931,7 @@ class AccessSecretVersionResponse {
 
 /// Request message for
 /// [SecretManagerService.DeleteSecret][google.cloud.secretmanager.v1.SecretManagerService.DeleteSecret].
-class DeleteSecretRequest {
+class DeleteSecretRequest extends CloudMessage {
 
   /// Required. The resource name of the
   /// [Secret][google.cloud.secretmanager.v1.Secret] to delete in the format
@@ -941,7 +951,7 @@ class DeleteSecretRequest {
 
 /// Request message for
 /// [SecretManagerService.DisableSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.DisableSecretVersion].
-class DisableSecretVersionRequest {
+class DisableSecretVersionRequest extends CloudMessage {
 
   /// Required. The resource name of the
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to disable in
@@ -963,7 +973,7 @@ class DisableSecretVersionRequest {
 
 /// Request message for
 /// [SecretManagerService.EnableSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.EnableSecretVersion].
-class EnableSecretVersionRequest {
+class EnableSecretVersionRequest extends CloudMessage {
 
   /// Required. The resource name of the
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to enable in
@@ -985,7 +995,7 @@ class EnableSecretVersionRequest {
 
 /// Request message for
 /// [SecretManagerService.DestroySecretVersion][google.cloud.secretmanager.v1.SecretManagerService.DestroySecretVersion].
-class DestroySecretVersionRequest {
+class DestroySecretVersionRequest extends CloudMessage {
 
   /// Required. The resource name of the
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to destroy in

--- a/generator/testdata/dart/protobuf/golden/secretmanager/pubspec.yaml
+++ b/generator/testdata/dart/protobuf/golden/secretmanager/pubspec.yaml
@@ -24,5 +24,6 @@ environment:
 resolution: workspace
 
 dependencies:
+  google_cloud_common: any
   google_cloud_protobuf: any
   http: any


### PR DESCRIPTION
Introduce a base google_cloud_common package:
- add a new `package:google_cloud_common` hand-written base package that all generated packages can refer to
- have all messages, services and enums inherit from base classes (`CloudMessage`, `CloudService`, and `CloudEnum`). `CloudService` will let us provide common behavior wrt RPC calls to services. CloudMessage and CloudEnum will provide some shorthand facilities for JSON encoding.
- extracted from https://github.com/googleapis/google-cloud-rust/pull/1454



