### PR TITLE
refactor(generator/rust): split `Generate()` function

### DIFF
--- a/generator/internal/rust/generate.go
+++ b/generator/internal/rust/generate.go
@@ -1,0 +1,61 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rust
+
+import (
+	"embed"
+
+	"github.com/googleapis/google-cloud-rust/generator/internal/api"
+	"github.com/googleapis/google-cloud-rust/generator/internal/config"
+	"github.com/googleapis/google-cloud-rust/generator/internal/language"
+)
+
+//go:embed all:templates
+var templates embed.FS
+
+func Generate(model *api.API, outdir string, cfg *config.Config) error {
+	codec, err := newCodec(cfg.General.SpecificationFormat == "protobuf", cfg.Codec)
+	if err != nil {
+		return err
+	}
+	annotations := annotateModel(model, codec, outdir)
+	provider := templatesProvider()
+	generatedFiles := codec.generatedFiles(annotations.HasServices)
+	return language.GenerateFromRoot(outdir, model, provider, generatedFiles)
+}
+
+func templatesProvider() language.TemplateProvider {
+	return func(name string) (string, error) {
+		contents, err := templates.ReadFile(name)
+		if err != nil {
+			return "", err
+		}
+		return string(contents), nil
+	}
+}
+
+func (c *codec) generatedFiles(hasServices bool) []language.GeneratedFile {
+	if c.templateOverride != "" {
+		return language.WalkTemplatesDir(templates, c.templateOverride)
+	}
+	var root string
+	switch {
+	case !hasServices:
+		root = "templates/nosvc"
+	default:
+		root = "templates/crate"
+	}
+	return language.WalkTemplatesDir(templates, root)
+}


### PR DESCRIPTION
This organizes the code a little better, moving the main public API to
its own file (module a really small number of helpers).

Follow up to #1464
