### PR TITLE
feat(generator/rust): new `mod-prost` templates

### DIFF
--- a/generator/internal/rust/templates/mod-prost/enum.mustache
+++ b/generator/internal/rust/templates/mod-prost/enum.mustache
@@ -1,0 +1,16 @@
+{{!
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{> ../common/enum}}

--- a/generator/internal/rust/templates/mod-prost/message.mustache
+++ b/generator/internal/rust/templates/mod-prost/message.mustache
@@ -1,0 +1,16 @@
+{{!
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{> ../common/message}}

--- a/generator/internal/rust/templates/mod-prost/mod.rs.mustache
+++ b/generator/internal/rust/templates/mod-prost/mod.rs.mustache
@@ -1,0 +1,16 @@
+{{!
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{> ../mod/mod.rs}}

--- a/generator/internal/rust/templates/mod-prost/oneof.mustache
+++ b/generator/internal/rust/templates/mod-prost/oneof.mustache
@@ -1,0 +1,25 @@
+{{!
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+{{> ../common/oneof}}
+
+impl {{Codec.EnumName}} {
+    {{#Fields}}
+    /// Initializes the enum to the [{{Codec.BranchName}}] branch.
+    pub fn from_{{Codec.SetterName}}(value: impl Into<{{{Codec.FieldType}}}>) -> Self {
+        Self::{{Codec.BranchName}}(value.into())
+    }
+    {{/Fields}}
+}


### PR DESCRIPTION
These will create a module-only library (or part thereof) with some
additional helpers to create `oneof` fields. We decided not to add these
helpers to all libraries because they slow down compilation too much. We
can always change this decision in the future.

Part of the work for #1414
