### PR TITLE
feat(generator/dart): add toString() methods to messages

### DIFF
--- a/generator/dart/packages/generated/google_cloud_protobuf/lib/protobuf.dart
+++ b/generator/dart/packages/generated/google_cloud_protobuf/lib/protobuf.dart
@@ -102,6 +102,15 @@ class Duration extends CloudMessage {
   }) {
     _validate();
   }
+
+  @override
+  String toString() {
+    final contents = [
+      if (seconds != null) 'seconds=$seconds',
+      if (nanos != null) 'nanos=$nanos',
+    ].join(',');
+    return 'Duration($contents)';
+  }
 }
 
 /// `FieldMask` represents a set of symbolic field paths, for example:
@@ -311,4 +320,7 @@ class FieldMask extends CloudMessage {
   FieldMask({
     this.paths,
   });
+
+  @override
+  String toString() => 'FieldMask()';
 }

--- a/generator/dart/packages/generated/google_cloud_rpc/lib/rpc.dart
+++ b/generator/dart/packages/generated/google_cloud_rpc/lib/rpc.dart
@@ -81,6 +81,15 @@ class ErrorInfo extends CloudMessage {
     this.domain,
     this.metadata,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (reason != null) 'reason=$reason',
+      if (domain != null) 'domain=$domain',
+    ].join(',');
+    return 'ErrorInfo($contents)';
+  }
 }
 
 /// Describes when the clients can retry a failed request. Clients could ignore
@@ -104,6 +113,9 @@ class RetryInfo extends CloudMessage {
   RetryInfo({
     this.retryDelay,
   });
+
+  @override
+  String toString() => 'RetryInfo()';
 }
 
 /// Describes additional debugging info.
@@ -119,6 +131,14 @@ class DebugInfo extends CloudMessage {
     this.stackEntries,
     this.detail,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (detail != null) 'detail=$detail',
+    ].join(',');
+    return 'DebugInfo($contents)';
+  }
 }
 
 /// Describes how a quota check failed.
@@ -140,6 +160,9 @@ class QuotaFailure extends CloudMessage {
   QuotaFailure({
     this.violations,
   });
+
+  @override
+  String toString() => 'QuotaFailure()';
 }
 
 /// A message type used to describe a single quota violation.  For example, a
@@ -164,6 +187,15 @@ class QuotaFailure$Violation extends CloudMessage {
     this.subject,
     this.description,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (subject != null) 'subject=$subject',
+      if (description != null) 'description=$description',
+    ].join(',');
+    return 'Violation($contents)';
+  }
 }
 
 /// Describes what preconditions have failed.
@@ -179,6 +211,9 @@ class PreconditionFailure extends CloudMessage {
   PreconditionFailure({
     this.violations,
   });
+
+  @override
+  String toString() => 'PreconditionFailure()';
 }
 
 /// A message type used to describe a single precondition failure.
@@ -205,6 +240,16 @@ class PreconditionFailure$Violation extends CloudMessage {
     this.subject,
     this.description,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (type != null) 'type=$type',
+      if (subject != null) 'subject=$subject',
+      if (description != null) 'description=$description',
+    ].join(',');
+    return 'Violation($contents)';
+  }
 }
 
 /// Describes violations in a client request. This error type focuses on the
@@ -217,6 +262,9 @@ class BadRequest extends CloudMessage {
   BadRequest({
     this.fieldViolations,
   });
+
+  @override
+  String toString() => 'BadRequest()';
 }
 
 /// A message type used to describe a single bad request field.
@@ -282,6 +330,16 @@ class BadRequest$FieldViolation extends CloudMessage {
     this.reason,
     this.localizedMessage,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (field != null) 'field=$field',
+      if (description != null) 'description=$description',
+      if (reason != null) 'reason=$reason',
+    ].join(',');
+    return 'FieldViolation($contents)';
+  }
 }
 
 /// Contains metadata about the request that clients can attach when filing a bug
@@ -300,6 +358,15 @@ class RequestInfo extends CloudMessage {
     this.requestId,
     this.servingData,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (requestId != null) 'requestId=$requestId',
+      if (servingData != null) 'servingData=$servingData',
+    ].join(',');
+    return 'RequestInfo($contents)';
+  }
 }
 
 /// Describes the resource that is being accessed.
@@ -332,6 +399,17 @@ class ResourceInfo extends CloudMessage {
     this.owner,
     this.description,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (resourceType != null) 'resourceType=$resourceType',
+      if (resourceName != null) 'resourceName=$resourceName',
+      if (owner != null) 'owner=$owner',
+      if (description != null) 'description=$description',
+    ].join(',');
+    return 'ResourceInfo($contents)';
+  }
 }
 
 /// Provides links to documentation or for performing an out of band action.
@@ -347,6 +425,9 @@ class Help extends CloudMessage {
   Help({
     this.links,
   });
+
+  @override
+  String toString() => 'Help()';
 }
 
 /// Describes a URL link.
@@ -362,6 +443,15 @@ class Help$Link extends CloudMessage {
     this.description,
     this.url,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (description != null) 'description=$description',
+      if (url != null) 'url=$url',
+    ].join(',');
+    return 'Link($contents)';
+  }
 }
 
 /// Provides a localized error message that is safe to return to the user
@@ -380,6 +470,15 @@ class LocalizedMessage extends CloudMessage {
     this.locale,
     this.message,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (locale != null) 'locale=$locale',
+      if (message != null) 'message=$message',
+    ].join(',');
+    return 'LocalizedMessage($contents)';
+  }
 }
 
 /// Represents an HTTP request.
@@ -404,6 +503,16 @@ class HttpRequest extends CloudMessage {
     this.headers,
     this.body,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (method != null) 'method=$method',
+      if (uri != null) 'uri=$uri',
+      if (body != null) 'body=$body',
+    ].join(',');
+    return 'HttpRequest($contents)';
+  }
 }
 
 /// Represents an HTTP response.
@@ -428,6 +537,16 @@ class HttpResponse extends CloudMessage {
     this.headers,
     this.body,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (status != null) 'status=$status',
+      if (reason != null) 'reason=$reason',
+      if (body != null) 'body=$body',
+    ].join(',');
+    return 'HttpResponse($contents)';
+  }
 }
 
 /// Represents an HTTP header.
@@ -443,6 +562,15 @@ class HttpHeader extends CloudMessage {
     this.key,
     this.value,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (key != null) 'key=$key',
+      if (value != null) 'value=$value',
+    ].join(',');
+    return 'HttpHeader($contents)';
+  }
 }
 
 /// The `Status` type defines a logical error model that is suitable for
@@ -473,6 +601,15 @@ class Status extends CloudMessage {
     this.message,
     this.details,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (code != null) 'code=$code',
+      if (message != null) 'message=$message',
+    ].join(',');
+    return 'Status($contents)';
+  }
 }
 
 /// The canonical error codes for gRPC APIs.

--- a/generator/dart/packages/generated/google_cloud_type/lib/type.dart
+++ b/generator/dart/packages/generated/google_cloud_type/lib/type.dart
@@ -77,4 +77,15 @@ class Expr extends CloudMessage {
     this.description,
     this.location,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (expression != null) 'expression=$expression',
+      if (title != null) 'title=$title',
+      if (description != null) 'description=$description',
+      if (location != null) 'location=$location',
+    ].join(',');
+    return 'Expr($contents)';
+  }
 }

--- a/generator/internal/dart/darttemplate_test.go
+++ b/generator/internal/dart/darttemplate_test.go
@@ -173,3 +173,37 @@ func TestCalculateImports(t *testing.T) {
 		})
 	}
 }
+
+func TestAnnotateMessageToString(t *testing.T) {
+	model := api.NewTestAPI(
+		[]*api.Message{sample.Secret(), sample.SecretVersion(), sample.Replication(),
+			sample.Automatic(), sample.CustomerManagedEncryption()},
+		[]*api.Enum{sample.EnumState()},
+		[]*api.Service{},
+	)
+
+	for _, test := range []struct {
+		message  *api.Message
+		expected int
+	}{
+		// Expect the number of fields less the number of message fields.
+		{message: sample.Secret(), expected: 1},
+		{message: sample.SecretVersion(), expected: 2},
+		{message: sample.Replication(), expected: 0},
+		{message: sample.Automatic(), expected: 0},
+	} {
+		t.Run(test.message.Name, func(t *testing.T) {
+			packageMapping := map[string]string{}
+			imports := map[string]string{}
+
+			annotateMessage(test.message, model.State, packageMapping, imports)
+
+			codec := test.message.Codec.(*messageAnnotation)
+			actual := codec.ToStringLines
+
+			if len(actual) != test.expected {
+				t.Errorf("Expected list of length %d, got %d", test.expected, len(actual))
+			}
+		})
+	}
+}

--- a/generator/internal/dart/templates/lib/message.mustache
+++ b/generator/internal/dart/templates/lib/message.mustache
@@ -28,6 +28,21 @@ class {{Codec.Name}} extends CloudMessage {
     this.{{Codec.Name}},
   {{/Fields}}
   }){{Codec.ConstructorBody}}
+
+  @override
+  {{#Codec.HasToStringLines}}
+  String toString() {
+    final contents = [
+      {{#Codec.ToStringLines}}
+      {{{.}}}
+      {{/Codec.ToStringLines}}
+    ].join(',');
+    return '{{Name}}($contents)';
+  }
+  {{/Codec.HasToStringLines}}
+  {{^Codec.HasToStringLines}}
+  String toString() => '{{Name}}()';
+  {{/Codec.HasToStringLines}}
 }
 {{#Messages}}
 {{> message}}

--- a/generator/internal/sample/api.go
+++ b/generator/internal/sample/api.go
@@ -327,6 +327,14 @@ func Automatic() *api.Message {
 	}
 }
 
+func CustomerManagedEncryption() *api.Message {
+	return &api.Message{
+		Name:    "CustomerManagedEncryption",
+		ID:      "..CustomerManagedEncryption",
+		Package: Package,
+	}
+}
+
 func SecretPayload() *api.Message {
 	return &api.Message{
 		Name:          "SecretPayload",

--- a/generator/testdata/dart/protobuf/golden/secretmanager/lib/secretmanager.dart
+++ b/generator/testdata/dart/protobuf/golden/secretmanager/lib/secretmanager.dart
@@ -282,6 +282,15 @@ class Secret extends CloudMessage {
     this.versionDestroyTtl,
     this.customerManagedEncryption,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (name != null) 'name=$name',
+      if (etag != null) 'etag=$etag',
+    ].join(',');
+    return 'Secret($contents)';
+  }
 }
 
 /// A secret version resource in the Secret Manager API.
@@ -352,6 +361,17 @@ class SecretVersion extends CloudMessage {
     this.scheduledDestroyTime,
     this.customerManagedEncryption,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (name != null) 'name=$name',
+      if (state != null) 'state=$state',
+      if (etag != null) 'etag=$etag',
+      if (clientSpecifiedPayloadChecksum != null) 'clientSpecifiedPayloadChecksum=$clientSpecifiedPayloadChecksum',
+    ].join(',');
+    return 'SecretVersion($contents)';
+  }
 }
 
 /// The state of a
@@ -404,6 +424,9 @@ class Replication extends CloudMessage {
     this.automatic,
     this.userManaged,
   });
+
+  @override
+  String toString() => 'Replication()';
 }
 
 /// A replication policy that replicates the
@@ -425,6 +448,9 @@ class Replication$Automatic extends CloudMessage {
   Replication$Automatic({
     this.customerManagedEncryption,
   });
+
+  @override
+  String toString() => 'Automatic()';
 }
 
 /// A replication policy that replicates the
@@ -441,6 +467,9 @@ class Replication$UserManaged extends CloudMessage {
   Replication$UserManaged({
     this.replicas,
   });
+
+  @override
+  String toString() => 'UserManaged()';
 }
 
 /// Represents a Replica for this
@@ -466,6 +495,14 @@ class Replication$UserManaged$Replica extends CloudMessage {
     this.location,
     this.customerManagedEncryption,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (location != null) 'location=$location',
+    ].join(',');
+    return 'Replica($contents)';
+  }
 }
 
 /// Configuration for encrypting secret payloads using customer-managed
@@ -490,6 +527,14 @@ class CustomerManagedEncryption extends CloudMessage {
   CustomerManagedEncryption({
     this.kmsKeyName,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (kmsKeyName != null) 'kmsKeyName=$kmsKeyName',
+    ].join(',');
+    return 'CustomerManagedEncryption($contents)';
+  }
 }
 
 /// The replication status of a
@@ -518,6 +563,9 @@ class ReplicationStatus extends CloudMessage {
     this.automatic,
     this.userManaged,
   });
+
+  @override
+  String toString() => 'ReplicationStatus()';
 }
 
 /// The replication status of a
@@ -536,6 +584,9 @@ class ReplicationStatus$AutomaticStatus extends CloudMessage {
   ReplicationStatus$AutomaticStatus({
     this.customerManagedEncryption,
   });
+
+  @override
+  String toString() => 'AutomaticStatus()';
 }
 
 /// The replication status of a
@@ -553,6 +604,9 @@ class ReplicationStatus$UserManagedStatus extends CloudMessage {
   ReplicationStatus$UserManagedStatus({
     this.replicas,
   });
+
+  @override
+  String toString() => 'UserManagedStatus()';
 }
 
 /// Describes the status of a user-managed replica for the
@@ -572,6 +626,14 @@ class ReplicationStatus$UserManagedStatus$ReplicaStatus extends CloudMessage {
     this.location,
     this.customerManagedEncryption,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (location != null) 'location=$location',
+    ].join(',');
+    return 'ReplicaStatus($contents)';
+  }
 }
 
 /// Describes the status of customer-managed encryption.
@@ -585,6 +647,14 @@ class CustomerManagedEncryptionStatus extends CloudMessage {
   CustomerManagedEncryptionStatus({
     this.kmsKeyVersionName,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (kmsKeyVersionName != null) 'kmsKeyVersionName=$kmsKeyVersionName',
+    ].join(',');
+    return 'CustomerManagedEncryptionStatus($contents)';
+  }
 }
 
 /// A Pub/Sub topic which Secret Manager will publish to when control plane
@@ -601,6 +671,14 @@ class Topic extends CloudMessage {
   Topic({
     this.name,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (name != null) 'name=$name',
+    ].join(',');
+    return 'Topic($contents)';
+  }
 }
 
 /// The rotation time and period for a
@@ -638,6 +716,9 @@ class Rotation extends CloudMessage {
     this.nextRotationTime,
     this.rotationPeriod,
   });
+
+  @override
+  String toString() => 'Rotation()';
 }
 
 /// A secret payload resource in the Secret Manager API. This contains the
@@ -670,6 +751,15 @@ class SecretPayload extends CloudMessage {
     this.data,
     this.dataCrc32C,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (data != null) 'data=$data',
+      if (dataCrc32C != null) 'dataCrc32C=$dataCrc32C',
+    ].join(',');
+    return 'SecretPayload($contents)';
+  }
 }
 
 /// Request message for
@@ -703,6 +793,17 @@ class ListSecretsRequest extends CloudMessage {
     this.pageToken,
     this.filter,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (parent != null) 'parent=$parent',
+      if (pageSize != null) 'pageSize=$pageSize',
+      if (pageToken != null) 'pageToken=$pageToken',
+      if (filter != null) 'filter=$filter',
+    ].join(',');
+    return 'ListSecretsRequest($contents)';
+  }
 }
 
 /// Response message for
@@ -729,6 +830,15 @@ class ListSecretsResponse extends CloudMessage {
     this.nextPageToken,
     this.totalSize,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (nextPageToken != null) 'nextPageToken=$nextPageToken',
+      if (totalSize != null) 'totalSize=$totalSize',
+    ].join(',');
+    return 'ListSecretsResponse($contents)';
+  }
 }
 
 /// Request message for
@@ -756,6 +866,15 @@ class CreateSecretRequest extends CloudMessage {
     this.secretId,
     this.secret,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (parent != null) 'parent=$parent',
+      if (secretId != null) 'secretId=$secretId',
+    ].join(',');
+    return 'CreateSecretRequest($contents)';
+  }
 }
 
 /// Request message for
@@ -776,6 +895,14 @@ class AddSecretVersionRequest extends CloudMessage {
     this.parent,
     this.payload,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (parent != null) 'parent=$parent',
+    ].join(',');
+    return 'AddSecretVersionRequest($contents)';
+  }
 }
 
 /// Request message for
@@ -790,6 +917,14 @@ class GetSecretRequest extends CloudMessage {
   GetSecretRequest({
     this.name,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (name != null) 'name=$name',
+    ].join(',');
+    return 'GetSecretRequest($contents)';
+  }
 }
 
 /// Request message for
@@ -824,6 +959,17 @@ class ListSecretVersionsRequest extends CloudMessage {
     this.pageToken,
     this.filter,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (parent != null) 'parent=$parent',
+      if (pageSize != null) 'pageSize=$pageSize',
+      if (pageToken != null) 'pageToken=$pageToken',
+      if (filter != null) 'filter=$filter',
+    ].join(',');
+    return 'ListSecretVersionsRequest($contents)';
+  }
 }
 
 /// Response message for
@@ -851,6 +997,15 @@ class ListSecretVersionsResponse extends CloudMessage {
     this.nextPageToken,
     this.totalSize,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (nextPageToken != null) 'nextPageToken=$nextPageToken',
+      if (totalSize != null) 'totalSize=$totalSize',
+    ].join(',');
+    return 'ListSecretVersionsResponse($contents)';
+  }
 }
 
 /// Request message for
@@ -871,6 +1026,14 @@ class GetSecretVersionRequest extends CloudMessage {
   GetSecretVersionRequest({
     this.name,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (name != null) 'name=$name',
+    ].join(',');
+    return 'GetSecretVersionRequest($contents)';
+  }
 }
 
 /// Request message for
@@ -888,6 +1051,9 @@ class UpdateSecretRequest extends CloudMessage {
     this.secret,
     this.updateMask,
   });
+
+  @override
+  String toString() => 'UpdateSecretRequest()';
 }
 
 /// Request message for
@@ -908,6 +1074,14 @@ class AccessSecretVersionRequest extends CloudMessage {
   AccessSecretVersionRequest({
     this.name,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (name != null) 'name=$name',
+    ].join(',');
+    return 'AccessSecretVersionRequest($contents)';
+  }
 }
 
 /// Response message for
@@ -927,6 +1101,14 @@ class AccessSecretVersionResponse extends CloudMessage {
     this.name,
     this.payload,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (name != null) 'name=$name',
+    ].join(',');
+    return 'AccessSecretVersionResponse($contents)';
+  }
 }
 
 /// Request message for
@@ -947,6 +1129,15 @@ class DeleteSecretRequest extends CloudMessage {
     this.name,
     this.etag,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (name != null) 'name=$name',
+      if (etag != null) 'etag=$etag',
+    ].join(',');
+    return 'DeleteSecretRequest($contents)';
+  }
 }
 
 /// Request message for
@@ -969,6 +1160,15 @@ class DisableSecretVersionRequest extends CloudMessage {
     this.name,
     this.etag,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (name != null) 'name=$name',
+      if (etag != null) 'etag=$etag',
+    ].join(',');
+    return 'DisableSecretVersionRequest($contents)';
+  }
 }
 
 /// Request message for
@@ -991,6 +1191,15 @@ class EnableSecretVersionRequest extends CloudMessage {
     this.name,
     this.etag,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (name != null) 'name=$name',
+      if (etag != null) 'etag=$etag',
+    ].join(',');
+    return 'EnableSecretVersionRequest($contents)';
+  }
 }
 
 /// Request message for
@@ -1013,4 +1222,13 @@ class DestroySecretVersionRequest extends CloudMessage {
     this.name,
     this.etag,
   });
+
+  @override
+  String toString() {
+    final contents = [
+      if (name != null) 'name=$name',
+      if (etag != null) 'etag=$etag',
+    ].join(',');
+    return 'DestroySecretVersionRequest($contents)';
+  }
 }


### PR DESCRIPTION
- add toString() methods to messages
- extracted from https://github.com/googleapis/google-cloud-rust/pull/1454

Having reasonable toString() methods - mostly used for debugging for Dart - is more of a quality of life thing than super necessary; I found them useful when printing out the results from the end-to-end call.
